### PR TITLE
ci: send Slack notification on GKE node pool creation failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -801,7 +801,21 @@ commands:
           condition: <<parameters.gpus-per-machine>>
           steps:
             - run:
-                command: gcloud container node-pools create accel --cluster ${CLUSTER_ID} --region <<parameters.region>> --num-nodes <<parameters.num-machines>> --accelerator type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>> --machine-type=<<parameters.machine-type>> --scopes cloud-platform --node-taints=<<parameters.accel-node-taints>>
+                command: |
+                  gcloud container node-pools create accel \
+                    --cluster ${CLUSTER_ID} \
+                    --region '<<parameters.region>>' \
+                    --num-nodes '<<parameters.num-machines>>' \
+                    --accelerator 'type=<<parameters.gpu-type>>,count=<<parameters.gpus-per-machine>>' \
+                    --machine-type='<<parameters.machine-type>>' \
+                    --scopes cloud-platform \
+                    --node-taints='<<parameters.accel-node-taints>>' \
+                    || (
+                      curl "$SLACK_WEBHOOK" \
+                        -H 'Content-Type: application/json' \
+                        -d "{\"text\":\"GKE node pool creation failed! $CIRCLE_BUILD_URL\"}"
+                      circleci-agent step halt
+                    )
                 name: Create GPU node pool
       - unless:
           condition: <<parameters.gpus-per-machine>>


### PR DESCRIPTION
## Description

In order to prevent quota failures from showing up as CI failures, this makes node pool creation failure send a Slack notification and mark the job as successful.

I couldn't figure out how to use the Slack orb while distinguishing this particular situation from the general failure case, so I just slapped in a direct request to the already-configured Slack webhook for sending messages to #ci-bots.

`circleci-agent step halt` marks the job as successful, which is why we want a notification at all. For some reason, CircleCI fails to provide an equivalent for marking the job as canceled or some other state besides success/failure; we could make a call to the CircleCI API to cancel the current job, but that would rely on having a CircleCI token available, which we're trying to get away from.

## Test Plan

- [x] run the command in CI and make sure it makes a message appear