### PR TITLE
fix: fetchProjects waits for currentUser to be defined [WEB-1005]

### DIFF
--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -154,11 +154,7 @@ const Dashboard: React.FC = () => {
     setSubmissionsLoading(false);
   }, [currentUser, fetchExperiments, fetchProjects, fetchTasks]);
 
-  const fetchAll = useCallback(() => {
-    fetchSubmissions();
-  }, [fetchSubmissions]);
-
-  const { stopPolling } = usePolling(fetchAll, { rerunOnNewFn: true });
+  const { stopPolling } = usePolling(fetchSubmissions, { rerunOnNewFn: true });
 
   useEffect(() => {
     setSubmissions(

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -146,14 +146,17 @@ const Dashboard: React.FC = () => {
 
   const fetchSubmissions = useCallback(async () => {
     if (!currentUser) return;
-    await Promise.allSettled([fetchExperiments(currentUser), fetchTasks(currentUser)]);
+    await Promise.allSettled([
+      fetchProjects(),
+      fetchExperiments(currentUser),
+      fetchTasks(currentUser),
+    ]);
     setSubmissionsLoading(false);
-  }, [currentUser, fetchExperiments, fetchTasks]);
+  }, [currentUser, fetchExperiments, fetchProjects, fetchTasks]);
 
   const fetchAll = useCallback(() => {
-    fetchProjects();
     fetchSubmissions();
-  }, [fetchSubmissions, fetchProjects]);
+  }, [fetchSubmissions]);
 
   const { stopPolling } = usePolling(fetchAll, { rerunOnNewFn: true });
 


### PR DESCRIPTION
## Description

`getProjectsByUserActivity` activity was being called from dashboard, and error-ing if the user was signed out

Moved into a group of callbacks dependent on currentUser which are uncalled when currentUser === undefined

## Test Plan

- `/det/dashboard` loads project list successfully
- Sign out
- In a new tab, go to `/det/dashboard` - you are redirected to login with no error messages appearing

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.