### PR TITLE
chore: add release notes

### DIFF
--- a/docs/release-notes/pt-images.rst
+++ b/docs/release-notes/pt-images.rst
@@ -2,8 +2,8 @@
 
 **New Features**
 
-*  Container Images: Add maintained images for PyTorch-only environments.
+-  Container Images: Add maintained images for PyTorch-only environments.
 
-   *  Current environment images contain both PyTorch and TensorFlow which
-	  results in large image sizes. Adding a class of images for users who
-	  do not require TensorFlow but may still require TensorBoard.
+      -  Current environment images contain both PyTorch and TensorFlow which results in large image
+         sizes. Adding a class of images for users who do not require TensorFlow but may still
+         require TensorBoard.

--- a/docs/release-notes/pt-images.rst
+++ b/docs/release-notes/pt-images.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+**New Features**
+
+*  Container Images: Add maintained images for PyTorch-only environments.
+
+   *  Current environment images contain both PyTorch and TensorFlow which
+	  results in large image sizes. Adding a class of images for users who
+	  do not require TensorFlow but may still require TensorBoard.


### PR DESCRIPTION
## Description
Adding release notes for Pytorch-only images


## Checklist
- [x] Release notes should be added as a separate file under `docs/release-notes/`.