### PR TITLE
feat: show trial hyperparameters for custom searchers [MLG-343]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -209,71 +209,92 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
   ]);
 
   const tabItems: TabsProps['items'] = useMemo(() => {
-    return [
-      {
-        children: (
-          <LearningCurve
-            experiment={experiment}
-            filters={visualizationFilters}
-            fullHParams={fullHParams.current}
-            selectedMaxTrial={filters.maxTrial}
-            selectedMetric={filters.metric}
-            selectedScale={filters.scale}
-          />
-        ),
-        key: ExperimentVisualizationType.LearningCurve,
-        label: 'Learning Curve',
-      },
-      {
-        children: (
-          <HpParallelCoordinates
-            experiment={experiment}
-            filters={visualizationFilters}
-            fullHParams={fullHParams.current}
-            selectedBatch={filters.batch}
-            selectedBatchMargin={filters.batchMargin}
-            selectedHParams={filters.hParams}
-            selectedMetric={filters.metric}
-            selectedScale={filters.scale}
-          />
-        ),
-        key: ExperimentVisualizationType.HpParallelCoordinates,
-        label: 'HP Parallel Coordinates',
-      },
-      {
-        children: (
-          <HpScatterPlots
-            experiment={experiment}
-            filters={visualizationFilters}
-            fullHParams={fullHParams.current}
-            selectedBatch={filters.batch}
-            selectedBatchMargin={filters.batchMargin}
-            selectedHParams={filters.hParams}
-            selectedMetric={filters.metric}
-            selectedScale={filters.scale}
-          />
-        ),
-        key: ExperimentVisualizationType.HpScatterPlots,
-        label: 'HP Scatter Plots',
-      },
-      {
-        children: (
-          <HpHeatMaps
-            experiment={experiment}
-            filters={visualizationFilters}
-            fullHParams={fullHParams.current}
-            selectedBatch={filters.batch}
-            selectedBatchMargin={filters.batchMargin}
-            selectedHParams={filters.hParams}
-            selectedMetric={filters.metric}
-            selectedScale={filters.scale}
-            selectedView={filters.view}
-          />
-        ),
-        key: ExperimentVisualizationType.HpHeatMap,
-        label: 'HP Heat Map',
-      },
-    ];
+    // In the case of Custom Searchers, all the tabs besides
+    // "Learning Curve" aren't helpful or relevant, so we are hiding them
+    if (experiment.config.searcher.name === ExperimentSearcherName.Custom) {
+      return [
+        {
+          children: (
+            <LearningCurve
+              experiment={experiment}
+              filters={visualizationFilters}
+              fullHParams={fullHParams.current}
+              selectedMaxTrial={filters.maxTrial}
+              selectedMetric={filters.metric}
+              selectedScale={filters.scale}
+            />
+          ),
+          key: ExperimentVisualizationType.LearningCurve,
+          label: 'Learning Curve',
+        },
+      ];
+    } else {
+      return [
+        {
+          children: (
+            <LearningCurve
+              experiment={experiment}
+              filters={visualizationFilters}
+              fullHParams={fullHParams.current}
+              selectedMaxTrial={filters.maxTrial}
+              selectedMetric={filters.metric}
+              selectedScale={filters.scale}
+            />
+          ),
+          key: ExperimentVisualizationType.LearningCurve,
+          label: 'Learning Curve',
+        },
+        {
+          children: (
+            <HpParallelCoordinates
+              experiment={experiment}
+              filters={visualizationFilters}
+              fullHParams={fullHParams.current}
+              selectedBatch={filters.batch}
+              selectedBatchMargin={filters.batchMargin}
+              selectedHParams={filters.hParams}
+              selectedMetric={filters.metric}
+              selectedScale={filters.scale}
+            />
+          ),
+          key: ExperimentVisualizationType.HpParallelCoordinates,
+          label: 'HP Parallel Coordinates',
+        },
+        {
+          children: (
+            <HpScatterPlots
+              experiment={experiment}
+              filters={visualizationFilters}
+              fullHParams={fullHParams.current}
+              selectedBatch={filters.batch}
+              selectedBatchMargin={filters.batchMargin}
+              selectedHParams={filters.hParams}
+              selectedMetric={filters.metric}
+              selectedScale={filters.scale}
+            />
+          ),
+          key: ExperimentVisualizationType.HpScatterPlots,
+          label: 'HP Scatter Plots',
+        },
+        {
+          children: (
+            <HpHeatMaps
+              experiment={experiment}
+              filters={visualizationFilters}
+              fullHParams={fullHParams.current}
+              selectedBatch={filters.batch}
+              selectedBatchMargin={filters.batchMargin}
+              selectedHParams={filters.hParams}
+              selectedMetric={filters.metric}
+              selectedScale={filters.scale}
+              selectedView={filters.view}
+            />
+          ),
+          key: ExperimentVisualizationType.HpHeatMap,
+          label: 'HP Heat Map',
+        },
+      ];
+    }
   }, [
     experiment,
     filters.batch,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -209,41 +209,28 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
   ]);
 
   const tabItems: TabsProps['items'] = useMemo(() => {
-    // In the case of Custom Searchers, all the tabs besides
-    // "Learning Curve" aren't helpful or relevant, so we are hiding them
-    if (experiment.config.searcher.name === ExperimentSearcherName.Custom) {
-      return [
-        {
-          children: (
-            <LearningCurve
-              experiment={experiment}
-              filters={visualizationFilters}
-              fullHParams={fullHParams.current}
-              selectedMaxTrial={filters.maxTrial}
-              selectedMetric={filters.metric}
-              selectedScale={filters.scale}
-            />
-          ),
-          key: ExperimentVisualizationType.LearningCurve,
-          label: 'Learning Curve',
-        },
-      ];
-    } else {
-      return [
-        {
-          children: (
-            <LearningCurve
-              experiment={experiment}
-              filters={visualizationFilters}
-              fullHParams={fullHParams.current}
-              selectedMaxTrial={filters.maxTrial}
-              selectedMetric={filters.metric}
-              selectedScale={filters.scale}
-            />
-          ),
-          key: ExperimentVisualizationType.LearningCurve,
-          label: 'Learning Curve',
-        },
+    /**
+     * In the case of Custom Searchers, all the tabs besides
+     * "Learning Curve" aren't helpful or relevant, so we are hiding them
+     */
+    const tabs: TabsProps['items'] = [
+      {
+        children: (
+          <LearningCurve
+            experiment={experiment}
+            filters={visualizationFilters}
+            fullHParams={fullHParams.current}
+            selectedMaxTrial={filters.maxTrial}
+            selectedMetric={filters.metric}
+            selectedScale={filters.scale}
+          />
+        ),
+        key: ExperimentVisualizationType.LearningCurve,
+        label: 'Learning Curve',
+      },
+    ];
+    if (experiment.config.searcher.name !== ExperimentSearcherName.Custom) {
+      tabs.push(
         {
           children: (
             <HpParallelCoordinates
@@ -293,8 +280,9 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
           key: ExperimentVisualizationType.HpHeatMap,
           label: 'HP Heat Map',
         },
-      ];
+      );
     }
+    return tabs;
   }, [
     experiment,
     filters.batch,

--- a/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialRangeHyperparameters.tsx
@@ -25,9 +25,11 @@ interface HyperParameter {
 
 const TrialRangeHyperparameters: React.FC<Props> = ({ experiment, trial }: Props) => {
   const hyperparameters: HyperParameter[] = useMemo(() => {
-    // In the case of Custom Searchers, we may not have experiment
-    // configs to generate the ranges with. Instead, simply show
-    // the values as constants.
+    /**
+     * In the case of Custom Searchers, we may not have experiment
+     * configs to generate the ranges with. Instead, simply show
+     * the values as constants.
+     */
     if (experiment.config.searcher.name === ExperimentSearcherName.Custom) {
       return Object.entries(trial.hyperparameters).map(([name, value]) => {
         return {


### PR DESCRIPTION
## Description
[MLG-343] [MLG-296]

We want to change the webui in the case of Custom Searchers. The Experiment graph tabs other than "Learning Curves" are not helpful, as we won't have an experiment config to anchor it.

Same goes for the hyperparameters displayed on each trial. Since we can't assume that we will have an experiment config, we are opting to simply show the hyperparameters from the trial as constants.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

## Test Plan

Without this change, custom searchers will display this for an individual Trial:

![Screenshot 2023-03-07 at 11 08 43 AM](https://user-images.githubusercontent.com/12143960/223525914-22cc66fe-835c-4cef-b855-7dfaf453ffd4.png)

And the Experiment Page Visualization tabs other than "Learning Curves" are blank:

![Screenshot 2023-03-07 at 11 09 41 AM](https://user-images.githubusercontent.com/12143960/223526125-17bbccc8-922e-48c7-95f7-802efb276403.png)

**With the change:**

The "Learning Curves" tab is the only one shown:

![Screenshot 2023-03-07 at 11 10 31 AM](https://user-images.githubusercontent.com/12143960/223526894-22a10ab2-b895-4033-8b87-464ba2823d6f.png)

And the individual Trials show their hyperparameters:

![Screenshot 2023-03-07 at 11 11 28 AM](https://user-images.githubusercontent.com/12143960/223526455-6682a6a7-0ba7-455a-9bba-7a41d2829003.png)

All other types of searchers are unchanged.

**How to Test**
- Run a custom searcher before and after to see the results displayed above.
```shell
cd examples/custom_search_method/asha_search_method
det experiment create remote_search_runner/searcher.yaml .
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-343]: https://determinedai.atlassian.net/browse/MLG-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLG-296]: https://determinedai.atlassian.net/browse/MLG-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ