### PR TITLE
feat: add TrialReference.get_hparams() [MLG-315]

### DIFF
--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -109,7 +109,9 @@ class ExperimentReference:
 
         resps = api.read_paginated(get_with_offset)
 
-        return [trial.TrialReference(t.id, self._session) for r in resps for t in r.trials]
+        return [
+            trial.TrialReference._from_bindings(t, self._session) for r in resps for t in r.trials
+        ]
 
     def await_first_trial(self, interval: float = 0.1) -> trial.TrialReference:
         """
@@ -118,7 +120,7 @@ class ExperimentReference:
         while True:
             resp = bindings.get_GetExperimentTrials(self._session, experimentId=self._id)
             if len(resp.trials) > 0:
-                return trial.TrialReference(resp.trials[0].id, self._session)
+                return trial.TrialReference._from_bindings(resp.trials[0], self._session)
             time.sleep(interval)
 
     def kill(self) -> None:


### PR DESCRIPTION
The name get_hparams() begins with "get_" because it may cause a round trip to the master under some circumstances.  But it tries hard to cache static values (like hparams) on the TrialReference to prevent unnecessary round trips to the master.


## Test Plan

- [ ] write an automated test

## Commentary (optional)

I would propose we use this pattern for exposing constant values on objects in the python sdk, as it communicates to users that a round trip to the master is possible from this call, but it does not ever cause a round trip when one was not already necessary.