### PR TITLE
fix: useMemo does not depend on trial having been loaded

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHyperparameters.tsx
@@ -25,7 +25,7 @@ interface HyperParameter {
 }
 
 const TrialDetailsHyperparameters: React.FC<Props> = ({ trial, pageRef }: Props) => {
-  const config = useMemo(() => configForTrial(trial.id), [trial.id]);
+  const config = useMemo(() => configForTrial(trial?.id), [trial?.id]);
   const { settings, updateSettings } = useSettings<Settings>(config);
 
   const columns: ColumnDef<HyperParameter>[] = useMemo(

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -72,7 +72,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   const { contextHolder, modalOpen: openProjectCreate } = useModalProjectCreate({
     workspaceId: workspace.id,
   });
-  const config = useMemo(() => configForWorkspace(workspace.id), [workspace.id]);
+  const config = useMemo(() => configForWorkspace(id), [id]);
   const { settings, updateSettings } = useSettings<WorkspaceDetailsSettings>(config);
 
   const fetchProjects = useCallback(async () => {


### PR DESCRIPTION
## Description

For release party: TrialDetailsHyperparameters throws a JavaScript error until there is 1+ trial available

<img width="572" alt="Screen Shot 2023-03-08 at 12 10 34 PM" src="https://user-images.githubusercontent.com/643918/223804385-22d49a98-60fc-466d-a1fa-7f3fe068d1ee.png">

I believe this is caused by #6128 where we use [trial.id] in useMemo, while other parts of the page are more protected (`trial?.hyperparameters`)

This is less of an issue for experiment or workspace tabs because the object is already present. For safety I did change WorkspaceProjects to use `id`

## Test Plan

Visit an experiment with 0 trials and click on the Hyperparameters tab

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.