### PR TITLE
fix: hide Foldable menu options when button is visible

### DIFF
--- a/webui/react/src/components/PageHeaderFoldable.module.scss
+++ b/webui/react/src/components/PageHeaderFoldable.module.scss
@@ -85,7 +85,7 @@
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(1) {
-    display: none;
+    display: none !important;
   }
   .optionsDropdownOneChild {
     display: none !important;
@@ -97,7 +97,7 @@
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(2) {
-    display: none;
+    display: none !important;
   }
   .optionsDropdownTwoChild {
     display: none !important;
@@ -109,7 +109,7 @@
     display: inline-block !important;
   }
   .optionsDropdownItem:nth-child(3) {
-    display: none;
+    display: none !important;
   }
   .optionsDropdownThreeChild {
     display: none !important;


### PR DESCRIPTION


## Description

This fixes an issue where, when using a `PageHeaderFoldable` component, options that appear in the header always appear in the overflow menu.


## Test Plan

buttons in the page header should not have duplicate options in the overflow menu visible at the same time


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[WEB-961]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-961]: https://determinedai.atlassian.net/browse/WEB-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ