### PR TITLE
fix: don't print ':' when err msg is empty

### DIFF
--- a/master/internal/sproto/resources.go
+++ b/master/internal/sproto/resources.go
@@ -155,7 +155,10 @@ func NewResourcesFailure(
 
 func (f ResourcesFailure) Error() string {
 	if f.ExitCode == nil {
-		return fmt.Sprintf("%s: %s", f.FailureType, f.ErrMsg)
+		if len(f.ErrMsg) > 0 {
+			return fmt.Sprintf("%s: %s", f.FailureType, f.ErrMsg)
+		}
+		return fmt.Sprintf("%s", f.FailureType)
 	}
 	return fmt.Sprintf("%s: %s (exit code %d)", f.FailureType, f.ErrMsg, *f.ExitCode)
 }


### PR DESCRIPTION
## Description

The problem is the ending: at this line of the message

[2023-03-01T16:51:47.462154Z]          || ERROR: Command (formally-key-stallion) was terminated: allocation failed: resources failed with non-zero exit code:

After the fix, it will read like this without ending ':'
[2023-03-09T15:48:16.856735Z]          || ERROR: Command (vastly-caring-gnat) was terminated: allocation failed: resources failed with non-zero exit code

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
