### PR TITLE
fix: support mixed CPU/GPU k8s quotas

### DIFF
--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1218,11 +1218,16 @@ func cpuAndGpuQuotas(quotas *k8sV1.ResourceQuotaList) []k8sV1.ResourceQuota {
 
 	result := []k8sV1.ResourceQuota{}
 	for _, q := range quotas.Items {
+		foundRelevant := false
 		for resourceName := range q.Spec.Hard {
 			switch resourceName {
 			case k8sV1.ResourceCPU, ResourceTypeNvidia, "limits." + ResourceTypeNvidia:
-				result = append(result, q)
+				foundRelevant = true
 			}
+		}
+
+		if foundRelevant {
+			result = append(result, q)
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes an issue where quotas with both CPU and GPU limits were counted twice and therefore skipped (since we currently only support one quota for now).

## Test Plan

Create and apply a quota (e.g. `kubectl apply -f quota.yml --namespace=default`) that includes both CPU and GPU limits such as this:

```yaml
apiVersion: v1
kind: List
items:
- apiVersion: v1
  kind: ResourceQuota
  metadata:
    name: default-quota
  spec:
    hard:
      cpu: "7"
      memory: 1Gi
      pods: "10"
      nvidia.com/gpu: "9"
```

The cluster info page should reflect the correct number of slots (e.g. 9 in the above example).

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
