### PR TITLE
chore: preparing to integrate UserByExternalToken with SCIM support

### DIFF
--- a/master/go.mod
+++ b/master/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-pg/migrations/v8 v8.1.0
 	github.com/go-pg/pg/v10 v10.10.6
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.3.0

--- a/master/internal/user/external_users.go
+++ b/master/internal/user/external_users.go
@@ -1,0 +1,12 @@
+package user
+
+import (
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+// UserByExternalToken returns a user session derived from an external authentication token.
+func UserByExternalToken(tokenText string,
+	ext *model.ExternalSessions,
+) (*model.User, *model.UserSession, error) {
+	return nil, nil, nil
+}

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -2,17 +2,13 @@ package user
 
 import (
 	"context"
-	"crypto/rsa"
 	"database/sql"
-	"encoding/json"
 	"time"
 
-	"github.com/golang-jwt/jwt"
 	"github.com/o1egl/paseto"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
-	"gopkg.in/guregu/null.v3"
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -112,57 +108,6 @@ func AddUserExec(user *model.User) error {
 	}
 
 	return nil
-}
-
-// UserByExternalToken returns a user session derived from an external authentication token.
-func UserByExternalToken(tokenText string,
-	ext *model.ExternalSessions,
-) (*model.User, *model.UserSession, error) {
-	type externalToken struct {
-		*jwt.StandardClaims
-		Email string
-	}
-
-	token, err := jwt.ParseWithClaims(tokenText, &externalToken{},
-		func(token *jwt.Token) (interface{}, error) {
-			var publicKey rsa.PublicKey
-			err := json.Unmarshal([]byte(ext.JwtKey), &publicKey)
-			if err != nil {
-				log.Errorf("error parsing JWT key: %s", err.Error())
-				return nil, err
-			}
-			return &publicKey, nil
-		},
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	claims := token.Claims.(*externalToken)
-
-	user, err := UserByUsername(claims.Email)
-	if err != nil {
-		if err != db.ErrNotFound {
-			return nil, nil, err
-		}
-		user = &model.User{
-			Username:     claims.Email,
-			PasswordHash: null.NewString("", false),
-			Admin:        true,
-			Active:       true,
-		}
-		err := AddUserExec(user)
-		if err != nil {
-			return nil, nil, errors.WithStack(err)
-		}
-	}
-
-	session := &model.UserSession{
-		ID:     model.SessionID(user.ID),
-		UserID: user.ID,
-		Expiry: time.Unix(claims.ExpiresAt, 0),
-	}
-
-	return user, session, nil
 }
 
 // UserByToken returns a user session given an authentication token.


### PR DESCRIPTION
## Description

This is a small refactor to allow changes to UserByExternalToken to not cause rebase conflicts between forks. Moving UserByExternalToken to its own file and just putting a no-op placeholder, because it's never used in the main fork. And allowing existing DB queries to be run through a singleton instance, similar to what we do with Bun.