### PR TITLE
fix: default tag in AWS stack updates

### DIFF
--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -185,6 +185,10 @@ def update_stack(
 
     tags = [
         {
+            "Key": constants.defaults.STACK_TAG_KEY,
+            "Value": constants.defaults.STACK_TAG_VALUE,
+        },
+        {
             "Key": constants.deployment_types.TYPE_TAG_KEY,
             "Value": deployment_type,
         },


### PR DESCRIPTION
## Description

In `update_stack`, the list `tags` is missing the key-value pair `constants.defaults.STACK_TAG_*` ("managed-by=determined" at the time of this writing). The consequences of this is that any stack that has been updated will not appear in the output from `det deploy aws list`.

## Test Plan

This was manually tested by running `det deploy aws up --cluster-id drh-zwei ...`, which had been updated like this before and did not appear in the output of `det deploy aws list`. It does now.

## Commentary (optional)

Thanks to @azhou-determined for help finding this bug!

TODO: create an automated test that checks for consistency between a new stack and an updated stack?? This could be prohibitively expensive.

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
