### PR TITLE
chore: remove deprecated validation callbacks [MLG-21]

### DIFF
--- a/docs/release-notes/remove-pt-callbacks.rst
+++ b/docs/release-notes/remove-pt-callbacks.rst
@@ -2,6 +2,6 @@
 
 **Breaking Changes**
 
--  Trial API: ``on_validation_step_start`` and ``on_validation_step_end`` were previously 
-   deprecated callbacks on ``PyTorchTrial`` and ``DeepspeedTrial`` and have been removed. Please 
-   use ``on_validation_start`` and ``on_validation_end`` instead. 
+-  Trial API: ``on_validation_step_start`` and ``on_validation_step_end`` callbacks on 
+   ``PyTorchTrial`` and ``DeepspeedTrial`` were deprecated in 0.12.12 (Jul 2020) and have been 
+   removed. Please use ``on_validation_start`` and ``on_validation_end`` instead. 

--- a/docs/release-notes/remove-pt-callbacks.rst
+++ b/docs/release-notes/remove-pt-callbacks.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Breaking Changes**
+
+-  Trial API: ``on_validation_step_start`` and ``on_validation_step_end`` were previously 
+   deprecated callbacks on ``PyTorchTrial`` and ``DeepspeedTrial`` and have been removed. Please 
+   use ``on_validation_start`` and ``on_validation_end`` instead. 

--- a/docs/release-notes/remove-pt-callbacks.rst
+++ b/docs/release-notes/remove-pt-callbacks.rst
@@ -2,6 +2,6 @@
 
 **Breaking Changes**
 
--  Trial API: ``on_validation_step_start`` and ``on_validation_step_end`` callbacks on 
-   ``PyTorchTrial`` and ``DeepspeedTrial`` were deprecated in 0.12.12 (Jul 2020) and have been 
-   removed. Please use ``on_validation_start`` and ``on_validation_end`` instead. 
+-  Trial API: ``on_validation_step_start`` and ``on_validation_step_end`` callbacks on
+   ``PyTorchTrial`` and ``DeepspeedTrial`` were deprecated in 0.12.12 (Jul 2020) and have been
+   removed. Please use ``on_validation_start`` and ``on_validation_end`` instead.

--- a/harness/determined/pytorch/_callback.py
+++ b/harness/determined/pytorch/_callback.py
@@ -60,20 +60,6 @@ class PyTorchCallback:
         """
         pass
 
-    def on_validation_step_start(self) -> None:
-        """
-        Run before every validation step begins.
-        """
-        # TODO(DET-3555): remove this once it has been deprecated long enough.
-        pass
-
-    def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
-        """
-        Run after every validation step ends.
-        """
-        # TODO(DET-3555): remove this once it has been deprecated long enough.
-        pass
-
     def on_checkpoint_load_start(self, checkpoint: Dict[str, Any]) -> None:
         """
         Run before state_dict is restored.

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -916,14 +916,6 @@ class _PyTorchTrialController:
         step_start_time = time.time()
 
         for callback in self.callbacks.values():
-            if util.is_overridden(callback.on_validation_step_start, pytorch.PyTorchCallback):
-                logging.warning(
-                    "on_validation_step_start is now deprecated, "
-                    "please use on_validation_start instead."
-                )
-                callback.on_validation_step_start()
-
-        for callback in self.callbacks.values():
             callback.on_validation_start()
 
         num_inputs = 0
@@ -1009,7 +1001,6 @@ class _PyTorchTrialController:
 
         if self.context.distributed.size > 1 and any(
             util.is_overridden(c.on_validation_end, pytorch.PyTorchCallback)
-            or util.is_overridden(c.on_validation_step_end, pytorch.PyTorchCallback)
             for c in self.callbacks.values()
         ):
             logging.debug(
@@ -1017,14 +1008,6 @@ class _PyTorchTrialController:
                 "validation step end callback."
             )
             metrics = self.context.distributed.broadcast(metrics)
-
-        for callback in self.callbacks.values():
-            if util.is_overridden(callback.on_validation_step_end, pytorch.PyTorchCallback):
-                logging.warning(
-                    "on_validation_step_end is now deprecated, please use on_validation_end "
-                    "instead."
-                )
-                callback.on_validation_step_end(metrics)
 
         for callback in self.callbacks.values():
             callback.on_validation_end(metrics)

--- a/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
@@ -544,14 +544,6 @@ class DeepSpeedTrialController(det.TrialController):
         step_start_time = time.time()
 
         for callback in self.callbacks.values():
-            if util.is_overridden(callback.on_validation_step_start, pytorch.PyTorchCallback):
-                logging.warning(
-                    "on_validation_step_start is now deprecated, "
-                    "please use on_validation_start instead"
-                )
-                callback.on_validation_step_start()
-
-        for callback in self.callbacks.values():
             callback.on_validation_start()
 
         num_inputs = 0
@@ -612,7 +604,6 @@ class DeepSpeedTrialController(det.TrialController):
 
         if self.context.distributed.size > 1 and any(
             util.is_overridden(c.on_validation_end, pytorch.PyTorchCallback)
-            or util.is_overridden(c.on_validation_step_end, pytorch.PyTorchCallback)
             for c in self.callbacks.values()
         ):
             logging.debug(
@@ -620,13 +611,6 @@ class DeepSpeedTrialController(det.TrialController):
                 "validation step end callback"
             )
             metrics = self.context.distributed.broadcast(metrics)
-
-        for callback in self.callbacks.values():
-            if util.is_overridden(callback.on_validation_step_end, pytorch.PyTorchCallback):
-                logging.warning(
-                    "on_validation_step_end is now deprecated, please use on_validation_end instead"
-                )
-                callback.on_validation_step_end(metrics)
 
         for callback in self.callbacks.values():
             callback.on_validation_end(metrics)


### PR DESCRIPTION
## Description
remove deprecated on_validation_step_begin/end callbacks.
This should go out in the next breaking change release, which will be 0.21.0 for Trainer API.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
