### PR TITLE
fix: Load multi-trial learning curve with only training metrics [WEB-1026]

### DIFF
--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -355,10 +355,10 @@ SELECT t.id FROM (
   SELECT t.id,
     %s((v.metrics->'validation_metrics'->>$1)::float8) as best_metric
   FROM trials t
-  JOIN validations v ON t.id = v.trial_id
+  LEFT JOIN validations v ON t.id = v.trial_id
   WHERE t.experiment_id=$2
   GROUP BY t.id
-  ORDER BY best_metric %s
+  ORDER BY best_metric %s NULLS LAST
   LIMIT $3
 ) t;`, aggregate, order), metric, experimentID, maxTrials)
 	return trials, err

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
@@ -20,7 +20,7 @@ export interface VisualizationFilters {
   batchMargin: number;
   hParams: string[];
   maxTrial: number;
-  metric: Metric;
+  metric: Metric | null;
   scale: Scale;
   view: ViewType;
 }
@@ -251,7 +251,7 @@ const ExperimentVisualizationFilters: React.FC<Props> = ({
           label="Metric"
           metrics={metrics}
           multiple={false}
-          value={localFilters.metric}
+          value={localFilters.metric || undefined}
           width={250}
           onChange={handleMetricChange}
         />

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
@@ -39,7 +39,7 @@ interface Props {
   selectedBatch: number;
   selectedBatchMargin: number;
   selectedHParams: string[];
-  selectedMetric: Metric;
+  selectedMetric: Metric | null;
   selectedScale: Scale;
   selectedView: ViewType;
 }
@@ -97,6 +97,7 @@ const HpHeatMaps: React.FC<Props> = ({
 
   const smallerIsBetter = useMemo(() => {
     if (
+      selectedMetric &&
       selectedMetric.type === MetricType.Validation &&
       selectedMetric.name === experiment.config.searcher.metric
     ) {
@@ -110,7 +111,7 @@ const HpHeatMaps: React.FC<Props> = ({
   }, [chartData, smallerIsBetter, ui.theme]);
 
   const chartProps = useMemo(() => {
-    if (!chartData) return undefined;
+    if (!chartData || !selectedMetric) return undefined;
 
     const props: Record<string, UPlotScatterProps> = {};
     const rgbaStroke0 = str2rgba(colorScale[0].color);
@@ -215,7 +216,7 @@ const HpHeatMaps: React.FC<Props> = ({
   }, [selectedHParams]);
 
   useEffect(() => {
-    if (ui.isPageHidden) return;
+    if (ui.isPageHidden || !selectedMetric) return;
 
     const canceler = new AbortController();
     const trialIds: number[] = [];
@@ -338,7 +339,7 @@ const HpHeatMaps: React.FC<Props> = ({
 
   if (pageError) {
     return <Message title={pageError.message} />;
-  } else if (hasLoaded && !chartData) {
+  } else if ((hasLoaded && !chartData) || !selectedMetric) {
     return isExperimentTerminal ? (
       <Message title="No data to plot." type={MessageType.Empty} />
     ) : (

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -45,7 +45,7 @@ interface Props {
   selectedBatch: number;
   selectedBatchMargin: number;
   selectedHParams: string[];
-  selectedMetric: Metric;
+  selectedMetric: Metric | null;
   selectedScale: Scale;
 }
 
@@ -101,6 +101,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
   const smallerIsBetter = useMemo(() => {
     if (
+      selectedMetric &&
       selectedMetric.type === MetricType.Validation &&
       selectedMetric.name === experiment.config.searcher.metric
     ) {
@@ -165,7 +166,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
         data: {
           colorScale: {
             colors: colorScale.map((scale) => scale.color),
-            dimensionKey: metricToStr(selectedMetric),
+            dimensionKey: selectedMetric ? metricToStr(selectedMetric) : '',
           },
         },
         dimension: { label: { angle: Math.PI / 4, truncate: 24 } },
@@ -194,7 +195,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
     });
 
     // Add metric as column to parcoords dimension list
-    if (chartData?.metricRange) {
+    if (chartData?.metricRange && selectedMetric) {
       const key = metricToStr(selectedMetric);
       newDimensions.push(
         selectedScale === Scale.Log
@@ -218,7 +219,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
   const clearSelected = useCallback(() => setSelectedRowKeys([]), []);
 
   useEffect(() => {
-    if (ui.isPageHidden) return;
+    if (ui.isPageHidden || !selectedMetric) return;
 
     const canceler = new AbortController();
     const trialMetricsMap: Record<number, number> = {};
@@ -363,7 +364,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
 
   if (pageError) {
     return <Message title={pageError.message} />;
-  } else if (hasLoaded && !chartData) {
+  } else if ((hasLoaded && !chartData) || !selectedMetric) {
     return isExperimentTerminal ? (
       <Message title="No data to plot." type={MessageType.Empty} />
     ) : (

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -28,7 +28,7 @@ interface Props {
   selectedBatch: number;
   selectedBatchMargin: number;
   selectedHParams: string[];
-  selectedMetric: Metric;
+  selectedMetric: Metric | null;
   selectedScale: Scale;
 }
 
@@ -64,7 +64,7 @@ const ScatterPlots: React.FC<Props> = ({
   const isExperimentTerminal = terminalRunStates.has(experiment.state);
 
   const chartProps = useMemo(() => {
-    if (!chartData) return undefined;
+    if (!chartData || !selectedMetric) return undefined;
 
     return selectedHParams.reduce((acc, hParam) => {
       const xLabel = hParam;
@@ -133,7 +133,7 @@ const ScatterPlots: React.FC<Props> = ({
   }, [selectedHParams]);
 
   useEffect(() => {
-    if (ui.isPageHidden) return;
+    if (ui.isPageHidden || !selectedMetric) return;
 
     const canceler = new AbortController();
     const trialIds: number[] = [];

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -46,7 +46,7 @@ interface Props {
   filters?: React.ReactNode;
   fullHParams: string[];
   selectedMaxTrial: number;
-  selectedMetric: Metric;
+  selectedMetric: Metric | null;
   selectedScale: Scale;
 }
 
@@ -180,7 +180,7 @@ const LearningCurve: React.FC<Props> = ({
   }, []);
 
   useEffect(() => {
-    if (ui.isPageHidden) return;
+    if (ui.isPageHidden || !selectedMetric) return;
 
     const canceler = new AbortController();
     const trialIdsMap: Record<number, number> = {};
@@ -333,7 +333,7 @@ const LearningCurve: React.FC<Props> = ({
 
   if (pageError) {
     return <Message title={pageError.message} />;
-  } else if (hasLoaded && !hasTrials) {
+  } else if ((hasLoaded && !hasTrials) || !selectedMetric) {
     return isExperimentTerminal ? (
       <Message title="No learning curve data to show." type={MessageType.Empty} />
     ) : (


### PR DESCRIPTION
## Description

LearningCurve typically is based on its searcher metric from the validation metrics. This causes a delay if validation hasn't happened and filled metric names yet.

Solution: similar to our single-trial charts, if our preferred metric is not available yet, show the 0th metric.

## Test Plan

- Visit a previous multi-trial experiment and it should show validation metric.
- Create a test experiment with no validation metrics, or in `src/hooks/useMetricNames.ts`, simulate by commenting out

```typescript
        (event.validationMetrics || [])
          .filter((metric) => !xAxisMetrics.includes(metric))
          .forEach((metric) => (validationMetricsMap[metric] = true));
```

- With validation metrics removed, a multi-trial experiment will show one of its training metrics.
- Fork a multi-trial experiment and it will start out blank. When metric names updates (can take 15-30 seconds after the first recorded metrics) then the chart will appear with the training metric. 
- Fork a multi-trial experiment and once it is active/running, refresh repeatedly; as soon as metrics are recorded it will show the training metric.
- Learning Curve metric filter is not persisted (when you return after validation metrics are recorded or re-enabled, it will prefer the searcher metric over a previous selection)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.