### PR TITLE
docs: use theme templates better

### DIFF
--- a/docs/_templates/analytics.html
+++ b/docs/_templates/analytics.html
@@ -1,0 +1,15 @@
+<!-- Analytics -->
+<script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+
+    ga('create', 'UA-110089850-1', 'auto');
+    ga('set', 'transport', 'beacon');
+    ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
+<script type="text/javascript">
+    var DID=258260;
+    var MyPageName = window.location.href.replace("http://","");
+</script>
+<script async src="//stats.sa-as.com/live.js"></script>

--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,182 +1,23 @@
-{% extends "base.html" %}
+{# We are modifying furo's page.html directly here.  We aren't totally
+   overwriting it or we would extend "base.html" like furo's page.html does,
+   but rather we are just overwriting specific blocks from it. #}
+{% extends "!page.html" %}
 
+{# Include an analytics script. #}
 {% block extrahead %}
-<!-- Analytics -->
-<script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-
-    ga('create', 'UA-110089850-1', 'auto');
-    ga('set', 'transport', 'beacon');
-    ga('send', 'pageview');
-</script>
-<script async src='https://www.google-analytics.com/analytics.js'></script>
-
-<script type="text/javascript">
-    var DID=258260;
-    var MyPageName = window.location.href.replace("http://","");
-</script>
-<script async src="//stats.sa-as.com/live.js"></script>
+{% include "analytics.html" %}
 {% endblock %}
 
-{% block body -%}
-{% include "partials/icons.html" %}
-
-<input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation">
-<input type="checkbox" class="sidebar-toggle" name="__toc" id="__toc">
-<label class="overlay sidebar-overlay" for="__navigation">
-  <div class="visually-hidden">Hide navigation sidebar</div>
-</label>
-<label class="overlay toc-overlay" for="__toc">
-  <div class="visually-hidden">Hide table of contents sidebar</div>
-</label>
-
-{% if theme_announcement -%}
-<div class="announcement">
-  <aside class="announcement-content">
-    {% block announcement %} {{ theme_announcement }} {% endblock announcement %}
-  </aside>
-</div>
-{%- endif %}
-
-<div class="page">
-  <header class="mobile-header">
-    <div class="header-left">
-      <label class="nav-overlay-icon" for="__navigation">
-        <div class="visually-hidden">Toggle site navigation sidebar</div>
-        <i class="icon"><svg><use href="#svg-menu"></use></svg></i>
-      </label>
+{# HACK: include a top-nav like component in our right sidebar. #}
+{% block right_sidebar %}
+{% if not furo_hide_toc %}
+<div class="toc-sticky toc-scroll">
+  {% include "header.html" %}
+  <div class="toc-tree-container">
+    <div class="toc-tree">
+      {{ toc }}
     </div>
-    <div class="header-center">
-      <a href="{{ pathto(master_doc) }}"><div class="brand">{{ docstitle if docstitle else project }}</div></a>
-    </div>
-    <div class="header-right">
-      <div class="theme-toggle-container theme-toggle-header">
-        <button class="theme-toggle">
-          <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
-          <svg class="theme-icon-when-auto"><use href="#svg-sun-half"></use></svg>
-          <svg class="theme-icon-when-dark"><use href="#svg-moon"></use></svg>
-          <svg class="theme-icon-when-light"><use href="#svg-sun"></use></svg>
-        </button>
-      </div>
-      <label class="toc-overlay-icon toc-header-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
-        <div class="visually-hidden">Toggle table of contents sidebar</div>
-        <i class="icon"><svg><use href="#svg-toc"></use></svg></i>
-      </label>
-    </div>
-  </header>
-  <aside class="sidebar-drawer">
-    <div class="sidebar-container">
-      {% block left_sidebar %}
-      <div class="sidebar-sticky">
-        {%- for sidebar_section in sidebars %}
-          {%- include sidebar_section %}
-        {%- endfor %}
-      </div>
-      {% endblock left_sidebar %}
-    </div>
-  </aside>
-  <div class="main">
-    <div class="content">
-      <div class="article-container">
-        <div class="content-icon-container">
-          <div class="theme-toggle-container theme-toggle-content">
-            <button class="theme-toggle">
-              <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
-              <svg class="theme-icon-when-auto"><use href="#svg-sun-half"></use></svg>
-              <svg class="theme-icon-when-dark"><use href="#svg-moon"></use></svg>
-              <svg class="theme-icon-when-light"><use href="#svg-sun"></use></svg>
-            </button>
-          </div>
-          <label class="toc-overlay-icon toc-content-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
-            <div class="visually-hidden">Toggle table of contents sidebar</div>
-            <i class="icon"><svg><use href="#svg-toc"></use></svg></i>
-          </label>
-        </div>
-        <article role="main">
-          {% block content %}{{ body }}{% endblock %}
-        </article>
-      </div>
-      <footer>
-        {% block footer %}
-        <div class="related-pages">
-          {% if next -%}
-            <a class="next-page" href="{{ next.link }}">
-              <div class="page-info">
-                <div class="context">
-                  <span>{{ _("Next") }}</span>
-                </div>
-                <div class="title">{{ next.title }}</div>
-              </div>
-              <svg><use href="#svg-arrow-right"></use></svg>
-            </a>
-          {%- endif %}
-          {% if prev -%}
-            <a class="prev-page" href="{{ prev.link }}">
-              <svg><use href="#svg-arrow-right"></use></svg>
-              <div class="page-info">
-                <div class="context">
-                  <span>{{ _("Previous") }}</span>
-                </div>
-                {% if prev.link == pathto(master_doc) %}
-                <div class="title">{{ _("Home") }}</div>
-                {% else %}
-                <div class="title">{{ prev.title }}</div>
-                {% endif %}
-              </div>
-            </a>
-          {%- endif %}
-        </div>
-
-        <div class="related-information">
-          {%- if show_copyright %}
-            {%- if hasdoc('copyright') %}
-              {% trans path=pathto('copyright'), copyright=copyright|e -%}
-                <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}.
-              {%- endtrans %}
-            {%- else %}
-              {% trans copyright=copyright|e -%}
-                Copyright &#169; {{ copyright }}
-              {%- endtrans %}
-            {%- endif %}
-          {%- endif %}
-          {%- if last_updated %}
-            {%- if show_copyright %} | {%- endif %}
-            {% trans last_updated=last_updated|e -%}
-              Last updated on {{ last_updated }}.
-            {%- endtrans %}
-          {%- endif %}
-          {%- if show_sphinx %}
-            {%- if show_copyright or last_updated %} | {%- endif %}
-            {% trans -%}
-              Built with <a href="https://www.sphinx-doc.org/">Sphinx</a>
-              and
-              <a class="muted-link" href="https://pradyunsg.me">@pradyunsg</a>'s
-              <a href="https://github.com/pradyunsg/furo">Furo theme</a>.
-            {%- endtrans %}
-          {%- endif %}
-          {%- if show_source and has_source and sourcename %}
-            {%- if show_copyright or last_updated or show_sphinx %} | {%- endif %}
-            <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
-               rel="nofollow">
-              {{ _('Show Source') }}
-            </a>
-          {%- endif %}
-        </div>
-        {% endblock footer %}
-      </footer>
-    </div>
-    <aside class="toc-drawer">
-      {% block right_sidebar %}
-      <div class="toc-sticky toc-scroll">
-        {% include "header.html" %}
-        <div class="toc-tree-container">
-          <div class="toc-tree">
-            {{ toc }}
-          </div>
-        </div>
-      </div>
-      {% endblock right_sidebar %}
-    </aside>
   </div>
 </div>
-{%- endblock %}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Previously, we copy/pasted page.html from the furo theme, then made modifications throughout it.

Now, we extend page.html and (nearly) all of our modifications fit inside blocks specifically exposed to us.

As a result, we are no longer so tightly bound to the furo version.

# Commentary

Before this change, the diff between our `page.html` and furo's `page.html` were as follows:
```diff
--- /home/rb/code/source/furo/src/furo/theme/furo/page.html	2023-03-14 15:57:45.562008862 -0600
+++ _templates/page.html	2023-03-14 16:33:28.527841043 -0600
@@ -1,12 +1,30 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+<!-- Analytics -->
+<script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+
+    ga('create', 'UA-110089850-1', 'auto');
+    ga('set', 'transport', 'beacon');
+    ga('send', 'pageview');
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
+<script type="text/javascript">
+    var DID=258260;
+    var MyPageName = window.location.href.replace("http://","");
+</script>
+<script async src="//stats.sa-as.com/live.js"></script>
+{% endblock %}
+
 {% block body -%}
 {% include "partials/icons.html" %}
 
 <input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation">
 <input type="checkbox" class="sidebar-toggle" name="__toc" id="__toc">
 <label class="overlay sidebar-overlay" for="__navigation">
   <div class="visually-hidden">Hide navigation sidebar</div>
 </label>
 <label class="overlay toc-overlay" for="__toc">
   <div class="visually-hidden">Hide table of contents sidebar</div>
@@ -140,31 +158,25 @@
             {%- if show_copyright or last_updated or show_sphinx %} | {%- endif %}
             <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
                rel="nofollow">
               {{ _('Show Source') }}
             </a>
           {%- endif %}
         </div>
         {% endblock footer %}
       </footer>
     </div>
-    <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">
+    <aside class="toc-drawer">
       {% block right_sidebar %}
-      {% if not furo_hide_toc %}
       <div class="toc-sticky toc-scroll">
-        <div class="toc-title-container">
-          <span class="toc-title">
-            {{ _("Contents") }}
-          </span>
-        </div>
+        {% include "header.html" %}
         <div class="toc-tree-container">
           <div class="toc-tree">
             {{ toc }}
           </div>
         </div>
       </div>
-      {% endif %}
       {% endblock right_sidebar %}
     </aside>
   </div>
 </div>
 {%- endblock %}
```

It should be pretty clear (for those with a little `jinja` knowledge) how this current form implements the differences above, without the big copy/paste.  The only exception is the `furo_hide_toc` checks that were (selectively) removed in our customized page.html.  I can't find any pages that look visually different to me, and we are planning on scrapping the theme soon anyway, so I'm in favor of just reverting the `furo_hide_toc` modifications.