### PR TITLE
fix: Chart focus maintained as series changes

### DIFF
--- a/webui/react/src/components/LearningCurveChart.tsx
+++ b/webui/react/src/components/LearningCurveChart.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { AlignedData } from 'uplot';
 
 import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
@@ -35,8 +35,6 @@ const LearningCurveChart: React.FC<Props> = ({
   trialIds,
   xValues,
 }: Props) => {
-  const [focusIndex, setFocusIndex] = useState<number>();
-
   const selectedTrialsIdsSet = useMemo(() => new Set(selectedTrialIds), [selectedTrialIds]);
 
   const chartData: AlignedData = useMemo(() => {
@@ -81,6 +79,7 @@ const LearningCurveChart: React.FC<Props> = ({
         { label: 'batches' },
         ...trialIds.map((trialId) => {
           return {
+            alpha: focusedTrialId === undefined || trialId === focusedTrialId ? 1 : 0.4,
             label: `trial ${trialId}`,
             scale: 'y',
             show:
@@ -104,18 +103,7 @@ const LearningCurveChart: React.FC<Props> = ({
     focusedTrialId,
   ]);
 
-  /*
-   * Focus on a trial series if provided.
-   */
-  useEffect(() => {
-    let seriesIdx = -1;
-    if (focusedTrialId && trialIds.includes(focusedTrialId)) {
-      seriesIdx = trialIds.findIndex((id) => id === focusedTrialId);
-    }
-    setFocusIndex(seriesIdx !== -1 ? seriesIdx : undefined);
-  }, [focusedTrialId, trialIds]);
-
-  return <UPlotChart data={chartData} focusIndex={focusIndex} options={chartOptions} />;
+  return <UPlotChart data={chartData} options={chartOptions} />;
 };
 
 export default LearningCurveChart;

--- a/webui/react/src/components/UPlot/UPlotChart.tsx
+++ b/webui/react/src/components/UPlot/UPlotChart.tsx
@@ -25,7 +25,6 @@ interface Props {
   allowDownload?: boolean;
   data?: AlignedData | FacetedData;
   experimentId?: number;
-  focusIndex?: number;
   noDataMessage?: string;
   options?: Partial<Options>;
   style?: React.CSSProperties;
@@ -84,7 +83,6 @@ type ChartType = 'Line' | 'Scatter';
 const UPlotChart: React.FC<Props> = ({
   allowDownload,
   data,
-  focusIndex,
   options,
   style,
   noDataMessage,
@@ -199,15 +197,6 @@ const UPlotChart: React.FC<Props> = ({
       }
     }
   }, [data, hasData, extendedOptions, previousOptions, chartType]);
-
-  /**
-   * When a focus index is provided, highlight applicable series.
-   */
-  useEffect(() => {
-    if (!chartRef.current) return;
-    const hasFocus = focusIndex !== undefined;
-    chartRef.current.setSeries(hasFocus ? (focusIndex as number) + 1 : null, { focus: hasFocus });
-  }, [focusIndex]);
 
   useEffect(() => {
     extendedOptions.series.forEach((ser, i) => {

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -191,6 +191,7 @@ export const LineChart: React.FC<Props> = ({
         { label: xLabel ?? xAxis ?? 'X' },
         ...series.map((serie, idx) => {
           return {
+            alpha: focusedSeries === undefined || focusedSeries === idx ? 1 : 0.4,
             label: seriesNames[idx],
             points: { show: (serie.data[xAxis] || []).length <= 1 },
             scale: 'y',
@@ -217,6 +218,7 @@ export const LineChart: React.FC<Props> = ({
     seriesNames,
     hasPopulatedSeries,
     propPlugins,
+    focusedSeries,
   ]);
 
   return (
@@ -226,7 +228,6 @@ export const LineChart: React.FC<Props> = ({
         allowDownload={hasPopulatedSeries}
         data={chartData}
         experimentId={experimentId}
-        focusIndex={focusedSeries}
         options={chartOptions}
       />
       {showLegend && (


### PR DESCRIPTION
## Description

Saw this while debugging other code. The focus / highlight series on DesignKit was getting erased as new data was added.

The best way to support this isn't the `chartRef.current.setSeries` from our current uPlotChart helper library, but setting alpha value directly.  The only other place using this feature is the soon-to-be-removed LearningCurve chart. I changed the setting there and removed it from uPlotChart.

## Test Plan

- Visit `/det/design` and scroll to second chart
- Purple line remains "focused" while new data is being added

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.