### PR TITLE
chore: helm files rm images static refs added in values.yaml

### DIFF
--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: change-password
-        image: "{{ .Values.imageRegistry }}/utility:py-3.7-pw-changer"
+        image: {{ .Values.defaultImages.passwordChangeUtility | quote }}
         imagePullPolicy: "Always"
         command: ["/bin/bash"]
         args:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -131,8 +131,6 @@ data:
       {{- toYaml .Values.resourcePools | nindent 6}}
     {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0e4beb5")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0e4beb5")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}
@@ -151,10 +149,10 @@ data:
       image:
          cpu: {{ .Values.taskContainerDefaults.cpuImage | quote }}
          gpu: {{ .Values.taskContainerDefaults.gpuImage | quote }}
-      {{- else if .Values.imageRegistry }}
+      {{- else }}
       image:
-         cpu: {{ .Values.imageRegistry }}/{{ $cpuImage }}
-         gpu: {{ .Values.imageRegistry }}/{{ $gpuImage }}
+         cpu: {{ .Values.defaultImages.cpuImage | quote }}
+         gpu: {{ .Values.defaultImages.gpuImage | quote }}
       {{- if or .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
         {{ required "A valid .Values.taskContainerDefaults.cpuImage entry is required if setting .Values.taskContainerDefaults.gpuImage!" .Values.taskContainerDefaults.cpuImage }}
         {{ required "A valid .Values.taskContainerDefaults.gpuImage entry is required if setting .Values.taskContainerDefaults.cpuImage!" .Values.taskContainerDefaults.gpuImage }}
@@ -163,11 +161,11 @@ data:
       {{- if .Values.taskContainerDefaults.forcePullImage }}
       force_pull_image: {{ .Values.taskContainerDefaults.forcePullImage }}
       {{- end }}
-    {{ else if .Values.imageRegistry }}
+    {{ else }}
     task_container_defaults:
       image:
-         cpu: {{ .Values.imageRegistry }}/{{ $cpuImage }}
-         gpu: {{ .Values.imageRegistry }}/{{ $gpuImage }}
+         cpu: {{ .Values.defaultImages.cpuImage | quote }}
+         gpu: {{ .Values.defaultImages.gpuImage | quote }}
     {{ end }}
 
     {{- if .Values.telemetry }}

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -32,9 +32,9 @@ spec:
         - --config=/etc/config/config.yaml
         name: {{ $schedulerType }}
         {{- if eq $schedulerType "preemption"}}
-        image: determinedai/kube-scheduler:0.17.0
+        image: "{{ .Values.defaultImages.kubeSchedulerPreemption }}"
         {{- else }}
-        image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9
+        image: "{{ .Values.defaultImages.kubeScheduler }}"
         {{- end}}
         imagePullPolicy: "Always"
         livenessProbe:

--- a/helm/charts/determined/values-mlde.yaml
+++ b/helm/charts/determined/values-mlde.yaml
@@ -1,5 +1,5 @@
 # The image registry to use for main image. Defaults to the determinedai repository in DockerHub.
-imageRegistry: determinedai
+imageRegistry: hub.myenterpriselicense.hpe.com/hpe-mlde/<SKU>
 
 ### Default images used in the configuration
 defaultImages:
@@ -19,11 +19,11 @@ defaultImages:
   
 
 # Install Determined enterprise edition.
-enterpriseEdition: false
+enterpriseEdition: true
 
 # Should be configured if using the master image in the Determined enterprise edition
-# or private registry.
-imagePullSecretName:
+# or private registry. Name of the Secret containing the hub.myenterpriselicense.hpe.com credentials
+imagePullSecretName: 
 
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080
@@ -232,7 +232,7 @@ telemetry:
 # notebookTimeout: 1800
 
 # defaultPassword sets the password for the admin and determined user accounts.
-# defaultPassword:
+#defaultPassword:
 
 ## Configure how trial logs are stored.
 # logging:


### PR DESCRIPTION
## Description

This change is related to helm charts only.

The change results from the experience made during the installation of MLDE in the ISP's K8s environment. The **HPE MSC** (HPE My Software Center) images registry for **licensed** image download was used.

**Removed**: the static image references that were left inside the templates and created for each image a "default" var in `values.yaml`.

**Added**: an MLDE `values.yam`l example (`values-mlde.yaml`) reporting the defaults to use the HPE MSC.

**Modified files**:
```
- values.yaml - lines 4-18
- templates/change-password.
- templates/master-config.yaml - lines 134-168
- scheduler-config.yaml - lines 34-38
```

