### PR TITLE
chore: make 'slot list' work for dispatcher RM

### DIFF
--- a/harness/determined/cli/agent.py
+++ b/harness/determined/cli/agent.py
@@ -12,6 +12,7 @@ from determined.cli import task as cli_task
 from determined.cli.errors import CliError
 from determined.common import api
 from determined.common.api import authentication, bindings
+from determined.common.api.bindings import devicev1Type, v1Slot
 from determined.common.check import check_false
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
@@ -67,9 +68,8 @@ def list_agents(args: argparse.Namespace) -> None:
 @authentication.required
 def list_slots(args: argparse.Namespace) -> None:
     task_res = api.get(args.master, "tasks")
-    agent_res = api.get(args.master, "agents")
+    resp = bindings.get_GetAgents(cli.setup_session(args))
 
-    agents = agent_res.json()
     allocations = task_res.json()
 
     c_names = {
@@ -79,44 +79,60 @@ def list_slots(args: argparse.Namespace) -> None:
         if r["container_id"]
     }
 
-    def get_task_name(containers: Dict[str, Any], slot: Dict[str, Any]) -> str:
-        if not slot["container"]:
+    def device_type_string(deviceType: devicev1Type) -> str:
+        if deviceType == devicev1Type.TYPE_CUDA:
+            return "cuda"
+        if deviceType == devicev1Type.TYPE_ROCM:
+            return "rocm"
+        if deviceType == devicev1Type.TYPE_CPU:
+            return "cpu"
+        return "unknown"
+
+    def get_task_name(containers: Dict[str, Any], slot: v1Slot) -> str:
+        if not slot.container:
             return "FREE"
 
-        container_id = slot["container"]["id"]
+        container_id = slot.container.id
 
-        if slot["container"] and container_id in containers:
+        if slot.container and container_id in containers:
             return str(containers[container_id]["name"])
 
-        if slot["container"] and (
+        if slot.container and (
             "determined-master-deployment" in container_id
             or "determined-db-deployment" in container_id
         ):
             return f"Determined System Task: {container_id}"
+
+        if slot.container and ("cluster" in container_id):
+            return ""  # slot:task relationship not tracked on HPC clusters
 
         return f"Non-Determined Task: {container_id}"
 
     slots = [
         OrderedDict(
             [
-                ("agent_id", local_id(agent_id)),
-                ("resource_pool", agent["resource_pool"]),
+                ("agent_id", local_id(agent.id)),
+                (
+                    "resource_pools",
+                    ", ".join(agent.resourcePools) if agent.resourcePools is not None else "",
+                ),
                 ("slot_id", local_id(slot_id)),
-                ("enabled", slot["enabled"]),
-                ("draining", slot.get("draining", False)),
+                ("enabled", agent.slots[slot_id].enabled),
+                ("draining", agent.slots[slot_id].draining),
                 (
                     "allocation_id",
-                    c_names[slot["container"]["id"]]["allocation_id"]
-                    if slot["container"] and slot["container"]["id"] in c_names
-                    else ("OCCUPIED" if slot["container"] else "FREE"),
+                    c_names[agent.slots[slot_id].container.id]["allocation_id"]
+                    if agent.slots[slot_id].container
+                    and agent.slots[slot_id].container.id in c_names
+                    else ("OCCUPIED" if agent.slots[slot_id].container else "FREE"),
                 ),
-                ("task_name", get_task_name(c_names, slot)),
-                ("type", slot["device"]["type"]),
-                ("device", slot["device"]["brand"]),
+                ("task_name", get_task_name(c_names, agent.slots[slot_id])),
+                ("type", device_type_string(agent.slots[slot_id].device.type)),
+                ("device", agent.slots[slot_id].device.brand),
             ]
         )
-        for agent_id, agent in sorted(agents.items())
-        for slot_id, slot in sorted(agent["slots"].items())
+        for agent in sorted(resp.agents or [], key=attrgetter("id"))
+        for slot_id in sorted(agent.slots or [])
     ]
 
     headers = [


### PR DESCRIPTION
## Description

'det slot list' was failing in fetching the agents, so I made it more like 'det agent' which does not suffer from this defect.


## Test Plan

% devcluster -c tools/devcluster.yaml --oneshot
% det -m http://localhost:8080 slot list

 Agent ID                   | Resource Pool   |   Slot ID | Enabled   | Draining   | Allocation ID   | Task Name   | Type   | Device
----------------------------+-----------------+-----------+-----------+------------+-----------------+-------------+--------+----------
 Canmings-MacBook-Pro.local | default         |         0 | True      | False      | FREE            | FREE        | cpu    | Apple

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
