### PR TITLE
fix: Nameplate icon width bug

### DIFF
--- a/webui/react/src/components/kit/Nameplate.module.scss
+++ b/webui/react/src/components/kit/Nameplate.module.scss
@@ -1,4 +1,4 @@
-.avatarCard {
+.base {
   align-items: center;
   display: flex;
 

--- a/webui/react/src/components/kit/Nameplate.tsx
+++ b/webui/react/src/components/kit/Nameplate.tsx
@@ -10,12 +10,15 @@ export interface Props {
 }
 
 const Nameplate: React.FC<Props> = ({ alias, compact, icon, name }) => {
-  const classnames = [css.avatarCard];
+  const classnames = [css.base];
   if (compact) classnames.push(css.compact);
 
   return (
     <div className={classnames.join(' ')}>
-      {icon}
+      <div>
+        {/* icon needs wrapper to maintain width */}
+        {icon}
+      </div>
       <div className={css.text}>
         {alias && <span className={css.alias}>{alias}</span>}
         {<span>{name}</span>}


### PR DESCRIPTION
## Description

Needs to maintain width when sidebar is collapsed

![Screenshot 2023-03-16 at 11-06-41 Cluster - HPE Machine Learning Development Environment](https://user-images.githubusercontent.com/97752292/225708088-11ae1237-dcb3-4c81-8c32-16fec5b3e670.png)


## Test Plan

Collapse sidebar and make sure Avatar in top-left is at full width



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1048

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
