### PR TITLE
ci: increase timeout and retries for `pip install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,13 +386,13 @@ commands:
           name: Install <<parameters.extras-requires>>
           command: |
             if [ -n "<<parameters.extras-requires>>" ]; then
-              pip install --progress-bar off <<parameters.extras-requires>>
+              pip install --retries 10 --timeout 30 --progress-bar off <<parameters.extras-requires>>
             fi
       - run:
           name: Install <<parameters.extra-requirements-file>>
           command: |
             if [ -n "<<parameters.extra-requirements-file>>" ]; then
-              pip install -r <<parameters.extra-requirements-file>>
+              pip install --retries 10 --timeout 30 -r <<parameters.extra-requirements-file>>
             fi
       - save_cache:
           key: det-python-deps-<<pipeline.parameters.cache-buster>>-{{ checksum "/tmp/cachefile" }}


### PR DESCRIPTION
## Description

We keep seeing timeouts on these installs, so increase to a timeout of 30 seconds with 10 retries, up from the default of 15 seconds and 5 retries.

There are other places that run `pip install` in CI, but I think these are the only ones I've seen fail (presumably because all the really big installs go through them), so let's stick with them for now.

## Test Plan

- [ ] CI