### PR TITLE
test: initialize certs properly in an auth utility [DET-9104]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1066,7 +1066,7 @@ jobs:
       - checkout
       - skip-if-docs-only
       - skip-if-webui-only
-      - reinstall-go      
+      - reinstall-go
       - attach_workspace:
           at: .
       - setup_remote_docker:
@@ -1910,6 +1910,7 @@ jobs:
           master-port: ${MASTER_PORT:-8080}
           master-cert: ${MASTER_TLS_CERT}
           master-cert-name: ${MASTER_CERT_NAME}
+          wait-for-master: false
       - locate-cloudwatch-logs:
           cluster-id: ${CLUSTER_ID}
       - terminate-aws-cluster:

--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -46,6 +46,7 @@ def create_test_user(
 def configure_token_store(credentials: authentication.Credentials) -> None:
     """Authenticate the user for CLI usage with the given credentials."""
     token_store = authentication.TokenStore(conf.make_master_url())
+    certs.cli_cert = certs.default_load(conf.make_master_url())
     token = authentication.do_login(
         conf.make_master_url(), credentials.username, credentials.password, certs.cli_cert
     )


### PR DESCRIPTION
## Description

`certs.default_load` is called by the auth-related helpers, but not by `configure_token_store` sometimes used in e2e tests.
`using_k8s` fixture uses `configure_token_store`.
when a handful of tests that use `using_k8s` became the first in the test split, it broke.

## Test Plan

`test-e2e-gpu-single` works.

## Commentary (optional)

`circleci tests split --split-by=timings` is a source of non-determinism.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
