### PR TITLE
chore: update code for new flake8 upgrade

### DIFF
--- a/model_hub/model_hub/mmdetection/_callbacks.py
+++ b/model_hub/model_hub/mmdetection/_callbacks.py
@@ -32,7 +32,7 @@ class FakeRunner:
 
     @property
     def optimizer(self) -> Dict[int, Any]:
-        return {i: opt for i, opt in enumerate(self.context.optimizers)}
+        return dict(enumerate(self.context.optimizers))
 
     @property
     def data_loader(self) -> Optional[DummyDataloader]:


### PR DESCRIPTION
flake8-comprehensions==3.11.0 just dropped and it found a simplification for us to make.

## Test Plan

It is straightforward to validate that this change is a noop:

```python
optimizers = ['a', 'b', 'c', 'd', 'e']
old = {i: opt for i, opt in enumerate(optimizers)}
new = dict(enumerate(optimizers))
assert old == new
```