### PR TITLE
fix: use queueMicrotask in addLogs [WEB-9125]

### DIFF
--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -182,10 +182,12 @@ const LogViewer: React.FC<Props> = ({
   const addLogs = useCallback(
     (newLogs: ViewerLog[], prepend = false): void => {
       if (newLogs.length === 0) return;
-      flushSync(() => {
-        setLogs((prevLogs) => (prepend ? [...newLogs, ...prevLogs] : [...prevLogs, ...newLogs]));
+      queueMicrotask(() => {
+        flushSync(() => {
+          setLogs((prevLogs) => (prepend ? [...newLogs, ...prevLogs] : [...prevLogs, ...newLogs]));
+        });
+        resizeLogs();
       });
-      resizeLogs();
     },
     [resizeLogs],
   );


### PR DESCRIPTION
## Description

WEB-9125 describes an occasional CI error where `addLogs` is calling React's `flushSync` in the middle of a test.
The error suggests `consider moving this call to a scheduler task or micro task`

Change here uses `queueMicrotask(() => { ...  })` - for more info https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask

## Test Plan

- Tests pass
- Scroll to bottom of logs on a running experiment; logs continue to be added
- Scroll to top of logs on a running experiment; log viewer continues to function

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.