### PR TITLE
feat: propogate gcp cluster labels to dynamic agents [MLG-365]

### DIFF
--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 from pathlib import Path
@@ -61,6 +62,9 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         return
 
     det_configs["labels"] = dict(det_configs.get("add_label", []))
+    if "managed-by" in det_configs["labels"]:
+        logging.warning("The label \"managed-by\" is reserved for agent discovery. "
+                        "Agents will likely not have the given label value.")
 
     # Handle Up subcommand.
     if (args.cpu_env_image and not args.gpu_env_image) or (

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -63,8 +63,10 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
 
     det_configs["labels"] = dict(det_configs.get("add_label", []))
     if "managed-by" in det_configs["labels"]:
-        logging.warning("The label \"managed-by\" is reserved for agent discovery. "
-                        "Agents will likely not have the given label value.")
+        logging.warning(
+            'The label "managed-by" is reserved for agent discovery. '
+            "Agents will likely not have the given label value."
+        )
 
     # Handle Up subcommand.
     if (args.cpu_env_image and not args.gpu_env_image) or (

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import os
 import sys
 from pathlib import Path
@@ -63,10 +62,8 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
 
     det_configs["labels"] = dict(det_configs.get("add_label", []))
     if "managed-by" in det_configs["labels"]:
-        logging.warning(
-            'The label "managed-by" is reserved for agent discovery. '
-            "Agents will likely not have the given label value."
-        )
+        print("The label 'managed-by' is reserved for agent discovery.")
+        sys.exit(1)
 
     # Handle Up subcommand.
     if (args.cpu_env_image and not args.gpu_env_image) or (

--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -61,8 +61,14 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
         return
 
     det_configs["labels"] = dict(det_configs.get("add_label", []))
-    if "managed-by" in det_configs["labels"]:
-        print("The label 'managed-by' is reserved for agent discovery.")
+    reserved_labels = {
+        "determined-master-host",
+        "determined-master-port",
+        "determined-resource-pool",
+        "managed-by",
+    }
+    if reserved_labels.intersection(det_configs["labels"]):
+        print(f"The labels {reserved_labels} are reserved for agents.")
         sys.exit(1)
 
     # Handle Up subcommand.

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -78,6 +78,7 @@ resource "google_compute_instance" "master_instance" {
         max_agent_starting_period: ${var.max_agent_starting_period}
         type: gcp
         name_prefix: det-dynamic-agent-${var.unique_id}-${var.det_version_key}-
+        labels: ${jsonencode(var.labels)}
         label_key: managed-by
         label_value: det-master-${var.unique_id}-${var.det_version_key}
         network_interface:

--- a/harness/determined/deploy/gcp/terraform/outputs.tf
+++ b/harness/determined/deploy/gcp/terraform/outputs.tf
@@ -46,6 +46,10 @@ output "C2--Filestore-address" {
   value = "${local.filestore_address}\n"
 }
 
+output "User-Labels" {
+  value = var.labels
+}
+
 output "NOTE" {
   value = "> To use the Determined CLI without needing to specify the master in each command, run:\n\n  export DET_MASTER=${module.compute.web_ui}\n"
 }

--- a/harness/determined/deploy/gcp/terraform/variables.tf
+++ b/harness/determined/deploy/gcp/terraform/variables.tf
@@ -159,7 +159,7 @@ variable "preemption_enabled" {
 }
 
 variable "labels" {
-  type = map
+  type = map(string)
   default = {}
 }
 

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -165,6 +165,7 @@ func (c *GCPClusterConfig) Merge() *compute.Instance {
 	}
 
 	maps.Copy(rb.Labels, c.Labels)
+	rb.Labels[c.LabelKey] = c.LabelValue
 
 	if len(c.NetworkInterface.Network) > 0 && len(c.NetworkInterface.Subnetwork) > 0 {
 		networkInterface := &compute.NetworkInterface{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/maps"
-
 	"cloud.google.com/go/compute/metadata"
 	"github.com/pkg/errors"
 	"google.golang.org/api/compute/v1"
@@ -164,7 +162,12 @@ func (c *GCPClusterConfig) Merge() *compute.Instance {
 		}, rb.Disks...)
 	}
 
-	maps.Copy(rb.Labels, c.Labels)
+	if rb.Labels == nil {
+		rb.Labels = make(map[string]string)
+	}
+	for k, v := range c.Labels {
+		rb.Labels[k] = v
+	}
 	rb.Labels[c.LabelKey] = c.LabelValue
 
 	if len(c.NetworkInterface.Network) > 0 && len(c.NetworkInterface.Subnetwork) > 0 {

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -3,6 +3,7 @@ package provconfig
 import (
 	"encoding/json"
 	"fmt"
+	"golang.org/x/exp/maps"
 	"strings"
 	"time"
 
@@ -162,15 +163,7 @@ func (c *GCPClusterConfig) Merge() *compute.Instance {
 		}, rb.Disks...)
 	}
 
-	if rb.Labels == nil {
-		rb.Labels = make(map[string]string)
-	}
-	for labelKey, labelValue := range c.Labels {
-		rb.Labels[labelKey] = labelValue
-	}
-	if len(c.LabelKey) > 0 && len(c.LabelValue) > 0 {
-		rb.Labels[c.LabelKey] = c.LabelValue
-	}
+	maps.Copy(rb.Labels, c.Labels)
 
 	if len(c.NetworkInterface.Network) > 0 && len(c.NetworkInterface.Subnetwork) > 0 {
 		networkInterface := &compute.NetworkInterface{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -33,6 +33,7 @@ type GCPClusterConfig struct {
 	BootDiskSize        int    `json:"boot_disk_size"`
 	BootDiskSourceImage string `json:"boot_disk_source_image"`
 
+	Labels     map[string]string `json:"labels"`
 	LabelKey   string `json:"label_key"`
 	LabelValue string `json:"label_value"`
 	NamePrefix string `json:"name_prefix"`

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -3,9 +3,10 @@ package provconfig
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/exp/maps"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/maps"
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/pkg/errors"

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -34,9 +34,9 @@ type GCPClusterConfig struct {
 	BootDiskSourceImage string `json:"boot_disk_source_image"`
 
 	Labels     map[string]string `json:"labels"`
-	LabelKey   string `json:"label_key"`
-	LabelValue string `json:"label_value"`
-	NamePrefix string `json:"name_prefix"`
+	LabelKey   string            `json:"label_key"`
+	LabelValue string            `json:"label_value"`
+	NamePrefix string            `json:"name_prefix"`
 
 	NetworkInterface gceNetworkInterface `json:"network_interface"`
 	NetworkTags      []string            `json:"network_tags"`
@@ -162,10 +162,13 @@ func (c *GCPClusterConfig) Merge() *compute.Instance {
 		}, rb.Disks...)
 	}
 
+	if rb.Labels == nil {
+		rb.Labels = make(map[string]string)
+	}
+	for labelKey, labelValue := range c.Labels {
+		rb.Labels[labelKey] = labelValue
+	}
 	if len(c.LabelKey) > 0 && len(c.LabelValue) > 0 {
-		if rb.Labels == nil {
-			rb.Labels = make(map[string]string)
-		}
 		rb.Labels[c.LabelKey] = c.LabelValue
 	}
 

--- a/master/internal/config/provconfig/gcp_config_test.go
+++ b/master/internal/config/provconfig/gcp_config_test.go
@@ -37,6 +37,9 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 	"zone": "test-zone",
 	"boot_disk_size": 100,
 	"boot_disk_source_image": "test-source_image",
+	"labels": {
+	    "test-label-key": "test-label-value"
+	},
 	"label_key": "test-label-key",
 	"label_value": "test-label-value",
 	"name_prefix": "test-name",
@@ -62,6 +65,7 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 			Zone:                "test-zone",
 			BootDiskSize:        100,
 			BootDiskSourceImage: "test-source_image",
+			Labels:              map[string]string{"test-label-key": "test-label-value"},
 			LabelKey:            "test-label-key",
 			LabelValue:          "test-label-value",
 			NamePrefix:          "test-name",

--- a/master/internal/config/provconfig/gcp_config_test.go
+++ b/master/internal/config/provconfig/gcp_config_test.go
@@ -38,7 +38,7 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 	"boot_disk_size": 100,
 	"boot_disk_source_image": "test-source_image",
 	"labels": {
-	    "test-label-key": "test-label-value"
+	    "test-labels-key": "test-labels-value"
 	},
 	"label_key": "test-label-key",
 	"label_value": "test-label-value",
@@ -65,7 +65,7 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 			Zone:                "test-zone",
 			BootDiskSize:        100,
 			BootDiskSourceImage: "test-source_image",
-			Labels:              map[string]string{"test-label-key": "test-label-value"},
+			Labels:              map[string]string{"test-labels-key": "test-labels-value"},
 			LabelKey:            "test-label-key",
 			LabelValue:          "test-label-value",
 			NamePrefix:          "test-name",

--- a/master/packaging/master.yaml
+++ b/master/packaging/master.yaml
@@ -78,6 +78,7 @@
 #      zone: <zone>
 #      boot_disk_size: 200
 #      boot_disk_source_image: projects/<project-id>/global/images/<image-name>
+#      labels: {<key1>: <val1>, <key2>: <val2>, ...}
 #      label_key: <label key for agent discovery>
 #      label_value: <label value for agent discovery>
 #      name_prefix: <name prefix>


### PR DESCRIPTION
## Description

These changes make user-defined labels on GCP deployments, specified as in `det deploy gcp up ... --add-label foo=bar`, be propogated to dynamic agents. [MLG-365]
This does not happen already because, while other components of a Determined GCP deployment are handled by Terraform run in subprocesses created by the `harness`, dynamic agents are created by API calls in `determined-master`.

## Test Plan

1. Add an extra volume to the determined-master Docker container command in the metadata_startup_script of the master instance: `-v /path/to/determined-master:/usr/bin/determined-master`. This change should not be committed!
2. Create a deployment with the modification from step 1, including at least one user-defined label like `--add-label foo=bar`. The master health check is _expected to fail_ (because the Docker container can’t find the file specified in the extra volume).
3. Build `determined-master` (i.e., `make -C master build`) with the changes to the provisioner (this must be done on a machine with the same architecture as the deployment master instance, so, e.g., not on a MacBook).
4. Use `gcloud compute scp ...` to move the executable from step 3 to the master instance (the location must match the filepath in step 1).
5. On the master instance, the startup script will have failed. Stop the Docker container and network, and restart the instance.
6. Determined should now be running (you should be able to see the browser UI as usual). Create an experiment. Check for errors in the master log. Check the GCloud Console for dynamic agent instances: they should have the user-defined label `foo=bar` as well as the usual `managed-by=...`, etc.

## Commentary (optional)

Internally, there is some redundancy in working with label key-value pairs (viz. `Labels`, `LabelKey`, `LabelValue` in `GCPClusterConfig`). The attributes `LabelKey` and `LabelValue` can be left (for now), or further work can be done to get rid of them now.

Here is an example of the manual test outlined above. Note the label that means nothing to anyone except the author: 
<img width="1728" alt="MLG-365_success" src="https://user-images.githubusercontent.com/103537968/227034766-10452627-2d0a-47e3-95b2-239f68450ba2.png">


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-365]: https://hpe-aiatscale.atlassian.net/browse/MLG-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ