### PR TITLE
fix: allocation rekill shouldn't use time.UTC in fine time checks [DET-9149]

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -125,7 +125,7 @@ type (
 )
 
 const (
-	killCooldown       = 30 * time.Second
+	killCooldown       = 15 * time.Second
 	okExitMessage      = "allocation exited successfully"
 	missingExitMessage = ""
 )
@@ -808,8 +808,8 @@ func (a *Allocation) kill(ctx *actor.Context, reason string) {
 
 	// Once a job has been killed, resend the kill every 30s, in the event it is lost (has
 	// happened before due to network failures).
-	a.killCooldown = ptrs.Ptr(time.Now().Add(killCooldown / 2))
-	actors.NotifyAfter(ctx, killCooldown, sproto.AllocationSignalWithReason{
+	a.killCooldown = ptrs.Ptr(time.Now().Add(killCooldown))
+	actors.NotifyAfter(ctx, killCooldown*2, sproto.AllocationSignalWithReason{
 		AllocationSignal:    sproto.KillAllocation,
 		InformationalReason: "killing again after 30s without all container exits",
 	})

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -784,7 +784,7 @@ func (a *Allocation) preempt(ctx *actor.Context, reason string) {
 }
 
 func (a *Allocation) kill(ctx *actor.Context, reason string) {
-	if a.killCooldown != nil && time.Now().UTC().Before(*a.killCooldown) {
+	if a.killCooldown != nil && time.Now().Before(*a.killCooldown) {
 		ctx.Log().Debug("still inside of kill cooldown")
 		return
 	}
@@ -808,7 +808,7 @@ func (a *Allocation) kill(ctx *actor.Context, reason string) {
 
 	// Once a job has been killed, resend the kill every 30s, in the event it is lost (has
 	// happened before due to network failures).
-	a.killCooldown = ptrs.Ptr(time.Now().UTC().Add(killCooldown))
+	a.killCooldown = ptrs.Ptr(time.Now().Add(killCooldown / 2))
 	actors.NotifyAfter(ctx, killCooldown, sproto.AllocationSignalWithReason{
 		AllocationSignal:    sproto.KillAllocation,
 		InformationalReason: "killing again after 30s without all container exits",


### PR DESCRIPTION
## Description
`time.Now().UTC()` internally calls `t.stripMono()` which makes this check susceptible to clock resets.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [???] reproducing this is very hard
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
