### PR TITLE
chore: replacement for sync.Map and/or maps beside mutexes with long names

### DIFF
--- a/master/pkg/syncx/mapx/mapx.go
+++ b/master/pkg/syncx/mapx/mapx.go
@@ -1,0 +1,55 @@
+package mapx
+
+import "sync"
+
+// New creates an empty map.
+func New[K comparable, V any]() Map[K, V] {
+	return Map[K, V]{inner: make(map[K]V)}
+}
+
+// Map is a generic, thread-safe map to supersede usages of sync.Map.
+type Map[K comparable, V any] struct {
+	mu    sync.RWMutex
+	inner map[K]V
+}
+
+// Load the value corresponding to k.
+func (m *Map[K, V]) Load(k K) (V, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	v, ok := m.inner[k]
+	return v, ok
+}
+
+// Delete the value corresponding to k, idempotently.
+func (m *Map[K, V]) Delete(k K) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.inner, k)
+}
+
+// Store the (k,v) pair.
+func (m *Map[K, V]) Store(k K, v V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.inner[k] = v
+}
+
+// Len of the map (number of stored pairs).
+func (m *Map[K, V]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return len(m.inner)
+}
+
+// WithLock runs the given function on the underlying map with a write lock.
+func (m *Map[K, V]) WithLock(f func(m map[K]V)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	f(m.inner)
+}

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -1,0 +1,33 @@
+package mapx
+
+import (
+	"testing"
+
+	"golang.org/x/exp/maps"
+)
+
+// FuzzMap tests for bad concurrent access. Run the command below to test it, if you change the map.
+//
+//	go test -fuzz FuzzMap --parallel 64 github.com/determined-ai/determined/master/pkg/syncx/mapx
+func FuzzMap(f *testing.F) {
+	m := New[uint8, string]()
+
+	f.Add(uint8(0), uint8(0), "hello")
+	f.Fuzz(func(t *testing.T, op, k uint8, v string) {
+		switch op % 5 {
+		case 0:
+			m.Len()
+		case 1:
+			m.Store(k, v)
+		case 2:
+			_, _ = m.Load(k)
+		case 3:
+			m.Delete(k)
+		case 4:
+			var _ []uint8
+			m.WithLock(func(m map[uint8]string) {
+				_ = maps.Keys(m)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Description
Slurm code has a ton of sync.Maps and/or map[K]V with a mutex beside it called `mapNameMutex`. Both kinda suck, and this is easy enough to add.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [x] have a fuzz test, not gonna waste the energy to run it in CI though.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
eh. open to some oss lib, too, but I didn't see anything. or a better name.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
