### PR TITLE
fix: Indicate and clear user search filter [WEB-1074]

### DIFF
--- a/webui/react/src/pages/Settings/UserManagement.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.tsx
@@ -241,6 +241,7 @@ const UserManagement: React.FC = () => {
         defaultWidth: DEFAULT_COLUMN_WIDTHS['displayName'],
         filterDropdown: nameFilterSearch,
         filterIcon: filterIcon,
+        isFiltered: (settings: unknown) => !!(settings as UserManagementSettings)?.name,
         key: V1GetUsersRequestSortBy.NAME,
         onCell: onRightClickableCell,
         render: (_: string, r: DetailedUser) => <UserBadge user={r} />,
@@ -332,6 +333,9 @@ const UserManagement: React.FC = () => {
               onClick={onClickCreateUser}>
               {CREATE_USER}
             </Button>
+            {settings.name && (
+              <Button onClick={handleNameSearchReset}>{'Clear Filters (1)'}</Button>
+            )}
           </Space>
         }
         title={USER_TITLE}>

--- a/webui/react/src/pages/Settings/UserManagement.tsx
+++ b/webui/react/src/pages/Settings/UserManagement.tsx
@@ -201,13 +201,13 @@ const UserManagement: React.FC = () => {
 
   const handleNameSearchApply = useCallback(
     (name: string) => {
-      updateSettings({ name: name || undefined, row: undefined });
+      updateSettings({ name: name || undefined, row: undefined, tableOffset: 0 });
     },
     [updateSettings],
   );
 
   const handleNameSearchReset = useCallback(() => {
-    updateSettings({ name: undefined, row: undefined });
+    updateSettings({ name: undefined, row: undefined, tableOffset: 0 });
   }, [updateSettings]);
 
   const nameFilterSearch = useCallback(


### PR DESCRIPTION
## Description

Makes the users table more like ExperimentList in indicating when a name filter is applied. Uses isFiltered and a button which calls an existing filter reset.

There is no filter like this on the Groups filter.

## Test Plan

- As admin, visit the Users page. There is no filter applied, all users are shown, the 🔍 on the name column is grey
- Click the 🔍 and enter in a name to filter users by name.
- The users list is limited. The 🔍 is now blue, and a button "Clear Filters (1)" appears at top right of the table.
- Refreshing the page keeps filter settings, and blue 🔍 and Clear Filters button.
- Clicking Clear Filter returns to all users view
- Refreshing the page keeps all-users view

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.