### PR TITLE
fix: expand torch + distutils workaround [DET-9158]

### DIFF
--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -967,6 +967,12 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         """
 
         if self._tbd_writer is None:
+            # As of torch v1.9.0, torch.utils.tensorboard has a bug that is exposed by setuptools
+            # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
+            # without actually importing distutils.version.  We can workaround this by prepopulating
+            # the distutils.version submodule in the distutils module.
+            import distutils.version  # noqa: F401
+
             from torch.utils.tensorboard import SummaryWriter
 
             self._tbd_writer = SummaryWriter(self.get_tensorboard_path())  # type: ignore

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -363,6 +363,12 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         """
 
         if self._tbd_writer is None:
+            # As of torch v1.9.0, torch.utils.tensorboard has a bug that is exposed by setuptools
+            # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
+            # without actually importing distutils.version.  We can workaround this by prepopulating
+            # the distutils.version submodule in the distutils module.
+            import distutils.version  # noqa: F401
+
             from torch.utils.tensorboard import SummaryWriter
 
             self._tbd_writer = SummaryWriter(self.get_tensorboard_path())  # type: ignore


### PR DESCRIPTION
When we added more imports of SummaryWriter, we forgot to include the workaround for the distutils bug affecting torch >=1.9 <1.11.