### PR TITLE
fix: expand torch + distutils workaround [DET-9158] 

### DIFF
--- a/examples/deepspeed/gpt_neox/det_utils.py
+++ b/examples/deepspeed/gpt_neox/det_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from attrdict import AttrMap
 from eval_tasks.eval_adapter import run_eval_harness
 from megatron.neox_arguments import NeoXArgs
-from torch.util.tensorboard import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from determined.pytorch import MetricReducer, PyTorchCallback
 

--- a/examples/deepspeed/gpt_neox/gpt2_trial.py
+++ b/examples/deepspeed/gpt_neox/gpt2_trial.py
@@ -21,7 +21,7 @@ from megatron.data.data_utils import build_datasets_from_neox_args
 import deepspeed
 from determined import LOG_FORMAT, InvalidHP
 from determined.pytorch import DataLoader
-from determined.pytorch.deepspeed import DeepSpeedTrial, DeepSpeedTrialContext, ModelParallelUnitS
+from determined.pytorch.deepspeed import DeepSpeedTrial, DeepSpeedTrialContext, ModelParallelUnit
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -967,6 +967,12 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         """
 
         if self._tbd_writer is None:
+            # As of torch v1.9.0, torch.utils.tensorboard has a bug that is exposed by setuptools
+            # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
+            # without actually importing distutils.version.  We can workaround this by prepopulating
+            # the distutils.version submodule in the distutils module.
+            import distutils.version  # noqa: F401
+
             from torch.utils.tensorboard import SummaryWriter
 
             self._tbd_writer = SummaryWriter(self.get_tensorboard_path())  # type: ignore

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -363,6 +363,12 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         """
 
         if self._tbd_writer is None:
+            # As of torch v1.9.0, torch.utils.tensorboard has a bug that is exposed by setuptools
+            # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
+            # without actually importing distutils.version.  We can workaround this by prepopulating
+            # the distutils.version submodule in the distutils module.
+            import distutils.version  # noqa: F401
+
             from torch.utils.tensorboard import SummaryWriter
 
             self._tbd_writer = SummaryWriter(self.get_tensorboard_path())  # type: ignore


### PR DESCRIPTION
When we added more imports of SummaryWriter, we forgot to include the workaround for the distutils bug affecting torch >=1.9 <1.11.