### PR TITLE
fix: Prevent closest point plugin from focusing hidden points

### DIFF
--- a/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
@@ -46,6 +46,9 @@ export const closestPointPlugin = ({
     let closestDistance: number = Number.MAX_VALUE;
     let closestPoint: Point | undefined;
 
+    // filter out hidden y series
+    const shownData = uPlot.data.slice(1).filter((_, idx) => uPlot.series[idx + 1].show);
+
     // find idx range
     // note: assuming X data to be sorted, uPlot behaves odd if that's false
     const cursorValX = uPlot.posToVal(cursorLeft, 'x');
@@ -61,8 +64,8 @@ export const closestPointPlugin = ({
     for (let idx = idxMin; idx <= idxMax; idx++) {
       const posX = uPlot.valToPos(uPlot.data[0][idx], 'x');
 
-      for (let seriesIdx = 1; seriesIdx < uPlot.data.length; seriesIdx++) {
-        const yVal = uPlot.data[seriesIdx][idx];
+      for (let seriesIdx = 0; seriesIdx < shownData.length; seriesIdx++) {
+        const yVal = shownData[seriesIdx][idx];
 
         // value is inside Y range
         if (yVal && yVal >= yValMin && yVal <= yValMax) {


### PR DESCRIPTION


## Description

This fixes an issue where the learning curve visualization graph would flash when selecting a single trial and then hovering over the graph. This is because the closestPointPlugin would find points close to the mouse cursor from series that were hidden.

## Test Plan

In the multi-trial experiments view, when showing the learning curve, hovering over the graph should only focus points on visible experiments.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1050


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
