### PR TITLE
feat: show log viewer agent filter options even when there is one option

### DIFF
--- a/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
@@ -49,9 +49,9 @@ const LogViewerSelect: React.FC<Props> = ({
     const { agentIds, allocationIds, containerIds, rankIds } = options;
     return {
       ...options,
-      agentIds: agentIds ? agentIds.sortAll(alphaNumericSorter) : undefined,
-      allocationIds: allocationIds ? allocationIds.sortAll(alphaNumericSorter) : undefined,
-      containerIds: containerIds ? containerIds.sortAll(alphaNumericSorter) : undefined,
+      agentIds: agentIds?.sortAll(alphaNumericSorter),
+      allocationIds: allocationIds?.sortAll(alphaNumericSorter),
+      containerIds: containerIds?.sortAll(alphaNumericSorter),
       levels: Object.entries(LogLevelFromApi)
         .filter((entry) => entry[1] !== LogLevelFromApi.Unspecified)
         .map(([key, value]) => ({ label: key, value })),
@@ -117,7 +117,7 @@ const LogViewerSelect: React.FC<Props> = ({
             ))}
           </Select>
         )}
-        {moreThanOne.agentIds && (
+        {!!selectOptions?.agentIds?.length && (
           <Select
             disableTags
             mode="multiple"

--- a/webui/react/src/shared/prototypes.ts
+++ b/webui/react/src/shared/prototypes.ts
@@ -62,6 +62,7 @@ function quickSort<T>(arr: T[], low: number, high: number, compareFn: (a: T, b: 
  * how `null` values are treated.
  */
 Array.prototype.sortAll = function (compareFn) {
+  if (this.length <= 1) return this;
   return quickSort(this, 0, this.length - 1, compareFn);
 };
 


### PR DESCRIPTION
## Description

NOTE: If we decide to send back an empty string for agent ID filter option, the WebUI will automatically show a `No Agent ID` as an option also.

PROBLEM:
Problem, we hide the agents filter today when there is 1 or less option. Because we don't show agent ID info in the logs, it's hard to discern what agent the task logs are coming from.

SOLUTION:
Update log viewer filters to show agents filter if there is at least one entry. @trentwatt did all the heavy lifting for this.

<img width="1274" alt="Screenshot 2023-03-23 at 9 43 12 AM" src="https://user-images.githubusercontent.com/220971/227257524-45730299-17f1-4712-acf7-d688072e5df7.png">

ADDITIONAL FIX:
Fix the sortAll logic to handle 0 or 1 element.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- [ ] navigate to logs on a trial detail page
- [ ] verify that the agents filter is displayed

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1083

<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
