### PR TITLE
fix: Learning curve on validation-only experiment

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -431,7 +431,7 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
   } else if (pageError !== undefined) {
     return <Message title={PAGE_ERROR_MESSAGES[pageError]} type={MessageType.Alert} />;
   } else if (!hasLoaded && experiment.state !== RunState.Paused) {
-    return <Spinner tip="Fetching metrics..." />;
+    return <Spinner spinning tip="Fetching metrics..." />;
   } else if (!hasData) {
     return isExperimentTerminal || experiment.state === RunState.Paused ? (
       <Message title="No data to plot." type={MessageType.Empty} />

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -191,9 +191,15 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
           ...filters,
           metric: searcherMetric.current,
         });
+      } else if (metrics.length > 0 && !activeMetric) {
+        setActiveMetric(metrics[0]);
+        handleFiltersChange({
+          ...filters,
+          metric: metrics[0],
+        });
       }
     }
-  }, [hasSearcherMetric, setActiveMetric, handleFiltersChange, filters, metrics]);
+  }, [hasSearcherMetric, setActiveMetric, handleFiltersChange, filters, metrics, activeMetric]);
 
   const handleTabChange = useCallback(
     (type: string) => {


### PR DESCRIPTION
## Description

This resolves an issue where this validation-only experiment ( https://gcloud.determined.ai/det/experiments/2301/visualization/learning-curve ) has trials but no chart or loading message.

- I discovered that this page shows `<Spinner tip="Fetching metrics..." />` but it is not visible for unclear reasons?
- With the new changes, if there is no activeMetric, and searcherMetric is not available, we will graph the 0th metric

## Test Plan

With devcluster to run this code locally,
- command + space = open the omnibar
- Enter `dev serverAddress https://gcloud.determined.ai` to change backends
- Log in as admin using password for that server
- Visit `localhost:3000/det/experiments/2301` and confirm a learning curve chart now appears

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.