### PR TITLE
fix: Indicate and clear workspace member search filter [WEB-1088]

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceMembers.tsx
@@ -142,13 +142,13 @@ const WorkspaceMembers: React.FC<Props> = ({
 
   const handleNameSearchApply = useCallback(
     (newSearch: string) => {
-      updateSettings({ name: newSearch || undefined });
+      updateSettings({ name: newSearch || undefined, tableOffset: 0 });
     },
     [updateSettings],
   );
 
   const handleNameSearchReset = useCallback(() => {
-    updateSettings({ name: undefined });
+    updateSettings({ name: undefined, tableOffset: 0 });
   }, [updateSettings]);
 
   const nameFilterSearch = useCallback(
@@ -215,6 +215,7 @@ const WorkspaceMembers: React.FC<Props> = ({
         defaultWidth: DEFAULT_COLUMN_WIDTHS['name'],
         filterDropdown: nameFilterSearch,
         filterIcon: tableSearchIcon,
+        isFiltered: (settings: unknown) => !!(settings as WorkspaceMembersSettings)?.name,
         key: 'name',
         render: nameRenderer,
         sorter: (a: Readonly<UserOrGroupWithRoleInfo>, b: Readonly<UserOrGroupWithRoleInfo>) => {
@@ -255,6 +256,7 @@ const WorkspaceMembers: React.FC<Props> = ({
           canAssignRoles({ workspace }) &&
           !workspace.immutable &&
           !workspace.archived && <Button onClick={handleAddMembersClick}> Add Members</Button>}
+        {settings.name && <Button onClick={handleNameSearchReset}>{'Clear Filters (1)'}</Button>}
       </div>
       {settings ? (
         <InteractiveTable


### PR DESCRIPTION
## Description

Code based on #6309 - when we filter the workspace members by username, we should:
- highlight the 🔍 icon in blue
- reset tableOffset setting to 0 (to avoid being on page 2 and not showing a unique username)
- show a "Clear Filters (1)" button to remove name search

## Test Plan

In EE (where workspaces have a Members tab):
- filter the workspace members by username
- confirm visibility of blue 🔍 on column, and Clear Filters button
- click Clear Filters button to remove the filters

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.