### PR TITLE
fix: wording in pytorch trainer guide

### DIFF
--- a/docs/training/apis-howto/api-pytorch-ug.rst
+++ b/docs/training/apis-howto/api-pytorch-ug.rst
@@ -656,7 +656,7 @@ The PyTorch Trainer API lets you do the following:
 -  Debug models in your favorite debug environment (e.g., directly on your machine, IDE, or Jupyter
    notebook).
 -  Run training scripts without needing to use an experiment configuration file.
--  Load previous saved checkpoints directly into your model.
+-  Load previously saved checkpoints directly into your model.
 
 Initializing the Trainer
 ========================
@@ -708,7 +708,7 @@ Run Your Training Script Locally
 
 Run training scripts locally without submitting to a cluster or defining an experiment configuration
 file. Be sure to specify ``max_length`` in the ``.fit()`` call, which is used in local training mode
-to determined the maximum number of steps to train for.
+to determine the maximum number of steps to train for.
 
 .. code:: python
 


### PR DESCRIPTION
## Description

One old typo and one wording fix.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
