### PR TITLE
Chore/web 1020/add accordion

### DIFF
--- a/webui/react/src/components/kit/Accordion.test.tsx
+++ b/webui/react/src/components/kit/Accordion.test.tsx
@@ -1,0 +1,211 @@
+import { StyleProvider } from '@ant-design/cssinjs';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Accordion from './Accordion';
+
+const user = userEvent.setup();
+type AccordionProps = Parameters<typeof Accordion>[0];
+type AccordionGroupProps = Parameters<typeof Accordion.Group>[0];
+
+const titleText = 'title';
+const childText = 'child';
+const singleSetup = (props: Omit<AccordionProps, 'title' | 'children'> = {}) => {
+  return render(
+    <StyleProvider container={document.body} hashPriority="high">
+      <Accordion title={titleText} {...props}>
+        {childText}
+      </Accordion>
+    </StyleProvider>,
+  );
+};
+
+const groupInfo = {
+  [1]: {
+    child: 'One -- Child',
+    title: 'One -- Title',
+  },
+  [2]: {
+    child: 'Two -- Child',
+    title: 'Two -- Title',
+  },
+  [3]: {
+    child: 'Three -- Child',
+    title: 'Three -- Title',
+  },
+} as const;
+
+const groupSetup = (props: Omit<AccordionGroupProps, 'children'> = {}) => {
+  return render(
+    <StyleProvider container={document.body} hashPriority="high">
+      <Accordion.Group {...props}>
+        {Object.entries(groupInfo).map(([key, texts]) => (
+          // children are mounted immediately to make testing the group state easier
+          <Accordion key={key} mountChildren="immediately" title={texts.title}>
+            {texts.child}
+          </Accordion>
+        ))}
+      </Accordion.Group>
+    </StyleProvider>,
+  );
+};
+
+describe('Accordion', () => {
+  describe('single', () => {
+    it('displays title and children when clicked', async () => {
+      singleSetup();
+      const title = screen.getByText(titleText);
+      expect(title).toBeVisible();
+      await user.click(title);
+      expect(screen.getByText(childText)).toBeVisible();
+    });
+    describe('mountChildren', () => {
+      it('when mountChildren is set to immediately, the child is mounted on mount', () => {
+        singleSetup({ mountChildren: 'immediately' });
+        expect(screen.getByText(childText)).toBeInTheDocument();
+      });
+      it('when mountChildren is set to on-mount, the child is unmounted on close', async () => {
+        singleSetup({ mountChildren: 'on-open' });
+        expect(screen.queryByText(childText)).toBeNull();
+        const title = screen.getByText(titleText);
+        await user.click(title);
+        expect(screen.getByText(childText)).toBeInTheDocument();
+        await user.click(title);
+        expect(screen.queryByText(childText)).toBeNull();
+      });
+      it('when mountchildren is set to on-mount-once, the child remains mounted on close', async () => {
+        singleSetup({ mountChildren: 'once-on-open' });
+        expect(screen.queryByText(childText)).toBeNull();
+        const title = screen.getByText(titleText);
+        await user.click(title);
+        expect(screen.getByText(childText)).toBeInTheDocument();
+        await user.click(title);
+        expect(screen.getByText(childText)).toBeInTheDocument();
+      });
+    });
+    describe('control', () => {
+      it('when defaultOpen is set to true, the child is open on mount and uncontrolled', async () => {
+        singleSetup({ defaultOpen: true });
+        const child = screen.getByText(childText);
+        const title = screen.getByText(titleText);
+        expect(child).toBeVisible();
+        await user.click(title);
+        expect(child).not.toBeVisible();
+      });
+      it('when defaultOpen is set to false, the child is closed on mount and uncontrolled', async () => {
+        singleSetup({ defaultOpen: false });
+        expect(screen.queryByText(childText)).toBeNull();
+        const title = screen.getByText(titleText);
+        await user.click(title);
+        expect(screen.queryByText(childText)).toBeVisible();
+      });
+      it('when open is true, the child is open on mount and controlled', async () => {
+        singleSetup({ open: true });
+        const child = screen.getByText(childText);
+        const title = screen.getByText(titleText);
+        expect(child).toBeVisible();
+        await user.click(title);
+        expect(child).toBeVisible();
+      });
+      it('when open is false, the child is closed on mount and controlled', async () => {
+        singleSetup({ open: false });
+        expect(screen.queryByText(childText)).toBeNull();
+        const title = screen.getByText(titleText);
+        await user.click(title);
+        expect(screen.queryByText(childText)).toBeNull();
+      });
+    });
+  });
+  describe('group', () => {
+    type AccordionState = 'open' | 'closed';
+    interface GroupState {
+      [1]: AccordionState;
+      [2]: AccordionState;
+      [3]: AccordionState;
+    }
+    const expectGroupState = (groupState: GroupState) => {
+      Object.entries(groupState).forEach(([key, val]) => {
+        // cast here because key types are collapsed on iteration
+        const childText = groupInfo[key as unknown as 1 | 2 | 3].child;
+        if (val === 'open') {
+          expect(screen.getByText(childText)).toBeVisible();
+        } else {
+          expect(screen.getByText(childText)).not.toBeVisible();
+        }
+      });
+    };
+    it('renders the accordion group', async () => {
+      groupSetup();
+      expectGroupState({
+        [1]: 'closed',
+        [2]: 'closed',
+        [3]: 'closed',
+      });
+      const oneTitle = groupInfo[1].title;
+      await user.click(screen.getByText(oneTitle));
+      expectGroupState({
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'closed',
+      });
+    });
+    it('can be controlled via openKey', async () => {
+      groupSetup({ openKey: 1 });
+      const expectedGroupState = {
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'closed',
+      } as const;
+      expectGroupState(expectedGroupState);
+      const oneTitle = groupInfo[1].title;
+      await user.click(screen.getByText(oneTitle));
+      expectGroupState(expectedGroupState);
+    });
+    it('can have defaults set via defaultOpenKey', async () => {
+      groupSetup({ defaultOpenKey: 1 });
+      expectGroupState({
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'closed',
+      });
+      const oneTitle = groupInfo[1].title;
+      await user.click(screen.getByText(oneTitle));
+      expectGroupState({
+        [1]: 'closed',
+        [2]: 'closed',
+        [3]: 'closed',
+      });
+    });
+    it('can set multiple children to open via openKey', () => {
+      groupSetup({ openKey: [1, 3] });
+      expectGroupState({
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'open',
+      });
+    });
+    it('can default multiple children to open via defaultOpenKey', () => {
+      groupSetup({ defaultOpenKey: [1, 3] });
+      expectGroupState({
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'open',
+      });
+    });
+    it('can keep only one child open in exclusive mode', async () => {
+      groupSetup({ defaultOpenKey: 3, exclusive: true });
+      expectGroupState({
+        [1]: 'closed',
+        [2]: 'closed',
+        [3]: 'open',
+      });
+      const oneTitle = groupInfo[1].title;
+      await user.click(screen.getByText(oneTitle));
+      expectGroupState({
+        [1]: 'open',
+        [2]: 'closed',
+        [3]: 'closed',
+      });
+    });
+  });
+});

--- a/webui/react/src/components/kit/Accordion.tsx
+++ b/webui/react/src/components/kit/Accordion.tsx
@@ -1,0 +1,90 @@
+import { Collapse } from 'antd';
+import React from 'react';
+
+import { ConditionalWrapper } from 'components/ConditionalWrapper';
+
+interface AccordionProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+  key?: string | number;
+  open?: boolean;
+  defaultOpen?: boolean;
+  mountChildren?: 'immediately' | 'on-open' | 'once-on-open';
+}
+
+interface AccordionGroupProps {
+  exclusive?: boolean;
+  openKey?: string | number | string[] | number[];
+  defaultOpenKey?: string | number | string[] | number[];
+  children: React.ReactNode;
+}
+
+const AccordionGroup: React.FC<AccordionGroupProps> = ({
+  exclusive,
+  children,
+  openKey,
+  defaultOpenKey,
+}) => {
+  // handle uncontrolled behavior
+  const activeProp = openKey !== undefined ? { activeKey: openKey } : {};
+  // disable default collapse accordion behavior where the first child is open
+  const defaultActiveKey = defaultOpenKey ? defaultOpenKey : exclusive ? [] : undefined;
+  return (
+    <Collapse accordion={exclusive} {...activeProp} defaultActiveKey={defaultActiveKey}>
+      {children}
+    </Collapse>
+  );
+};
+
+const Accordion: React.FC<AccordionProps> & { Group: typeof AccordionGroup } = ({
+  title,
+  children,
+  open,
+  defaultOpen,
+  mountChildren = 'once-on-open',
+  ...otherProps
+}) => {
+  // Collapse passes housekeeping props through to the child -- assume
+  // that we're in a multi-accordion situation when we encounter this
+  const inGroup = 'panelKey' in otherProps;
+  // key used for single accordion cases
+  const key = -1;
+
+  const wrapper = (c: React.ReactElement) => {
+    // handle isActive for single accordions
+    let collapseProps = {};
+    if (defaultOpen !== undefined) {
+      collapseProps = { defaultActiveKey: key };
+    }
+    if (open !== undefined) {
+      collapseProps = { activeKey: open ? key : '' };
+    }
+    return <Collapse {...collapseProps}>{c}</Collapse>;
+  };
+  let panelProps = {};
+  switch (mountChildren) {
+    case 'immediately': {
+      panelProps = { forceRender: true };
+      break;
+    }
+    case 'on-open': {
+      panelProps = { destroyInactivePanel: true };
+      break;
+    }
+    case 'once-on-open':
+    default: {
+      panelProps = {};
+    }
+  }
+
+  return (
+    <ConditionalWrapper condition={!inGroup} wrapper={wrapper}>
+      <Collapse.Panel header={title} {...otherProps} {...panelProps} key={key}>
+        {children}
+      </Collapse.Panel>
+    </ConditionalWrapper>
+  );
+};
+
+export default Accordion;
+Accordion.Group = AccordionGroup;

--- a/webui/react/src/components/kit/Accordion.tsx
+++ b/webui/react/src/components/kit/Accordion.tsx
@@ -54,7 +54,7 @@ const Accordion: React.FC<AccordionProps> & { Group: typeof AccordionGroup } = (
     // handle isActive for single accordions
     let collapseProps = {};
     if (defaultOpen !== undefined) {
-      collapseProps = { defaultActiveKey: key };
+      collapseProps = { defaultActiveKey: defaultOpen ? key : '' };
     }
     if (open !== undefined) {
       collapseProps = { activeKey: open ? key : '' };

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -4,6 +4,7 @@ import { LabeledValue, SelectValue } from 'antd/es/select';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import Accordion from 'components/kit/Accordion';
 import Breadcrumb from 'components/kit/Breadcrumb';
 import Button from 'components/kit/Button';
 import Card from 'components/kit/Card';
@@ -57,6 +58,7 @@ import { CheckpointsDict } from './TrialDetails/F_TrialDetailsOverview';
 import WorkspaceCard from './WorkspaceList/WorkspaceCard';
 
 const ComponentTitles = {
+  Accordion: 'Accordion',
   Breadcrumbs: 'Breadcrumbs',
   Buttons: 'Buttons',
   Cards: 'Cards',
@@ -2013,7 +2015,157 @@ const ModalSection: React.FC = () => {
   );
 };
 
+const LongLoadingComponent = () => {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    let active = true;
+    setTimeout(() => {
+      if (active) setLoaded(true);
+    }, 5000);
+    return () => {
+      active = false;
+    };
+  });
+
+  return <div>This component is {loaded ? 'done loading!!!!!! wowza!!' : 'not loaded :('}</div>;
+};
+
+const AccordionSection: React.FC = () => {
+  const [controlStateSingle, setControlStateSingle] = useState(false);
+  const [controlStateGroup, setControlStateGroup] = useState(1);
+  return (
+    <ComponentSection id="Accordion" title="Accordion">
+      <AntDCard>
+        <p>
+          An <code>{'<Accordion>'}</code> hides content behind a header. Typically found in forms,
+          they hide complex content until the user interacts with the header.
+        </p>
+      </AntDCard>
+      <AntDCard title="Singular usage">
+        <p>
+          An <code>{'<Accordion>'}</code> requires a title and content to show:
+        </p>
+        <Accordion title="Title">Children</Accordion>
+        <p>
+          By default, <code>{'<Accordion>'}</code> components control their open state themselves,
+          but can be controlled externally:
+        </p>
+        <Checkbox
+          checked={controlStateSingle}
+          onChange={(e) => setControlStateSingle(e.target.checked)}>
+          Check me to open the accordion below!
+        </Checkbox>
+        <Accordion open={controlStateSingle} title="Controlled by the above checkbox">
+          Hello!
+        </Accordion>
+        <p>You can also render an uncontrolled accordion as open by default:</p>
+        <Accordion defaultOpen title="Open by default">
+          You should see me on page load.
+        </Accordion>
+        <p>
+          By default, the content of an <code>{'<Accordion>'}</code> isn&apost;t mounted until
+          opened, after which, the content stays mounted:
+        </p>
+        <Accordion title="Child will mount when opened and stay mounted after close">
+          <LongLoadingComponent />
+        </Accordion>
+        <p>
+          This can be changed to either mount the content along with the rest of the{' '}
+          <code>{'<Accordion>'}</code> or to mount the content each time the component is opened:
+        </p>
+        <Accordion mountChildren="immediately" title="Child is already mounted">
+          <LongLoadingComponent />
+        </Accordion>
+        <Accordion
+          mountChildren="on-open"
+          title="Child will mount when opened and unmount on close">
+          <LongLoadingComponent />
+        </Accordion>
+      </AntDCard>
+      <AntDCard title="Group usage">
+        <p>
+          <code>{'<Accordion>'}</code> components can be grouped together:
+        </p>
+        <Accordion.Group>
+          <Accordion title="First child">One</Accordion>
+          <Accordion title="Second child">Two</Accordion>
+          <Accordion title="Third child">Three</Accordion>
+        </Accordion.Group>
+        <p>
+          When grouped, the <code>{'<Accordion.Group>'}</code> component is responsible for keeping
+          track of which component is open. As before, by default, the component keeps its own
+          internal state, but can be controlled externally, as well as with a default initial state.
+        </p>
+        <Select value={controlStateGroup} onChange={(e) => setControlStateGroup(e as number)}>
+          <Option key={1} value={1}>
+            One
+          </Option>
+          <Option key={2} value={2}>
+            Two
+          </Option>
+          <Option key={3} value={3}>
+            Three
+          </Option>
+        </Select>
+        <Accordion.Group openKey={controlStateGroup}>
+          <Accordion key={1} title="First child">
+            One
+          </Accordion>
+          <Accordion key={2} title="Second child">
+            Two
+          </Accordion>
+          <Accordion key={3} title="Third child">
+            Three
+          </Accordion>
+        </Accordion.Group>
+        <Accordion.Group defaultOpenKey={3}>
+          <Accordion key={1} title="First child">
+            One
+          </Accordion>
+          <Accordion key={2} title="Second child">
+            Two
+          </Accordion>
+          <Accordion key={3} title="Third child">
+            Three! I&apos;m open by default!
+          </Accordion>
+        </Accordion.Group>
+        <p>
+          Controlled/uncontrolled <code>{'<Accordion.Group>'}</code> components can have multiple
+          components open at the same time by default as well:
+        </p>
+        <Accordion.Group defaultOpenKey={[1, 3]}>
+          <Accordion key={1} title="First child">
+            One! I&apos;m open by default!
+          </Accordion>
+          <Accordion key={2} title="Second child">
+            Two
+          </Accordion>
+          <Accordion key={3} title="Third child">
+            Three! I&apos;m also open by default.
+          </Accordion>
+        </Accordion.Group>
+        <p>
+          You can configure an uncontrolled <code>{'<Accordion.Group>'}</code>
+          component to only be able to have one child open at a time
+        </p>
+        <Accordion.Group exclusive>
+          <Accordion key={1} title="First child">
+            One! I&apos;m open by default!
+          </Accordion>
+          <Accordion key={2} title="Second child">
+            Two
+          </Accordion>
+          <Accordion key={3} title="Third child">
+            Three! I&apos;m also open by default.
+          </Accordion>
+        </Accordion.Group>
+      </AntDCard>
+    </ComponentSection>
+  );
+};
+
 const Components = {
+  Accordion: <AccordionSection />,
   Breadcrumbs: <BreadcrumbsSection />,
   Buttons: <ButtonsSection />,
   Cards: <CardsSection />,


### PR DESCRIPTION
## Description

This adds an Accordion component based off of the antd Collapse
component to the design kit. The Accordion component can be controlled
or uncontrolled and can be grouped together with other Accordion
components.

## Screenshots
Closed:
![image](https://user-images.githubusercontent.com/701438/227655922-3bfe25ce-2ff7-4940-819d-6208ba662f65.png)

Open:
![image](https://user-images.githubusercontent.com/701438/227655993-65848cc8-5a39-4a2b-bae9-71bdd36a7763.png)

Grouped:
![image](https://user-images.githubusercontent.com/701438/227656066-1f9ec811-3604-4e85-b2c9-3c5c5e4f03f0.png)

Grouped + one open:
![image](https://user-images.githubusercontent.com/701438/227656124-5483a0bf-058a-4823-aa11-de06391b3496.png)


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1020


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
