### PR TITLE
fix: dataBounds was never updated, use unzoomedBounds for chartgrid sync [WEB-1039]

### DIFF
--- a/webui/react/src/components/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/UPlot/SyncProvider.tsx
@@ -5,6 +5,10 @@ import uPlot, { AlignedData } from 'uplot';
 import { generateUUID } from 'shared/utils/string';
 
 type Bounds = {
+  dataBounds: {
+    max: number;
+    min: number;
+  } | null;
   unzoomedBounds: {
     max: number;
     min: number;
@@ -16,7 +20,7 @@ type Bounds = {
 };
 
 class SyncService {
-  bounds = observable<Bounds>({ unzoomedBounds: null, zoomBounds: null });
+  bounds = observable<Bounds>({ dataBounds: null, unzoomedBounds: null, zoomBounds: null });
 
   pubSub: uPlot.SyncPubSub;
 
@@ -55,8 +59,8 @@ class SyncService {
     const dataMax = xValues[lastIdx];
 
     this.bounds.update((b) => {
-      let max = Math.max(b.unzoomedBounds?.max ?? dataMax, dataMax);
-      let min = Math.min(b.unzoomedBounds?.min ?? dataMin, dataMin);
+      let max = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
+      let min = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
       const width = max - min;
       if (width <= 0) {
         // default handling of min = max is not great
@@ -67,7 +71,11 @@ class SyncService {
         max = max + margin;
         min = min - margin;
       }
-      return { ...b, unzoomedBounds: { max, min } };
+      return {
+        ...b,
+        dataBounds: { max: dataMax, min: dataMin },
+        unzoomedBounds: { max, min },
+      };
     });
   }
 }

--- a/webui/react/src/components/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/UPlot/SyncProvider.tsx
@@ -5,10 +5,6 @@ import uPlot, { AlignedData } from 'uplot';
 import { generateUUID } from 'shared/utils/string';
 
 type Bounds = {
-  dataBounds: {
-    max: number;
-    min: number;
-  } | null;
   unzoomedBounds: {
     max: number;
     min: number;
@@ -20,7 +16,7 @@ type Bounds = {
 };
 
 class SyncService {
-  bounds = observable<Bounds>({ dataBounds: null, unzoomedBounds: null, zoomBounds: null });
+  bounds = observable<Bounds>({ unzoomedBounds: null, zoomBounds: null });
 
   pubSub: uPlot.SyncPubSub;
 
@@ -59,8 +55,8 @@ class SyncService {
     const dataMax = xValues[lastIdx];
 
     this.bounds.update((b) => {
-      let max = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
-      let min = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
+      let max = Math.max(b.unzoomedBounds?.max ?? dataMax, dataMax);
+      let min = Math.min(b.unzoomedBounds?.min ?? dataMin, dataMin);
       const width = max - min;
       if (width <= 0) {
         // default handling of min = max is not great


### PR DESCRIPTION
## Description

In ChartGrids with different maximum X values, the final point is not hover-able. Discovered that `dataBounds` was not updated (always undefined when we show up here) ~, so we can just use `unzoomedBounds`~

## Test Plan

I've been using 2125 from latest-master

Set `f_chart=on`

Test streaming in of data from a running experiment, then refresh to test on a completed experiment.

In LineChart, after `yValues[serieIndex][xVal] = Number.isFinite(pt[1]) ? pt[1] : null;` , you can make validation series add a second point at different x-values after the training data.

```typescript
        if (serieIndex % 2) {
          const xVal2 = Math.round(pt[0] * (1 + Math.random()));
          xSet.add(xVal2);
          yValues[serieIndex][xVal2] = pt[1] * 1.2;
        }
```

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.