### PR TITLE
fix: handle duplicate workspace name DB errors [DET-8808]

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -341,7 +341,12 @@ func (a *apiServer) PostWorkspace(
 	}
 
 	_, err = tx.NewInsert().Model(w).Exec(ctx)
+
 	if err != nil {
+		if strings.Contains(err.Error(), db.CodeUniqueViolation) {
+			return nil,
+				status.Errorf(codes.AlreadyExists, "avoid names equal to other workspaces (case-insensitive)")
+		}
 		return nil, errors.Wrapf(err, "error creating workspace %s in database", req.Name)
 	}
 
@@ -447,6 +452,10 @@ func (a *apiServer) PatchWorkspace(
 		Where("id = ?", currWorkspace.Id).
 		Exec(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), db.CodeUniqueViolation) {
+			return nil,
+				status.Errorf(codes.AlreadyExists, "avoid names equal to other workspaces (case-insensitive)")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description
Previously, when a workspace with a duplicate name was attempted to be created, the result was an internal server error.

Now, when a workspace with a duplicate name is created (either through a Post or a Patch) the result is:
- gRPC code 6 (AlreadyExists)
- HTML 409 Conflict
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Added checks in `e2e_tests/tests/cluster/test_workspace_org.py`:`test_workspace_org`
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-8808
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
