### PR TITLE
fix: update ubuntu ami tables

### DIFF
--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -28,7 +28,7 @@ def get_ubuntu_ami(table: List[List[str]], release: str, region: str) -> Union[N
                 # Only use EBS, not instance-store.
                 line[4] == "ebs-ssd",
                 # Only use HVM virtualization, not paravirtualization.
-                line[8] == "hvm",
+                line[10] == "hvm",
             ]
         )
 
@@ -101,18 +101,18 @@ if __name__ == "__main__":
     parser.add_argument("--packer-json", metavar="/PATH/TO/ENIRONMENTS-PACKER.JSON")
     args = parser.parse_args()
 
-    if not args.bumpenvs_yaml and not args.packer_json:
+    """if not args.bumpenvs_yaml and not args.packer_json:
         parser.print_help(sys.stderr)
-        sys.exit(1)
+        sys.exit(1)"""
 
     req = requests.get("https://cloud-images.ubuntu.com/query/focal/server/released.current.txt")
     req.raise_for_status()
-    table = [re.split(r"\t+", row) for row in re.split(r"\n+", req.text)[:-1]]
+    table = [re.split(r"\t", row) for row in re.split(r"\n", req.text)[:-1]]
     gov_req = requests.get(
         "https://cloud-images.ubuntu.com/query.govcloud/focal/server/released.current.txt"
     )
     gov_req.raise_for_status()
-    gov_table = [re.split(r"\t+", row) for row in re.split(r"\n+", gov_req.text)[:-1]]
+    gov_table = [re.split(r"\t", row) for row in re.split(r"\n", gov_req.text)[:-1]]
     table += gov_table
 
     if args.bumpenvs_yaml:

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -101,9 +101,9 @@ if __name__ == "__main__":
     parser.add_argument("--packer-json", metavar="/PATH/TO/ENIRONMENTS-PACKER.JSON")
     args = parser.parse_args()
 
-    """if not args.bumpenvs_yaml and not args.packer_json:
+    if not args.bumpenvs_yaml and not args.packer_json:
         parser.print_help(sys.stderr)
-        sys.exit(1)"""
+        sys.exit(1)
 
     req = requests.get("https://cloud-images.ubuntu.com/query/focal/server/released.current.txt")
     req.raise_for_status()

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -22,13 +22,13 @@ def get_ubuntu_ami(table: List[List[str]], release: str, region: str) -> Union[N
     def filters(line: List[str]) -> bool:
         return all(
             [
-                line[0] == region,
-                line[1] == release,
-                line[3] == "amd64",
+                line[6] == region,
+                line[0] == release,
+                line[5] == "amd64",
                 # Only use EBS, not instance-store.
-                line[4] == "hvm:ebs-ssd",
+                line[4] == "ebs-ssd",
                 # Only use HVM virtualization, not paravirtualization.
-                line[7] == "hvm",
+                line[8] == "hvm",
             ]
         )
 
@@ -40,17 +40,7 @@ def get_ubuntu_ami(table: List[List[str]], release: str, region: str) -> Union[N
         print(f"Failed to find AMI for {region}!", file=sys.stderr)
         return None
 
-    # The only canonical endpoint for that shows us gov endpoints also gives us inline-html we have
-    # to strip to get the actual ami name.
-    href = results[0][6]
-
-    # We'll match the whole <a href=...>AMI</a> string to ensure that if canonical changes their
-    # format that we catch it (by puking).
-    pattern = '^<a href="[a-zA-Z_.:/?#=&-]*">(ami-[0-9a-f]*)</a>$'
-    match = re.match('^<a href="[a-zA-Z0-9_.:/?#=&-]*">(ami-[0-9a-f]*)</a>$', href)
-    assert match, f"failed to match '{pattern}' against '{href}'"
-
-    return match[1]
+    return  results[0][7]
 
 
 def update_tag_for_image_type(subconf: Dict[str, str], new_tag: str) -> bool:
@@ -115,13 +105,13 @@ if __name__ == "__main__":
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    # Do one fetch for all the ubuntu amis.
-    # Note that this is not a public endpoint, but it's the only one that has the gov amis.
-    req = requests.get("https://cloud-images.ubuntu.com/locator/ec2/releasesTable")
+    req = requests.get('https://cloud-images.ubuntu.com/query/focal/server/released.current.txt')
     req.raise_for_status()
-    table = yaml.safe_load(req.text)
-    # Discard useless layer of data.
-    table = table["aaData"]
+    table = [re.split(r'\t+', row) for row in re.split(r'\n+', req.text)[:-1]]
+    gov_req = requests.get('https://cloud-images.ubuntu.com/query.govcloud/focal/server/released.current.txt')
+    gov_req.raise_for_status()
+    gov_table = [re.split(r'\t+', row) for row in re.split(r'\n+', gov_req.text)[:-1]]
+    table += gov_table
 
     if args.bumpenvs_yaml:
         update_bumpenvs_yaml(table, args.bumpenvs_yaml)

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -40,7 +40,7 @@ def get_ubuntu_ami(table: List[List[str]], release: str, region: str) -> Union[N
         print(f"Failed to find AMI for {region}!", file=sys.stderr)
         return None
 
-    return  results[0][7]
+    return results[0][7]
 
 
 def update_tag_for_image_type(subconf: Dict[str, str], new_tag: str) -> bool:
@@ -105,12 +105,14 @@ if __name__ == "__main__":
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    req = requests.get('https://cloud-images.ubuntu.com/query/focal/server/released.current.txt')
+    req = requests.get("https://cloud-images.ubuntu.com/query/focal/server/released.current.txt")
     req.raise_for_status()
-    table = [re.split(r'\t+', row) for row in re.split(r'\n+', req.text)[:-1]]
-    gov_req = requests.get('https://cloud-images.ubuntu.com/query.govcloud/focal/server/released.current.txt')
+    table = [re.split(r"\t+", row) for row in re.split(r"\n+", req.text)[:-1]]
+    gov_req = requests.get(
+        "https://cloud-images.ubuntu.com/query.govcloud/focal/server/released.current.txt"
+    )
     gov_req.raise_for_status()
-    gov_table = [re.split(r'\t+', row) for row in re.split(r'\n+', gov_req.text)[:-1]]
+    gov_table = [re.split(r"\t+", row) for row in re.split(r"\n+", gov_req.text)[:-1]]
     table += gov_table
 
     if args.bumpenvs_yaml:

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -105,12 +105,17 @@ if __name__ == "__main__":
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    req = requests.get("https://cloud-images.ubuntu.com/query/focal/server/released.current.txt")
+    release = "focal"
+    req_url = "https://cloud-images.ubuntu.com/query/{}/server/released.current.txt".format(release)
+    gov_req_url = (
+        "https://cloud-images.ubuntu.com/query.govcloud/{}/server/released.current.txt".format(
+            release
+        )
+    )
+    req = requests.get(req_url)
     req.raise_for_status()
     table = [re.split(r"\t", row) for row in re.split(r"\n", req.text)[:-1]]
-    gov_req = requests.get(
-        "https://cloud-images.ubuntu.com/query.govcloud/focal/server/released.current.txt"
-    )
+    gov_req = requests.get(gov_req_url)
     gov_req.raise_for_status()
     gov_table = [re.split(r"\t", row) for row in re.split(r"\n", gov_req.text)[:-1]]
     table += gov_table

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -22,11 +22,11 @@ def get_ubuntu_ami(table: List[List[str]], release: str, region: str) -> Union[N
     def filters(line: List[str]) -> bool:
         return all(
             [
-                line[6] == region,
                 line[0] == release,
-                line[5] == "amd64",
                 # Only use EBS, not instance-store.
                 line[4] == "ebs-ssd",
+                line[5] == "amd64",
+                line[6] == region,
                 # Only use HVM virtualization, not paravirtualization.
                 line[10] == "hvm",
             ]
@@ -106,12 +106,11 @@ if __name__ == "__main__":
         sys.exit(1)
 
     release = "focal"
-    req_url = "https://cloud-images.ubuntu.com/query/{}/server/released.current.txt".format(release)
+    req_url = f"https://cloud-images.ubuntu.com/query/{release}/server/released.current.txt"
     gov_req_url = (
-        "https://cloud-images.ubuntu.com/query.govcloud/{}/server/released.current.txt".format(
-            release
-        )
+        f"https://cloud-images.ubuntu.com/query.govcloud/{release}/server/released.current.txt"
     )
+
     req = requests.get(req_url)
     req.raise_for_status()
     table = [re.split(r"\t", row) for row in re.split(r"\n", req.text)[:-1]]


### PR DESCRIPTION
## Description

update-ubuntu-amis.py is not finding AMIs due to changes made to the table we were querying.
This PR changes the query endpoints we use and how these new endpoints are parsed.

## Test Plan

run `refresh-ubuntu-amis.py --bumpenvs-yaml ...`
run `refresh-ubuntu-amis.py --packer-json ...`



## Checklist

- [x] Changes have been manually QA'd

## Ticket
MLG-368