### PR TITLE
fix: isEqual utility function

### DIFF
--- a/webui/react/src/shared/utils/data.ts
+++ b/webui/react/src/shared/utils/data.ts
@@ -50,11 +50,7 @@ export const isEqual = (a: unknown, b: unknown): boolean => {
     return JSON.stringify(Array.from(a)) === JSON.stringify(Array.from(b));
   }
   if (isSymbol(a) && isSymbol(b)) return a.toString() === b.toString();
-  if (isObject(a) && isObject(b))
-    return (
-      JSON.stringify(a, Object.keys(a as object).sort()) ===
-      JSON.stringify(b, Object.keys(b as object).sort())
-    );
+  if (isObject(a) && isObject(b)) return JSON.stringify(a) === JSON.stringify(b);
   if (isSet(a) && isSet(b)) {
     if (a.size !== b.size) return false;
     for (const elem of a.values()) {


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
App theme not applied due to `checkDeepEquality` uses `isEqual` to detect state changes, and `isEqual` sorts on object keys, which isn't quite correct for nested objects. 
https://github.com/determined-ai/determined/blob/0d4281e1632da8de98049a91352c7537d9b6d678/webui/react/src/shared/utils/store.ts#L16



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Verify that app style can properly load.
Before:
<img width="1900" alt="Screen Shot 2023-03-27 at 11 12 51 PM" src="https://user-images.githubusercontent.com/40620519/228126296-cb208d6b-60ca-4196-86c7-c397896f2dc7.png">

After:
<img width="1901" alt="Screen Shot 2023-03-27 at 11 13 07 PM" src="https://user-images.githubusercontent.com/40620519/228126316-448d96d3-00a8-43ed-a22d-8709f0a22c0b.png">


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->
Changes in this PR only reverts what's been done in https://github.com/determined-ai/determined/pull/6202 to `isEqual` function.
I also attempted to replace our current `isEqual` with the `isEqual` from lodash, but according to the test cases, we want 
`{ abc: 123 }, { abc: 123, ghi: undefined }` equal 
`Symbol('coin'), Symbol('coin')` equal
`new Set([[1]]), new Set([[1]])` not equal
These test cases do not align with lodash's `isEqual` behavior  


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
