### PR TITLE
chore: Fix router/app circular dependency

### DIFF
--- a/webui/react/src/__mocks__/router.tsx
+++ b/webui/react/src/__mocks__/router.tsx
@@ -1,7 +1,4 @@
-const router = {
-  navigate: (path: string): void => {
-    global.window.history.pushState({}, '', path);
-  },
-};
+const { default: router } = await vi.importActual<typeof import('router')>('router');
 
+router.initRouter(<div />);
 export default router;

--- a/webui/react/src/ee/SamlAuth.ts
+++ b/webui/react/src/ee/SamlAuth.ts
@@ -19,7 +19,7 @@ export const handleRelayState = <T>(queries: WithRelayState<T>): T => {
     ...queryString.parse(queries.relayState),
   };
   delete newQueries.relayState;
-  router.navigate(`${window.location.pathname}?${queryString.stringify(newQueries)}`);
+  router.getRouter().navigate(`${window.location.pathname}?${queryString.stringify(newQueries)}`);
 
   return newQueries;
 };

--- a/webui/react/src/index.tsx
+++ b/webui/react/src/index.tsx
@@ -5,8 +5,11 @@ import { RouterProvider } from 'react-router-dom';
 /* Import the styles first to allow components to override styles. */
 import 'uplot/dist/uPlot.min.css';
 
-import router from './router';
+import App from 'App';
+import router from 'router';
+
 import * as serviceWorker from './serviceWorker';
+
 import 'shared/prototypes';
 import 'dev';
 
@@ -14,14 +17,14 @@ import 'dev';
 if (process.env.PUBLIC_URL && window.location.pathname === '/') {
   window.history.replaceState({}, '', process.env.PUBLIC_URL);
 }
-
+router.initRouter(<App />);
 const container = document.getElementById('root');
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(container!);
 
 root.render(
   // <React.StrictMode>
-  <RouterProvider router={router} />,
+  <RouterProvider router={router.getRouter()} />,
   // </React.StrictMode>,
 );
 

--- a/webui/react/src/pages/InteractiveTask.test.tsx
+++ b/webui/react/src/pages/InteractiveTask.test.tsx
@@ -11,7 +11,8 @@ import InteractiveTask from './InteractiveTask';
 const TASK_NAME = 'JupyterLab (test-task-name)';
 const TASK_RESOURCE_POOL = 'aux-pool';
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
   useParams: () => ({
     taskId: 'task-id',
     taskName: TASK_NAME,

--- a/webui/react/src/router.tsx
+++ b/webui/react/src/router.tsx
@@ -1,15 +1,24 @@
+import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import 'shared/styles/index.scss';
 
-import App from './App';
+class AppRouter {
+  routerInstance: ReturnType<typeof createBrowserRouter> | null = null;
+  getRouter() {
+    if (this.routerInstance) return this.routerInstance;
+    throw new Error('Router called before instantiation -- call AppRouter#initRouter first');
+  }
+  initRouter(app: React.ReactElement) {
+    this.routerInstance = createBrowserRouter(
+      [
+        // match everything with "*"
+        { element: app, path: '*' },
+      ],
+      { basename: process.env.PUBLIC_URL },
+    );
+    return this.routerInstance;
+  }
+}
 
-const router = createBrowserRouter(
-  [
-    // match everything with "*"
-    { element: <App />, path: '*' },
-  ],
-  { basename: process.env.PUBLIC_URL },
-);
-
-export default router;
+export default new AppRouter();

--- a/webui/react/src/shared/utils/routes.test.ts
+++ b/webui/react/src/shared/utils/routes.test.ts
@@ -1,3 +1,4 @@
+import { Router } from '@remix-run/router';
 import React from 'react';
 
 import router from 'router';
@@ -306,25 +307,27 @@ describe('Routes Utilities', () => {
   });
 
   describe('routeToReactUrl', () => {
+    let instance: Router;
     beforeEach(() => {
-      vi.spyOn(router, 'navigate');
+      instance = router.getRouter();
+      vi.spyOn(instance, 'navigate');
     });
 
     it('should route to react URL', () => {
       const path = '/clusters';
-      expect(router.navigate).not.toHaveBeenCalled();
+      expect(instance.navigate).not.toHaveBeenCalled();
       routes.routeToReactUrl(path);
-      expect(router.navigate).toHaveBeenCalledTimes(1);
-      expect(router.navigate).toHaveBeenCalledWith(path);
+      expect(instance.navigate).toHaveBeenCalledTimes(1);
+      expect(instance.navigate).toHaveBeenCalledWith(path);
     });
 
     it('should route to react URL with determined.ai base url', () => {
       setup('/', 'https://www.determined.ai');
       const path = '/dashboard';
-      expect(router.navigate).not.toHaveBeenCalled();
+      expect(instance.navigate).not.toHaveBeenCalled();
       routes.routeToReactUrl(path);
-      expect(router.navigate).toHaveBeenCalledTimes(1);
-      expect(router.navigate).toHaveBeenCalledWith(path);
+      expect(instance.navigate).toHaveBeenCalledTimes(1);
+      expect(instance.navigate).toHaveBeenCalledWith(path);
     });
   });
 });

--- a/webui/react/src/shared/utils/routes.ts
+++ b/webui/react/src/shared/utils/routes.ts
@@ -73,5 +73,5 @@ export const routeToExternalUrl = (path: string): void => {
 };
 export const routeToReactUrl = (path: string): void => {
   logger.trace('routing to react url', path);
-  router.navigate(`${process.env.PUBLIC_URL}${stripUrl(path)}`);
+  router.getRouter().navigate(`${process.env.PUBLIC_URL}${stripUrl(path)}`);
 };

--- a/webui/react/src/utils/error.ts
+++ b/webui/react/src/utils/error.ts
@@ -76,7 +76,7 @@ const handleError = (error: DetError | unknown, options?: DetErrorOptions): DetE
     // to the page dismount and end up throwing after the user is logged out.
     const path = window.location.pathname;
     if (!path.includes(paths.login()) && !path.includes(paths.logout())) {
-      router.navigate(`/det${paths.logout()}`);
+      router.getRouter().navigate(`/det${paths.logout()}`);
     }
   }
 


### PR DESCRIPTION
## Description

Some cleanup ahead of WEB-1043 where we need the ability to display the designkit without the server running -- this removes the circular dependency where the router is dependent on itself. Instead, we wrap the router in an object that's instantiated in the index file. The mock is also updated for testing purposes.


## Test Plan

- [ ] internal links continue to work
- [ ] external links continue to work
- [ ] webapp logout on unauthorized error continues to work

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No ticket

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
