### PR TITLE
chore: bumpenvs and bump master amis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9d07809
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1
+            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809
 
   login-docker:
     parameters:
@@ -1972,7 +1972,7 @@ jobs:
         type: string
         default: "1"
       environment-image:
-        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
+        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
         type: string
       accel-node-taints:
         type: string

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
@@ -402,5 +402,5 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --compute-agent-instance-type a2-highgpu-1g --gpu-num 1 \
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
-      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0 \
-      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
+      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1 \
+      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
@@ -24,11 +24,11 @@ by default in this version of Determined are described below.
 +-------------+-------------------------------------------------------------------------+
 | Environment | File Name                                                               |
 +=============+=========================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1``    |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809``    |
 +-------------+-------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1`` |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809`` |
 +-------------+-------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1`` |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809`` |
 +-------------+-------------------------------------------------------------------------+
 
 See :doc:`/training/setup-guide/set-environment-images` for the images Docker Hub location, and add

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -350,7 +350,7 @@ platform. There may be additional per-user configuration that is required.
 
    .. code:: bash
 
-      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809
       cd /shared/enroot/images
       enroot import docker://$image
       enroot create /shared/enroot/images/${image//[\/:]/\+}.sqsh

--- a/docs/reference/reference-deploy/config/helm-config-reference.rst
+++ b/docs/reference/reference-deploy/config/helm-config-reference.rst
@@ -173,11 +173,11 @@
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0``.
+      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults
-      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0``.
+      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise edition.
 

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -55,9 +55,9 @@ The master supports the following configuration settings:
       ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks
       using the ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0`` for NVIDIA GPUs.
-      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0`` for CPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1`` for NVIDIA GPUs.
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1`` for ROCm.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1`` for CPUs.
 
    -  ``environment_variables``: A list of environment variables that will be set in every task
       container. Each element of the list should be a string of the form ``NAME=VALUE``. See

--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -45,9 +45,9 @@ The following configuration settings are supported:
       different container images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6),
       CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0`` for NVIDIA GPUs.
-      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0`` for CPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1`` for NVIDIA GPUs.
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1`` for ROCm.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1`` for CPUs.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker registry and bypass the Docker
       cache. Defaults to ``false``.

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -1044,9 +1044,9 @@ workloads for this experiment. For more information on customizing the trial env
    images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using ``cpu``
    key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
-   -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0`` for NVIDIA GPUs.
-   -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0`` for CPUs.
-   -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0`` for ROCm.
+   -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1`` for NVIDIA GPUs.
+   -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1`` for CPUs.
+   -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1`` for ROCm.
 
    When the cluster is configured with :ref:`resource_manager.type: slurm
    <cluster-configuration-slurm>` and ``container_run_type: singularity``, images are executed using

--- a/docs/training/apis-howto/overview.rst
+++ b/docs/training/apis-howto/overview.rst
@@ -70,15 +70,15 @@ Determined supports both TensorFlow 1 and 2. The version of TensorFlow that is u
 experiment is controlled by the container image that has been configured for that experiment.
 Determined provides prebuilt Docker images that include TensorFlow 2.8, 1.15, and 2.7, respectively:
 
--  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0`` (default)
--  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0``
--  ``determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.0``
+-  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1`` (default)
+-  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1``
+-  ``determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.1``
 
 We also provide lightweight CPU-only counterparts:
 
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0``
--  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.0``
--  ``determinedai/environments:py-3.8-tf-2.7-cpu-0.21.0``
+-  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1``
+-  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.1``
+-  ``determinedai/environments:py-3.8-tf-2.7-cpu-0.21.1``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`
@@ -94,7 +94,7 @@ images.
 Determined has experimental support for ROCm. Determined provides a prebuilt Docker image that
 includes ROCm 4.2, PyTorch 1.9 and Tensorflow 2.5:
 
--  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0``
+-  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1``
 
 Known limitations:
 

--- a/docs/training/setup-guide/custom-env.rst
+++ b/docs/training/setup-guide/custom-env.rst
@@ -101,11 +101,11 @@ Default Images
 +-------------+-----------------------------------------------------------------------------------+
 | Environment | File Name                                                                         |
 +=============+===================================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0``               |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1``               |
 +-------------+-----------------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0``            |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1``            |
 +-------------+-----------------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0``            |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1``            |
 +-------------+-----------------------------------------------------------------------------------+
 
 .. _custom-docker-images:
@@ -132,7 +132,7 @@ Example Dockerfile that installs custom ``conda``-, ``pip``-, and ``apt``-based 
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
+   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
 
    # Custom Configuration
    RUN apt-get update && \
@@ -195,7 +195,7 @@ environments using :ref:`custom images <custom-docker-images>`:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
+   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.8

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -13,12 +13,12 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-835d8b1"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
-DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-835d8b1"
-DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-835d8b1"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9d07809"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9d07809"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
+DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-9d07809"
+DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-9d07809"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1
 

--- a/examples/computer_vision/efficientdet_pytorch/const.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
+++ b/examples/computer_vision/efficientdet_pytorch/const_fake.yaml
@@ -1,6 +1,6 @@
 description: efficientdet_const
 environment:
-  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0
+  image: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1
 hyperparameters:
   global_batch_size: 16
   min_loss_scale: 16.0

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809

--- a/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/adaptive.yaml
@@ -42,4 +42,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0"
+  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1"

--- a/examples/decision_trees/gbt_titanic_estimator/const.yaml
+++ b/examples/decision_trees/gbt_titanic_estimator/const.yaml
@@ -20,4 +20,4 @@ searcher:
 entrypoint: model_def:BoostedTreesTrial
 scheduling_unit: 1
 environment:
-  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0"
+  image: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1"

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_moe/moe.yaml
+++ b/examples/deepspeed/cifar10_moe/moe.yaml
@@ -21,7 +21,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
+        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/cifar10_moe/zero_stages.yaml
+++ b/examples/deepspeed/cifar10_moe/zero_stages.yaml
@@ -22,7 +22,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/gpt_neox/Dockerfile
+++ b/examples/deepspeed/gpt_neox/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-835d8b1
+FROM determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-9d07809
 
 # Install deepspeed & dependencies
 RUN apt-get install -y mpich

--- a/examples/deepspeed/pipeline_parallelism/distributed.yaml
+++ b/examples/deepspeed/pipeline_parallelism/distributed.yaml
@@ -20,7 +20,7 @@ environment:
     #    - CUDA_LAUNCH_BLOCKING=1
     #    - NCCL_BLOCKING_WAIT=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
 resources:
   slots_per_trial: 2
 records_per_epoch: 50000

--- a/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
@@ -32,4 +32,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809

--- a/examples/graphs/proteins_pytorch_geometric/const.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/const.yaml
@@ -18,4 +18,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809

--- a/examples/graphs/proteins_pytorch_geometric/distributed.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/distributed.yaml
@@ -18,6 +18,6 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809
 resources:
   slots_per_trial: 4

--- a/harness/determined/common/schemas/expconf/_v0.py
+++ b/harness/determined/common/schemas/expconf/_v0.py
@@ -223,12 +223,12 @@ class EnvironmentImageV0(schemas.SchemaBase):
 
     def runtime_defaults(self) -> None:
         if self.cpu is None:
-            self.cpu = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1"
+            self.cpu = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809"
         if self.rocm is None:
-            self.rocm = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"
+            self.rocm = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"
 
         if self.cuda is None:
-            self.cuda = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
+            self.cuda = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
 
 
 class EnvironmentVariablesV0(schemas.SchemaBase):

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0991c62696aa7ccfd
+      Master: ami-00910ef9457f0df47
+      Agent: ami-095dc4fb79f2496da
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0e731ff15c9cd271c
+    #   Master: ami-035e3e44dc41db6a2
+    #   Agent: ami-078bb019c9a133349
     # ap-southeast-1:
-    #   Master: ami-09f03fa5572692399
-    #   Agent: ami-0117b4415fa85f5fd
+    #   Master: ami-0fd1ee6c8b656f020
+    #   Agent: ami-0d926ac4d57af0fe2
     # ap-southeast-2:
-    #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-07f3405e83ad9e60f
+    #   Master: ami-0b62ecd3babd1c548
+    #   Agent: ami-04cc5e46f80b88805
     eu-central-1:
-      Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-087ce2a855248c888
+      Master: ami-0abbe417ed83c0b29
+      Agent: ami-0337795faa3fa47e8
     eu-west-1:
-      Master: ami-029cfca952b331b52
-      Agent: ami-0554426cc52af7b5c
+      Master: ami-0e3f7dd2dc743e48a
+      Agent: ami-01005388142fe709e
     # eu-west-2:
-    #   Master: ami-035469b606478d63d
-    #   Agent: ami-0b311171d796d1d06
+    #   Master: ami-0d78429fb6af30994
+    #   Agent: ami-0c961f624e82afc9e
     us-east-1:
-      Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0fdc0e3d660394d83
+      Master: ami-0172070f66a8ebe63
+      Agent: ami-0d66a70e16e8b5cf0
     us-east-2:
-      Master: ami-0cbea92f2377277a4
-      Agent: ami-0948c4d44ce80874c
+      Master: ami-0bafa3699418551cd
+      Agent: ami-007bd0d8cecde0ad0
     us-west-2:
-      Master: ami-0d31d7c9fc9503726
-      Agent: ami-05ee2b3249ae2e713
+      Master: ami-0ceeab680f529cc36
+      Agent: ami-0eb117edc93f5a736
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -2,36 +2,36 @@ Description:  This template deploys a VPC, with a public and private subnet, and
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0991c62696aa7ccfd
+      Master: ami-00910ef9457f0df47
+      Agent: ami-095dc4fb79f2496da
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0e731ff15c9cd271c
+    #   Master: ami-035e3e44dc41db6a2
+    #   Agent: ami-078bb019c9a133349
     # ap-southeast-1:
-    #   Master: ami-09f03fa5572692399
-    #   Agent: ami-0117b4415fa85f5fd
+    #   Master: ami-0fd1ee6c8b656f020
+    #   Agent: ami-0d926ac4d57af0fe2
     # ap-southeast-2:
-    #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-07f3405e83ad9e60f
+    #   Master: ami-0b62ecd3babd1c548
+    #   Agent: ami-04cc5e46f80b88805
     eu-central-1:
-      Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-087ce2a855248c888
+      Master: ami-0abbe417ed83c0b29
+      Agent: ami-0337795faa3fa47e8
     eu-west-1:
-      Master: ami-029cfca952b331b52
-      Agent: ami-0554426cc52af7b5c
+      Master: ami-0e3f7dd2dc743e48a
+      Agent: ami-01005388142fe709e
     # eu-west-2:
-    #   Master: ami-035469b606478d63d
-    #   Agent: ami-0b311171d796d1d06
+    #   Master: ami-0d78429fb6af30994
+    #   Agent: ami-0c961f624e82afc9e
     us-east-1:
-      Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0fdc0e3d660394d83
+      Master: ami-0172070f66a8ebe63
+      Agent: ami-0d66a70e16e8b5cf0
     us-east-2:
-      Master: ami-0cbea92f2377277a4
-      Agent: ami-0948c4d44ce80874c
+      Master: ami-0bafa3699418551cd
+      Agent: ami-007bd0d8cecde0ad0
     us-west-2:
-      Master: ami-0d31d7c9fc9503726
-      Agent: ami-05ee2b3249ae2e713
+      Master: ami-0ceeab680f529cc36
+      Agent: ami-0eb117edc93f5a736
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -4,10 +4,10 @@ Description: Determined Template
 Mappings:
   RegionMap:
     us-gov-east-1:
-      Master: ami-0b36c558c9dd26c75
+      Master: ami-0cd066f69b98b61b2
       Agent: ami-0b71e56244b8ac1cb
     us-gov-west-1:
-      Master: ami-0f1289f37e46c1eff
+      Master: ami-0cbd5dbd94f397bdd
       Agent: ami-0d26002529bfac823
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -3,46 +3,46 @@ Description:  This template deploys a VPC, with a public and private subnet. It 
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0991c62696aa7ccfd
-      Bastion: ami-0c7cb70d3eb61492b
+      Master: ami-00910ef9457f0df47
+      Agent: ami-095dc4fb79f2496da
+      Bastion: ami-00910ef9457f0df47
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0e731ff15c9cd271c
-    #   Bastion: ami-003bb1772f36a39a3
+    #   Master: ami-035e3e44dc41db6a2
+    #   Agent: ami-078bb019c9a133349
+    #   Bastion: ami-035e3e44dc41db6a2
     # ap-southeast-1:
-    #   Master: ami-09f03fa5572692399
-    #   Agent: ami-0117b4415fa85f5fd
-    #   Bastion: ami-09f03fa5572692399
+    #   Master: ami-0fd1ee6c8b656f020
+    #   Agent: ami-0d926ac4d57af0fe2
+    #   Bastion: ami-0fd1ee6c8b656f020
     # ap-southeast-2:
-    #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-07f3405e83ad9e60f
-    #   Bastion: ami-06139e5e22cc2f7b1
+    #   Master: ami-0b62ecd3babd1c548
+    #   Agent: ami-04cc5e46f80b88805
+    #   Bastion: ami-0b62ecd3babd1c548
     eu-central-1:
-      Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-087ce2a855248c888
-      Bastion: ami-0b81e95bb0a06ea8c
+      Master: ami-0abbe417ed83c0b29
+      Agent: ami-0337795faa3fa47e8
+      Bastion: ami-0abbe417ed83c0b29
     eu-west-1:
-      Master: ami-029cfca952b331b52
-      Agent: ami-0554426cc52af7b5c
-      Bastion: ami-029cfca952b331b52
+      Master: ami-0e3f7dd2dc743e48a
+      Agent: ami-01005388142fe709e
+      Bastion: ami-0e3f7dd2dc743e48a
     # eu-west-2:
-    #   Master: ami-035469b606478d63d
-    #   Agent: ami-0b311171d796d1d06
-    #   Bastion: ami-035469b606478d63d
+    #   Master: ami-0d78429fb6af30994
+    #   Agent: ami-0c961f624e82afc9e
+    #   Bastion: ami-0d78429fb6af30994
     us-east-1:
-      Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0fdc0e3d660394d83
-      Bastion: ami-0b93ce03dcbcb10f6
+      Master: ami-0172070f66a8ebe63
+      Agent: ami-0d66a70e16e8b5cf0
+      Bastion: ami-0172070f66a8ebe63
     us-east-2:
-      Master: ami-0cbea92f2377277a4
-      Agent: ami-0948c4d44ce80874c
-      Bastion: ami-0cbea92f2377277a4
+      Master: ami-0bafa3699418551cd
+      Agent: ami-007bd0d8cecde0ad0
+      Bastion: ami-0bafa3699418551cd
     us-west-2:
-      Master: ami-0d31d7c9fc9503726
-      Agent: ami-05ee2b3249ae2e713
-      Bastion: ami-0d31d7c9fc9503726
+      Master: ami-0ceeab680f529cc36
+      Agent: ami-0eb117edc93f5a736
+      Bastion: ami-0ceeab680f529cc36
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -4,36 +4,36 @@ Description: Determined Template
 Mappings:
   RegionMap:
     ap-northeast-1:
-      Master: ami-0c7cb70d3eb61492b
-      Agent: ami-0991c62696aa7ccfd
+      Master: ami-00910ef9457f0df47
+      Agent: ami-095dc4fb79f2496da
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
-    #   Master: ami-003bb1772f36a39a3
-    #   Agent: ami-0e731ff15c9cd271c
+    #   Master: ami-035e3e44dc41db6a2
+    #   Agent: ami-078bb019c9a133349
     # ap-southeast-1:
-    #   Master: ami-09f03fa5572692399
-    #   Agent: ami-0117b4415fa85f5fd
+    #   Master: ami-0fd1ee6c8b656f020
+    #   Agent: ami-0d926ac4d57af0fe2
     # ap-southeast-2:
-    #   Master: ami-06139e5e22cc2f7b1
-    #   Agent: ami-07f3405e83ad9e60f
+    #   Master: ami-0b62ecd3babd1c548
+    #   Agent: ami-04cc5e46f80b88805
     eu-central-1:
-      Master: ami-0b81e95bb0a06ea8c
-      Agent: ami-087ce2a855248c888
+      Master: ami-0abbe417ed83c0b29
+      Agent: ami-0337795faa3fa47e8
     eu-west-1:
-      Master: ami-029cfca952b331b52
-      Agent: ami-0554426cc52af7b5c
+      Master: ami-0e3f7dd2dc743e48a
+      Agent: ami-01005388142fe709e
     # eu-west-2:
-    #   Master: ami-035469b606478d63d
-    #   Agent: ami-0b311171d796d1d06
+    #   Master: ami-0d78429fb6af30994
+    #   Agent: ami-0c961f624e82afc9e
     us-east-1:
-      Master: ami-0b93ce03dcbcb10f6
-      Agent: ami-0fdc0e3d660394d83
+      Master: ami-0172070f66a8ebe63
+      Agent: ami-0d66a70e16e8b5cf0
     us-east-2:
-      Master: ami-0cbea92f2377277a4
-      Agent: ami-0948c4d44ce80874c
+      Master: ami-0bafa3699418551cd
+      Agent: ami-007bd0d8cecde0ad0
     us-west-2:
-      Master: ami-0d31d7c9fc9503726
-      Agent: ami-05ee2b3249ae2e713
+      Master: ami-0ceeab680f529cc36
+      Agent: ami-0eb117edc93f5a736
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,7 +3,7 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
-    ENVIRONMENT_IMAGE = "det-environments-835d8b1"
+    ENVIRONMENT_IMAGE = "det-environments-9d07809"
     GPU_NUM = 4
     GPU_TYPE = "nvidia-tesla-t4"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -818,7 +818,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0``).
+    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/determined/keras/_tf_keras_trial.py
+++ b/harness/determined/keras/_tf_keras_trial.py
@@ -973,7 +973,7 @@ class TFKerasTrial(det.Trial):
     legacy TensorFlow 1.x, specify a TensorFlow 1.x image in the
     :ref:`environment.image <exp-environment-image>` field of the experiment
     configuration (e.g.,
-    ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0``).
+    ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1``).
 
     Trials default to using eager execution with TensorFlow 2.x but not with
     TensorFlow 1.x. To override the default behavior, call the appropriate

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
@@ -38,9 +38,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"
       },
       "pod_spec": null,
       "ports": {},

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -131,8 +131,8 @@ data:
       {{- toYaml .Values.resourcePools | nindent 6}}
     {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -49,16 +49,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0991c62696aa7ccfd",
-	"ap-northeast-2": "ami-0e731ff15c9cd271c",
-	"ap-southeast-1": "ami-0117b4415fa85f5fd",
-	"ap-southeast-2": "ami-07f3405e83ad9e60f",
-	"us-east-2":      "ami-0948c4d44ce80874c",
-	"us-east-1":      "ami-0fdc0e3d660394d83",
-	"us-west-2":      "ami-05ee2b3249ae2e713",
-	"eu-central-1":   "ami-087ce2a855248c888",
-	"eu-west-2":      "ami-0b311171d796d1d06",
-	"eu-west-1":      "ami-0554426cc52af7b5c",
+	"ap-northeast-1": "ami-095dc4fb79f2496da",
+	"ap-northeast-2": "ami-078bb019c9a133349",
+	"ap-southeast-1": "ami-0d926ac4d57af0fe2",
+	"ap-southeast-2": "ami-04cc5e46f80b88805",
+	"us-east-2":      "ami-007bd0d8cecde0ad0",
+	"us-east-1":      "ami-0d66a70e16e8b5cf0",
+	"us-west-2":      "ami-0eb117edc93f5a736",
+	"eu-central-1":   "ami-0337795faa3fa47e8",
+	"eu-west-2":      "ami-0c961f624e82afc9e",
+	"eu-west-1":      "ami-01005388142fe709e",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -53,7 +53,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-835d8b1",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-9d07809",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1"
-	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
-	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"
+	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809"
+	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
+	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -111,7 +111,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-aaa3750"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-aaa3750"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},
@@ -245,7 +245,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"),
 					},
 					RawPodSpec: &PodSpec{
 						TypeMeta: metaV1.TypeMeta{
@@ -332,8 +332,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-835d8b1
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9d07809
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9d07809
                   ports: {}
                   registry_auth: null
                 hyperparameters:
@@ -410,9 +410,9 @@ func TestLegacyConfig(t *testing.T) {
 						RawROCM: []string{},
 					},
 					RawImage: &EnvironmentImageMap{
-						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1"),
-						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-835d8b1"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1"),
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9d07809"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9d07809"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -32,9 +32,9 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1
-        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
-        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1
+        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809
+        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809
+        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,119 +1,119 @@
 ap_northeast_1_agent_ami:
-  new: ami-0991c62696aa7ccfd
-  old: ami-07ff017fdcb873d21
+  new: ami-095dc4fb79f2496da
+  old: ami-0991c62696aa7ccfd
 ap_northeast_1_bastion_ami:
-  new: ami-0c7cb70d3eb61492b
-  old: ami-09b18720cb71042df
+  new: ami-00910ef9457f0df47
+  old: ami-0c7cb70d3eb61492b
 ap_northeast_1_master_ami:
-  new: ami-0c7cb70d3eb61492b
-  old: ami-09b18720cb71042df
+  new: ami-00910ef9457f0df47
+  old: ami-0c7cb70d3eb61492b
 ap_northeast_2_agent_ami:
-  new: ami-0e731ff15c9cd271c
-  old: ami-0f4325d6bb0693ea8
+  new: ami-078bb019c9a133349
+  old: ami-0e731ff15c9cd271c
 ap_northeast_2_bastion_ami:
-  new: ami-003bb1772f36a39a3
-  old: ami-07d16c043aa8e5153
+  new: ami-035e3e44dc41db6a2
+  old: ami-003bb1772f36a39a3
 ap_northeast_2_master_ami:
-  new: ami-003bb1772f36a39a3
-  old: ami-07d16c043aa8e5153
+  new: ami-035e3e44dc41db6a2
+  old: ami-003bb1772f36a39a3
 ap_southeast_1_agent_ami:
-  new: ami-0117b4415fa85f5fd
-  old: ami-08e217c995685b256
+  new: ami-0d926ac4d57af0fe2
+  old: ami-0117b4415fa85f5fd
 ap_southeast_1_bastion_ami:
-  new: ami-09f03fa5572692399
-  old: ami-00e912d13fbb4f225
+  new: ami-0fd1ee6c8b656f020
+  old: ami-09f03fa5572692399
 ap_southeast_1_master_ami:
-  new: ami-09f03fa5572692399
-  old: ami-00e912d13fbb4f225
+  new: ami-0fd1ee6c8b656f020
+  old: ami-09f03fa5572692399
 ap_southeast_2_agent_ami:
-  new: ami-07f3405e83ad9e60f
-  old: ami-032ab618bc592a2f3
+  new: ami-04cc5e46f80b88805
+  old: ami-07f3405e83ad9e60f
 ap_southeast_2_bastion_ami:
-  new: ami-06139e5e22cc2f7b1
-  old: ami-055166f8a8041fbf1
+  new: ami-0b62ecd3babd1c548
+  old: ami-06139e5e22cc2f7b1
 ap_southeast_2_master_ami:
-  new: ami-06139e5e22cc2f7b1
-  old: ami-055166f8a8041fbf1
+  new: ami-0b62ecd3babd1c548
+  old: ami-06139e5e22cc2f7b1
 deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-835d8b1
 deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.21.0
 deepspeed_gpu_1_hashed:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-9119094
 deepspeed_gpu_1_versioned:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-0.19.1
 eu_central_1_agent_ami:
-  new: ami-087ce2a855248c888
-  old: ami-0108d2301feb1d1a6
+  new: ami-0337795faa3fa47e8
+  old: ami-087ce2a855248c888
 eu_central_1_bastion_ami:
-  new: ami-0b81e95bb0a06ea8c
-  old: ami-06148e0e81e5187c8
+  new: ami-0abbe417ed83c0b29
+  old: ami-0b81e95bb0a06ea8c
 eu_central_1_master_ami:
-  new: ami-0b81e95bb0a06ea8c
-  old: ami-06148e0e81e5187c8
+  new: ami-0abbe417ed83c0b29
+  old: ami-0b81e95bb0a06ea8c
 eu_west_1_agent_ami:
-  new: ami-0554426cc52af7b5c
-  old: ami-051b575f3d38c142f
+  new: ami-01005388142fe709e
+  old: ami-0554426cc52af7b5c
 eu_west_1_bastion_ami:
-  new: ami-029cfca952b331b52
-  old: ami-0fd8802f94ed1c969
+  new: ami-0e3f7dd2dc743e48a
+  old: ami-029cfca952b331b52
 eu_west_1_master_ami:
-  new: ami-029cfca952b331b52
-  old: ami-0fd8802f94ed1c969
+  new: ami-0e3f7dd2dc743e48a
+  old: ami-029cfca952b331b52
 eu_west_2_agent_ami:
-  new: ami-0b311171d796d1d06
-  old: ami-086a85853ca268f19
+  new: ami-0c961f624e82afc9e
+  old: ami-0b311171d796d1d06
 eu_west_2_bastion_ami:
-  new: ami-035469b606478d63d
-  old: ami-04842bc62789b682e
+  new: ami-0d78429fb6af30994
+  old: ami-035469b606478d63d
 eu_west_2_master_ami:
-  new: ami-035469b606478d63d
-  old: ami-04842bc62789b682e
+  new: ami-0d78429fb6af30994
+  old: ami-035469b606478d63d
 gcp_env:
-  new: det-environments-835d8b1
-  old: det-environments-0e4beb5
+  new: det-environments-9d07809
+  old: det-environments-835d8b1
 gpt_neox_deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-835d8b1
 gpt_neox_deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.21.0
 gpt_neox_deepspeed_gpu_1_hashed:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094
 gpt_neox_deepspeed_gpu_1_versioned:
   new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1
 pt_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-835d8b1
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0e4beb5
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-9d07809
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-835d8b1
 pt_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.0
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.20.1
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.0
 pt_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-835d8b1
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0e4beb5
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-9d07809
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-835d8b1
 pt_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.0
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.20.1
+  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.0
 pt_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-835d8b1
 pt_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.0
 pt_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-835d8b1
 pt_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.0
 pytorch10_tf27_rocm50_0_hashed:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0e4beb5
+  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1
 pytorch10_tf27_rocm50_0_versioned:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.20.1
+  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.0
 pytorch19_tf25_rocm_0_hashed:
   new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730
   old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-ecee7c1
@@ -125,29 +125,29 @@ pytorch19_tf25_rocm_1_hashed:
 pytorch19_tf25_rocm_1_versioned:
   new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4
 tf1_cpu_0_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0e4beb5
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9d07809
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-835d8b1
 tf1_cpu_0_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.0
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.20.1
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.1
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.0
 tf1_cpu_1_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-835d8b1
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0e4beb5
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-9d07809
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-835d8b1
 tf1_cpu_1_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.0
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.20.1
+  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.1
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.0
 tf1_gpu_0_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-835d8b1
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0e4beb5
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9d07809
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-835d8b1
 tf1_gpu_0_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.20.1
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.0
 tf1_gpu_1_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-835d8b1
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0e4beb5
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-9d07809
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-835d8b1
 tf1_gpu_1_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.0
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.20.1
+  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.1
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.0
 tf24_cpu_0_hashed:
   new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-24586f0
   old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-1c769fb
@@ -221,89 +221,89 @@ tf26_gpu_1_versioned:
   new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-0.19.10
   old: determinedai/environments:cuda-11.2-tf-2.6-gpu-mpi-0.19.4
 tf27_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-835d8b1
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-0e4beb5
+  new: determinedai/environments:py-3.8-tf-2.7-cpu-9d07809
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-835d8b1
 tf27_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.0
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-0.20.1
+  new: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.1
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.0
 tf27_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-835d8b1
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0e4beb5
+  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-9d07809
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-835d8b1
 tf27_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.0
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.20.1
+  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.1
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.0
 tf27_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-835d8b1
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0e4beb5
+  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-9d07809
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-835d8b1
 tf27_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.0
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.20.1
+  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.1
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.0
 tf27_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-835d8b1
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0e4beb5
+  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-9d07809
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-835d8b1
 tf27_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.0
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.20.1
+  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.1
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.0
 tf2_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0e4beb5
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1
 tf2_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.20.1
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.0
 tf2_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-835d8b1
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0e4beb5
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-9d07809
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-835d8b1
 tf2_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.0
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.20.1
+  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.1
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.0
 tf2_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1
 tf2_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.0
 tf2_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-835d8b1
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0e4beb5
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-9d07809
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-835d8b1
 tf2_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.0
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.20.1
+  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.1
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.0
 us_east_1_agent_ami:
-  new: ami-0fdc0e3d660394d83
-  old: ami-03ec29f0d7c14e20c
+  new: ami-0d66a70e16e8b5cf0
+  old: ami-0fdc0e3d660394d83
 us_east_1_bastion_ami:
-  new: ami-0b93ce03dcbcb10f6
-  old: ami-0149b2da6ceec4bb0
+  new: ami-0172070f66a8ebe63
+  old: ami-0b93ce03dcbcb10f6
 us_east_1_master_ami:
-  new: ami-0b93ce03dcbcb10f6
-  old: ami-0149b2da6ceec4bb0
+  new: ami-0172070f66a8ebe63
+  old: ami-0b93ce03dcbcb10f6
 us_east_2_agent_ami:
-  new: ami-0948c4d44ce80874c
-  old: ami-06332e9495a7eebda
+  new: ami-007bd0d8cecde0ad0
+  old: ami-0948c4d44ce80874c
 us_east_2_bastion_ami:
-  new: ami-0cbea92f2377277a4
-  old: ami-0d5bf08bc8017c83b
+  new: ami-0bafa3699418551cd
+  old: ami-0cbea92f2377277a4
 us_east_2_master_ami:
-  new: ami-0cbea92f2377277a4
-  old: ami-0d5bf08bc8017c83b
+  new: ami-0bafa3699418551cd
+  old: ami-0cbea92f2377277a4
 us_gov_east_1_agent_ami:
-  new: ami-0320f952a99904df0
-  old: ami-040f4b2296afbced8
+  new: ami-0fa6828b565a67c4c
+  old: ami-0320f952a99904df0
 us_gov_east_1_master_ami:
-  new: ami-0b36c558c9dd26c75
-  old: ami-03106245b0320c1b6
+  new: ami-0cd066f69b98b61b2
+  old: ami-0b36c558c9dd26c75
 us_gov_west_1_agent_ami:
-  new: ami-061ec1ebdae22abf6
-  old: ami-02538d3a61cd9fb4a
+  new: ami-07746f11dbc3fa3d7
+  old: ami-061ec1ebdae22abf6
 us_gov_west_1_master_ami:
-  new: ami-0f1289f37e46c1eff
-  old: ami-06bc7677241f6bdeb
+  new: ami-0cbd5dbd94f397bdd
+  old: ami-0f1289f37e46c1eff
 us_west_2_agent_ami:
-  new: ami-05ee2b3249ae2e713
-  old: ami-016612711ba734ade
+  new: ami-0eb117edc93f5a736
+  old: ami-05ee2b3249ae2e713
 us_west_2_bastion_ami:
-  new: ami-0d31d7c9fc9503726
-  old: ami-0c09c7eb16d3e8e70
+  new: ami-0ceeab680f529cc36
+  old: ami-0d31d7c9fc9503726
 us_west_2_master_ami:
-  new: ami-0d31d7c9fc9503726
-  old: ami-0c09c7eb16d3e8e70
+  new: ami-0ceeab680f529cc36
+  old: ami-0d31d7c9fc9503726

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
         },
         "pod_spec": {
           "metadata": {

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-835d8b1",
-      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-835d8b1"
+      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809",
+      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
@@ -69,7 +69,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809',
           },
           pod_spec: null,
           ports: {},
@@ -762,7 +762,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-835d8b1',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9d07809',
           },
           pod_spec: null,
           ports: {},


### PR DESCRIPTION
## Description

This PR follows an update to our environments to support systems with NVSwitch architecture. This will enable users to run det deploy with AWS p4d instances.


## Test Plan

Create an AWS cluster with p4d agent instances using the new agent AMIs, verify that jobs can be run.
Create an AWS cluster with non-p4d agent instances using the new agent AMIs, verify that jobs can be run.


## Checklist

- [x] Changes have been manually QA'd

## Ticket
MLG-344