### PR TITLE
fix: allow `det checkpoint download` for completed checkpoints only [DET-3786]

### DIFF
--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -3,7 +3,6 @@ from argparse import Namespace
 from typing import Any, List, Optional
 
 from determined import cli, errors
-from determined.cli.errors import CliError
 from determined.common import experimental
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
@@ -100,7 +99,7 @@ def download(args: Namespace) -> None:
     try:
         path = checkpoint.download(path=args.output_dir, mode=args.mode)
     except errors.CheckpointStateException as ex:
-        raise CliError(str(ex))
+        raise cli.errors.CliError(str(ex))
 
     if args.quiet:
         print(path)

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -2,7 +2,8 @@ import json
 from argparse import Namespace
 from typing import Any, List, Optional
 
-from determined import cli
+from determined import cli, errors
+from determined.cli.errors import CliError
 from determined.common import experimental
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
@@ -96,7 +97,10 @@ def list_checkpoints(args: Namespace) -> None:
 def download(args: Namespace) -> None:
     checkpoint = Determined(args.master, None).get_checkpoint(args.uuid)
 
-    path = checkpoint.download(path=args.output_dir, mode=args.mode)
+    try:
+        path = checkpoint.download(path=args.output_dir, mode=args.mode)
+    except errors.CheckpointStateException as ex:
+        raise CliError(str(ex))
 
     if args.quiet:
         print(path)

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -143,6 +143,10 @@ class Checkpoint:
             mode (DownloadMode): Mode governs how a checkpoint is downloaded. Refer to
                 the definition of DownloadMode for details.
         """
+        if self.state != CheckpointState.COMPLETED:
+            raise errors.CheckpointStateException(
+                f"Only COMPLETED checkpoints can be downloaded. Checkpoint state: {self.state.value}"
+            )
         if path is not None:
             local_ckpt_dir = pathlib.Path(path)
         else:

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -145,7 +145,8 @@ class Checkpoint:
         """
         if self.state != CheckpointState.COMPLETED:
             raise errors.CheckpointStateException(
-                f"Only COMPLETED checkpoints can be downloaded. Checkpoint state: {self.state.value}"
+                "Only COMPLETED checkpoints can be downloaded. "
+                f"Checkpoint state: {self.state.value}"
             )
         if path is not None:
             local_ckpt_dir = pathlib.Path(path)

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -95,6 +95,7 @@ class CheckpointNotFound(Exception):
 
 class CheckpointStateException(Exception):
     """CheckpointStateException indicates a checkpoint is in an inappropriate state."""
+
     pass
 
 

--- a/harness/determined/errors.py
+++ b/harness/determined/errors.py
@@ -93,6 +93,11 @@ class CheckpointNotFound(Exception):
     """
 
 
+class CheckpointStateException(Exception):
+    """CheckpointStateException indicates a checkpoint is in an inappropriate state."""
+    pass
+
+
 class NoDirectStorageAccess(Exception):
     """Direct checkpoint storage access unavailable, e.g., no credentials or permissions."""
 


### PR DESCRIPTION
## Description

- Only allow downloading completed checkpoints
- Print a nicer error message for the others

## Test Plan

- downloading good checkpoints should work ok.
- downloading deleted checkpoints should print a nice error.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
