### PR TITLE
docs: add a known issue and its fix for PBS - Display valid value for Accelerator field in the Resource Pool Configuration

### DIFF
--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -322,15 +322,8 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
  PBS Known Issues
 ******************
 
--  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the Accelerator
-   field might include an ``unconfigured`` value. This happens when the GPU type information is not
-   set in the PBS ``resources_available`` object.
-
-   Steps to view Resource Pool Configuration:
-
-   -  Select the Cluster tab on the Determined Web UI
-   -  Click on a Resource Pool Card
-   -  Navigate to the Configuration tab on the Resource Pool Details View.
+-  The resource pool card on the Cluster tab shows the ``Accelerator`` field as ``unconfigured``. 
+   This happens when the GPU type information is not set in the PBS ``resources_available`` object.
 
    HPC system administrators can set this information using the following set of commands:
 
@@ -344,12 +337,15 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
 
+   -  If there are multiple types of GPUs on the node, provide a comma separated value.
+      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
+
    -  Verify that the ``resources_available.accel_type`` value is now set.
 
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
 
    Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can
-   verify the Accelerator field on the Web UI using the steps mentioned above.
+   verify the Accelerator field on the Cluster tab of the Web UI.
 
 ***********************
  AMD/ROCm Known Issues

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -323,9 +323,9 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
  PBS Known Issues
 ********************
 
--  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the Accelerator 
-   field might include an ``unconfigured`` value. This happens when the GPU type information is not 
-   set in the PBS ``resources_available`` object. 
+-  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the 
+   Accelerator field might include an ``unconfigured`` value. This happens when the GPU type 
+   information is not set in the PBS ``resources_available`` object. 
    
    Steps to view Resource Pool Configuration: 
 
@@ -348,8 +348,8 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
 
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
 
-   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can 
-   verify the Accelerator field on the Web UI using the steps mentioned above.
+   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins 
+   can verify the Accelerator field on the Web UI using the steps mentioned above.
 
 ***********************
  AMD/ROCm Known Issues

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -318,24 +318,24 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
       ``slurm.slots_per_node`` to enable multiple CPUs to be used on each node. Without
       ``slurm.slots_per_node`` the job will request ``slots_per_trial`` nodes.
 
-
-********************
+******************
  PBS Known Issues
-********************
+******************
 
--  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the 
-   Accelerator field might include an ``unconfigured`` value. This happens when the GPU type 
-   information is not set in the PBS ``resources_available`` object. 
-   
-   Steps to view Resource Pool Configuration: 
+-  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the Accelerator
+   field might include an ``unconfigured`` value. This happens when the GPU type information is not
+   set in the PBS ``resources_available`` object.
+
+   Steps to view Resource Pool Configuration:
 
    -  Select the Cluster tab on the Determined Web UI
    -  Click on a Resource Pool Card
-   -  Navigate to the Configuration tab on the Resource Pool Details View. 
+   -  Navigate to the Configuration tab on the Resource Pool Details View.
 
    HPC system administrators can set this information using the following set of commands:
 
    -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
+
    -  Verify that ``resources_available.accel_type`` is not set for each node we are going to edit.
 
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
@@ -348,8 +348,8 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
 
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
 
-   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins 
-   can verify the Accelerator field on the Web UI using the steps mentioned above.
+   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can
+   verify the Accelerator field on the Web UI using the steps mentioned above.
 
 ***********************
  AMD/ROCm Known Issues

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -336,10 +336,12 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
    -  Set the desired value for ``resources_available.accel_type`` for the nodes containing GPUs.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
+      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla"``
 
    -  If there are multiple types of GPUs on the node, provide a comma separated value.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
+      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"``
 
    -  Verify that the ``resources_available.accel_type`` value is now set.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -318,6 +318,39 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
       ``slurm.slots_per_node`` to enable multiple CPUs to be used on each node. Without
       ``slurm.slots_per_node`` the job will request ``slots_per_trial`` nodes.
 
+
+********************
+ PBS Known Issues
+********************
+
+-  With PBS Workload Manager, when users try to view a Resource Pool Configuration, the Accelerator 
+   field might include an ``unconfigured`` value. This happens when the GPU type information is not 
+   set in the PBS ``resources_available`` object. 
+   
+   Steps to view Resource Pool Configuration: 
+
+   -  Select the Cluster tab on the Determined Web UI
+   -  Click on a Resource Pool Card
+   -  Navigate to the Configuration tab on the Resource Pool Details View. 
+
+   HPC system administrators can set this information using the following set of commands:
+
+   -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
+   -  Verify that ``resources_available.accel_type`` is not set for each node we are going to edit.
+
+      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
+
+   -  Set the desired value for ``resources_available.accel_type`` for the nodes containing GPUs.
+
+      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
+
+   -  Verify that the ``resources_available.accel_type`` value is now set.
+
+      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
+
+   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can 
+   verify the Accelerator field on the Web UI using the steps mentioned above.
+
 ***********************
  AMD/ROCm Known Issues
 ***********************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -318,38 +318,6 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
       ``slurm.slots_per_node`` to enable multiple CPUs to be used on each node. Without
       ``slurm.slots_per_node`` the job will request ``slots_per_trial`` nodes.
 
-******************
- PBS Known Issues
-******************
-
--  The resource pool card on the Cluster tab shows the ``Accelerator`` field as ``unconfigured``.
-   This happens when the GPU type information is not set in the PBS ``resources_available`` object.
-
-   HPC system administrators can set this information using the following set of commands:
-
-   -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
-
-   -  Verify that ``resources_available.accel_type`` is not set for each node we are going to edit.
-
-      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
-
-   -  Set the desired value for ``resources_available.accel_type`` for the nodes containing GPUs.
-
-      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
-      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla"``
-
-   -  If there are multiple types of GPUs on the node, provide a comma separated value.
-
-      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
-      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"``
-
-   -  Verify that the ``resources_available.accel_type`` value is now set.
-
-      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
-
-   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can
-   verify the Accelerator field on the Cluster tab of the Web UI.
-
 ***********************
  AMD/ROCm Known Issues
 ***********************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -337,8 +337,9 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
 
-   -  If there are multiple types of GPUs on the node, provide a comma separated value. - ``qmgr -c
-      "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
+   -  If there are multiple types of GPUs on the node, provide a comma separated value.
+
+      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
 
    -  Verify that the ``resources_available.accel_type`` value is now set.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-known-issues.rst
@@ -322,7 +322,7 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
  PBS Known Issues
 ******************
 
--  The resource pool card on the Cluster tab shows the ``Accelerator`` field as ``unconfigured``. 
+-  The resource pool card on the Cluster tab shows the ``Accelerator`` field as ``unconfigured``.
    This happens when the GPU type information is not set in the PBS ``resources_available`` object.
 
    HPC system administrators can set this information using the following set of commands:
@@ -337,8 +337,8 @@ sometimes resolved by additionally installing the ``apptainer-setuid`` package.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
 
-   -  If there are multiple types of GPUs on the node, provide a comma separated value.
-      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
+   -  If there are multiple types of GPUs on the node, provide a comma separated value. - ``qmgr -c
+      "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
 
    -  Verify that the ``resources_available.accel_type`` value is now set.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -183,11 +183,11 @@ to optimize how Determined interacts with PBS:
 
 -  Configure PBS to report GPU Accelerator type.
 
-   PBS administrators need to set the value for ``resources_available.accel_type`` on each node 
-   that has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value 
+   PBS administrators need to set the value for ``resources_available.accel_type`` on each node that
+   has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value
    ``unconfigured`` for the ``Accelerator`` field in the Resource Pool information.
-   
-   PBS administrator can use the following set of commands to set the value of 
+
+   PBS administrator can use the following set of commands to set the value of
    ``resources_available.accel_type`` on a single node:
 
    -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
@@ -212,8 +212,8 @@ to optimize how Determined interacts with PBS:
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
       -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
 
-   Repeat the above steps to set the ``resources_available.accel_type`` value for every node 
-   containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary 
+   Repeat the above steps to set the ``resources_available.accel_type`` value for every node
+   containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary
    nodes, admins can verify the Accelerator field on the Cluster tab of the Web UI.
 
 -  Ensure homogeneous PBS queues.

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -216,7 +216,6 @@ to optimize how Determined interacts with PBS:
    containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary 
    nodes, admins can verify the Accelerator field on the Cluster tab of the Web UI.
 
-
 -  Ensure homogeneous PBS queues.
 
    Determined maps PBS queues to Determined resource pools. It is recommended that the nodes within

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -183,34 +183,36 @@ to optimize how Determined interacts with PBS:
 
 -  Configure PBS to report GPU Accelerator type.
 
-   PBS administrators need to set the value for ``resources_available.accel_type`` on each node that
-   has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value
-   ``unconfigured`` for the ``Accelerator`` field in the Resource Pool information.
+   PBS administrators should set the value for ``resources_available.accel_type`` on each node with
+   a GPU. Otherwise, the Cluster tab on the Determined Web UI will show ``unconfigured`` for the
+   ``Accelerator`` field in the Resource Pool information.
 
-   PBS administrator can use the following set of commands to set the value of
+   PBS administrators can use the following set of commands to set the value of
    ``resources_available.accel_type`` on a single node:
 
-   -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
+   -  Check if the ``resources_available.accel_type`` value is set.
 
-   -  Check if ``resources_available.accel_type`` is set.
+   .. code:: bash
 
-      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
-      -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
+      pbsnodes -v node001 | grep resources_available.accel_type
 
    -  If required, set the desired value for ``resources_available.accel_type``.
 
-      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
-      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla"``
+   .. code:: bash
 
-   -  If there are multiple types of GPUs on the node, provide a comma separated value.
+      sudo qmgr -c "set node node001 resources_available.accel_type=tesla"
 
-      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
-      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"``
+   -  When there are multiple types of GPUs on the node, use a comma-separated value.
+
+   .. code:: bash
+
+      sudo qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"
 
    -  Verify that the ``resources_available.accel_type`` value is now set.
 
-      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
-      -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
+   .. code:: bash
+
+      pbsnodes -v node001 | grep resources_available.accel_type
 
    Repeat the above steps to set the ``resources_available.accel_type`` value for every node
    containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -192,27 +192,27 @@ to optimize how Determined interacts with PBS:
 
    -  Check if the ``resources_available.accel_type`` value is set.
 
-   .. code:: bash
+      .. code:: bash
 
-      pbsnodes -v node001 | grep resources_available.accel_type
+         pbsnodes -v node001 | grep resources_available.accel_type
 
    -  If required, set the desired value for ``resources_available.accel_type``.
 
-   .. code:: bash
+      .. code:: bash
 
-      sudo qmgr -c "set node node001 resources_available.accel_type=tesla"
+         sudo qmgr -c "set node node001 resources_available.accel_type=tesla"
 
    -  When there are multiple types of GPUs on the node, use a comma-separated value.
 
-   .. code:: bash
+      .. code:: bash
 
-      sudo qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"
+         sudo qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"
 
    -  Verify that the ``resources_available.accel_type`` value is now set.
 
-   .. code:: bash
+      .. code:: bash
 
-      pbsnodes -v node001 | grep resources_available.accel_type
+         pbsnodes -v node001 | grep resources_available.accel_type
 
    Repeat the above steps to set the ``resources_available.accel_type`` value for every node
    containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -183,9 +183,9 @@ to optimize how Determined interacts with PBS:
 
 -  Configure PBS to report GPU Accelerator type.
 
-   PBS administrators should set the value for ``resources_available.accel_type`` on each node with
-   a GPU. Otherwise, the Cluster tab on the Determined Web UI will show ``unconfigured`` for the
-   ``Accelerator`` field in the Resource Pool information.
+   It is recommended that PBS administrators set the value for ``resources_available.accel_type`` on
+   each node that contains an accelerator. Otherwise, the Cluster tab on the Determined Web UI will
+   show ``unconfigured`` for the ``Accelerator`` field in the Resource Pool information.
 
    PBS administrators can use the following set of commands to set the value of
    ``resources_available.accel_type`` on a single node:

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -164,7 +164,7 @@ recommended to optimize how Determined interacts with Slurm:
 Determined should function with your existing PBS configuration. The following steps are recommended
 to optimize how Determined interacts with PBS:
 
--  Configure PBS to report GPU Accelerator type.
+-  Configure PBS to manage GPU resources.
 
    Determined works best when allocating GPUs. By default, Determined selects compute nodes with
    GPUs using the option ``-select={slots_per_trial}:ngpus=1``. If PBS cannot be configured to
@@ -180,6 +180,8 @@ to optimize how Determined interacts with PBS:
    utilize a single GPU on each node. To fully utilize multiple GPUs, you must either manually
    define ``CUDA_VISIBLE_DEVICES`` appropriately or provide the ``pbs.slots_per_node`` setting in
    your experiment configuration to indicate how many GPU slots are intended for Determined to use.
+
+-  Configure PBS to report GPU Accelerator type.
 
    PBS administrators need to set the value for ``resources_available.accel_type`` on each node 
    that has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -164,7 +164,7 @@ recommended to optimize how Determined interacts with Slurm:
 Determined should function with your existing PBS configuration. The following steps are recommended
 to optimize how Determined interacts with PBS:
 
--  Configure PBS to manage GPU resources.
+-  Configure PBS to report GPU Accelerator type.
 
    Determined works best when allocating GPUs. By default, Determined selects compute nodes with
    GPUs using the option ``-select={slots_per_trial}:ngpus=1``. If PBS cannot be configured to
@@ -180,6 +180,39 @@ to optimize how Determined interacts with PBS:
    utilize a single GPU on each node. To fully utilize multiple GPUs, you must either manually
    define ``CUDA_VISIBLE_DEVICES`` appropriately or provide the ``pbs.slots_per_node`` setting in
    your experiment configuration to indicate how many GPU slots are intended for Determined to use.
+
+   PBS administrators need to set the value for ``resources_available.accel_type`` on each node 
+   that has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value 
+   ``unconfigured`` for the ``Accelerator`` field in the Resource Pool information.
+   
+   PBS administrator can use the following set of commands to set the value for 
+   ``resources_available.accel_type``:
+
+   -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
+
+   -  Verify that ``resources_available.accel_type`` is not set for each node we are going to edit.
+
+      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
+      -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
+
+   -  Set the desired value for ``resources_available.accel_type`` for the nodes containing GPUs.
+
+      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
+      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla"``
+
+   -  If there are multiple types of GPUs on the node, provide a comma separated value.
+
+      -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU_Type_1,GPU_Type_2>"``
+      -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla,kepler"``
+
+   -  Verify that the ``resources_available.accel_type`` value is now set.
+
+      -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
+      -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
+
+   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can
+   verify the Accelerator field on the Cluster tab of the Web UI.
+
 
 -  Ensure homogeneous PBS queues.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -187,17 +187,17 @@ to optimize how Determined interacts with PBS:
    that has a GPU. Otherwise, the Cluster tab on the Determined Web UI will show the value 
    ``unconfigured`` for the ``Accelerator`` field in the Resource Pool information.
    
-   PBS administrator can use the following set of commands to set the value for 
-   ``resources_available.accel_type``:
+   PBS administrator can use the following set of commands to set the value of 
+   ``resources_available.accel_type`` on a single node:
 
    -  Login as a root level user or use ``sudo -i`` to quickly change to a root level user.
 
-   -  Verify that ``resources_available.accel_type`` is not set for each node we are going to edit.
+   -  Check if ``resources_available.accel_type`` is set.
 
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
       -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
 
-   -  Set the desired value for ``resources_available.accel_type`` for the nodes containing GPUs.
+   -  If required, set the desired value for ``resources_available.accel_type``.
 
       -  ``qmgr -c "set node <node name> resources_available.accel_type=<GPU Type>"``
       -  For example, ``qmgr -c "set node node001 resources_available.accel_type=tesla"``
@@ -212,8 +212,9 @@ to optimize how Determined interacts with PBS:
       -  ``pbsnodes -v <node name> | grep resources_available.accel_type``
       -  For example, ``pbsnodes -v node001 | grep resources_available.accel_type``
 
-   Once the ``resources_available.accel_type`` value is set for all the necessary nodes, admins can
-   verify the Accelerator field on the Cluster tab of the Web UI.
+   Repeat the above steps to set the ``resources_available.accel_type`` value for every node 
+   containing GPU. Once the ``resources_available.accel_type`` value is set for all the necessary 
+   nodes, admins can verify the Accelerator field on the Cluster tab of the Web UI.
 
 
 -  Ensure homogeneous PBS queues.


### PR DESCRIPTION
## Description
PBS Workload Manager relies on the value `resources_available.accel_type` to identify the GPU type. This value is used to populate the `Accelerator` field on the Resource Pool Configuration page. If the value of `resources_available.accel_type` is not set on a node. The Resource Pool Configuration page will include a value `unconfigured` in the Accelerator field. To fix this problem, HPC system admins can set the value for `resources_available.accel_type`. This PR describes this issue as part of the `slurm-known-issues` section and also provides instructions on how to fix the issue.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
These instructions were manually tested on the casablanca-login2 machine.
Before
<img width="1904" alt="accelerator-unconfigured" src="https://user-images.githubusercontent.com/7717367/228736906-240e501e-eb6f-4675-8063-9c7e1a780d9c.png">

After
<img width="1904" alt="accelerator-corrected" src="https://user-images.githubusercontent.com/7717367/228736932-e718c7ad-11c4-4ab1-9084-f8e53f7db6b4.png">


Please refer the image below for the newly added sub-section.
<img width="834" alt="image" src="https://user-images.githubusercontent.com/7717367/230124483-1a6cf4d0-e792-4032-b8f0-e8f4fb1871fe.png">


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
