### PR TITLE
feat: allow direct connectivity between master, agents and containers

### DIFF
--- a/master/internal/rm/kubernetesrm/pod.go
+++ b/master/internal/rm/kubernetesrm/pod.go
@@ -595,8 +595,6 @@ func getResourcesStartedForPod(pod *k8sV1.Pod, ports []int) sproto.ResourcesStar
 		addresses = append(addresses, cproto.Address{
 			ContainerIP:   pod.Status.PodIP,
 			ContainerPort: port,
-			HostIP:        pod.Status.PodIP,
-			HostPort:      port,
 		})
 	}
 

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -874,7 +874,7 @@ func (a *Allocation) registerProxies(ctx *actor.Context, addresses []cproto.Addr
 			ServiceID: pcfg.ServiceID,
 			URL: &url.URL{
 				Scheme: "http",
-				Host:   fmt.Sprintf("%s:%d", address.HostIP, address.HostPort),
+				Host:   fmt.Sprintf("%s:%d", address.TargetIP(), address.TargetPort()),
 			},
 			ProxyTCP:        pcfg.ProxyTCP,
 			Unauthenticated: pcfg.Unauthenticated,
@@ -921,8 +921,6 @@ func (a *Allocation) containerProxyAddresses() []cproto.Address {
 		result = append(result, cproto.Address{
 			ContainerIP:   *a.proxyAddress,
 			ContainerPort: pp.Port,
-			HostIP:        *a.proxyAddress,
-			HostPort:      pp.Port,
 		})
 	}
 

--- a/master/internal/task/allocation_intg_test.go
+++ b/master/internal/task/allocation_intg_test.go
@@ -131,13 +131,15 @@ func TestAllocation(t *testing.T) {
 				containerStateChanged.ResourcesState = sproto.Starting
 				require.NoError(t, system.Ask(self, containerStateChanged).Error())
 				containerStateChanged.ResourcesState = sproto.Running
+				containerHostIP := "0.0.0.0"
+				containerHostPort := 1734
 				containerStateChanged.ResourcesStarted = &sproto.ResourcesStarted{
 					Addresses: []cproto.Address{
 						{
 							ContainerIP:   "172.0.0.3",
 							ContainerPort: 1734,
-							HostIP:        "0.0.0.0",
-							HostPort:      1734,
+							HostIP:        &containerHostIP,
+							HostPort:      &containerHostPort,
 						},
 					},
 				}

--- a/master/internal/task/rendezvous.go
+++ b/master/internal/task/rendezvous.go
@@ -256,7 +256,7 @@ func (r *rendezvous) info() ([]cAddress, []string, []int32, error) {
 		}
 
 		if len(addrs) == 1 {
-			raddrs = append(raddrs, addrs[0].HostIP)
+			raddrs = append(raddrs, addrs[0].TargetIP())
 			slots = append(slots, int32(caddr.slots))
 		} else {
 			err = multierror.Append(err, fmt.Errorf(

--- a/master/internal/task/rendezvous_test.go
+++ b/master/internal/task/rendezvous_test.go
@@ -187,12 +187,15 @@ func TestRendezvousTimeout(t *testing.T) {
 }
 
 func addressesFromContainerID(rID sproto.ResourcesID) []cproto.Address {
+	hostIP := fmt.Sprintf("%s.example.com", rID)
+	hostPort := 1734
+
 	return []cproto.Address{
 		{
 			ContainerIP:   "172.0.1.2",
 			ContainerPort: 1734,
-			HostIP:        fmt.Sprintf("%s.example.com", rID),
-			HostPort:      1734,
+			HostIP:        &hostIP,
+			HostPort:      &hostPort,
 		},
 	}
 }

--- a/master/pkg/aproto/master_message.go
+++ b/master/pkg/aproto/master_message.go
@@ -105,8 +105,6 @@ func (c ContainerStarted) Addresses() []cproto.Address {
 			addresses = append(addresses, cproto.Address{
 				ContainerIP:   proxy,
 				ContainerPort: port.Int(),
-				HostIP:        proxy,
-				HostPort:      port.Int(),
 			})
 		}
 	default:
@@ -120,6 +118,17 @@ func (c ContainerStarted) Addresses() []cproto.Address {
 		}
 
 		for port, bindings := range info.NetworkSettings.Ports {
+			// Unpublished port (possibly under direct connectivity mode)
+			if len(bindings) == 0 {
+				for _, ip := range ipAddresses {
+					addresses = append(addresses, cproto.Address{
+						ContainerIP:   ip,
+						ContainerPort: port.Int(),
+					})
+				}
+				continue
+			}
+
 			for _, binding := range bindings {
 				for _, ip := range ipAddresses {
 					hostIP := binding.HostIP
@@ -148,8 +157,8 @@ func (c ContainerStarted) Addresses() []cproto.Address {
 					addresses = append(addresses, cproto.Address{
 						ContainerIP:   ip,
 						ContainerPort: port.Int(),
-						HostIP:        hostIP,
-						HostPort:      hostPort,
+						HostIP:        &hostIP,
+						HostPort:      &hostPort,
 					})
 				}
 			}

--- a/master/pkg/cproto/address.go
+++ b/master/pkg/cproto/address.go
@@ -12,12 +12,32 @@ type Address struct {
 	// HostIP is the IP address from outside the container. This can be
 	// different than the ContainerIP because of network forwarding on the host
 	// machine.
-	HostIP string `json:"host_ip"`
+	HostIP *string `json:"host_ip,omitentry"`
 	// HostPort is the IP port from outside the container. This can be different
 	// than the ContainerPort because of network forwarding on the host machine.
-	HostPort int `json:"host_port"`
+	HostPort *int `json:"host_port,omitentry"`
 }
 
 func (a Address) String() string {
-	return fmt.Sprintf("%s:%d:%s:%d", a.HostIP, a.HostPort, a.ContainerIP, a.ContainerPort)
+	addrString := fmt.Sprintf("%s:%d", a.ContainerIP, a.ContainerPort)
+	if a.HostIP != nil {
+		addrString = fmt.Sprintf("%s:%d:%s", *a.HostIP, *a.HostPort, addrString)
+	}
+	return addrString
+}
+
+func (a Address) TargetIP() string {
+	if a.HostIP != nil {
+		return *a.HostIP
+	} else {
+		return a.ContainerIP
+	}
+}
+
+func (a Address) TargetPort() int {
+	if a.HostPort != nil {
+		return *a.HostPort
+	} else {
+		return a.ContainerPort
+	}
 }

--- a/master/pkg/cproto/address.go
+++ b/master/pkg/cproto/address.go
@@ -12,10 +12,10 @@ type Address struct {
 	// HostIP is the IP address from outside the container. This can be
 	// different than the ContainerIP because of network forwarding on the host
 	// machine.
-	HostIP *string `json:"host_ip,omitentry"`
+	HostIP *string `json:"host_ip,omitempty"`
 	// HostPort is the IP port from outside the container. This can be different
 	// than the ContainerPort because of network forwarding on the host machine.
-	HostPort *int `json:"host_port,omitentry"`
+	HostPort *int `json:"host_port,omitempty"`
 }
 
 func (a Address) String() string {
@@ -29,15 +29,13 @@ func (a Address) String() string {
 func (a Address) TargetIP() string {
 	if a.HostIP != nil {
 		return *a.HostIP
-	} else {
-		return a.ContainerIP
 	}
+	return a.ContainerIP
 }
 
 func (a Address) TargetPort() int {
 	if a.HostPort != nil {
 		return *a.HostPort
-	} else {
-		return a.ContainerPort
 	}
+	return a.ContainerPort
 }

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -29,6 +29,7 @@ type TaskContainerDefaultsConfig struct {
 	GLOOPortRange          string                `json:"gloo_port_range,omitempty"`
 	ShmSizeBytes           int64                 `json:"shm_size_bytes,omitempty"`
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
+	DirectConnectivity     bool                  `json:"direct_connectivity,omitentry"`
 	CPUPodSpec             *k8sV1.Pod            `json:"cpu_pod_spec"`
 	GPUPodSpec             *k8sV1.Pod            `json:"gpu_pod_spec"`
 	Image                  *RuntimeItem          `json:"image,omitempty"`

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -29,7 +29,7 @@ type TaskContainerDefaultsConfig struct {
 	GLOOPortRange          string                `json:"gloo_port_range,omitempty"`
 	ShmSizeBytes           int64                 `json:"shm_size_bytes,omitempty"`
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
-	DirectConnectivity     bool                  `json:"direct_connectivity,omitentry"`
+	DirectConnectivity     bool                  `json:"direct_connectivity,omitempty"`
 	CPUPodSpec             *k8sV1.Pod            `json:"cpu_pod_spec"`
 	GPUPodSpec             *k8sV1.Pod            `json:"gpu_pod_spec"`
 	Image                  *RuntimeItem          `json:"image,omitempty"`

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -236,6 +236,7 @@ func (t *TaskSpec) ToDockerSpec() cproto.Spec {
 	if t.UseHostMode {
 		network = hostMode
 	}
+	publishPorts := !(network == hostMode || t.TaskContainerDefaults.DirectConnectivity)
 
 	shmSize := t.ShmSize
 	if shmSize == 0 {
@@ -271,7 +272,7 @@ func (t *TaskSpec) ToDockerSpec() cproto.Spec {
 			HostConfig: docker.HostConfig{
 				NetworkMode:     network,
 				Mounts:          t.Mounts,
-				PublishAllPorts: true,
+				PublishAllPorts: publishPorts,
 				ShmSize:         shmSize,
 				CapAdd:          env.AddCapabilities(),
 				CapDrop:         env.DropCapabilities(),

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -170,8 +170,8 @@ export type State = CommandState | typeof RunState;
 export interface CommandAddress {
   containerIp: string;
   containerPort: number;
-  hostIp: string;
-  hostPort: number;
+  hostIp?: string;
+  hostPort?: number;
   protocol?: string;
 }
 


### PR DESCRIPTION
## Description
Allow a flat network topology between master, agents and containers, as described in issue #4100. This adds a boolean `direct_connectivity` config item to `task_container_defaults`.

## Test Plan
I run the modified master and agents image locally and can confirm it works for the Web UI and Jupyter notebook. Not sure about the situation of experiments, Tensorboard and other services though.

## Commentary (optional)
I'll update the commit description and add API changes entry once you're ok with the code.

## Checklist

- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
