### PR TITLE
fix: set unique port reqs on trial's shallow copied task spec

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -431,12 +431,6 @@ func (t *trial) buildTaskSpec(ctx *actor.Context) (tasks.TaskSpec, error) {
 		stepsCompleted = latestCheckpoint.StepsCompleted
 	}
 
-	t.taskSpec.UniqueExposedPortRequests = make(map[string]int)
-	t.taskSpec.UniqueExposedPortRequests[tasks.DTrainSSHPort] = tasks.DtrainSSHPortBase
-	t.taskSpec.UniqueExposedPortRequests[tasks.InterTrainProcessCommPort1] = tasks.InterTrainProcessCommPort1Base //nolint:lll
-	t.taskSpec.UniqueExposedPortRequests[tasks.InterTrainProcessCommPort2] = tasks.InterTrainProcessCommPort2Base //nolint:lll
-	t.taskSpec.UniqueExposedPortRequests[tasks.C10DPort] = tasks.C10DPortBase
-
 	return tasks.TrialSpec{
 		Base: *t.taskSpec,
 

--- a/master/pkg/tasks/task_trial.go
+++ b/master/pkg/tasks/task_trial.go
@@ -36,6 +36,13 @@ func (s TrialSpec) ToTaskSpec(keys *ssh.PrivateAndPublicKeys) TaskSpec {
 
 	res.Environment = s.MakeEnvPorts()
 
+	res.UniqueExposedPortRequests = map[string]int{
+		DTrainSSHPort:              DtrainSSHPortBase,
+		InterTrainProcessCommPort1: InterTrainProcessCommPort1Base,
+		InterTrainProcessCommPort2: InterTrainProcessCommPort2Base,
+		C10DPort:                   C10DPortBase,
+	}
+
 	res.ResourcesConfig = s.ExperimentConfig.Resources()
 	res.SlurmConfig = s.ExperimentConfig.SlurmConfig()
 	res.PbsConfig = s.ExperimentConfig.PbsConfig()


### PR DESCRIPTION
## Description
All trials within an experiment share their default task spec, so writing to a map on it causes concurrent map writes. Fix this by moving writes to after the trial creates its shallow copy.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [ ] run a large adaptive search?
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
@jerryharrow / @erikwilson , I presume you saw this with HP search? That would mostly confirm deny my theory.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
