### PR TITLE
feat: specify disk size and type for dynamic agents in gcp deployment [MLG-224]

### DIFF
--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -287,6 +287,18 @@ args_description = Cmd(
                             help="zone to create the cluster in (defaults to `region`-b)",
                         ),
                         Arg(
+                            "--disk-size",
+                            type=int,
+                            default=constants.defaults.BOOT_DISK_SIZE,
+                            help="Boot disk size for cluster agents, in GB",
+                        ),
+                        Arg(
+                            "--disk-type",
+                            type=str,
+                            default=constants.defaults.BOOT_DISK_TYPE,
+                            help="Boot disk type for cluster agents",
+                        ),
+                        Arg(
                             "--environment-image",
                             type=str,
                             default=constants.defaults.ENVIRONMENT_IMAGE,

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -3,6 +3,8 @@ class defaults:
     AUX_AGENT_INSTANCE_TYPE = "n1-standard-4"
     COMPUTE_AGENT_INSTANCE_TYPE = "n1-standard-32"
     DB_PASSWORD = "postgres"
+    BOOT_DISK_SIZE = 200
+    BOOT_DISK_TYPE = "pd-standard"
     ENVIRONMENT_IMAGE = "det-environments-9d07809"
     GPU_NUM = 4
     GPU_TYPE = "nvidia-tesla-t4"

--- a/harness/determined/deploy/gcp/terraform/main.tf
+++ b/harness/determined/deploy/gcp/terraform/main.tf
@@ -149,6 +149,8 @@ module "compute" {
   project_id = var.project_id
   region = var.region
   zone = var.zone
+  disk_size = var.disk_size
+  disk_type = var.disk_type
   environment_image = var.environment_image
   image_repo_prefix = var.image_repo_prefix
   det_version = var.det_version

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -70,7 +70,9 @@ resource "google_compute_instance" "master_instance" {
             gpu_num: ${var.gpu_num}
             preemptible: ${var.preemptible}
       gcp:
+        boot_disk_size: ${var.disk_size}
         boot_disk_source_image: projects/determined-ai/global/images/${var.environment_image}
+        boot_disk_type: ${var.disk_type}
         agent_docker_image: ${var.image_repo_prefix}/determined-agent:${var.det_version}
         master_url: ${var.scheme}://internal-ip:${var.port}
         agent_docker_network: ${var.agent_docker_network}

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -140,7 +140,6 @@ resource "google_compute_instance" "master_instance" {
         --name determined-master-configurator \
         --rm \
         -v /usr/local/determined/etc/:/etc/determined/ \
-        -v /home/danielrhunter/determined-master:/usr/bin/determined-master \
         --entrypoint /bin/bash \
         ${var.image_repo_prefix}/determined-master:${var.det_version} \
         -c "/usr/bin/determined-gotmpl -i /etc/determined/master.yaml.context /etc/determined/master.yaml.tmpl > /etc/determined/master.yaml"
@@ -153,7 +152,6 @@ resource "google_compute_instance" "master_instance" {
         --log-driver=gcplogs \
         -p ${var.port}:${var.port} \
         -v /usr/local/determined/etc/:/etc/determined/ \
-        -v /home/danielrhunter/determined-master:/usr/bin/determined-master \
         ${var.image_repo_prefix}/determined-master:${var.det_version}
 
   EOT

--- a/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/main.tf
@@ -72,7 +72,7 @@ resource "google_compute_instance" "master_instance" {
       gcp:
         boot_disk_size: ${var.disk_size}
         boot_disk_source_image: projects/determined-ai/global/images/${var.environment_image}
-        boot_disk_type: ${var.disk_type}
+        boot_disk_type: projects/determined-ai/zones/${var.zone}/diskTypes/${var.disk_type}
         agent_docker_image: ${var.image_repo_prefix}/determined-agent:${var.det_version}
         master_url: ${var.scheme}://internal-ip:${var.port}
         agent_docker_network: ${var.agent_docker_network}
@@ -140,6 +140,7 @@ resource "google_compute_instance" "master_instance" {
         --name determined-master-configurator \
         --rm \
         -v /usr/local/determined/etc/:/etc/determined/ \
+        -v /home/danielrhunter/determined-master:/usr/bin/determined-master \
         --entrypoint /bin/bash \
         ${var.image_repo_prefix}/determined-master:${var.det_version} \
         -c "/usr/bin/determined-gotmpl -i /etc/determined/master.yaml.context /etc/determined/master.yaml.tmpl > /etc/determined/master.yaml"
@@ -152,6 +153,7 @@ resource "google_compute_instance" "master_instance" {
         --log-driver=gcplogs \
         -p ${var.port}:${var.port} \
         -v /usr/local/determined/etc/:/etc/determined/ \
+        -v /home/danielrhunter/determined-master:/usr/bin/determined-master \
         ${var.image_repo_prefix}/determined-master:${var.det_version}
 
   EOT

--- a/harness/determined/deploy/gcp/terraform/modules/compute/variables.tf
+++ b/harness/determined/deploy/gcp/terraform/modules/compute/variables.tf
@@ -7,6 +7,12 @@ variable "det_version_key" {
 variable "project_id" {
 }
 
+variable "disk_size" {
+}
+
+variable "disk_type" {
+}
+
 variable "environment_image" {
 }
 

--- a/harness/determined/deploy/gcp/terraform/variables.tf
+++ b/harness/determined/deploy/gcp/terraform/variables.tf
@@ -167,6 +167,16 @@ variable "labels" {
 	Determined
  *****************************************/
 
+variable "disk_size" {
+  type = number
+  default = 200
+}
+
+variable "disk_type" {
+  type = string
+  default = "pd-standard"
+}
+
 variable "environment_image" {
   type = string
 }

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -32,6 +32,7 @@ type GCPClusterConfig struct {
 
 	BootDiskSize        int    `json:"boot_disk_size"`
 	BootDiskSourceImage string `json:"boot_disk_source_image"`
+	BootDiskType        string `json:"boot_disk_type"`
 
 	Labels     map[string]string `json:"labels"`
 	LabelKey   string            `json:"label_key"`
@@ -55,6 +56,7 @@ func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
 		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-9d07809",
+		BootDiskType:        "pd-standard",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",
@@ -156,6 +158,7 @@ func (c *GCPClusterConfig) Merge() *compute.Instance {
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					SourceImage: c.BootDiskSourceImage,
 					DiskSizeGb:  int64(c.BootDiskSize),
+					DiskType:    c.BootDiskType,
 				},
 				AutoDelete: true,
 			},

--- a/master/internal/config/provconfig/gcp_config_test.go
+++ b/master/internal/config/provconfig/gcp_config_test.go
@@ -37,6 +37,7 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 	"zone": "test-zone",
 	"boot_disk_size": 100,
 	"boot_disk_source_image": "test-source_image",
+	"boot_disk_type": "test-disk_type",
 	"labels": {
 	    "test-labels-key": "test-labels-value"
 	},
@@ -65,6 +66,7 @@ func TestUnmarshalGCPClusterConfig(t *testing.T) {
 			Zone:                "test-zone",
 			BootDiskSize:        100,
 			BootDiskSourceImage: "test-source_image",
+			BootDiskType:        "test-disk_type",
 			Labels:              map[string]string{"test-labels-key": "test-labels-value"},
 			LabelKey:            "test-label-key",
 			LabelValue:          "test-label-value",


### PR DESCRIPTION
## Description

These changes allow users to specify the [boot disk size and type](https://cloud.google.com/compute/docs/disks) for dynamic agents. [MLG-224]
The parameters are written to a configuration file in the `metadata_startup_script`; this configuration file is used by the provisioner in `determined-master`.

## Test Plan

1. Add an extra volume to the determined-master Docker container command in the metadata_startup_script of the master instance: `-v /path/to/determined-master:/usr/bin/determined-master`. This change should not be committed!
2. Create a deployment with the modification from step 1, including specifications like `--disk-size 159 --disk-type pd-balanced` (the default values are `200` and `pd-standard`). The master health check is _expected to fail_ (because the Docker container can’t find the file specified in the extra volume).
3. Build `determined-master` (i.e., `make -C master build`) with the changes to the provisioner (this must be done on a machine with the same architecture as the deployment master instance, so, e.g., not on a MacBook).
4. Use `gcloud compute scp ...` to move the executable from step 3 to the master instance (the location must match the filepath in step 1).
5. On the master instance, the startup script will have failed. Stop the Docker container and network, and restart the instance.
6. Determined should now be running (you should be able to see the browser UI as usual). Create an experiment. Check for errors in the master log. Check the GCloud Console for dynamic agent instances: they should have the specified disk size and type (see the screenshot in the comments).


## Commentary (optional)

The project id and zone must be included in the disk type URI. Are there potential availability issues, similar to how not all GPUs are available in all zones?

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-224]: https://hpe-aiatscale.atlassian.net/browse/MLG-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ