### PR TITLE
fix: Pin version of pydata-sphinx-theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,5 +13,8 @@ myst_parser
 # Theme
 sphinx-book-theme==1.0.0
 
+# pin pydata-sphinx-theme at 0.13.1 to avoid extension import issue
+pydata-sphinx-theme==0.13.1
+
 # live.py
 watchdog


### PR DESCRIPTION
## Description

A version of `pydata-sphinx-theme` released today breaks our docs build step. Pinning version.

## Test Plan

Docs build in e2e_tests pass

Comment is sufficient for future reference

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.