### PR TITLE
fix: checkpoint insertion slow performance on big databases [DET-9219]

### DIFF
--- a/docs/release-notes/checkpoint-size-speedup-speedup.rst
+++ b/docs/release-notes/checkpoint-size-speedup-speedup.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Checkpoints: Fix an issue where checkpoint insertion on a cluster with a lot of checkpoints and
+   reported metrics could take a long time.

--- a/master/internal/db/postgres_checkpoints.go
+++ b/master/internal/db/postgres_checkpoints.go
@@ -30,7 +30,7 @@ func (db *PgDB) CheckpointByUUID(id uuid.UUID) (*model.Checkpoint, error) {
 func (db *PgDB) CheckpointByUUIDs(ckptUUIDs []uuid.UUID) ([]model.Checkpoint, error) {
 	var checkpoints []model.Checkpoint
 	if err := db.queryRows(`
-	SELECT * FROM checkpoints_view c WHERE c.uuid 
+	SELECT * FROM checkpoints_view c WHERE c.uuid
 	IN (SELECT UNNEST($1::uuid[]));`, &checkpoints, ckptUUIDs); err != nil {
 		return nil, fmt.Errorf("getting the checkpoints with a uuid in the set of given uuids: %w", err)
 	}
@@ -155,23 +155,30 @@ func UpdateCheckpointSizeTx(ctx context.Context, idb bun.IDB, checkpoints []uuid
 	var experimentIDs []int
 	err := idb.NewRaw(`
 UPDATE trials SET checkpoint_size=sub.size, checkpoint_count=sub.count FROM (
-	SELECT t.id AS trial_id,
-	COALESCE(SUM(size) FILTER (WHERE c.state != 'DELETED'), 0) AS size,
-	COUNT(*) FILTER (WHERE c.state != 'DELETED') AS count
-	FROM raw_checkpoints c INNER JOIN trials t on c.trial_id = t.id
-	WHERE t.id IN (
-		SELECT trial_id FROM checkpoints_view WHERE uuid IN (?)
-	)
-	GROUP BY t.id
-	UNION
-	SELECT t.id AS trial_id,
-	COALESCE(SUM(size) FILTER (WHERE checkpoints_v2.state != 'DELETED'), 0) AS size,
-	COUNT(*) FILTER (WHERE checkpoints_v2.state != 'DELETED') AS count
-	FROM checkpoints_v2 INNER JOIN trials t on checkpoints_v2.task_id = t.task_id
-	WHERE t.id IN (
-		SELECT trial_id FROM checkpoints_view WHERE uuid IN (?)
-	)
-	GROUP BY t.id
+	SELECT trial_id, sum(size) as size, sum(count) as count
+	FROM (
+		WITH trial_ids AS (
+			SELECT trial_id FROM raw_checkpoints WHERE uuid IN (?)
+			UNION
+			SELECT t.id
+			FROM checkpoints_v2 INNER JOIN trials t ON checkpoints_v2.task_id = t.task_id
+			WHERE uuid IN (?)
+		)
+		SELECT t.id AS trial_id,
+		COALESCE(SUM(size) FILTER (WHERE c.state != 'DELETED'), 0) AS size,
+		COUNT(*) FILTER (WHERE c.state != 'DELETED') AS count
+		FROM raw_checkpoints c INNER JOIN trials t on c.trial_id = t.id
+		WHERE t.id IN (SELECT trial_id FROM trial_ids)
+		GROUP BY t.id
+		UNION ALL
+		SELECT t.id AS trial_id,
+		COALESCE(SUM(size) FILTER (WHERE checkpoints_v2.state != 'DELETED'), 0) AS size,
+		COUNT(*) FILTER (WHERE checkpoints_v2.state != 'DELETED') AS count
+		FROM checkpoints_v2 INNER JOIN trials t on checkpoints_v2.task_id = t.task_id
+		WHERE t.id IN (SELECT trial_id FROM trial_ids)
+		GROUP BY t.id
+	) ssub
+	GROUP BY trial_id
 ) sub
 WHERE trials.id = sub.trial_id
 RETURNING experiment_id`, bun.In(checkpoints), bun.In(checkpoints)).Scan(ctx, &experimentIDs)

--- a/master/internal/db/postgres_checkpoints.go
+++ b/master/internal/db/postgres_checkpoints.go
@@ -155,17 +155,26 @@ func UpdateCheckpointSizeTx(ctx context.Context, idb bun.IDB, checkpoints []uuid
 	var experimentIDs []int
 	err := idb.NewRaw(`
 UPDATE trials SET checkpoint_size=sub.size, checkpoint_count=sub.count FROM (
-	SELECT trial_id,
-	COALESCE(SUM(size) FILTER (WHERE state != 'DELETED'), 0) AS size,
-	COUNT(*) FILTER (WHERE state != 'DELETED') AS count
-	FROM checkpoints_view
-	WHERE trial_id IN (
+	SELECT t.id AS trial_id,
+	COALESCE(SUM(size) FILTER (WHERE c.state != 'DELETED'), 0) AS size,
+	COUNT(*) FILTER (WHERE c.state != 'DELETED') AS count
+	FROM raw_checkpoints c INNER JOIN trials t on c.trial_id = t.id
+	WHERE t.id IN (
 		SELECT trial_id FROM checkpoints_view WHERE uuid IN (?)
 	)
-	GROUP BY trial_id
+	GROUP BY t.id
+	UNION
+	SELECT t.id AS trial_id,
+	COALESCE(SUM(size) FILTER (WHERE checkpoints_v2.state != 'DELETED'), 0) AS size,
+	COUNT(*) FILTER (WHERE checkpoints_v2.state != 'DELETED') AS count
+	FROM checkpoints_v2 INNER JOIN trials t on checkpoints_v2.task_id = t.task_id
+	WHERE t.id IN (
+		SELECT trial_id FROM checkpoints_view WHERE uuid IN (?)
+	)
+	GROUP BY t.id
 ) sub
 WHERE trials.id = sub.trial_id
-RETURNING experiment_id`, bun.In(checkpoints)).Scan(ctx, &experimentIDs)
+RETURNING experiment_id`, bun.In(checkpoints), bun.In(checkpoints)).Scan(ctx, &experimentIDs)
 	if err != nil {
 		return errors.Wrap(err, "errors updating trial checkpoint sizes and counts")
 	}

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -60,7 +60,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 				ckpt := uuid.New()
 				checkpointIDs = append(checkpointIDs, ckpt)
 				// Ensure it works with both checkpoint versions.
-				if i == 0 && j == 0 && k == 0 {
+				if i == 0 {
 					checkpointBun := struct {
 						bun.BaseModel `bun:"table:checkpoints"`
 						TrialID       int
@@ -74,7 +74,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 					}{
 						TrialID:      tr.ID,
 						TrialRunID:   1,
-						TotalBatches: 1,
+						TotalBatches: k,
 						State:        model.ActiveState,
 						UUID:         ckpt.String(),
 						EndTime:      time.Now().UTC().Truncate(time.Millisecond),
@@ -84,6 +84,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 
 					_, err := Bun().NewInsert().Model(&checkpointBun).Exec(ctx)
 					require.NoError(t, err)
+					require.NoError(t, UpdateCheckpointSizeTx(ctx, nil, []uuid.UUID{ckpt}))
 				} else {
 					checkpoint := MockModelCheckpoint(ckpt, tr, allocation)
 					checkpoint.Resources = resources[resourcesIndex]

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -60,7 +60,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 				ckpt := uuid.New()
 				checkpointIDs = append(checkpointIDs, ckpt)
 				// Ensure it works with both checkpoint versions.
-				if i == 0 {
+				if i == 0 && j == 0 && k == 0 {
 					checkpointBun := struct {
 						bun.BaseModel `bun:"table:checkpoints"`
 						TrialID       int
@@ -74,7 +74,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 					}{
 						TrialID:      tr.ID,
 						TrialRunID:   1,
-						TotalBatches: k,
+						TotalBatches: 1,
 						State:        model.ActiveState,
 						UUID:         ckpt.String(),
 						EndTime:      time.Now().UTC().Truncate(time.Millisecond),
@@ -84,7 +84,6 @@ func TestUpdateCheckpointSize(t *testing.T) {
 
 					_, err := Bun().NewInsert().Model(&checkpointBun).Exec(ctx)
 					require.NoError(t, err)
-					require.NoError(t, UpdateCheckpointSizeTx(ctx, nil, []uuid.UUID{ckpt}))
 				} else {
 					checkpoint := MockModelCheckpoint(ckpt, tr, allocation)
 					checkpoint.Resources = resources[resourcesIndex]


### PR DESCRIPTION
## Description

Usage of checkpoints view caused postgres to do a bunch of unnecessary joins. Going to both checkpoint tables improves this.

## Test Plan

Existing integration tests.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
