### PR TITLE
ci: retry deploying AWS clusters [DET-9232]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,7 @@ commands:
             echo "-----BEGIN ARGS-----"
             cat /tmp/det-deploy-extra-args
             echo "-----END ARGS-----"
-            det deploy aws up \
+            tools/scripts/retry.sh det deploy aws up \
               $(< /tmp/det-deploy-extra-args) \
               --cluster-id <<parameters.cluster-id>> \
               --det-version <<parameters.det-version>> \
@@ -615,7 +615,7 @@ commands:
           when: always
           no_output_timeout: 20m
           command: |
-            det deploy aws down \
+            tools/scripts/retry.sh det deploy aws down \
               --cluster-id <<parameters.cluster-id>> --yes
 
   setup-aws-cluster:


### PR DESCRIPTION
## Description

Deploying the latest-master cluster sometimes fails when two commits land too close together; the queue job keeps the actual executions from overlapping, but it seems that CloudFormation will still sometimes fail, with no error logging that I can find other than the failed command, if two deploys happen in sufficiently quick succession. So throw a retry on there, as is our wont.

Stack deletion can also fail; I have no idea why that is, but throw a retry on there too.

## Test Plan

- [x] make sure it still works under normal circumstances
- [ ] hope for the best