### PR TITLE
chore: allocate less address space in e2e gke cluster tests [DET-9231]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -730,6 +730,13 @@ commands:
       accel-node-taints:
         type: string
         default: ""
+      cluster-ipv4-cidr:
+        type: string
+        description: The IP address range for the pods in this cluster.
+        # This was previously allowed to use default values provided by GKE.
+        # We are specifying this since the cluster doesn't need to be very large and GKE was intermittently
+        # choosing an excessively large range.
+        default: "10.0.0.0/16"
     steps:
       - set-cluster-id:
           cluster-id: <<parameters.cluster-id>>
@@ -757,7 +764,7 @@ commands:
       - run:
           command: |
             echo "Console URL for cluster: https://console.cloud.google.com/kubernetes/clusters/details/<<parameters.region>>/${CLUSTER_ID}?project=determined-ai"
-            gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default
+            gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default --cluster-ipv4-cidr=<<parameters.cluster-ipv4-cidr>>
           name: Create GKE cluster
           no_output_timeout: 30m
       - run:


### PR DESCRIPTION
## Description
[DET-9231]

Our e2e tests were using the default CIDR for pods as defined by GKE, which was as large as /14 in some cases. We are now specifying this to /16 to prevent intermittent test issues.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
CI is green. Shouldn't need manual testing.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[DET-9231]: https://hpe-aiatscale.atlassian.net/browse/DET-9231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ