### PR TITLE
docs: Add resource_manager.launcher_jvm_args [DET-9230]

### DIFF
--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -321,6 +321,9 @@ The master supports the following configuration settings:
          standard location on the compute node. For example,
          ``LD_LIBRARY_PATH=/cm/shared/apps/slurm/21.08.6/lib:/cm/shared/apps/slurm/21.08.6/lib/slurm:${LD_LIBRARY_PATH}``.
 
+      -  ``launcher_jvm_args``: Provides an override of the default HPC launcher JVM heap
+         configuration.
+
       -  ``tres_supported``: Indicates if ``SelectType=select/cons_tres`` is set in the Slurm
          configuration. Affects how Determined requests GPUs from Slurm. The default is true.
 

--- a/docs/release-notes/launcher-jvm-args.rst
+++ b/docs/release-notes/launcher-jvm-args.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+**Improvement**
+
+-  Cluster: HPC Launcher support for JVM resource configuration.
+
+   -  The master configuration ``resource_manager.launcher_jvm_args`` can be used to override the
+      default HPC launcher JVM heap configuration. This support requires HPC Launcher version 3.2.6
+      or greater.


### PR DESCRIPTION

## Description

- Add master config reference doc for resource_manager.launcher_jvm_args
- Add release note


## Test Plan

- Validated text via grammerly.com

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
