### PR TITLE
fix: slot enable/disable for HPC cluster

### DIFF
--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -6,8 +6,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/pkg/errors"
+
 	"github.com/determined-ai/determined/master/internal/cluster"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -90,7 +93,15 @@ func (a *apiServer) EnableSlot(
 	if err := a.canUpdateAgents(ctx); err != nil {
 		return nil, err
 	}
-	return resp, a.ask(slotAddr(req.AgentId, req.SlotId), req, &resp)
+	resp, err = a.m.rm.EnableSlot(a.m.system, req)
+	switch {
+	case errors.Is(err, rmerrors.ErrNotSupported):
+		return resp, status.Error(codes.Unimplemented, err.Error())
+	case err != nil:
+		return nil, err
+	default:
+		return resp, nil
+	}
 }
 
 func (a *apiServer) DisableSlot(
@@ -99,5 +110,13 @@ func (a *apiServer) DisableSlot(
 	if err := a.canUpdateAgents(ctx); err != nil {
 		return nil, err
 	}
-	return resp, a.ask(slotAddr(req.AgentId, req.SlotId), req, &resp)
+	resp, err = a.m.rm.DisableSlot(a.m.system, req)
+	switch {
+	case errors.Is(err, rmerrors.ErrNotSupported):
+		return resp, status.Error(codes.Unimplemented, err.Error())
+	case err != nil:
+		return nil, err
+	default:
+		return resp, nil
+	}
 }

--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/cluster"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/rm/actorrm"
 	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -32,7 +33,7 @@ func agentAddr(agentID string) actor.Address {
 }
 
 func slotAddr(agentID, slotID string) actor.Address {
-	return sproto.AgentsAddr.Child(agentID).Child("slots").Child(slotID)
+	return actorrm.SlotAddr(agentID, slotID)
 }
 
 func (a *apiServer) GetAgent(

--- a/master/internal/rm/actorrm/actor_resource_manager.go
+++ b/master/internal/rm/actorrm/actor_resource_manager.go
@@ -325,7 +325,8 @@ func (r ResourceManager) TaskContainerDefaults(
 	return fallbackConfig, nil
 }
 
-func slotAddr(agentID, slotID string) actor.Address {
+// SlotAddr calculates and returns a slot address.
+func SlotAddr(agentID, slotID string) actor.Address {
 	return sproto.AgentsAddr.Child(agentID).Child("slots").Child(slotID)
 }
 
@@ -334,7 +335,7 @@ func (r ResourceManager) EnableSlot(
 	m actor.Messenger,
 	req *apiv1.EnableSlotRequest,
 ) (resp *apiv1.EnableSlotResponse, err error) {
-	return resp, AskAt(r.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+	return resp, AskAt(r.Ref().System(), SlotAddr(req.AgentId, req.SlotId), req, &resp)
 }
 
 // DisableSlot implements 'det slot disable...' functionality.
@@ -342,5 +343,5 @@ func (r ResourceManager) DisableSlot(
 	m actor.Messenger,
 	req *apiv1.DisableSlotRequest,
 ) (resp *apiv1.DisableSlotResponse, err error) {
-	return resp, AskAt(r.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+	return resp, AskAt(r.Ref().System(), SlotAddr(req.AgentId, req.SlotId), req, &resp)
 }

--- a/master/internal/rm/actorrm/actor_resource_manager.go
+++ b/master/internal/rm/actorrm/actor_resource_manager.go
@@ -324,3 +324,23 @@ func (r ResourceManager) TaskContainerDefaults(
 ) (model.TaskContainerDefaultsConfig, error) {
 	return fallbackConfig, nil
 }
+
+func slotAddr(agentID, slotID string) actor.Address {
+	return sproto.AgentsAddr.Child(agentID).Child("slots").Child(slotID)
+}
+
+// EnableSlot implements 'det slot enable...' functionality.
+func (r ResourceManager) EnableSlot(
+	m actor.Messenger,
+	req *apiv1.EnableSlotRequest,
+) (resp *apiv1.EnableSlotResponse, err error) {
+	return resp, AskAt(r.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+}
+
+// DisableSlot implements 'det slot disable...' functionality.
+func (r ResourceManager) DisableSlot(
+	m actor.Messenger,
+	req *apiv1.DisableSlotRequest,
+) (resp *apiv1.DisableSlotResponse, err error) {
+	return resp, AskAt(r.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+}

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -755,3 +755,23 @@ func (a ResourceManager) TaskContainerDefaults(
 	req := taskContainerDefaults{fallbackDefault: fallbackConfig, resourcePool: pool}
 	return result, a.Ask(ctx, req, &result)
 }
+
+func slotAddr(agentID, slotID string) actor.Address {
+	return sproto.AgentsAddr.Child(agentID).Child("slots").Child(slotID)
+}
+
+// EnableSlot implements 'det slot enable...' functionality.
+func (a ResourceManager) EnableSlot(
+	m actor.Messenger,
+	req *apiv1.EnableSlotRequest,
+) (resp *apiv1.EnableSlotResponse, err error) {
+	return resp, actorrm.AskAt(a.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+}
+
+// DisableSlot implements 'det slot disable...' functionality.
+func (a ResourceManager) DisableSlot(
+	m actor.Messenger,
+	req *apiv1.DisableSlotRequest,
+) (resp *apiv1.DisableSlotResponse, err error) {
+	return resp, actorrm.AskAt(a.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+}

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -756,16 +756,12 @@ func (a ResourceManager) TaskContainerDefaults(
 	return result, a.Ask(ctx, req, &result)
 }
 
-func slotAddr(agentID, slotID string) actor.Address {
-	return sproto.AgentsAddr.Child(agentID).Child("slots").Child(slotID)
-}
-
 // EnableSlot implements 'det slot enable...' functionality.
 func (a ResourceManager) EnableSlot(
 	m actor.Messenger,
 	req *apiv1.EnableSlotRequest,
 ) (resp *apiv1.EnableSlotResponse, err error) {
-	return resp, actorrm.AskAt(a.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+	return resp, actorrm.AskAt(a.Ref().System(), actorrm.SlotAddr(req.AgentId, req.SlotId), req, &resp)
 }
 
 // DisableSlot implements 'det slot disable...' functionality.
@@ -773,5 +769,5 @@ func (a ResourceManager) DisableSlot(
 	m actor.Messenger,
 	req *apiv1.DisableSlotRequest,
 ) (resp *apiv1.DisableSlotResponse, err error) {
-	return resp, actorrm.AskAt(a.Ref().System(), slotAddr(req.AgentId, req.SlotId), req, &resp)
+	return resp, actorrm.AskAt(a.Ref().System(), actorrm.SlotAddr(req.AgentId, req.SlotId), req, &resp)
 }

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/rm/actorrm"
+	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -636,4 +637,20 @@ func (k *kubernetesResourceManager) getTaskContainerDefaults(
 		}
 	}
 	return result
+}
+
+// EnableSlot implements 'det slot enable...' functionality.
+func (k ResourceManager) EnableSlot(
+	m actor.Messenger,
+	req *apiv1.EnableSlotRequest,
+) (resp *apiv1.EnableSlotResponse, err error) {
+	return nil, rmerrors.ErrNotSupported
+}
+
+// DisableSlot implements 'det slot disable...' functionality.
+func (k ResourceManager) DisableSlot(
+	m actor.Messenger,
+	req *apiv1.DisableSlotRequest,
+) (resp *apiv1.DisableSlotResponse, err error) {
+	return nil, rmerrors.ErrNotSupported
 }

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -87,6 +87,15 @@ type ResourceManager interface {
 	MoveJob(actor.Messenger, sproto.MoveJob) error
 	RecoverJobPosition(actor.Messenger, sproto.RecoverJobPosition)
 
+	EnableSlot(
+		actor.Messenger,
+		*apiv1.EnableSlotRequest,
+	) (*apiv1.EnableSlotResponse, error)
+	DisableSlot(
+		actor.Messenger,
+		*apiv1.DisableSlotRequest,
+	) (*apiv1.DisableSlotResponse, error)
+
 	// Escape hatch, do not use.
 	Ref() *actor.Ref
 }

--- a/master/internal/rm/rmerrors/errors.go
+++ b/master/internal/rm/rmerrors/errors.go
@@ -1,8 +1,13 @@
 package rmerrors
 
+import "github.com/pkg/errors"
+
 // ErrUnsupported is returned when an unsupported feature of a resource manager is used.
 type ErrUnsupported string
 
 func (e ErrUnsupported) Error() string {
 	return string(e)
 }
+
+// ErrNotSupported is returned when an unsupported feature of a resource manager is used.
+var ErrNotSupported = errors.New("operation not supported")


### PR DESCRIPTION
## Description
It is not the case that we will allow a determined admin to enable or disable slots in the cluster -- that would be up to the manager of the cluster. So lets print a better error message.

With guidance from Bradley this PR introduces new RM interfaces for slot management. The implementation for kubernetes is 'not supported', while for agents we get the same behavior as before. Once this change is in place we will add a dispatcher implementation (also 'not supported'), and this will be documented as a known limitation.

Here's what this would look like on a HPC cluster when all the parts are in place. First the old message:
_Failed to enable slot on agent: {"error":{"code":5,"reason":"NotFound","error":"actor /agents/node010/slots/2 could not be found"}}_

And the new message:
_Failed to enable slot on agent: {"error":{"code":12,"reason":"Unimplemented","error":"HPC cluster: Operation not supported"}}_


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
