### PR TITLE
Revert "chore: allocate less address space in e2e gke cluster tests [DET-9231]"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -730,13 +730,6 @@ commands:
       accel-node-taints:
         type: string
         default: ""
-      cluster-ipv4-cidr:
-        type: string
-        description: The IP address range for the pods in this cluster.
-        # This was previously allowed to use default values provided by GKE.
-        # We are specifying this since the cluster doesn't need to be very large and GKE was intermittently
-        # choosing an excessively large range.
-        default: "10.0.0.0/16"
     steps:
       - set-cluster-id:
           cluster-id: <<parameters.cluster-id>>
@@ -764,7 +757,7 @@ commands:
       - run:
           command: |
             echo "Console URL for cluster: https://console.cloud.google.com/kubernetes/clusters/details/<<parameters.region>>/${CLUSTER_ID}?project=determined-ai"
-            gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default --cluster-ipv4-cidr=<<parameters.cluster-ipv4-cidr>>
+            gcloud container clusters create ${CLUSTER_ID} --machine-type=n1-standard-8 --cluster-version=<<parameters.gke-version>> --region=<<parameters.region>> --node-locations=<<parameters.node-locations>> --scopes storage-rw,cloud-platform --num-nodes 1 --labels environment=ci,${LABELS} --no-enable-ip-alias --subnetwork default
           name: Create GKE cluster
           no_output_timeout: 30m
       - run:


### PR DESCRIPTION
Reverts determined-ai/determined#6393

Perhaps a much smaller space like /20 would be better? Reverting for now