### PR TITLE
build: fix examples makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,6 +37,13 @@ FEATURES_EXAMPLES_DIRS := $(patsubst features/%/., build/%.tgz, $(FEATURES_EXAMP
 CUSTOM_SEARCH_METHOD_EXAMPLES := $(wildcard custom_search_method/*/.)
 CUSTOM_SEARCH_METHOD_EXAMPLES_DIRS := $(patsubst custom_search_method/%/., build/%.tgz, $(CUSTOM_SEARCH_METHOD_EXAMPLES))
 
+
+# IGNORE is a `find` subcommand to ignore files that don't affect our outputs.
+IGNORE := \( -path ./build -o -path ./tests -o -name __pycache__ -o -name \*.pyc -o -name .mypy_cache \)
+
+# SRCS is a list of all files that could affect our outputs.
+SRCS := $(shell find . $(IGNORE) -prune -o -type f -print | sort)
+
 build/stamp: $(TUTORIAL_EXAMPLES_DIRS) $(CV_EXAMPLES_DIRS) $(NLP_EXAMPLES_DIRS) $(DEEPSPEED_EXAMPLES_DIRS) $(HPSEARCH_EXAMPLES_DIRS) $(NAS_EXAMPLES_DIRS) $(META_LEARNING_EXAMPLES_DIRS) $(DIFFUSION_EXAMPLES_DIRS) $(GAN_EXAMPLES_DIRS) $(GRAPHS_EXAMPLES_DIRS) $(DT_EXAMPLES_DIRS) $(FEATURES_EXAMPLES_DIRS) $(CUSTOM_SEARCH_METHOD_EXAMPLES_DIRS)
 	touch $@
 
@@ -48,10 +55,33 @@ clean:
 	find . \( -name __pycache__ -o -name \*.pyc -o -name .mypy_cache \) -print0 | xargs -0 rm -rf
 	rm -rf build/
 
-# The first `*/%/` defines '$<', the second `*/%/*` defines dependencies.
-build/%.tgz: */% */%/*
-	find "$<" \( -name __pycache__ -o -name \*.pyc \) -delete
-	mkdir -p $$(dirname "$@")
+# A quirk of make is that PHONY targets always run, and direct dependencies of
+# PHONY targets also always run.  But _their_ dependencies may choose not to
+# run.  We use this feature to have the build/manifest target always run, but
+# optionally modify its output.  Then the actual .tgz outputs depend on
+# build/manifest, and only run when build/manifest decides to modify its output.
+.PHONY: phony
+phony:
+
+# build/manifest is a file containing all filenames that go into examples.  We
+# modify the file whenever the list of filenames changes, enabling us to rebuild
+# whenever any files are added or deleted.
+build/manifest: phony
+	@mkdir -p build
+	@if [ ! -e "$@" ] || [ "$$(cat $@)" != "$(SRCS)" ] ; then echo "$(SRCS)" > $@ ; fi
+
+# build/newest is a file that is simply updated whenever any source file is
+# updated.  We could also make every target depend on all $(SRCS), but
+# that is much less performant.
+build/newest: $(SRCS)
+	@mkdir -p build
+	touch $@
+
+# */%/: just used to define '$<'.
+# build/manifest: rebuild if any files are added or deleted.
+# build/newest: rebuild if any source files are newer.
+build/%.tgz: */%/ build/newest build/manifest
+	find "$<" $(IGNORE) -delete
 	tar -czf "$@" -C $$(dirname "$<") $$(basename "$<")
 
 test:


### PR DESCRIPTION
There was a bug causing examples to not rebuild when they should have,
which was causing issues for engineers unaware of the bug.
Specifically, when new files appeared in glob patterns, but which were
created before the build.stamp (which can happen if you
build-then-rebase), then you could run `make -C examples build` and it
would insist there was no work to do.  The same issue would happen if a
file was deleted, no rebasing required.

Build bugs are always much worse for anyone not intimately familiar with
the build system, and as we grow this is getting more obvious.

The new logic is a bit faster for clean builds (1.5s to 1.1s for me) and
a bit slower on noop builds (0.05s to 0.11s).

Additionally, the new logic makes a couple of strategic sacrifices:

- The per-example incremental rebuild is gone.  The pattern is now
  "rebuild all examples if any change is detected".  This strategy is
  more performant and results in a simpler makefile.  In reality, I
  don't think anybody needs incremental builds of experiment tarballs;
  either somebody is writing experiments or they are building docs, but
  rarely are both happening in one workflow.

- The examples/Makefile is more complicated than if we just did a
  rebuild-from-scratch strategy every time.  However, for non-parallel
  builds, this strategy is nearly 10x faster than rebuilding each time.
  And there's no real reason to rebuild every example every time before
  building the docs (which would effectively result).
