### PR TITLE
fix: respect default pool task container defaults [DET-9241]

### DIFF
--- a/.circleci/devcluster/double.devcluster.yaml
+++ b/.circleci/devcluster/double.devcluster.yaml
@@ -24,6 +24,9 @@ stages:
         security:
           authz:
             rbac_ui_enabled: true
+        resource_manager:
+          default_aux_resource_pool: default
+          default_compute_resource_pool: default
         resource_pools:
           - pool_name: default
             task_container_defaults:  # for test_default_pool_task_container_defaults.

--- a/.circleci/devcluster/double.devcluster.yaml
+++ b/.circleci/devcluster/double.devcluster.yaml
@@ -25,6 +25,7 @@ stages:
           authz:
             rbac_ui_enabled: true
         resource_manager:
+          type: agent
           default_aux_resource_pool: default
           default_compute_resource_pool: default
         resource_pools:

--- a/.circleci/devcluster/double.devcluster.yaml
+++ b/.circleci/devcluster/double.devcluster.yaml
@@ -19,12 +19,17 @@ stages:
         log:
           level: debug
         root: tools/build
-        cache: 
+        cache:
           cache_dir: /tmp/determined-cache
         security:
           authz:
             rbac_ui_enabled: true
-            
+        resource_pools:
+          - pool_name: default
+            task_container_defaults:  # for test_default_pool_task_container_defaults.
+              environment_variables:
+                - SOMEVAR=SOMEVAL
+
   - custom:
       name: proxy
       cmd: ["socat", "-d", "-d", "TCP-LISTEN:8081,reuseaddr,fork", "TCP:localhost:8080"]

--- a/docs/release-notes/fix-default-pool-task-container-defaults.rst
+++ b/docs/release-notes/fix-default-pool-task-container-defaults.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix an issue where ``task_container_defaults`` for the default resource pools where not respected
+   for the experiments and tasks unless they specified the resource pool name explicitly, which has
+   been introduced in 0.19.9.

--- a/e2e_tests/tests/cluster/test_resource_pools.py
+++ b/e2e_tests/tests/cluster/test_resource_pools.py
@@ -1,0 +1,43 @@
+import pytest
+
+from determined.common import util
+from determined.experimental import client
+from tests import config as conf
+
+
+@pytest.mark.e2e_cpu
+def test_default_pool_task_container_defaults() -> None:
+    # This test assumes the default resource pool in master config has non-empty
+    # `task_containers_default` -> `environment_variables` configuration, for example:
+    #
+    #  - pool_name: default
+    #    task_container_defaults:
+    #    environment_variables:
+    #      - SOMEVAR=SOMEVAL
+    determined_master = conf.make_master_url()
+    d = client.Determined(determined_master)
+    config_path = conf.fixtures_path("no_op/single-medium-train-step.yaml")
+    e1 = d.create_experiment(
+        config=config_path,
+        model_dir=conf.fixtures_path("no_op"),
+    )
+
+    e1_config = e1.get_config()
+
+    assert len(e1_config["environment"]["environment_variables"]["cpu"]) > 0
+
+    with open(config_path) as fin:
+        config_text = fin.read()
+    parsed_config = util.safe_load_yaml_with_exceptions(config_text)
+    parsed_config["resources"] = {"resource_pool": e1_config["resources"]["resource_pool"]}
+
+    e2 = d.create_experiment(
+        config=parsed_config,
+        model_dir=conf.fixtures_path("no_op"),
+    )
+    e2_config = e2.get_config()
+
+    assert (
+        e1_config["environment"]["environment_variables"]["cpu"]
+        == e2_config["environment"]["environment_variables"]["cpu"]
+    )

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -109,7 +109,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	// Get the base TaskSpec.
 	taskContainerDefaults, err := a.m.rm.TaskContainerDefaults(
 		a.m.system,
-		resources.ResourcePool,
+		poolName,
 		a.m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -484,7 +484,7 @@ func (m *Master) parseCreateExperiment(params *CreateExperimentParams, user *mod
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
 		m.system,
-		resources.ResourcePool(),
+		poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -98,7 +98,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
 		m.system,
-		activeConfig.Resources().ResourcePool(),
+		poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

## Test Plan

- Specify some config in `task_container_defaults` for the default pool
- Submit a task to the default pool in a default way, that is, don't specify it in the config explicitly.
- Pool config still should be applied.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
