### PR TITLE
test: Make `test_launch` more portable.

### DIFF
--- a/harness/tests/launch/test_launch.py
+++ b/harness/tests/launch/test_launch.py
@@ -45,13 +45,13 @@ def test_launch_script(mock_validate_config: mock.MagicMock) -> None:
     with test_util.set_resources_id_env_var():
         with test_util.set_mock_cluster_info(["0.0.0.1"], 0, 1) as info:
             # Successful entrypoints exit 0.
-            info.trial._config["entrypoint"] = ["/bin/true"]
+            info.trial._config["entrypoint"] = ["true"]
             with pytest.raises(SystemExit) as e:
                 runpy.run_module("determined.exec.launch", run_name="__main__", alter_sys=True)
             assert e.value.code == 0, e
 
             # Failing entrypoints exit 1.
-            info.trial._config["entrypoint"] = ["/bin/false"]
+            info.trial._config["entrypoint"] = ["false"]
             with pytest.raises(SystemExit) as e:
                 runpy.run_module("determined.exec.launch", run_name="__main__", alter_sys=True)
             assert e.value.code == 1, e


### PR DESCRIPTION
`true` and `false` don't always exist in `/bin` in every POSIX-compliant system. This patch removes this assumption at the cost of assuming that the commands are either built into the shell or somewhere in the PATH environment variable.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

`pytest harness/tests/launch/test_launch.py`

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
