### PR TITLE
feat: k8s cluster info using taints/tolerations

### DIFF
--- a/master/go.mod
+++ b/master/go.mod
@@ -155,7 +155,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -245,6 +245,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			k.config.SlotType,
 			config.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
 			k.config.Fluent,
+			k.poolsConfig,
 			k.config.CredsDir,
 			k.config.MasterIP,
 			k.config.MasterPort,

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1026,6 +1026,7 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 						ID:    cproto.ID(id),
 						State: "RUNNING",
 					}
+					pseudoContainersAdded++
 				}
 
 				slots[id] = model.SlotSummary{
@@ -1328,6 +1329,7 @@ func allTaintsTolerated(taints []k8sV1.Taint, tolerations []k8sV1.Toleration) bo
 
 func extractSlotInfo(node model.AgentSummary) (numSlots int, devType device.Type) {
 	var gpuSlots, cpuSlots int
+
 	for _, slot := range node.Slots {
 		if slot.Device.Type == device.CPU {
 			cpuSlots++

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -11,12 +11,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
-<<<<<<< HEAD
-	"golang.org/x/exp/maps"
-	"gopkg.in/inf.v0"
-=======
 	"github.com/sirupsen/logrus"
->>>>>>> 8bb41fd6d (WIP: k8s cluster info using taints/tolerations)
+	"golang.org/x/exp/maps"
 	k8sV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -997,9 +997,9 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 		"lenPoolsToNodes":        len(poolsToNodes),
 		"lenNamespaceToPoolName": len(p.namespaceToPoolName),
 	}
-	for _, pool := range poolsToNodes {
+	for pool, nodes := range poolsToNodes {
 		key := fmt.Sprintf("lenNodesIn-%s", pool)
-		f[key] = len(poolsToNodes["default"])
+		f[key] = len(nodes)
 	}
 	logrus.WithFields(f).Debug("done associating nodes and pools")
 

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1210,29 +1210,6 @@ func numSlots(slots model.SlotsSummary) int {
 	return slotCountsByType[device.CPU]
 }
 
-func cpuAndGpuQuotas(quotas *k8sV1.ResourceQuotaList) []k8sV1.ResourceQuota {
-	if quotas == nil || len(quotas.Items) == 0 {
-		return nil
-	}
-
-	result := []k8sV1.ResourceQuota{}
-	for _, q := range quotas.Items {
-		foundRelevant := false
-		for resourceName := range q.Spec.Hard {
-			switch resourceName {
-			case k8sV1.ResourceCPU, ResourceTypeNvidia, "limits." + ResourceTypeNvidia:
-				foundRelevant = true
-			}
-		}
-
-		if foundRelevant {
-			result = append(result, q)
-		}
-	}
-
-	return result
-}
-
 func (p *pods) listPodsInAllNamespaces(
 	ctx context.Context, opts metaV1.ListOptions,
 ) (*k8sV1.PodList, error) {
@@ -1265,7 +1242,8 @@ func (p *pods) listConfigMapsInAllNamespaces(
 	return res, nil
 }
 
-func extractTCDs(resourcePoolConfigs []config.ResourcePoolConfig) map[string]*model.TaskContainerDefaultsConfig {
+func extractTCDs(resourcePoolConfigs []config.ResourcePoolConfig,
+) map[string]*model.TaskContainerDefaultsConfig {
 	result := map[string]*model.TaskContainerDefaultsConfig{}
 
 	for _, config := range resourcePoolConfigs {

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -958,7 +958,9 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 		for poolName, tcd := range taskContainerDefaults {
 			var poolTolerations []k8sV1.Toleration
 
-			if len(p.resourcePoolConfigs) == 0 {
+			// If they're using the default RP config, use the default tolerations.
+			if len(p.resourcePoolConfigs) <= 1 &&
+				(tcd == nil || (tcd.CPUPodSpec == nil && tcd.GPUPodSpec == nil)) {
 				poolTolerations = defaultTolerations
 			} else if tcd != nil {
 				// Decide which poolTolerations to use based on slot device type

--- a/master/internal/rm/kubernetesrm/pods_test.go
+++ b/master/internal/rm/kubernetesrm/pods_test.go
@@ -1,0 +1,108 @@
+package kubernetesrm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sV1 "k8s.io/api/core/v1"
+)
+
+func TestTaintTolerated(t *testing.T) {
+	cases := []struct {
+		expected    bool
+		taint       k8sV1.Taint
+		tolerations []k8sV1.Toleration
+	}{
+		{
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Value:    taintFooBar.Value,
+				Operator: k8sV1.TolerationOpEqual,
+			}},
+		}, {
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Operator: k8sV1.TolerationOpExists,
+			}},
+		}, {
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{
+				{
+					Key:      taintFooBar.Key,
+					Value:    taintFooBar.Value,
+					Operator: k8sV1.TolerationOpEqual,
+				}, {
+					Key:      "baz",
+					Value:    "qux",
+					Operator: k8sV1.TolerationOpEqual,
+				}},
+		}, {
+			expected: false,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Value:    taintFooBar.Value + taintFooBar.Value,
+				Operator: k8sV1.TolerationOpEqual,
+			}},
+		}, {
+			expected:    false,
+			taint:       taintFooBar,
+			tolerations: []k8sV1.Toleration{},
+		}, {
+			expected:    false,
+			taint:       taintFooBar,
+			tolerations: nil,
+		},
+	}
+
+	for i, c := range cases {
+		actual := taintTolerated(c.taint, c.tolerations)
+		require.Equal(t, c.expected, actual, "test case %d failed", i)
+	}
+}
+
+func TestAllTaintsTolerated(t *testing.T) {
+	cases := []struct {
+		expected    bool
+		taints      []k8sV1.Taint
+		tolerations []k8sV1.Toleration
+	}{
+		{
+			expected:    true,
+			taints:      nil,
+			tolerations: nil,
+		}, {
+			expected: true,
+			taints:   nil,
+			tolerations: []k8sV1.Toleration{
+				{
+					Key:      taintFooBar.Key,
+					Value:    taintFooBar.Value,
+					Operator: k8sV1.TolerationOpEqual,
+				},
+			},
+		}, {
+			expected:    false,
+			taints:      []k8sV1.Taint{taintFooBar},
+			tolerations: nil,
+		},
+	}
+
+	for i, c := range cases {
+		actual := allTaintsTolerated(c.taints, c.tolerations)
+		require.Equal(t, c.expected, actual, "test case %d failed", i)
+	}
+}
+
+var (
+	taintFooBar = k8sV1.Taint{
+		Key:    "foo",
+		Value:  "bar",
+		Effect: k8sV1.TaintEffectNoSchedule,
+	}
+)


### PR DESCRIPTION
## Description

Takes care of DET-9122.

## Test Plan

Cluster info page should accurately reflect your cluster setup by taking taints and tolerations into account. If a cluster has no taints, every node should belong to every resource pool.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
