### PR TITLE
feat: Add quota limits for helm

### DIFF
--- a/docs/reference/reference-deploy/config/helm-config-reference.rst
+++ b/docs/reference/reference-deploy/config/helm-config-reference.rst
@@ -64,9 +64,9 @@
 
    -  ``memRequest``: The memory requirements for the Determined database.
 
-   -  ``cpuLimit``: The CPU limits for the Determined database.
+   -  ``cpuLimit``: Optional configuration. The CPU limits for the Determined database.
 
-   -  ``memLimit``: The memory limits for the Determined database.
+   -  ``memLimit``: Optional configuration. The memory limits for the Determined database.
 
    -  ``useNodePortForDB``: Optional configuration that configures whether ClusterIP or NodePort
       service type is used for the Determined database. By default ClusterIP is used.
@@ -146,9 +146,9 @@
 
 -  ``masterMemRequest``: The memory requirements for the Determined master.
 
--  ``masterCpuLimit``: The CPU limits for the Determined master.
+-  ``masterCpuLimit``: Optional configuration. The CPU limits for the Determined master.
 
--  ``masterMemLimit``: The memory limits for the Determined master.
+-  ``masterMemLimit``: Optional configuration. The memory limits for the Determined master.
 
 -  ``taskContainerDefaults``: Specifies Docker defaults for all task containers. A task represents a
    single schedulable unit, such as a trial, command, or tensorboard.

--- a/docs/reference/reference-deploy/config/helm-config-reference.rst
+++ b/docs/reference/reference-deploy/config/helm-config-reference.rst
@@ -64,6 +64,10 @@
 
    -  ``memRequest``: The memory requirements for the Determined database.
 
+   -  ``cpuLimit``: The CPU limits for the Determined database.
+
+   -  ``memLimit``: The memory limits for the Determined database.
+
    -  ``useNodePortForDB``: Optional configuration that configures whether ClusterIP or NodePort
       service type is used for the Determined database. By default ClusterIP is used.
 
@@ -141,6 +145,10 @@
 -  ``masterCpuRequest``: The CPU requirements for the Determined master.
 
 -  ``masterMemRequest``: The memory requirements for the Determined master.
+
+-  ``masterCpuLimit``: The CPU limits for the Determined master.
+
+-  ``masterMemLimit``: The memory limits for the Determined master.
 
 -  ``taskContainerDefaults``: Specifies Docker defaults for all task containers. A task represents a
    single schedulable unit, such as a trial, command, or tensorboard.

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -32,6 +32,8 @@ spec:
             {{- if .Values.db.memRequest }}
             memory: {{ .Values.db.memRequest | quote }}
             {{- end}}
+
+          {{- if or .Values.db.cpuLimit .Values.db.memLimit }}
           limits:
             {{- if .Values.db.cpuLimit }}
             cpu: {{ .Values.db.cpuLimit | quote }}
@@ -39,6 +41,7 @@ spec:
             {{- if .Values.db.memLimit }}
             memory: {{ .Values.db.memLimit | quote }}
             {{- end}}
+          {{- end}}
         env:
           - name: POSTGRES_DB
             value: {{ .Values.db.name | quote }}

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -32,6 +32,13 @@ spec:
             {{- if .Values.db.memRequest }}
             memory: {{ .Values.db.memRequest | quote }}
             {{- end}}
+          limits:
+            {{- if .Values.db.cpuLimit }}
+            cpu: {{ .Values.db.cpuLimit | quote }}
+            {{- end }}
+            {{- if .Values.db.memLimit }}
+            memory: {{ .Values.db.memLimit | quote }}
+            {{- end}}
         env:
           - name: POSTGRES_DB
             value: {{ .Values.db.name | quote }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -69,6 +69,8 @@ spec:
             {{- if .Values.masterMemRequest }}
             memory: {{ .Values.masterMemRequest  | quote }}
             {{- end}}
+
+          {{- if or .Values.masterCpuLimit .Values.masterMemLimit }}
           limits:
             {{- if .Values.masterCpuLimit }}
             cpu: {{ .Values.masterCpuLimit  | quote }}
@@ -76,6 +78,7 @@ spec:
             {{- if .Values.masterMemLimit }}
             memory: {{ .Values.masterMemLimit  | quote }}
             {{- end}}
+          {{- end}}
       {{- if .Values.imagePullSecretName}}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecretName }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -69,6 +69,13 @@ spec:
             {{- if .Values.masterMemRequest }}
             memory: {{ .Values.masterMemRequest  | quote }}
             {{- end}}
+          limits:
+            {{- if .Values.masterCpuLimit }}
+            cpu: {{ .Values.masterCpuLimit  | quote }}
+            {{- end }}
+            {{- if .Values.masterMemLimit }}
+            memory: {{ .Values.masterMemLimit  | quote }}
+            {{- end}}
       {{- if .Values.imagePullSecretName}}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecretName }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -88,6 +88,8 @@ db:
   storageSize: 30Gi
   cpuRequest: 2
   memRequest: 8Gi
+  cpuLimit: 2
+  memLimit: 8Gi
 
   # useNodePortForDB configures whether ClusterIP or NodePort service type is used for the
   # Determined deployed DB. By default ClusterIP is used.
@@ -169,6 +171,8 @@ maxSlotsPerPod:
 # Memory and CPU requirements for the master instance. Should be adjusted for scale.
 masterCpuRequest: 2
 masterMemRequest: 8Gi
+masterCpuLimit: 2
+masterMemLimit: 8Gi
 
 ## Configure the task container defaults. Tasks include trials, commands, TensorBoards, notebooks,
 ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -88,8 +88,8 @@ db:
   storageSize: 30Gi
   cpuRequest: 2
   memRequest: 8Gi
-  cpuLimit: 2
-  memLimit: 8Gi
+  #  cpuLimit: 2
+  #  memLimit: 8Gi
 
   # useNodePortForDB configures whether ClusterIP or NodePort service type is used for the
   # Determined deployed DB. By default ClusterIP is used.
@@ -171,8 +171,8 @@ maxSlotsPerPod:
 # Memory and CPU requirements for the master instance. Should be adjusted for scale.
 masterCpuRequest: 2
 masterMemRequest: 8Gi
-masterCpuLimit: 2
-masterMemLimit: 8Gi
+# masterCpuLimit: 2
+# masterMemLimit: 8Gi
 
 ## Configure the task container defaults. Tasks include trials, commands, TensorBoards, notebooks,
 ## and shells. For all task containers, shm_size_bytes and network_mode are configurable. For


### PR DESCRIPTION
## Description
#6431 

## Test Plan
Deploying onth k8s with this helm chart. (HPE Ezmeral Runtime 5.6)

## Commentary (optional)

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

## Title
User-facing change types:

- feat: new user-facing feature

