### PR TITLE
fix: show states dropdown on ExperimentTrials

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -102,8 +102,6 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
 
   const stateFilterDropdown = useCallback(
     (filterProps: FilterDropdownProps) => {
-      if (!settings.state) return;
-
       return (
         <TableFilterDropdown
           {...filterProps}


### PR DESCRIPTION
## Description

For a multi-trial experiment which ran long enough to have trials (such as 2106 on latest-master db)
We were not showing the filter dropdown unless the user came into trials with a state filter set
This un-hides the dropdown

## Test Plan

- Open a page such as `/det/experiments/2106/trials`
- Click the filter icon on the State column to see a list of valid states for a trial
- Select only Errored state and Ok; this should hide the completed trials
- Add Completed in the state filter and click Ok; this should show the completed trials
- Open the filter again and select Reset; this should clear the filter and show all trials

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.