### PR TITLE
Chore: Introduce local-only designkit route

### DIFF
--- a/webui/react/src/components/ThemeProvider.tsx
+++ b/webui/react/src/components/ThemeProvider.tsx
@@ -139,10 +139,10 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
 
   // Update darkLight and theme when branding, system mode, or mode changes.
   useLayoutEffect(() => {
-    if (!info.branding) return;
+    const branding = info.branding || 'determined';
 
     const darkLight = getDarkLight(ui.mode, systemMode);
-    uiActions.setTheme(darkLight, themes[info.branding][darkLight]);
+    uiActions.setTheme(darkLight, themes[branding][darkLight]);
   }, [info.branding, uiActions, systemMode, ui.mode]);
 
   // Update setting mode when mode changes.

--- a/webui/react/src/designkit-standalone/index.html
+++ b/webui/react/src/designkit-standalone/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html class="no-js" lang="">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>Standalone Design Kit</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+        <!-- Place favicon.ico in the root directory -->
+
+    </head>
+    <body>
+        <div id="root" />
+        <script type="module" src="./index.tsx">
+        </script>
+    </body>
+</html>

--- a/webui/react/src/designkit-standalone/index.tsx
+++ b/webui/react/src/designkit-standalone/index.tsx
@@ -1,0 +1,38 @@
+import { Map } from 'immutable';
+import { observable } from 'micro-observables';
+import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
+import { BrowserRouter } from 'react-router-dom';
+import 'uplot/dist/uPlot.min.css';
+
+import css from 'App.module.scss';
+import ThemeProvider from 'components/ThemeProvider';
+import { Settings, UserSettings } from 'hooks/useSettingsProvider';
+import DesignKit from 'pages/DesignKit';
+import { StoreProvider as UIProvider } from 'shared/contexts/stores/UI';
+
+import 'antd/dist/reset.css';
+
+const fakeSettingsContext = {
+  clearQuerySettings: () => undefined,
+  isLoading: observable(false),
+  querySettings: '',
+  state: observable(Map<string, Settings>()),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+createRoot(document.getElementById('root')!).render(
+  <BrowserRouter>
+    <HelmetProvider>
+      <UIProvider>
+        <UserSettings.Provider value={fakeSettingsContext}>
+          <ThemeProvider>
+            <div className={css.base}>
+              <DesignKit />
+            </div>
+          </ThemeProvider>
+        </UserSettings.Provider>
+      </UIProvider>
+    </HelmetProvider>
+  </BrowserRouter>,
+);

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -1,7 +1,7 @@
 import { PoweroffOutlined } from '@ant-design/icons';
 import { Card as AntDCard, Space } from 'antd';
 import { SelectValue } from 'antd/es/select';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import Accordion from 'components/kit/Accordion';
@@ -33,28 +33,22 @@ import UserAvatar from 'components/kit/UserAvatar';
 import { useTags } from 'components/kit/useTags';
 import Label from 'components/Label';
 import Logo from 'components/Logo';
-import OverviewStats from 'components/OverviewStats';
 import Page from 'components/Page';
-import ProjectCard from 'components/ProjectCard';
-import ResourcePoolCard from 'components/ResourcePoolCard';
 import ResponsiveTable from 'components/Table/ResponsiveTable';
 import ThemeToggle from 'components/ThemeToggle';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin2';
-import resourcePools from 'fixtures/responses/cluster/resource-pools.json';
 import { V1LogLevel } from 'services/api-ts-sdk';
 import { mapV1LogsResponse } from 'services/decoder';
 import Icon from 'shared/components/Icon';
 import useUI from 'shared/contexts/stores/UI';
 import { ValueOf } from 'shared/types';
 import { noOp } from 'shared/utils/service';
-import { BrandingType, MetricType, Project, ResourcePool, User } from 'types';
+import { BrandingType, MetricType, User } from 'types';
 import { NotLoaded } from 'utils/loadable';
-import { generateTestProjectData, generateTestWorkspaceData } from 'utils/tests/generateTestData';
 
 import css from './DesignKit.module.scss';
 import { CheckpointsDict } from './TrialDetails/F_TrialDetailsOverview';
-import WorkspaceCard from './WorkspaceList/WorkspaceCard';
 
 const ComponentTitles = {
   Accordion: 'Accordion',
@@ -485,39 +479,60 @@ const SelectSection: React.FC = () => {
   );
 };
 
-const line1BatchesDataRaw: [number, number][] = [
-  [0, -2],
-  [2, Math.random() * 12],
-  [4, 15],
-  [6, Math.random() * 60],
-  [9, Math.random() * 40],
-  [10, Math.random() * 76],
-  [18, Math.random() * 80],
-  [19, 89],
-];
-const line2BatchesDataRaw: [number, number][] = [
-  [1, 15],
-  [2, 10.123456789],
-  [2.5, Math.random() * 22],
-  [3, 10.3909],
-  [3.25, 19],
-  [3.75, 4],
-  [4, 12],
-];
-
 const ChartsSection: React.FC = () => {
-  const timerRef = useRef<NodeJS.Timer | null>(null);
-  const [timer, setTimer] = useState(1);
+  const [line1Data, setLine1Data] = useState<[number, number][]>([
+    [0, -2],
+    [2, 7],
+    [4, 15],
+    [6, 35],
+    [9, 22],
+    [10, 76],
+    [18, 1],
+    [19, 89],
+  ]);
+  const [line2Data, setLine2Data] = useState<[number, number][]>([
+    [1, 15],
+    [2, 10.123456789],
+    [2.5, 22],
+    [3, 10.3909],
+    [3.25, 19],
+    [3.75, 4],
+    [4, 12],
+  ]);
+  const [timer, setTimer] = useState(line1Data.length);
   useEffect(() => {
-    timerRef.current = setInterval(() => setTimer((t) => t + 1), 2000);
+    let timeout: NodeJS.Timer | void;
+    if (timer <= line1Data.length) {
+      timeout = setTimeout(() => setTimer((t) => t + 1), 2000);
+    }
+    return () => timeout && clearTimeout(timeout);
+  }, [timer, line1Data]);
 
-    return () => {
-      if (timerRef.current !== null) clearInterval(timerRef.current);
-    };
+  const randomizeLineData = useCallback(() => {
+    setLine1Data([
+      [0, -2],
+      [2, Math.random() * 12],
+      [4, 15],
+      [6, Math.random() * 60],
+      [9, Math.random() * 40],
+      [10, Math.random() * 76],
+      [18, Math.random() * 80],
+      [19, 89],
+    ]);
+    setLine2Data([
+      [1, 15],
+      [2, 10.123456789],
+      [2.5, Math.random() * 22],
+      [3, 10.3909],
+      [3.25, 19],
+      [3.75, 4],
+      [4, 12],
+    ]);
   }, []);
+  const streamLineData = useCallback(() => setTimer(1), []);
 
-  const line1BatchesDataStreamed = useMemo(() => line1BatchesDataRaw.slice(0, timer), [timer]);
-  const line2BatchesDataStreamed = useMemo(() => line2BatchesDataRaw.slice(0, timer), [timer]);
+  const line1BatchesDataStreamed = useMemo(() => line1Data.slice(0, timer), [timer, line1Data]);
+  const line2BatchesDataStreamed = useMemo(() => line2Data.slice(0, timer), [timer, line2Data]);
 
   const line1: Serie = {
     color: '#009BDE',
@@ -586,10 +601,18 @@ const ChartsSection: React.FC = () => {
       </AntDCard>
       <AntDCard title="Label options">
         <p>A chart with two metrics, a title, a legend, an x-axis label, a y-axis label.</p>
+        <div>
+          <Button onClick={randomizeLineData}>Randomize line data</Button>
+          <Button onClick={streamLineData}>Stream line data</Button>
+        </div>
         <LineChart height={250} series={[line1, line2]} showLegend={true} title="Sample" />
       </AntDCard>
       <AntDCard title="Focus series">
         <p>Highlight a specific metric in the chart.</p>
+        <div>
+          <Button onClick={randomizeLineData}>Randomize line data</Button>
+          <Button onClick={streamLineData}>Stream line data</Button>
+        </div>
         <LineChart focusedSeries={1} height={250} series={[line1, line2]} title="Sample" />
       </AntDCard>
       <AntDCard title="States without data">
@@ -1276,10 +1299,6 @@ const PaginationSection: React.FC = () => {
 };
 
 const CardsSection: React.FC = () => {
-  const rps = resourcePools as unknown as ResourcePool[];
-  const project: Project = { ...generateTestProjectData(), lastExperimentStartedAt: new Date() };
-  const workspace = generateTestWorkspaceData();
-
   return (
     <ComponentSection id="Cards" title="Cards">
       <AntDCard>
@@ -1369,51 +1388,6 @@ const CardsSection: React.FC = () => {
           <Card size="medium" />
           <Card size="medium" />
         </Card.Group>
-        <strong>Card examples</strong>
-        <ul>
-          <li>
-            Project card (<code>{'<ProjectCard>'}</code>)
-          </li>
-          <Card.Group>
-            <ProjectCard project={project} />
-            <ProjectCard project={{ ...project, archived: true }} />
-            <ProjectCard
-              project={{
-                ...project,
-                name: 'Project with a very long name that spans many lines and eventually gets cut off',
-              }}
-            />
-            <ProjectCard
-              project={{
-                ...project,
-                workspaceId: 2,
-              }}
-              showWorkspace
-            />
-          </Card.Group>
-          <li>
-            Workspace card (<code>{'<WorkspaceCard>'}</code>)
-          </li>
-          <Card.Group size="medium">
-            <WorkspaceCard workspace={workspace} />
-            <WorkspaceCard workspace={{ ...workspace, archived: true }} />
-          </Card.Group>
-          <li>
-            Stats overview (<code>{'<OverviewStats>'}</code>)
-          </li>
-          <Card.Group>
-            <OverviewStats title="Active Experiments">0</OverviewStats>
-            <OverviewStats title="Clickable card" onClick={noOp}>
-              Example
-            </OverviewStats>
-          </Card.Group>
-          <li>
-            Resource pool card (<code>{'<ResourcePoolCard>'}</code>)
-          </li>
-          <Card.Group size="medium">
-            <ResourcePoolCard resourcePool={rps[0]} />
-          </Card.Group>
-        </ul>
       </AntDCard>
     </ComponentSection>
   );


### PR DESCRIPTION
Another prerequisite for visual regression testing. This adds a route available only when the dev server is running at
`/src/designkit-standalone` that loads the design kit page without contacting the server. In order to ensure that the components in the design kit are not reliant on store providers, we remove the card examples that relied on the state providers to work. In addition, the chart section is updated to use static data on load with the option to randomize the data and fake stream it.

## Test Plan

when running the dev server with `npm run start`, you should be able to visit the design kit without the api server running at `<server address>/src/designkit-standalone`


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1043


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
