### PR TITLE
feat: treat instance startup script as a secret #2 [DET-9214]

### DIFF
--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -78,7 +78,7 @@ func setupAPITest(t *testing.T, pgdb *db.PgDB) (*apiServer, model.User, context.
 					ExternalSessions: model.ExternalSessions{},
 				},
 				TaskContainerDefaults: model.TaskContainerDefaultsConfig{},
-				ResourceConfig: &config.ResourceConfig{
+				ResourceConfig: config.ResourceConfig{
 					ResourceManager: &config.ResourceManagerConfig{},
 				},
 			},

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -130,7 +130,7 @@ func DefaultConfig() *Config {
 			CoresPerWorker: 1,
 			MaxTrees:       100,
 		},
-		ResourceConfig: DefaultResourceConfig(),
+		ResourceConfig: *DefaultResourceConfig(),
 	}
 }
 
@@ -158,7 +158,7 @@ type Config struct {
 	Cache                 CacheConfig                       `json:"cache"`
 	Webhooks              WebhooksConfig                    `json:"webhooks"`
 	FeatureSwitches       []string                          `json:"feature_switches"`
-	*ResourceConfig
+	ResourceConfig
 
 	// Internal contains "hidden" useful debugging configurations.
 	InternalConfig InternalConfig `json:"__internal"`
@@ -207,6 +207,12 @@ func (c Config) Printable() ([]byte, error) {
 	}
 
 	c.CheckpointStorage = c.CheckpointStorage.Printable()
+
+	pools := make([]ResourcePoolConfig, 0, len(c.ResourcePools))
+	for _, poolConfig := range c.ResourcePools {
+		pools = append(pools, poolConfig.Printable())
+	}
+	c.ResourcePools = pools
 
 	optJSON, err := json.Marshal(c)
 	if err != nil {

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -56,7 +56,7 @@ resource_pools:
 			Host:     "hostname",
 			Port:     "3000",
 		},
-		ResourceConfig: &ResourceConfig{
+		ResourceConfig: ResourceConfig{
 			ResourceManager: &ResourceManagerConfig{
 				AgentRM: &AgentResourceManagerConfig{
 					Scheduler: &SchedulerConfig{
@@ -120,7 +120,7 @@ resource_pools:
       max_agent_starting_period: 40s
 `
 	expected := Config{
-		ResourceConfig: &ResourceConfig{
+		ResourceConfig: ResourceConfig{
 			ResourceManager: &ResourceManagerConfig{
 				AgentRM: &AgentResourceManagerConfig{
 					Scheduler: &SchedulerConfig{

--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -154,15 +154,13 @@ func (c *Config) InitMasterAddress() error {
 
 // Printable returns a printable object.
 func (c Config) Printable() Config {
-	res := c
-
 	const hiddenValue = "********"
-	if len(res.StartupScript) > 0 {
-		res.StartupScript = hiddenValue
+	if len(c.StartupScript) > 0 {
+		c.StartupScript = hiddenValue
 	}
-	if len(res.ContainerStartupScript) > 0 {
-		res.ContainerStartupScript = hiddenValue
+	if len(c.ContainerStartupScript) > 0 {
+		c.ContainerStartupScript = hiddenValue
 	}
 
-	return res
+	return c
 }

--- a/master/internal/config/provconfig/config.go
+++ b/master/internal/config/provconfig/config.go
@@ -151,3 +151,18 @@ func (c *Config) InitMasterAddress() error {
 	c.MasterURL = (&url.URL{Scheme: scheme, Host: fmt.Sprintf("%s:%s", host, port)}).String()
 	return nil
 }
+
+// Printable returns a printable object.
+func (c Config) Printable() Config {
+	res := c
+
+	const hiddenValue = "********"
+	if len(res.StartupScript) > 0 {
+		res.StartupScript = hiddenValue
+	}
+	if len(res.ContainerStartupScript) > 0 {
+		res.ContainerStartupScript = hiddenValue
+	}
+
+	return res
+}

--- a/master/internal/config/resource_pool_config.go
+++ b/master/internal/config/resource_pool_config.go
@@ -69,12 +69,10 @@ func (r ResourcePoolConfig) Validate() []error {
 
 // Printable returns a printable object.
 func (r ResourcePoolConfig) Printable() ResourcePoolConfig {
-	res := r
-
-	if res.Provider != nil {
-		p := res.Provider.Printable()
-		res.Provider = &p
+	if r.Provider != nil {
+		p := r.Provider.Printable()
+		r.Provider = &p
 	}
 
-	return res
+	return r
 }

--- a/master/internal/config/resource_pool_config.go
+++ b/master/internal/config/resource_pool_config.go
@@ -66,3 +66,15 @@ func (r ResourcePoolConfig) Validate() []error {
 			"resource pool max cpu containers per agent should be >= 0"),
 	}
 }
+
+// Printable returns a printable object.
+func (r ResourcePoolConfig) Printable() ResourcePoolConfig {
+	res := r
+
+	if res.Provider != nil {
+		p := res.Provider.Printable()
+		res.Provider = &p
+	}
+
+	return res
+}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1000,7 +1000,7 @@ func (m *Master) Run(ctx context.Context) error {
 		m.system,
 		m.db,
 		m.echo,
-		m.config.ResourceConfig,
+		&m.config.ResourceConfig,
 		&aproto.MasterSetAgentOptions{
 			MasterInfo:     m.Info(),
 			LoggingOptions: m.config.Logging,

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -513,6 +513,9 @@ func (a *agentResourceManager) createResourcePoolSummary(
 		return &resourcepoolv1.ResourcePool{}, err
 	}
 
+	// Hide secrets.
+	pool = pool.Printable()
+
 	// Static Pool defaults
 	poolType := resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_STATIC
 	preemptible := false


### PR DESCRIPTION
## Description

Another take on #6387 
`*ResourceConfig` pointer embedding was a landmine which made the value method `func (c Config) Printable` mutate the underlying config.

## Test Plan

- Deploy MLDE cluster using docker credentials `det deploy ... --docker-user ... --docker-password ...`
- Make sure these credentials are not visible in master config or cluster -> resource pool card -> config.
- Make sure the jobs still run.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
