### PR TITLE
ci: enable debug mode for `det deploy aws` commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,7 @@ commands:
             echo "-----BEGIN ARGS-----"
             cat /tmp/det-deploy-extra-args
             echo "-----END ARGS-----"
-            tools/scripts/retry.sh det deploy aws up \
+            DET_DEBUG=1 tools/scripts/retry.sh det deploy aws up \
               $(< /tmp/det-deploy-extra-args) \
               --cluster-id <<parameters.cluster-id>> \
               --det-version <<parameters.det-version>> \
@@ -615,7 +615,7 @@ commands:
           when: always
           no_output_timeout: 20m
           command: |
-            tools/scripts/retry.sh det deploy aws down \
+            DET_DEBUG=1 tools/scripts/retry.sh det deploy aws down \
               --cluster-id <<parameters.cluster-id>> --yes
 
   setup-aws-cluster:


### PR DESCRIPTION
## Description

These commands fail sometimes; enabling debug mode will show us a stack trace that is otherwise hidden.

## Test Plan

- [x] check locally that setting the variable causes `det deploy aws` to show the stack trace I want