### PR TITLE
chore: deprecate HDFS storage support

### DIFF
--- a/docs/release-notes/6460-hdfs.txt
+++ b/docs/release-notes/6460-hdfs.txt
@@ -1,0 +1,6 @@
+:orphan:
+
+**Deprecated Features**
+
+-  HDFS checkpoint storage support has been deprecated and will be removed in a future version.
+   Please contact Determined if you still need it, or else migrate to an different storage backend.

--- a/harness/determined/common/storage/hdfs.py
+++ b/harness/determined/common/storage/hdfs.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import warnings
 from typing import Optional, Union
 
 from hdfs.client import InsecureClient
@@ -20,6 +21,13 @@ class HDFSStorageManager(storage.CloudStorageManager):
         user: Optional[str] = None,
         temp_dir: Optional[str] = None,
     ) -> None:
+        warnings.warn(
+            "HDFS checkpoint storage support has been deprecated and will be removed in a future "
+            "version.  Please contact Determined if you still need it, or migrate to a different "
+            "storage backend.",
+            FutureWarning,
+            stacklevel=2,
+        )
         super().__init__(temp_dir if temp_dir is not None else tempfile.gettempdir())
 
         self.hdfs_url = hdfs_url


### PR DESCRIPTION
It has not been tested in years, and AFAIK no customer or user has successfully used it since we went open-source.