### PR TITLE
docs: do some copy editing

### DIFF
--- a/docs/architecture/introduction.rst
+++ b/docs/architecture/introduction.rst
@@ -28,23 +28,23 @@ Configuration settings are compatible with any Determined task unless otherwise 
 Determined CLI
 ==============
 
-One of the key components of the Determined platform is the :ref:`cli-ug`. The CLI serves as a
-primary entry point for interacting with Determined, providing a way to efficiently manage and
-control various aspects of the system. The following list describes some of the tasks users can
-perform with the Determined CLI:
+One of the key components of the Determined platform is the :ref:`command-line interface (CLI)
+<cli-ug>`. The CLI serves as a primary entry point for interacting with Determined, providing a way
+to efficiently manage and control various aspects of the system. The following list describes some
+of the tasks users can perform with the Determined CLI:
 
--  Experiment Management: Running experiments is a fundamental part of the machine learning process.
+-  Experiment management: Running experiments is a fundamental part of the machine learning process.
    With the CLI, users can effortlessly create, list, and manage experiments, as well as access
    important experiment metrics and logs.
 
--  Queue Management: The CLI enables users to manage their job queues, monitor the progress of
+-  Queue management: The CLI enables users to manage their job queues, monitor the progress of
    ongoing tasks, and even prioritize or cancel jobs as needed.
 
--  Notebook Management: Jupyter notebooks are an essential tool for data scientists and machine
+-  Notebook management: Jupyter notebooks are an essential tool for data scientists and machine
    learning engineers. The CLI simplifies the process of creating, launching, and managing Jupyter
    notebooks within the platform.
 
--  TensorBoard Integration: TensorBoard is a popular visualization tool for TensorFlow projects. The
+-  TensorBoard integration: TensorBoard is a popular visualization tool for TensorFlow projects. The
    CLI allows users to easily launch and manage TensorBoard instances, making it simple to visualize
    and analyze the training progress of their models.
 
@@ -52,7 +52,8 @@ Commands and Shells
 ===================
 
 In addition to structured model training workloads, which are handled using :ref:`experiments
-<experiments>`, Determined also supports more free-form tasks using :ref:`commands-and-shells`.
+<experiments>`, Determined also supports more free-form tasks using :ref:`commands and shells
+<commands-and-shells>`.
 
 Commands execute a user-specified program on the cluster. Shells start SSH servers that allow using
 cluster resources interactively.
@@ -294,7 +295,7 @@ To run tasks such as experiments or notebooks, Determined needs to have resource
 which to run the tasks. However, different tasks have different resource requirements and, given the
 cost of GPU resources, it is important to choose the right resources for specific goals so that you
 get the most value out of your money. For example, you may want to run your training on beefy V100
-GPU machines, while you want your Tensorboards to run on cheap CPU machines with minimal resources.
+GPU machines, while you want your TensorBoards to run on cheap CPU machines with minimal resources.
 
 Determined has the concept of a *resource pool*, which is a collection of identical resources that
 are located physically close to each other. Determined allows you to configure your cluster to have
@@ -303,7 +304,7 @@ different sets of resources for different tasks. Each resource pool handles sche
 provisioning independently.
 
 When you configure a cluster, you set which pool is the default for auxiliary tasks and which pool
-is the default for compute tasks. CPU-only tasks such as Tensorboards will run on the default
+is the default for compute tasks. CPU-only tasks such as TensorBoards will run on the default
 auxiliary pool unless you specify that they should run in a different pool when launching the task.
 Tasks which require a slot, such as experiments or GPU-notebooks, will use the default compute pool
 unless otherwise specified. For this reason it is recommended that you always create a cluster with
@@ -318,10 +319,10 @@ Here are some scenarios where it can be valuable to use multiple resource pools:
    You create one pool, ``aws-v100``, that provisions ``p3dn.24xlarge`` instances (large V100 EC2
    instances) and another pool, ``aws-cpu`` that provisions ``m5.large`` instances (small and cheap
    CPU instances). You train your experiments using the ``aws-v100`` pool, while you run your
-   Tensorboards in the ``aws-cpu`` pool. When your experiments complete, the ``aws-v100 pool`` can
+   TensorBoards in the ``aws-cpu`` pool. When your experiments complete, the ``aws-v100 pool`` can
    scale down to zero to save money, but you can continue to run your TensorBoard. Without resource
    pools, you would have needed to keep a ``p3dn.24xlarge`` instance running to keep the TensorBoard
-   alive. By default Tensorboard will always run on the default CPU pool.
+   alive. By default TensorBoard will always run on the default CPU pool.
 
 -  *Use GPUs in different availability zones on AWS.*
 
@@ -423,7 +424,7 @@ This example sets the cluster-wide scheduler defaults to use a best-fit, round r
 ``resource_manager.scheduler``. The scheduler settings at the pool level for ``pool1`` are then
 overwritten. Because ``scheduler.fitting_policy=worst`` is set, no settings are inherited from
 ``resource_manager.scheduler`` so pool1 uses a worst-fit, fair share scheduler because for a blank
-``scheduler.type`` field, the default value is ``fair_share``).
+``scheduler.type`` field, the default value is ``fair_share``.
 
 If you want to have ``pool1`` use a worst-fit, round robin scheduler, you need to make sure you
 redefine the scheduler type at the pool-specific level:
@@ -457,9 +458,9 @@ When creating a task, the job configuration file has a section called "resources
 
 If this field is not set, the task will be launched into one of the two default pools defined in the
 :ref:`master-config-reference`. Experiments will be launched into the default compute pool.
-Tensorboards will be launched into the default auxiliary pool. Commands, Shells, and Notebooks that
+TensorBoards will be launched into the default auxiliary pool. Commands, shells, and notebooks that
 request a slot (which is the default behavior if the ``resources.slots`` field is not set) will be
-launched into the default compute pool. Commands, Shells, and Notebooks that explicitly request 0
+launched into the default compute pool. Commands, shells, and notebooks that explicitly request 0
 slots (for example the "Launch CPU-only Notebook" button in the Web UI) will use the auxiliary pool.
 
 .. _scheduling:

--- a/docs/cluster-setup-guide/basic.rst
+++ b/docs/cluster-setup-guide/basic.rst
@@ -16,7 +16,7 @@ You can override the value in the command line using the ``-m`` option.
  Step 2 - Install the Determined CLI
 *************************************
 
-The Determined CLI is a command line tool that lets you launch new experiments and interact with a
+The Determined CLI is a command-line tool that lets you launch new experiments and interact with a
 Determined cluster. The CLI can be installed on any machine you want to use to access Determined. To
 install the CLI, follow the :ref:`installation <install-cli>` instructions.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/overview.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/overview.rst
@@ -21,7 +21,7 @@ In this topic guide, we will cover:
 :ref:`Installing Determined on Kubernetes <install-on-kubernetes>` deploys an instance of the
 Determined master and a Postgres database in the Kubernetes cluster. Once the master is up and
 running, users can launch :ref:`experiments <experiments>`, :ref:`notebooks <notebooks>`,
-:ref:`tensorboards <tensorboards>`, :ref:`commands <commands-and-shells>`, and :ref:`shells
+:ref:`TensorBoards <tensorboards>`, :ref:`commands <commands-and-shells>`, and :ref:`shells
 <commands-and-shells>`. When new workloads are submitted to the Determined master, the master
 launches pods and configMaps on the Kubernetes cluster to execute those workloads. Users of
 Determined shouldn't need to interact with Kubernetes directly after installation, as Determined

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/setup-eks-cluster.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/setup-eks-cluster.rst
@@ -48,7 +48,7 @@ Determined Helm chart.
 ********************
 
 The quickest and easiest way to deploy an EKS cluster is with ``eksctl``. ``eksctl`` supports
-cluster creation with either command line arguments or a cluster config file. Below is a template
+cluster creation with either command-line arguments or a cluster config file. Below is a template
 config that deploys a managed node group for Determined's master instance, as well as an autoscaling
 GPU node group for workers. To fill in the template, insert the cluster name and S3 bucket name.
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -51,7 +51,7 @@ The launcher has the following additional requirements on the installation node:
 -  Support for an RPM or Debian-based package installer
 -  Java 1.8 or greater
 -  Sudo is configured to process configuration files present in the ``/etc/sudoers.d`` directory
--  Access to the Slurm or PBS command line interface for the cluster
+-  Access to the Slurm or PBS command-line interface for the cluster
 -  Access to a cluster-wide file system with a consistent path names across the cluster
 
 .. _proxy-config-requirements:

--- a/docs/cluster-setup-guide/historical-cluster-usage-data.rst
+++ b/docs/cluster-setup-guide/historical-cluster-usage-data.rst
@@ -32,7 +32,7 @@ We build WebUI visualizations for a quick snapshot of the historical cluster usa
    :width: 100%
 
 ************************
- Command Line Interface
+ Command-line Interface
 ************************
 
 Alternatively, you can use the :ref:`CLI <cli-ug>` or the API endpoints to download the resource

--- a/docs/cluster-setup-guide/security/rbac.rst
+++ b/docs/cluster-setup-guide/security/rbac.rst
@@ -6,8 +6,8 @@
 
 .. attention::
 
-   RBAC feature applies only to Determined Enterprise Edition. Please see RBAC's current limitations
-   :ref:`here <rbac-limitations>`
+   RBAC is only available on Determined Enterprise Edition. Please see RBAC's current limitations
+   :ref:`here <rbac-limitations>`.
 
 *****************
  Getting Started
@@ -396,8 +396,8 @@ behind RBAC. These currently include:
 CLI
 ===
 
-:ref:`cli-ug` has a help built-in. Please see help for the top level commands, as well as their
-subcommands:
+The :ref:`Determined CLI <cli-ug>` has built-in help. Please see help for the top level commands, as
+well as their subcommands:
 
 .. code::
 
@@ -424,8 +424,8 @@ To list all existing cluster roles and the concrete permissions they include:
 ``Viewer``
 ==========
 
-``Viewer`` role allows a user to see workspaces, projects, Notebooks, Tensorboards, Shells, Commands
-(NTSC), experiments, as well as experiment metadata and artifacts within its scope.
+``Viewer`` role allows a user to see workspaces, projects, notebooks, TensorBoards, shells, commands
+(NTSC), and experiments, as well as experiment metadata and artifacts within its scope.
 
 ``Editor``
 ==========
@@ -458,10 +458,10 @@ assigned globally.
    .. code:: yaml
 
       security:
-             authz:
-                    workspace_creator_assign_role:
-                       enabled: true
-                       role_id: ROLE_ID
+        authz:
+          workspace_creator_assign_role:
+            enabled: true
+            role_id: ROLE_ID
 
    where ``ROLE_ID`` is the integer role identifier, as listed in ``det rbac list-roles``. To
    disable the assignment of any roles to the newly created workspace, set ``enabled: false``.
@@ -485,8 +485,8 @@ all permissions, and can only be assigned globally.
    .. code:: yaml
 
       security:
-         authz:
-            rbac_ui_enabled: true
+        authz:
+          rbac_ui_enabled: true
 
 #. Restart Determined for the config change to take effect. This config option will enable RBAC APIs
    and UI, but the RBAC rules will not be enforced, allowing administrators to set it up first.
@@ -503,8 +503,8 @@ all permissions, and can only be assigned globally.
    .. code:: yaml
 
       security:
-         authz:
-            type: rbac
+        authz:
+          type: rbac
 
 #. Restart master for the change to take effect.
 

--- a/docs/interfaces/cli-ug.rst
+++ b/docs/interfaces/cli-ug.rst
@@ -10,15 +10,15 @@
 | :doc:`/reference/cli-reference`               |
 +-----------------------------------------------+
 
-To use Determined, you'll need, at minimum, the Determined Command Line Interface (Determined CLI)
-and a Determined cluster. The Determined CLI includes the ``det`` command line tools for interacting
+To use Determined, you'll need, at minimum, the Determined command-line interface (Determined CLI)
+and a Determined cluster. The Determined CLI includes the ``det`` command-line tools for interacting
 with a Determined cluster. This page contains instructions for using the CLI, including installion
 and upgrade.
 
 .. warning::
 
    Although Determined supports password-based authentication, communication between the Determined
-   CLI, Determined WebUI, and the Determined master does not take place over an encrypted channel by
+   CLI, Determined WebUI, and Determined master does not take place over an encrypted channel by
    default.
 
 .. note::
@@ -27,7 +27,7 @@ and upgrade.
 
 .. note::
 
-   You can also interact with Determined using the :ref:`web-ui-if`.
+   You can also interact with Determined using the :ref:`web interface (WebUI) <web-ui-if>`.
 
 .. _install-cli:
 
@@ -124,8 +124,8 @@ cluster. The CLI is invoked with the ``det`` command.
 CLI subcommands usually follow a ``<noun> <verb>`` form, similar to the paradigm of `ip
 <http://www.policyrouting.org/iproute2.doc.html>`__. Certain abbreviations are supported, and a
 missing verb is the same as ``list``, when possible. The following examples show different ways to
-achieve the same outcome using the ``<noun><verb>`` form, followed by the abbreviation, followed by
-a missing ``<verb>``:
+achieve the same outcome using the full ``<noun> <verb>`` form, then with an abbreviation, and
+finally with an implicit ``list``:
 
 .. code:: bash
 
@@ -161,7 +161,7 @@ a missing ``<verb>``:
       -  Command
       -  Options
 
-   -  -  List all experiments
+   -  -  List all experiments.
       -  Display a list of all experiments in the cluster.
       -  ``det experiment list``
       -
@@ -171,7 +171,7 @@ a missing ``<verb>``:
       -  ``det -m 1.2.3.4 e``
       -
 
-   -  -  View a snapshot of logs
+   -  -  View a snapshot of logs.
       -  Display the most recent logs for a specific command.
       -  ``det command logs <command_id>``
       -  -f, --tail
@@ -181,12 +181,12 @@ a missing ``<verb>``:
       -  ``det t logs -f 289``
       -  -f
 
-   -  -  Add a label
+   -  -  Add a label.
       -  Add the label ``foobar`` to experiment 17.
       -  ``det e label add 17 foobar``
       -
 
-   -  -  Create an experiment
+   -  -  Create an experiment.
 
       -  Create an experiment in a paused state with the configuration file ``const.yaml`` and the
          code contained in the current directory. The paused experiment is not scheduled on the
@@ -196,33 +196,33 @@ a missing ``<verb>``:
 
       -
 
-   -  -  Describe an experiment
+   -  -  Describe an experiment.
       -  Display information about experiment 493, including full metrics, in CSV format.
       -  ``det e describe 493 --metrics --csv``
       -
 
-   -  -  Set max slots
+   -  -  Set max slots.
       -  Ensure that experiment 85 does not use more than 4 slots in the cluster.
       -  ``det e set max-slots 85 4``
       -
 
-   -  -  Display details about the CLI and master
+   -  -  Display details about the CLI and master.
       -  Show detailed information about the CLI and master. This command does not take both an
          object and an action.
       -  ``det version``
       -
 
-   -  -  Stop (kill) the command
+   -  -  Stop (kill) a command.
       -  Terminate a running command.
       -  ``det command kill <command_id>``
       -
 
-   -  -  Set a password for the admin user
+   -  -  Set a password for the admin user.
       -  Set the password for the admin user during cluster setup.
       -  ``det user change-password admin``
       -
 
-   -  -  Create a user
+   -  -  Create a user.
       -  Create a new user named ``hoid`` who has admin privileges.
       -  ``det u create --admin hoid``
       -

--- a/docs/interfaces/commands-and-shells.rst
+++ b/docs/interfaces/commands-and-shells.rst
@@ -4,11 +4,12 @@
  Commands and Shells
 #####################
 
-Determined Commands and Shells provide support for running a Determined cluster without writing a
-model. This page describes how to manage GPU-powered batch commands and interactive shells.
+Determined commands and shells provide support for running code on a Determined cluster without
+writing a model. This page describes how to manage GPU-powered batch commands and interactive
+shells.
 
-Commands and Shells are started through the Determined Command Line Interface (CLI). To learn more,
-including installation instructions, visit the :ref:`Determined CLI User Guide <cli-ug>` or
+Commands and shells are started through the Determined command-line interface (CLI). To learn more,
+including installation instructions, visit the :ref:`Determined CLI user guide <cli-ug>` or
 :ref:`Determined CLI Reference <cli-reference>`.
 
 Commands execute a user-specified program on the cluster. Commands are useful for running existing
@@ -20,10 +21,10 @@ Shells provide access to the cluster in the form of interactive `SSH
  Commands
 **********
 
-Determined commands start with ``det command``, abbreviated as ``det cmd``. The main subcommand is
-``det cmd run``, which runs a command in the cluster and streams its output. For example, the
-following CLI command uses ``nvidia-smi`` to display information about the GPUs available to tasks
-in the container:
+Determined commands are manipulated with CLI commands starting with ``det command``, abbreviated as
+``det cmd``. The main subcommand is ``det cmd run``, which runs a command in the cluster and streams
+its output. For example, the following CLI command uses ``nvidia-smi`` to display information about
+the GPUs available to tasks in the container:
 
 .. code::
 

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -15,7 +15,7 @@
          <div class="tile-container">
              <a class="tile" href="commands-and-shells.html">
                  <h2 class="tile-title">Commands and Shells</h2>
-                 <p class="tile-description">You can use a Determined cluster to run free-form programs.</p>
+                 <p class="tile-description">How to use a Determined cluster to run free-form programs.</p>
              </a>
          </div>
          <div class="tile-container">
@@ -27,12 +27,12 @@
          <div class="tile-container">
              <a class="tile" href="notebooks.html">
                  <h2 class="tile-title">Jupyter Notebooks</h2>
-                 <p class="tile-description">Launch and manage Jupyter Notebooks.</p>
+                 <p class="tile-description">Launching and managing Jupyter Notebooks.</p>
              </a>
          </div>
          <div class="tile-container">
              <a class="tile" href="tensorboard.html">
-                 <h2 class="tile-title">Using Tensorboard</h2>
+                 <h2 class="tile-title">Using TensorBoard</h2>
                  <p class="tile-description">Using TensorBoard to examine individual or compare multiple experiments.</p>
              </a>
          </div>

--- a/docs/interfaces/notebooks.rst
+++ b/docs/interfaces/notebooks.rst
@@ -29,8 +29,8 @@ directories into the container and save files in the persistent directories in t
 If you open a Notebook tab in JupyterLab, it will automatically open a kernel that will not be shut
 down automatically so you need to manually terminate the kernels.
 
-There are two ways to access notebooks in Determined: the :ref:`cli-ug` and the :ref:`web-ui-if`. To
-install the CLI, see :ref:`install-cli`.
+There are two ways to access notebooks in Determined: the :ref:`CLI <cli-ug>` and the :ref:`WebUI
+<web-ui-if>`. To install the CLI, see :ref:`install-cli`.
 
 **************
  Command Line
@@ -236,7 +236,8 @@ functionality.
  Use the Determined CLI in Notebooks
 *************************************
 
-The :ref:`cli-ug` is installed into notebook containers by default. This allows users to interact
-with Determined from inside a notebook---e.g., to launch new deep learning workloads or examine the
-metrics from an active or historical Determined experiment. For example, to list Determined
-experiments from inside a notebook, run the notebook command ``!det experiment list``.
+The :ref:`Determined CLI <cli-ug>` is installed into notebook containers by default. This allows
+users to interact with Determined from inside a notebook---e.g., to launch new deep learning
+workloads or examine the metrics from an active or historical Determined experiment. For example, to
+list Determined experiments from inside a notebook, run the notebook command ``!det experiment
+list``.

--- a/docs/reference/cli-reference.rst
+++ b/docs/reference/cli-reference.rst
@@ -16,7 +16,7 @@ The Determined CLI has built-in documentation that you can access by using the h
 help documentation. For example, to learn more about individual experiment commands, you can type
 ``det experiment help``.
 
-.. code:: bash
+.. code::
 
    usage: det [-h] [-u username] [-m address] [-v] command ...
 

--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -71,7 +71,7 @@ The following configuration settings are supported:
       -  ``email`` (optional)
 
    -  ``add_capabilities``: A list of Linux capabilities to grant to task containers. Each entry in
-      the list is equivalent to a ``--cap-add CAP`` command line argument to ``docker run``.
+      the list is equivalent to a ``--cap-add CAP`` command-line argument to ``docker run``.
       ``add_capabilities`` is honored by resource managers of type ``agent`` but is ignored by
       resource managers of type ``kubernetes``. See :ref:`master configuration
       <master-config-reference>` for details about resource managers.
@@ -105,7 +105,7 @@ The following configuration settings are supported:
       information.
 
    -  ``devices``: A list of device strings to pass to the Docker daemon. Each entry in the list is
-      equivalent to a ``--device DEVICE`` command line argument to ``docker run``. ``devices`` is
+      equivalent to a ``--device DEVICE`` command-line argument to ``docker run``. ``devices`` is
       honored by resource managers of type ``agent`` but is ignored by resource managers of type
       ``kubernetes``. See :ref:`master configuration <master-config-reference>` for details about
       resource managers.

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -963,7 +963,7 @@ The ``resources`` section defines the resources that an experiment is allowed to
 
 ``devices``
    A list of device strings to pass to the Docker daemon. Each entry in the list is equivalent to a
-   ``--device DEVICE`` command line argument to ``docker run``. ``devices`` is honored by resource
+   ``--device DEVICE`` command-line argument to ``docker run``. ``devices`` is honored by resource
    managers of type ``agent`` but is ignored by resource managers of type ``kubernetes``. See
    :ref:`master configuration <master-config-reference>` for details about resource managers.
 
@@ -1116,7 +1116,7 @@ workloads for this experiment. For more information on customizing the trial env
 
 ``add_capabilities``
    A list of Linux capabilities to grant to task containers. Each entry in the list is equivalent to
-   a ``--cap-add CAP`` command line argument to ``docker run``. ``add_capabilities`` is honored by
+   a ``--cap-add CAP`` command-line argument to ``docker run``. ``add_capabilities`` is honored by
    resource managers of type ``agent`` but is ignored by resource managers of type ``kubernetes``.
    See :ref:`master configuration <master-config-reference>` for details about resource managers.
 

--- a/docs/training/dtrain-introduction.rst
+++ b/docs/training/dtrain-introduction.rst
@@ -593,7 +593,7 @@ To launch the experiment with the template:
 Using the CLI to Work with Templates
 ------------------------------------
 
-The :ref:`Determined Command Line Interface <cli-ug>` can be used to list, create, update, and
+The :ref:`Determined command-line interface <cli-ug>` can be used to list, create, update, and
 delete configuration templates. This functionality can be accessed through the ``det template``
 sub-command. This command can be abbreviated as ``det tpl``.
 

--- a/docs/tutorials/pytorch-porting-tutorial.rst
+++ b/docs/tutorials/pytorch-porting-tutorial.rst
@@ -79,7 +79,7 @@ We also need to create an experiment configuration file. This file defines speci
 information such as: number of samples, training length, and hyperparameters.
 
 We recommend that all hyperparameters be added to this file. A good starting point is taking any
-command line arguments - you may see this as parser args - from the original script and immediately
+command-line arguments---you may see this as parser args---from the original script and immediately
 adding them to your file.
 
 In our case, since we’re using hyperparameters that don’t change, we’ve given this specific config


### PR DESCRIPTION
## Description

- If a link is used as if referring to a location (e.g., "see <link> for more"), then it may implicitly use the target's title as the link text. However, if the text of the link is intended to form a natural part of the surrounding sentence, then the text should be specified explicitly to ensure that the sentence continues to make sense even if the title is changed.

- We don't need to capitalize "command" or "shell", or "notebook" as a general concept (though "Jupyter Notebook" is the name of a particular product). But note the B in "TensorBoard"!

- The hyphenated "command-line interface" lines up better with our current usage (and my preference).

## Test Plan

- [x] render and examine docs