### PR TITLE
fix: do not merge user zero search config with defaults

### DIFF
--- a/ds_autotuning_prototype/core_api/ffn_example_torch_launcher/search_runner_config.yaml
+++ b/ds_autotuning_prototype/core_api/ffn_example_torch_launcher/search_runner_config.yaml
@@ -1,2 +1,0 @@
-name: user-specified search runner config
-max_restarts: 5

--- a/ds_autotuning_prototype/core_api/torchvison_models/zero_search_config.yaml
+++ b/ds_autotuning_prototype/core_api/torchvison_models/zero_search_config.yaml
@@ -1,14 +1,10 @@
 1:
-  reduce_bucket_size:
-    - 2e7
-    - 2e9
-    - 2e10
   allgather_bucket_size:
     - 2e7
     - 2e9
     - 2e10
 2:
-  allgather_bucket_size:
-    - 3e7
-    - 3e9
-    - 3e10
+  reduce_bucket_size:
+    - 2e7
+    - 2e9
+    - 2e10

--- a/harness/determined/pytorch/deepspeed/dsat/_dsat_search_method.py
+++ b/harness/determined/pytorch/deepspeed/dsat/_dsat_search_method.py
@@ -407,6 +407,7 @@ class DSATSearchMethodBase(searcher.SearchMethod):
         self.zero_optim_search_space = _utils.get_zero_optim_search_space(
             zero_search_config=self.zero_search_config
         )
+        # TODO: Delete print test
         logging.info(f"SEARCH SPACE {self.zero_optim_search_space}")
 
         self.slots = self.submitted_config_dict["resources"]["slots_per_trial"]
@@ -755,7 +756,6 @@ class DSATRandomSearchMethod(DSATSearchMethodBase):
         relevant_zero_stages = self.model_profile_info.viable_zero_stages & set(
             self.zero_optim_search_space
         )
-        print(f"TEST: {self.zero_optim_search_space}")
         random_zero_stage = random.choice(tuple(relevant_zero_stages))
         zero_optim_config = _utils.get_random_zero_optim_dict_from_search_space(
             random_zero_stage, self.zero_optim_search_space


### PR DESCRIPTION
## Description
Previously I merged user-supplied zero optimizations with the defaults, but it is cleaner to not do that.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
