### PR TITLE
feat: Right-click for context menu in Glide table [WEB-977]

### DIFF
--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -35,8 +35,8 @@ interface Props {
   experiment: ProjectExperiment;
   onComplete?: (action?: Action) => void;
   onVisibleChange?: (visible: boolean) => void;
-  settings: ExperimentListSettings;
-  updateSettings: UpdateSettings;
+  settings?: ExperimentListSettings;
+  updateSettings?: UpdateSettings;
   workspaceId?: number;
 }
 
@@ -113,7 +113,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
             break;
           }
           case Action.SwitchPin: {
-            const newPinned = { ...(settings.pinned ?? {}) };
+            const newPinned = { ...(settings?.pinned ?? {}) };
             const pinSet = new Set(newPinned[experiment.projectId]);
             if (pinSet.has(id)) {
               pinSet.delete(id);
@@ -128,7 +128,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
               pinSet.add(id);
             }
             newPinned[experiment.projectId] = Array.from(pinSet);
-            updateSettings({ pinned: newPinned });
+            updateSettings?.({ pinned: newPinned });
             break;
           }
           case Action.Kill:
@@ -197,7 +197,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
       id,
       onComplete,
       onVisibleChange,
-      settings.pinned,
+      settings?.pinned,
       updateSettings,
     ],
   );
@@ -205,7 +205,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
   const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions()).map(
     (action) => {
       if (action === Action.SwitchPin) {
-        const label = (settings.pinned?.[experiment.projectId] ?? []).includes(id)
+        const label = (settings?.pinned?.[experiment.projectId] ?? []).includes(id)
           ? 'Unpin'
           : 'Pin';
         return { key: action, label };

--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -33,6 +33,7 @@ import { openCommandResponse } from 'utils/wait';
 interface Props {
   children?: React.ReactNode;
   experiment: ProjectExperiment;
+  makeOpen?: boolean;
   onComplete?: (action?: Action) => void;
   onVisibleChange?: (visible: boolean) => void;
   settings?: ExperimentListSettings;
@@ -58,6 +59,7 @@ const stopPropagation = (e: React.MouseEvent): void => e.stopPropagation();
 
 const ExperimentActionDropdown: React.FC<Props> = ({
   experiment,
+  makeOpen,
   onComplete,
   onVisibleChange,
   settings,
@@ -202,8 +204,9 @@ const ExperimentActionDropdown: React.FC<Props> = ({
     ],
   );
 
-  const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions()).map(
-    (action) => {
+  const menuItems = getActionsForExperiment(experiment, dropdownActions, usePermissions())
+    .filter((action) => action !== Action.SwitchPin || settings)
+    .map((action) => {
       if (action === Action.SwitchPin) {
         const label = (settings?.pinned?.[experiment.projectId] ?? []).includes(id)
           ? 'Unpin'
@@ -212,8 +215,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
       } else {
         return { danger: action === Action.Delete, key: action, label: action };
       }
-    },
-  );
+    });
 
   const menu: DropdownProps['menu'] = useMemo(() => {
     return { items: [...menuItems], onClick: handleMenuClick };
@@ -235,6 +237,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
     <>
       <Dropdown
         menu={menu}
+        open={makeOpen}
         placement="bottomLeft"
         trigger={['contextMenu']}
         onOpenChange={onVisibleChange}>

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -126,6 +126,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
             handleScroll={handleScroll}
             initialScrollPositionSet={initialScrollPositionSet}
             page={page}
+            project={project}
             selectAll={selectAll}
             selectedExperimentIds={selectedExperimentIds}
             setSelectAll={setSelectAll}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -123,6 +123,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
           <GlideTable
             colorMap={colorMap}
             data={experiments}
+            fetchExperiments={fetchExperiments}
             handleScroll={handleScroll}
             initialScrollPositionSet={initialScrollPositionSet}
             page={page}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -27,6 +27,7 @@ import { useNavigate } from 'react-router';
 import useUI from 'shared/contexts/stores/UI';
 import usersStore from 'stores/users';
 import { ExperimentItem, Project } from 'types';
+import { getProjectExperimentForExperimentItem } from 'utils/experiment';
 import { Loadable } from 'utils/loadable';
 import { useObservable, WritableObservable } from 'utils/observable';
 
@@ -57,6 +58,7 @@ const cells: DataEditorProps['customRenderers'] = [
 interface Props {
   colorMap: MapOfIdsToColors;
   data: Loadable<ExperimentItem>[];
+  fetchExperiments: () => void;
   handleScroll?: (r: Rectangle) => void;
   initialScrollPositionSet: WritableObservable<boolean>;
   sortableColumnIds: ExperimentColumn[];
@@ -73,6 +75,7 @@ const STATIC_COLUMNS: ExperimentColumn[] = ['selected', 'name'];
 
 export const GlideTable: React.FC<Props> = ({
   data,
+  fetchExperiments,
   setSelectedExperimentIds,
   sortableColumnIds,
   setSortableColumnIds,
@@ -108,7 +111,8 @@ export const GlideTable: React.FC<Props> = ({
   });
 
   const [contextMenuIsOpen, setContextMenuIsOpen] = useState(false);
-  const [contextMenuProps, setContextMenuProps] = useState<Omit<TableContextMenuProps, 'open'>>();
+  const [contextMenuProps, setContextMenuProps] =
+    useState<Omit<TableContextMenuProps, 'open' | 'fetchExperiments'>>();
 
   const {
     ui: { darkLight },
@@ -250,9 +254,8 @@ export const GlideTable: React.FC<Props> = ({
 
       event.preventDefault();
       setContextMenuProps({
-        experiment,
+        experiment: getProjectExperimentForExperimentItem(experiment, project),
         handleClose: () => setContextMenuIsOpen(false),
-        project,
         x: event.bounds.x,
         y: event.bounds.y,
       });
@@ -319,7 +322,11 @@ export const GlideTable: React.FC<Props> = ({
       />
       <TableActionMenu {...menuProps} open={menuIsOpen} />
       {contextMenuProps?.experiment && (
-        <TableContextMenu {...contextMenuProps} open={contextMenuIsOpen} />
+        <TableContextMenu
+          {...contextMenuProps}
+          fetchExperiments={fetchExperiments}
+          open={contextMenuIsOpen}
+        />
       )}
     </div>
   );

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -235,8 +235,9 @@ export const GlideTable: React.FC<Props> = ({
     [data, columnIds, columnDefs],
   );
 
-  const handleGridSelectionChange = useCallback((newSelection: GridSelection) => {
-    const [, row] = newSelection.current?.cell ?? [undefined, undefined];
+  const handleGridSelectionChange = useCallback((cell: Item) => {
+    const [col, row] = cell;
+    if (col !== 0) return;
     if (row === undefined) return;
     setSelection(({ rows }: GridSelection) => ({
       columns: CompactSelection.empty(),
@@ -256,11 +257,10 @@ export const GlideTable: React.FC<Props> = ({
       setContextMenuProps({
         experiment: getProjectExperimentForExperimentItem(experiment, project),
         handleClose: () => setContextMenuIsOpen(false),
-        x: event.bounds.x,
-        y: event.bounds.y,
+        x: Math.max(0, event.bounds.x + event.localEventX - 4),
+        y: Math.max(0, event.bounds.y + event.localEventY - 4),
       });
       setContextMenuIsOpen(true);
-      return false;
     },
     [data, project, setContextMenuProps, setContextMenuIsOpen],
   );
@@ -306,16 +306,15 @@ export const GlideTable: React.FC<Props> = ({
         theme={theme}
         verticalBorder={verticalBorder}
         width="100%"
+        onCellClicked={handleGridSelectionChange}
         onCellContextMenu={onCellContextMenu}
         onColumnMoved={onColumnMoved}
         onColumnResize={onColumnResize}
         onColumnResizeEnd={onColumnResizeEnd}
-        onGridSelectionChange={handleGridSelectionChange}
         onHeaderClicked={onHeaderClicked}
         onVisibleRegionChanged={handleScroll}
         //
         // these might come in handy
-        // onCellClicked={onCellClicked}
         // onItemHovered={onItemHovered}
         // onHeaderContextMenu={onHeaderContextMenu}
         // onCellContextMenu={onCellContextMenu}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -122,7 +122,7 @@ export const GlideTable: React.FC<Props> = ({
     ui: { darkLight },
   } = useUI();
 
-  const users = useObservable(userStore.getUsers());
+  const users = useObservable(usersStore.getUsers());
 
   const columnIds = useMemo<ExperimentColumn[]>(
     () => [...STATIC_COLUMNS, ...sortableColumnIds],
@@ -250,6 +250,7 @@ export const GlideTable: React.FC<Props> = ({
 
   const onCellContextMenu = useCallback(
     (cell: Item, event: CellClickedEventArgs) => {
+      contextMenuOpen.set(false);
       const [, row] = cell;
       const experiment = Loadable.match(data?.[row], {
         Loaded: (record) => record,
@@ -269,7 +270,7 @@ export const GlideTable: React.FC<Props> = ({
         x: Math.max(0, event.bounds.x + event.localEventX - 4),
         y: Math.max(0, event.bounds.y + event.localEventY - 4),
       });
-      contextMenuOpen.set(true);
+      setTimeout(() => contextMenuOpen.set(true), 25);
     },
     [data, project, setContextMenuProps, contextMenuOpen],
   );

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -235,9 +235,8 @@ export const GlideTable: React.FC<Props> = ({
     [data, columnIds, columnDefs],
   );
 
-  const handleGridSelectionChange = useCallback((cell: Item) => {
-    const [col, row] = cell;
-    if (col !== 0) return;
+  const handleCellClicked = useCallback((cell: Item) => {
+    const [, row] = cell;
     if (row === undefined) return;
     setSelection(({ rows }: GridSelection) => ({
       columns: CompactSelection.empty(),
@@ -247,7 +246,8 @@ export const GlideTable: React.FC<Props> = ({
 
   const onCellContextMenu = useCallback(
     (cell: Item, event: CellClickedEventArgs) => {
-      const experiment = Loadable.match(data?.[cell[1]], {
+      const [, row] = cell;
+      const experiment = Loadable.match(data?.[row], {
         Loaded: (record) => record,
         NotLoaded: () => null,
       }); // could also use event.location[1]
@@ -306,7 +306,7 @@ export const GlideTable: React.FC<Props> = ({
         theme={theme}
         verticalBorder={verticalBorder}
         width="100%"
-        onCellClicked={handleGridSelectionChange}
+        onCellClicked={handleCellClicked}
         onCellContextMenu={onCellContextMenu}
         onColumnMoved={onColumnMoved}
         onColumnResize={onColumnResize}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -116,7 +116,7 @@ export const GlideTable: React.FC<Props> = ({
   const [contextMenuProps, setContextMenuProps] = useState<null | Omit<
     TableContextMenuProps,
     'open' | 'fetchExperiments'
-  >>();
+  >>(null);
 
   const {
     ui: { darkLight },

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -1,0 +1,70 @@
+import { Menu, MenuProps } from 'antd';
+import React, { MutableRefObject, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+
+import { paths } from 'routes/utils';
+
+// eslint-disable-next-line
+function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void) {
+  useEffect(() => {
+    /**
+     * Alert if clicked on outside of element
+     */
+    function handleClickOutside(event: Event) {
+      if (ref.current && !ref.current.contains(event.target)) {
+        handler();
+      }
+    }
+    // Bind the event listener
+    document.addEventListener('mouseup', handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mouseup', handleClickOutside);
+    };
+  }, [ref, handler]);
+}
+
+export interface TableContextMenuProps extends MenuProps {
+  open: boolean;
+  rowKey: number;
+  handleClose: () => void;
+  x: number;
+  y: number;
+}
+
+export const TableContextMenu: React.FC<TableContextMenuProps> = ({
+  x,
+  y,
+  open,
+  rowKey,
+  handleClose,
+}) => {
+  const containerRef = useRef(null);
+  useOutsideClickHandler(containerRef, handleClose);
+
+  const navigate = useNavigate();
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        border: 'solid 1px gold',
+        display: !open ? 'none' : undefined,
+        left: x,
+        position: 'fixed',
+        top: y,
+        width: 200,
+      }}>
+      <Menu
+        items={[
+          {
+            disabled: false,
+            key: '1',
+            label: 'Visit',
+            onClick: () => navigate(paths.experimentDetails(rowKey)),
+          },
+        ]}
+      />
+    </div>
+  );
+};

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -39,14 +39,14 @@ const dropdownActions = [
 ];
 
 // eslint-disable-next-line
-function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void) {
+function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Event) => void) {
   useEffect(() => {
     /**
      * Alert if clicked on outside of element
      */
     function handleClickOutside(event: Event) {
       if (ref.current && !ref.current.contains(event.target)) {
-        handler();
+        handler(event);
       }
     }
     // Bind the event listener
@@ -62,7 +62,7 @@ export interface TableContextMenuProps extends MenuProps {
   fetchExperiments: () => void;
   open: boolean;
   experiment: ProjectExperiment;
-  handleClose: () => void;
+  handleClose: (e?: Event) => void;
   x: number;
   y: number;
 }
@@ -81,9 +81,8 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
   const permissions = usePermissions();
 
   const onComplete = useCallback(() => {
-    handleClose();
     fetchExperiments();
-  }, [fetchExperiments, handleClose]);
+  }, [fetchExperiments]);
 
   const menuItems = experiment
     ? getActionsForExperiment(experiment, dropdownActions, permissions).map((action) => ({
@@ -115,6 +114,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
   const handleMenuClick = useCallback(
     async (params: MenuInfo): Promise<void> => {
       params.domEvent.stopPropagation();
+      handleClose();
       try {
         const action = params.key as Action;
         switch (
@@ -200,6 +200,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
       experiment.workspaceId,
       handleExperimentMove,
       handleHyperparameterSearch,
+      handleClose,
       onComplete,
     ],
   );

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -1,41 +1,8 @@
-import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { Menu, MenuProps } from 'antd';
-import { MenuInfo } from 'rc-menu/lib/interface';
+import { MenuProps } from 'antd';
 import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 
 import ExperimentActionDropdown from 'components/ExperimentActionDropdown';
-import usePermissions from 'hooks/usePermissions';
-import {
-  activateExperiment,
-  archiveExperiment,
-  cancelExperiment,
-  deleteExperiment,
-  killExperiment,
-  openOrCreateTensorBoard,
-  pauseExperiment,
-  unarchiveExperiment,
-} from 'services/api';
-import { ErrorLevel, ErrorType } from 'shared/utils/error';
-import { capitalize } from 'shared/utils/string';
-import { ExperimentAction as Action, ProjectExperiment } from 'types';
-import { modal } from 'utils/dialogApi';
-import handleError from 'utils/error';
-import { getActionsForExperiment } from 'utils/experiment';
-import { openCommandResponse } from 'utils/wait';
-
-const dropdownActions = [
-  // Action.SwitchPin, requires settings
-  Action.Activate,
-  Action.Pause,
-  Action.Archive,
-  Action.Unarchive,
-  Action.Cancel,
-  Action.Kill,
-  Action.Move,
-  Action.OpenTensorBoard,
-  Action.HyperparameterSearch,
-  Action.Delete,
-];
+import { ProjectExperiment } from 'types';
 
 // eslint-disable-next-line
 function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Event) => void) {
@@ -44,15 +11,21 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Eve
      * Alert if clicked on outside of element
      */
     function handleClickOutside(event: Event) {
-      if (ref.current && !ref.current.contains(event.target)) {
+      if (
+        ref.current &&
+        !ref.current.contains(event.target) &&
+        !(event.target ? (event.target as Element) : null)?.classList?.contains(
+          'ant-dropdown-menu-title-content',
+        )
+      ) {
         handler(event);
       }
     }
     // Bind the event listener
-    document.addEventListener('mouseup', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
     return () => {
       // Unbind the event listener on clean up
-      document.removeEventListener('mouseup', handleClickOutside);
+      document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [ref, handler]);
 }
@@ -79,24 +52,20 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
 
   const onComplete = useCallback(() => {
     fetchExperiments();
-  }, [fetchExperiments]);
-
-  // <Menu items={menuItems} onClick={handleMenuClick} />
+    handleClose();
+  }, [fetchExperiments, handleClose]);
 
   return (
     <div
       ref={containerRef}
       style={{
-        border: 'solid 1px gold',
-        display: !open ? 'none' : undefined,
         left: x,
         position: 'fixed',
         top: y,
-        width: 200,
       }}>
-      <ExperimentActionDropdown
-        experiment={experiment}
-        onComplete={onComplete} />
+      <ExperimentActionDropdown experiment={experiment} makeOpen={open} onComplete={onComplete}>
+        <div />
+      </ExperimentActionDropdown>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Right-clicking on the Glide table opens an antd Menu similar to our current experiment list context menu. These options are actions for the current user to apply to the selected experiment (e.g. Archive, Move)

Notes:
- Pin / Unpin is not supported in Glide, and current implementation has useSettings, so it's not used here
- The menu stays visible until the action is completed. There is an issue after I Archive, when I re-open the row it will stil show Archive (instead of Unarchive). The menu is not updated until experiments are reloaded from the API, or I select another experiment row. In the old table, this is anticipated with `handleActionComplete` refreshing the experiment list. Would like to see this handled differently but don't have the details just yet.
- This should probably share code with the new TableActionMenu, or the old ExperimentActionDropdown. antd.Table was triggering and filling the context menu dropdown in a way which isn't super accessible here

## Test Plan

Visit a project with a few experiments with the Glide table flag on (for latest-master backend, I used `/det/projects/107/experiments?f_explist_v2=on`)
- ""Right clicking"" on a table cell shows context menu at clicked location
- Clicking somewhere else on the page disappears the context menu
- Right clicking on a table header does not show context menu

Actions apply to experiments
- Archive an experiment
- The archived experiment's options include "Unarchive" and not forbidden for this state (Archive, Move)
- Selecting Unarchive successfully un-archives the selected experiment

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.