### PR TITLE
docs: Edit Page Title

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ You can quickly train almost any deep learning model using Determined.
          <div class="tile-container">
              <a class="tile" href="tutorials/index.html">
                  <h2 class="tile-title">Tutorials</h2>
-                 <p class="tile-description">Try Determined. Learn the basics of working with Determined and how to port your existing code to the Determined environment.</p>
+                 <p class="tile-description">Try Determined and learn the basics including how to port your existing code to the Determined environment.</p>
              </a>
          </div>
          <div class="tile-container">

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,6 +1,6 @@
-################
- Try Determined
-################
+###########
+ Tutorials
+###########
 
 Learn the basics of working with Determined and how to port your existing code to the Determined
 environment.


### PR DESCRIPTION
change title of tutorials page back to tutorials
(change from "Try" to "Tutorials")