### PR TITLE
fix: wait longer for stopping/terminating ec2 instances [DET-9256]

### DIFF
--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -10,7 +10,7 @@ from determined.deploy.aws import constants
 
 # Try waiting for stack to delete this many times. We break up the waiting so the delete job
 # will not fail CI.
-NUM_WAITS = 5
+NUM_WAITS = 10
 
 DELETE_MASTER_IGNORE_ERRORS = (
     "IncorrectInstanceState",


### PR DESCRIPTION
## Description

Our CI shows stopping instances can sometimes take a long time.
Hence doubling the timeout. 


## Test Plan

N/A

