### PR TITLE
docs: release note edits.

### DIFF
--- a/docs/release-notes/fix-default-pool-task-container-defaults.rst
+++ b/docs/release-notes/fix-default-pool-task-container-defaults.rst
@@ -2,6 +2,6 @@
 
 **Bug Fixes**
 
--  Fix an issue where ``task_container_defaults`` for the default resource pools where not respected
-   for the experiments and tasks unless they specified the resource pool name explicitly, which has
-   been introduced in 0.19.9.
+-  Fix an issue that caused ``task_container_defaults`` for the default resource pools to be ignored
+   for experiments and tasks, unless the resource pool name was explicitly specified. This issue
+   first appeared in version 0.19.9.

--- a/docs/release-notes/fix-zero-slot-limits.rst
+++ b/docs/release-notes/fix-zero-slot-limits.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: fix a crash in zero slot workloads with ``resources.limits`` and
-   ``resources.requests`` overrides explicitly specified in the pod spec.
+-  Kubernetes: Fix a crash affecting zero-slot workloads when ``resources.limits`` and
+   ``resources.requests`` overrides were explicitly specified in the pod spec.


### PR DESCRIPTION
## Description

Release note edits for k8s fixes.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
