### PR TITLE
fix: always wait for fluent container removal

### DIFF
--- a/agent/pkg/docker/docker.go
+++ b/agent/pkg/docker/docker.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"syscall"
 
@@ -54,6 +55,14 @@ const (
 	// ImagePullStatsKind describes the IMAGEPULL event.
 	ImagePullStatsKind = "IMAGEPULL"
 )
+
+// Docker error strings returned by the Docker API.
+var (
+	NoSuchContainer   = "No such container"
+	RemovalInProgress = regexp.MustCompile(`removal of container ([a-f0-9]+) is already in progress`)
+)
+
+var ForceRemoveOpts = types.ContainerRemoveOptions{Force: true}
 
 type (
 	// ContainerWaiter contains channels to wait on the termination of a running container.


### PR DESCRIPTION
## Description
The test flake seen in [here](https://app.circleci.com/pipelines/github/determined-ai/determined/36194/workflows/d3b7286c-a36b-40ab-8163-6cee964348b6/jobs/1299880) shows a two interesting behaviors:
1.  When removal of a container is already in progress, `docker.ContainerRemove` returns an error and does not block until the container is removed. So we can start fluent to bind to ports when it is being removed and perhaps still bound..
2. The fluentbit log stream is started just after the container, meaning we miss logs for instant removals.
3. We start fluentbit and wait for `WaitConditionNotRunning` which works, but if we wait before with `WaitConditionNextExit` we won't miss the exit code. Though 'exit code 1' isn't likely going to be much help.

This fixes 1, which will probably make the flake go away, unless fluent goes into a true crash/backoff loop. Unfortunately, only fixing 2 will likely make the unexplained fluent crashes in these flakes easier to explain, but as far as I can tell you cannot begin tailing logs for a container until it is started (unlike the nice `docker.ContainerWait` + `WaitConditionNextExit`). I can only scheme up using a file logging driver just for fluent. Fixing 3 is a 'nice to have' but I don't think it helps.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
