### PR TITLE
ci: more retries for `det deploy` [DET-9256]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,7 @@ commands:
             echo "-----BEGIN ARGS-----"
             cat /tmp/det-deploy-extra-args
             echo "-----END ARGS-----"
-            DET_DEBUG=1 tools/scripts/retry.sh det deploy aws up \
+            MAX_RETRIES=6 DET_DEBUG=1 tools/scripts/retry.sh det deploy aws up \
               $(< /tmp/det-deploy-extra-args) \
               --cluster-id <<parameters.cluster-id>> \
               --det-version <<parameters.det-version>> \
@@ -615,7 +615,7 @@ commands:
           when: always
           no_output_timeout: 20m
           command: |
-            DET_DEBUG=1 tools/scripts/retry.sh det deploy aws down \
+            MAX_RETRIES=6 DET_DEBUG=1 tools/scripts/retry.sh det deploy aws down \
               --cluster-id <<parameters.cluster-id>> --yes
 
   setup-aws-cluster:


### PR DESCRIPTION
## Description

We are seeing some failures caused by rate limits, hence we are bumping
the max number of retries with exponential backoff, which also reduces the 
request rate.



## Test Plan

N/A


