### PR TITLE
ci: skip a test that's currently broken

### DIFF
--- a/e2e_tests/tests/cluster/test_trial_collections.py
+++ b/e2e_tests/tests/cluster/test_trial_collections.py
@@ -126,6 +126,7 @@ def assert_collection_is_uniquely_represented_in_collections(
 
 @pytest.mark.e2e_cpu
 def test_trial_collections() -> None:
+    pytest.skip("Temporarily skipping this due to breakage from another test.")
 
     master_url = conf.make_master_url()
     authentication.cli_auth = authentication.Authentication(master_url)


### PR DESCRIPTION
## Description

## Test Plan

- [x] was already in EE

## Commentary

The API that's ultimately causing should get fixed this sprint, but we can put this in if the test is causing issues.