### PR TITLE
chore: fix mmdetection checkout in unit tests to last 2.x tag to avoid …

### DIFF
--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -27,6 +27,8 @@ def cleanup_dir(directory: str) -> None:
 @pytest.fixture(scope="module")
 def mmdet_config_dir() -> Generator[str, None, None]:
     git.Repo.clone_from("https://github.com/open-mmlab/mmdetection", "/tmp/mmdetection")
+    repo = git.Repo("/tmp/mmdetection")
+    repo.git.checkout("tags/v2.28.2")
     mmdet_config_dir = "/tmp/mmdetection/configs"
     os.environ["MMDETECTION_CONFIG_DIR"] = mmdet_config_dir
     yield mmdet_config_dir


### PR DESCRIPTION
…test failures due to schema naming changes.

## Description

mmdetection had a 3.0 released, which had breaking changes to config schema and naming that affected our unit tests.  I don't think we want to bother navigating the upgrade since this will hopefully be replaced by the new and improved model hub eventually, so I fixed the unit tests to use 2.28.


## Test Plan

Unit tests in `model_hub/tests/test_mmdetection.py` should run successfull.y

## Checklist

- [X] Changes have been manually QA'd

## Ticket
[DET-9291]

[DET-9291]: https://hpe-aiatscale.atlassian.net/browse/DET-9291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ