### PR TITLE
fix: task list race caused incorrect 404s to be returned [DET-9293]

### DIFF
--- a/docs/release-notes/tasks-404-fix.rst
+++ b/docs/release-notes/tasks-404-fix.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Tasks: Fix an issue where ``det task list`` would sometimes return an incorrect 404 error.

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -122,6 +123,11 @@ func (a *apiServer) canEditAllocation(ctx context.Context, allocationID string) 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
 		return err
+	}
+
+	if !strings.Contains(allocationID, ".") {
+		return status.Errorf(codes.InvalidArgument,
+			"allocationID %s does not  contain at least '.'", allocationID)
 	}
 
 	taskID := model.AllocationID(allocationID).ToTaskID()

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -3,8 +3,6 @@ package internal
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -39,25 +37,13 @@ var (
 	taskLogsFieldsBatchWaitTime = 5 * time.Second
 )
 
-func expFromAllocationID(
-	m *Master, allocationID model.AllocationID,
+func expFromTaskID(
+	m *Master, taskID model.TaskID,
 ) (isExperiment bool, exp *model.Experiment, err error) {
-	resp, err := m.rm.GetAllocationHandler(
-		m.system,
-		sproto.GetAllocationHandler{ID: allocationID},
-	)
-	if err != nil {
-		return false, nil, status.Errorf(codes.NotFound, "allocation not found: %s", allocationID)
-	}
-
-	parentParent := resp.Parent().Parent()
-	if parentParent.Parent() == nil || parentParent.Parent().Address().Local() != "experiments" {
-		// TaskType not trial.
+	expID, err := experimentIDFromTrialTaskID(taskID)
+	if errors.Is(err, errIsNotTrialTaskID) {
 		return false, nil, nil
-	}
-
-	expID, err := strconv.Atoi(parentParent.Address().Local())
-	if err != nil {
+	} else if err != nil {
 		return false, nil, err
 	}
 
@@ -101,7 +87,11 @@ func (a *apiServer) canDoActionsOnTask(
 
 	switch t.TaskType {
 	case model.TaskTypeTrial:
-		exp, err := db.ExperimentByTaskID(ctx, t.TaskID)
+		isExp, exp, err := expFromTaskID(a.m, taskID)
+		if !isExp {
+			return fmt.Errorf("error we failed to look up an experiment "+
+				"from taskID %s when we think it is a trial task", taskID)
+		}
 		if err != nil {
 			return err
 		}
@@ -134,15 +124,15 @@ func (a *apiServer) canEditAllocation(ctx context.Context, allocationID string) 
 		return err
 	}
 
+	taskID := model.AllocationID(allocationID).ToTaskID()
 	errAllocationNotFound := status.Errorf(codes.NotFound, "allocation not found: %s", allocationID)
-	isExp, exp, err := expFromAllocationID(a.m, model.AllocationID(allocationID))
+	isExp, exp, err := expFromTaskID(a.m, taskID)
 	if err != nil {
 		return err
 	}
 	if !isExp {
-		taskID, _, _ := strings.Cut(allocationID, ".")
 		var ok bool
-		if ok, err = canAccessNTSCTask(ctx, *curUser, model.TaskID(taskID)); err != nil {
+		if ok, err = canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
 			return err
 		} else if !ok {
 			return errAllocationNotFound
@@ -388,7 +378,7 @@ func (a *apiServer) GetTasks(
 
 	pbAllocationIDToSummary := make(map[string]*taskv1.AllocationSummary)
 	for allocationID, allocationSummary := range summary {
-		isExp, exp, err := expFromAllocationID(a.m, allocationID)
+		isExp, exp, err := expFromTaskID(a.m, allocationSummary.TaskID)
 		if err != nil {
 			return nil, err
 		}

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"testing"
 	"time"
@@ -31,7 +32,10 @@ func createTestTrial(
 ) *model.Trial {
 	exp := createTestExpWithProjectID(t, api, curUser, 1)
 
-	task := &model.Task{TaskType: model.TaskTypeTrial, TaskID: model.NewTaskID()}
+	task := &model.Task{
+		TaskType: model.TaskTypeTrial,
+		TaskID:   trialTaskID(exp.ID, model.NewRequestID(rand.Reader)),
+	}
 	require.NoError(t, api.m.db.AddTask(task))
 
 	trial := &model.Trial{

--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -16,8 +16,8 @@ func (m *Master) getTasks(c echo.Context) (interface{}, error) {
 
 	curUser := c.(*context.DetContext).MustGetUser()
 	ctx := c.Request().Context()
-	for allocationID := range summary {
-		isExp, exp, err := expFromAllocationID(m, allocationID)
+	for allocationID, allocationSummary := range summary {
+		isExp, exp, err := expFromTaskID(m, allocationSummary.TaskID)
 		if err != nil {
 			return nil, err
 		}

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -84,6 +84,12 @@ func (a AllocationID) String() string {
 	return string(a)
 }
 
+// ToTaskID converts an AllocationID to its taskID.
+func (a AllocationID) ToTaskID() TaskID {
+	taskID, _, _ := strings.Cut(string(a), ".")
+	return TaskID(taskID)
+}
+
 // Allocation is the model for an allocation in the database.
 type Allocation struct {
 	bun.BaseModel `bun:"table:allocations"`

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -86,8 +86,7 @@ func (a AllocationID) String() string {
 
 // ToTaskID converts an AllocationID to its taskID.
 func (a AllocationID) ToTaskID() TaskID {
-	taskID, _, _ := strings.Cut(string(a), ".")
-	return TaskID(taskID)
+	return TaskID(a[:strings.LastIndex(string(a), ".")])
 }
 
 // Allocation is the model for an allocation in the database.


### PR DESCRIPTION
## Description

Task list was asking the rm for task information twice causing a race for the task to not be found on the second ask.


## Test Plan

Existing tests + EE test run here

https://github.com/determined-ai/determined-ee/pull/798




## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
