### PR TITLE
fix: exp actions with workspace-specific user perm [DET-9300]

### DIFF
--- a/master/internal/experiment/bulk_action.go
+++ b/master/internal/experiment/bulk_action.go
@@ -184,7 +184,8 @@ func editableExperimentIds(ctx context.Context, inputExpIDs []int32,
 		ModelTableExpr("experiments AS e").
 		Model(&expIDs).
 		Column("e.id").
-		Where("id IN (?)", bun.In(experimentIDList))
+		Join("JOIN projects p ON e.project_id = p.id").
+		Where("e.id IN (?)", bun.In(experimentIDList))
 
 	if query, err = AuthZProvider.Get().
 		FilterExperimentsQuery(ctx, *curUser, nil, query,


### PR DESCRIPTION
## Description

`FilterExperimentsQuery` expects `workspace_id` column, but it was not present.


## Test Plan

1. Setup RBAC permissions so a user only has an editor role on a particular workspace, not globally.
2. Try to kill/activate/move/delete experiments in this workspace.

## Commentary (optional)

- This is a hot fix but we need automated tests for this.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
