### PR TITLE
fix: wrap shutil.rmtree in a loop [DET-9127]

### DIFF
--- a/harness/determined/common/storage/cloud.py
+++ b/harness/determined/common/storage/cloud.py
@@ -1,9 +1,9 @@
 import contextlib
 import os
 import pathlib
-import shutil
 from typing import Iterator, Optional, Union
 
+from determined import util
 from determined.common import storage
 
 
@@ -20,7 +20,7 @@ class CloudStorageManager(storage.StorageManager):
         try:
             yield pathlib.Path(dst)
         finally:
-            shutil.rmtree(dst, ignore_errors=True)
+            util.rmtree_nfs_safe(dst, ignore_errors=True)
 
     def post_store_path(self, src: Union[str, os.PathLike], dst: str) -> None:
         """
@@ -29,7 +29,7 @@ class CloudStorageManager(storage.StorageManager):
         try:
             self.upload(src, dst)
         finally:
-            shutil.rmtree(src, ignore_errors=True)
+            util.rmtree_nfs_safe(src, ignore_errors=True)
 
     def store_path_is_direct_access(self) -> bool:
         return False

--- a/harness/determined/common/storage/shared.py
+++ b/harness/determined/common/storage/shared.py
@@ -5,7 +5,7 @@ import pathlib
 import shutil
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
-from determined import errors
+from determined import errors, util
 from determined.common import check, storage
 
 # Based on shutil.copytree and shutil._copytree (for Python 3.8). Compared to the original
@@ -180,7 +180,7 @@ class SharedFSStorageManager(storage.StorageManager):
             return
         if not os.path.isdir(storage_dir):
             raise errors.CheckpointNotFound(f"Storage path is not a directory: {storage_dir}")
-        shutil.rmtree(storage_dir, ignore_errors=False)
+        util.rmtree_nfs_safe(storage_dir, ignore_errors=False)
 
     def upload(
         self, src: Union[str, os.PathLike], dst: str, paths: Optional[storage.Paths] = None

--- a/harness/determined/core/_distributed.py
+++ b/harness/determined/core/_distributed.py
@@ -1,11 +1,10 @@
 import logging
 import os
-import shutil
 import socket
 import tempfile
 from typing import Any, List, Optional
 
-from determined import constants, ipc
+from determined import constants, ipc, util
 
 
 class DistributedContext:
@@ -249,7 +248,7 @@ class DistributedContext:
         if self._is_local_chief:
             self._local_chief_zmq.close()
             if self.tempdir is not None:
-                shutil.rmtree(self.tempdir)
+                util.rmtree_nfs_safe(self.tempdir)
                 self.tempdir = None
         else:
             self._local_worker_zmq.close()

--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -11,6 +11,7 @@ import googleapiclient.discovery
 from google.auth.exceptions import DefaultCredentialsError
 from termcolor import colored
 
+from determined import util
 from determined.deploy import healthcheck
 
 from .preflight import check_quota
@@ -98,7 +99,7 @@ def terraform_init(configs: Dict, env: Dict) -> None:
     # we don't have to rely on users running `det deploy gcp up/down` from
     # different directories or with different Python environments.
     if os.path.exists(terraform_dir(configs)):
-        shutil.rmtree(terraform_dir(configs))
+        util.rmtree_nfs_safe(terraform_dir(configs))
 
     shutil.copytree(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "terraform"),

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -18,7 +18,7 @@ from tensorflow.python.util import function_utils
 from tensorflow_estimator.python.estimator.training import _NewCheckpointListenerForEvaluate
 
 import determined as det
-from determined import estimator, horovod, layers, monkey_patch, tensorboard, workload
+from determined import estimator, horovod, layers, monkey_patch, tensorboard, util, workload
 from determined._tf_rng import get_rng_state, set_rng_state
 from determined.common import check
 from determined.horovod import hvd
@@ -760,7 +760,7 @@ class EstimatorTrialController(det.TrialController):
 
             self.estimator_dir = pathlib.Path(tempfile.mkdtemp(suffix=suffix))
             if self.estimator_dir.exists():
-                shutil.rmtree(str(self.estimator_dir))
+                util.rmtree_nfs_safe(str(self.estimator_dir))
             logging.debug(f"Copying from {load_path} to {self.estimator_dir}.")
             shutil.copytree(str(load_path), str(self.estimator_dir))
 

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -4,6 +4,7 @@ import pathlib
 import shutil
 from typing import Any, List
 
+from determined import util
 from determined.tensorboard import base
 
 logger = logging.getLogger("determined.tensorboard")
@@ -42,4 +43,4 @@ class SharedFSTensorboardManager(base.TensorboardManager):
             shutil.copy(path, mangled_path)
 
     def delete(self) -> None:
-        shutil.rmtree(self.shared_fs_base, False)
+        util.rmtree_nfs_safe(self.shared_fs_base, False)


### PR DESCRIPTION
Apparently NFS can cause rmtree to fail, so we avoid calling it directly, and instead call it in a new rmtree_nfs_safe wrapper function.

## Commentary

I'm not going to lie, I don't have any experience with NFS, but I'm not entirely convinced that `rmtree` should fail on a healthy NFS.  It seems like there'd be a lot more evidence of it in google searches, and I'd kind of expect `shtuil` to have some sort of workaround for it by now.

Also, there's the matter of the filelocks that aren't getting cleaned up that also make me suspect this CI filesystem isn't fully healthy.

EE tests at https://github.com/determined-ai/determined-ee/pull/802.