### PR TITLE
feat: k8s cluster info using taints/tolerations incl. global ones

### DIFF
--- a/master/go.mod
+++ b/master/go.mod
@@ -155,7 +155,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1005,6 +1005,7 @@ func (m *Master) Run(ctx context.Context) error {
 		m.db,
 		m.echo,
 		&m.config.ResourceConfig,
+		&m.config.TaskContainerDefaults,
 		&aproto.MasterSetAgentOptions{
 			MasterInfo:     m.Info(),
 			LoggingOptions: m.config.Logging,

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -46,6 +46,7 @@ func New(
 	db *db.PgDB,
 	echo *echo.Echo,
 	config *config.ResourceConfig,
+	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 	opts *aproto.MasterSetAgentOptions,
 	cert *tls.Certificate,
 ) ResourceManager {
@@ -58,6 +59,7 @@ func New(
 		newKubernetesResourceManager(
 			config.ResourceManager.KubernetesRM,
 			config.ResourcePools,
+			taskContainerDefaults,
 			echo,
 			tlsConfig,
 			opts.LoggingOptions,
@@ -189,8 +191,9 @@ func isReattachEnabledForRP(rp string) bool {
 
 // kubernetesResourceProvider manages the lifecycle of k8s resources.
 type kubernetesResourceManager struct {
-	config      *config.KubernetesResourceManagerConfig
-	poolsConfig []config.ResourcePoolConfig
+	config                *config.KubernetesResourceManagerConfig
+	poolsConfig           []config.ResourcePoolConfig
+	taskContainerDefaults *model.TaskContainerDefaultsConfig
 
 	podsActor *actor.Ref
 	pools     map[string]*actor.Ref
@@ -203,13 +206,15 @@ type kubernetesResourceManager struct {
 func newKubernetesResourceManager(
 	config *config.KubernetesResourceManagerConfig,
 	poolsConfig []config.ResourcePoolConfig,
+	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 	echoRef *echo.Echo,
 	masterTLSConfig model.TLSClientConfig,
 	loggingConfig model.LoggingConfig,
 ) actor.Actor {
 	return &kubernetesResourceManager{
-		config:      config,
-		poolsConfig: poolsConfig,
+		config:                config,
+		poolsConfig:           poolsConfig,
+		taskContainerDefaults: taskContainerDefaults,
 
 		pools: make(map[string]*actor.Ref),
 
@@ -246,6 +251,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			config.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
 			k.config.Fluent,
 			k.poolsConfig,
+			k.taskContainerDefaults,
 			k.config.CredsDir,
 			k.config.MasterIP,
 			k.config.MasterPort,

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -245,6 +245,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 			k.config.SlotType,
 			config.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
 			k.config.Fluent,
+			k.poolsConfig,
 			k.config.CredsDir,
 			k.config.MasterIP,
 			k.config.MasterPort,

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1026,6 +1026,7 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 						ID:    cproto.ID(id),
 						State: "RUNNING",
 					}
+					pseudoContainersAdded++
 				}
 
 				slots[id] = model.SlotSummary{
@@ -1328,6 +1329,7 @@ func allTaintsTolerated(taints []k8sV1.Taint, tolerations []k8sV1.Toleration) bo
 
 func extractSlotInfo(node model.AgentSummary) (numSlots int, devType device.Type) {
 	var gpuSlots, cpuSlots int
+
 	for _, slot := range node.Slots {
 		if slot.Device.Type == device.CPU {
 			cpuSlots++

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -11,12 +11,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
-<<<<<<< HEAD
-	"golang.org/x/exp/maps"
-	"gopkg.in/inf.v0"
-=======
 	"github.com/sirupsen/logrus"
->>>>>>> 8bb41fd6d (WIP: k8s cluster info using taints/tolerations)
+	"golang.org/x/exp/maps"
 	k8sV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -997,9 +997,9 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 		"lenPoolsToNodes":        len(poolsToNodes),
 		"lenNamespaceToPoolName": len(p.namespaceToPoolName),
 	}
-	for _, pool := range poolsToNodes {
+	for pool, nodes := range poolsToNodes {
 		key := fmt.Sprintf("lenNodesIn-%s", pool)
-		f[key] = len(poolsToNodes["default"])
+		f[key] = len(nodes)
 	}
 	logrus.WithFields(f).Debug("done associating nodes and pools")
 

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1210,29 +1210,6 @@ func numSlots(slots model.SlotsSummary) int {
 	return slotCountsByType[device.CPU]
 }
 
-func cpuAndGpuQuotas(quotas *k8sV1.ResourceQuotaList) []k8sV1.ResourceQuota {
-	if quotas == nil || len(quotas.Items) == 0 {
-		return nil
-	}
-
-	result := []k8sV1.ResourceQuota{}
-	for _, q := range quotas.Items {
-		foundRelevant := false
-		for resourceName := range q.Spec.Hard {
-			switch resourceName {
-			case k8sV1.ResourceCPU, ResourceTypeNvidia, "limits." + ResourceTypeNvidia:
-				foundRelevant = true
-			}
-		}
-
-		if foundRelevant {
-			result = append(result, q)
-		}
-	}
-
-	return result
-}
-
 func (p *pods) listPodsInAllNamespaces(
 	ctx context.Context, opts metaV1.ListOptions,
 ) (*k8sV1.PodList, error) {
@@ -1265,7 +1242,8 @@ func (p *pods) listConfigMapsInAllNamespaces(
 	return res, nil
 }
 
-func extractTCDs(resourcePoolConfigs []config.ResourcePoolConfig) map[string]*model.TaskContainerDefaultsConfig {
+func extractTCDs(resourcePoolConfigs []config.ResourcePoolConfig,
+) map[string]*model.TaskContainerDefaultsConfig {
 	result := map[string]*model.TaskContainerDefaultsConfig{}
 
 	for _, config := range resourcePoolConfigs {

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -958,7 +958,9 @@ func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, err
 		for poolName, tcd := range taskContainerDefaults {
 			var poolTolerations []k8sV1.Toleration
 
-			if len(p.resourcePoolConfigs) == 0 {
+			// If they're using the default RP config, use the default tolerations.
+			if len(p.resourcePoolConfigs) <= 1 &&
+				(tcd == nil || (tcd.CPUPodSpec == nil && tcd.GPUPodSpec == nil)) {
 				poolTolerations = defaultTolerations
 			} else if tcd != nil {
 				// Decide which poolTolerations to use based on slot device type

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1303,7 +1303,6 @@ func extractSlotInfo(node model.AgentSummary) (numSlots int, devType device.Type
 
 func extractTolerations(tcd *model.TaskContainerDefaultsConfig,
 	slotType device.Type) []k8sV1.Toleration {
-
 	if tcd != nil {
 		if slotType == device.CUDA && tcd.GPUPodSpec != nil {
 			return tcd.GPUPodSpec.Spec.Tolerations

--- a/master/internal/rm/kubernetesrm/pods_test.go
+++ b/master/internal/rm/kubernetesrm/pods_test.go
@@ -1,0 +1,108 @@
+package kubernetesrm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sV1 "k8s.io/api/core/v1"
+)
+
+func TestTaintTolerated(t *testing.T) {
+	cases := []struct {
+		expected    bool
+		taint       k8sV1.Taint
+		tolerations []k8sV1.Toleration
+	}{
+		{
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Value:    taintFooBar.Value,
+				Operator: k8sV1.TolerationOpEqual,
+			}},
+		}, {
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Operator: k8sV1.TolerationOpExists,
+			}},
+		}, {
+			expected: true,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{
+				{
+					Key:      taintFooBar.Key,
+					Value:    taintFooBar.Value,
+					Operator: k8sV1.TolerationOpEqual,
+				}, {
+					Key:      "baz",
+					Value:    "qux",
+					Operator: k8sV1.TolerationOpEqual,
+				}},
+		}, {
+			expected: false,
+			taint:    taintFooBar,
+			tolerations: []k8sV1.Toleration{{
+				Key:      taintFooBar.Key,
+				Value:    taintFooBar.Value + taintFooBar.Value,
+				Operator: k8sV1.TolerationOpEqual,
+			}},
+		}, {
+			expected:    false,
+			taint:       taintFooBar,
+			tolerations: []k8sV1.Toleration{},
+		}, {
+			expected:    false,
+			taint:       taintFooBar,
+			tolerations: nil,
+		},
+	}
+
+	for i, c := range cases {
+		actual := taintTolerated(c.taint, c.tolerations)
+		require.Equal(t, c.expected, actual, "test case %d failed", i)
+	}
+}
+
+func TestAllTaintsTolerated(t *testing.T) {
+	cases := []struct {
+		expected    bool
+		taints      []k8sV1.Taint
+		tolerations []k8sV1.Toleration
+	}{
+		{
+			expected:    true,
+			taints:      nil,
+			tolerations: nil,
+		}, {
+			expected: true,
+			taints:   nil,
+			tolerations: []k8sV1.Toleration{
+				{
+					Key:      taintFooBar.Key,
+					Value:    taintFooBar.Value,
+					Operator: k8sV1.TolerationOpEqual,
+				},
+			},
+		}, {
+			expected:    false,
+			taints:      []k8sV1.Taint{taintFooBar},
+			tolerations: nil,
+		},
+	}
+
+	for i, c := range cases {
+		actual := allTaintsTolerated(c.taints, c.tolerations)
+		require.Equal(t, c.expected, actual, "test case %d failed", i)
+	}
+}
+
+var (
+	taintFooBar = k8sV1.Taint{
+		Key:    "foo",
+		Value:  "bar",
+		Effect: k8sV1.TaintEffectNoSchedule,
+	}
+)

--- a/master/internal/rm/setup.go
+++ b/master/internal/rm/setup.go
@@ -3,15 +3,15 @@ package rm
 import (
 	"crypto/tls"
 
-	"github.com/determined-ai/determined/master/internal/rm/agentrm"
-	"github.com/determined-ai/determined/master/internal/rm/kubernetesrm"
-
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/rm/agentrm"
+	"github.com/determined-ai/determined/master/internal/rm/kubernetesrm"
 	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 // New sets up the actor and endpoints for resource managers.
@@ -20,6 +20,7 @@ func New(
 	db *db.PgDB,
 	echo *echo.Echo,
 	config *config.ResourceConfig,
+	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 	opts *aproto.MasterSetAgentOptions,
 	cert *tls.Certificate,
 ) ResourceManager {
@@ -27,7 +28,7 @@ func New(
 	case config.ResourceManager.AgentRM != nil:
 		return agentrm.New(system, db, echo, config, opts, cert)
 	case config.ResourceManager.KubernetesRM != nil:
-		return kubernetesrm.New(system, db, echo, config, opts, cert)
+		return kubernetesrm.New(system, db, echo, config, taskContainerDefaults, opts, cert)
 	default:
 		panic("no expected resource manager config is defined")
 	}


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

Update to #6425 (which was reverted), but includes the global task container defaults' tolerations while deciding whether a node belongs to a resource pool. This fixes [an issue](https://app.circleci.com/pipelines/github/determined-ai/determined/36281/workflows/18c95a74-1bae-4617-a2a4-f44d98f4072f/jobs/1304145) detected by our end to end tests. Takes care of DET-9122.


## Test Plan

Same as #6425.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9122