### PR TITLE
chore: [FIX] replace helm pw-changer image with generic det env image…

### DIFF
--- a/helm/charts/determined/scripts/k8s-password-change.py
+++ b/helm/charts/determined/scripts/k8s-password-change.py
@@ -56,7 +56,7 @@ def getMasterAddress(
     if node_port != "true":
         while True:
             services = requests.get(
-                url=f"https://{service_host}:{service_post}/api/v1/namespaces/{namespace}/services",
+                url=f"https://{service_host}:{service_port}/api/v1/namespaces/{namespace}/services",
                 headers={"Authorization": f"Bearer {token}"},
                 verify=False,
             ).json()
@@ -73,7 +73,7 @@ def getMasterAddress(
                         return f"{status['ingress'][0]['ip']}:{master_port}"
 
     services = requests.get(
-        url=f"https://{service_host}:{service_post}/api/v1/namespaces/{namespace}/services",
+        url=f"https://{service_host}:{service_port}/api/v1/namespaces/{namespace}/services",
         headers={"Authorization": f"Bearer {token}"},
         verify=False,
     ).json()


### PR DESCRIPTION
### **This is a typo fix for the variable `service_port` from [PR 6483](https://github.com/determined-ai/determined/pull/6483). **
## Description
This change replaces the utility:pw-changer image with a generic determinedai/environments image with the intention to reduce the number of images that NGC/airgapped customers must pull in. Since the determinedai/environments doesn't include the kubernetes API or Determined API, that functionality is replaced with the built-in requests library.

## Test Plan
To test this change, please follow the general k8s setup from:
https://docs.determined.ai/latest/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/overview.html#
If you spin up your own GKE cluster, follow this log:

gcloud container clusters create ${GKE_CLUSTER_NAME} \
    --region us-west1 \
    --node-locations us-west1-b\
    --num-nodes=1 \
    --machine-type=n1-standard-8 \
		--create-subnetwork name="" \
		--enable-ip-alias --cluster-version=latest

gcloud container node-pools create ${GKE_GPU_NODE_POOL_NAME} \
  --cluster ${GKE_CLUSTER_NAME} \
  --accelerator type=${GPU_TYPE},count=1 \
  --zone us-west1 \
  --machine-type=n1-standard-8 \
  --scopes=storage-full

kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml

gsutil mb gs://${GCS_BUCKET_NAME}

helm install determined helm/charts/determined/ --values helm/charts/determined/values.yaml --set maxSlotsPerPod=1 --set defaultPassword=<newPassword>
where newPassword is whatever value you pass.

Then, to verify the change, once the helm release is deployed go to <EXTERNAL-IP>:8080 in your browser, where EXTERNAL-IP is the IP from the master service. You should be able to log in with either determined or admin username using the newPassword value, not an empty password.

## Ticket
DET-9110