### PR TITLE
chore: add --json to det e|task|trial logs [DET-8982]

### DIFF
--- a/docs/release-notes/exp-trial-task-logs-json.rst
+++ b/docs/release-notes/exp-trial-task-logs-json.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  CLI: Add ``det (experiment|trial|task) logs --json`` option, allowing user to get JSON-formatted
+   logs for experiments, trials, and tasks.

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -140,8 +140,17 @@ def _follow_experiment_logs(sess: api.Session, exp_id: int) -> None:
 
     first_trial_id = sorted(t_id.id for t_id in trials)[0]
     print(f"Following first trial with ID {first_trial_id}")
-    tlogs = logs.trial_logs(sess, first_trial_id, follow=True)
-    logs.pprint_trial_logs(first_trial_id, tlogs)
+    try:
+        tlogs = logs.trial_logs(sess, first_trial_id, follow=True)
+        logs.pprint_logs(tlogs)
+    finally:
+        print(
+            termcolor.colored(
+                "Trial log stream ended. To reopen log stream, run: "
+                "det trial logs -f {}".format(first_trial_id),
+                "green",
+            )
+        )
 
 
 def _follow_test_experiment_logs(sess: api.Session, exp_id: int) -> None:
@@ -211,8 +220,17 @@ def _follow_test_experiment_logs(sess: api.Session, exp_id: int) -> None:
         elif exp.state == bindings.experimentv1State.ERROR:
             print_progress(active_stage, ended=True)
             trial_id = trials[0].id
-            tlogs = logs.trial_logs(sess, trial_id)
-            logs.pprint_trial_logs(trial_id, tlogs)
+            try:
+                tlogs = logs.trial_logs(sess, trial_id)
+                logs.pprint_logs(tlogs)
+            finally:
+                print(
+                    termcolor.colored(
+                        "Trial log stream ended. To reopen log stream, run: "
+                        "det trial logs -f {}".format(trial_id),
+                        "green",
+                    )
+                )
             sys.exit(1)
         else:
             print_progress(active_stage, ended=False)
@@ -582,23 +600,34 @@ def experiment_logs(args: Namespace) -> None:
         )
         return
     first_trial_id = sorted(t_id.id for t_id in trials)[0]
-
-    logs = api.trial_logs(
-        cli.setup_session(args),
-        first_trial_id,
-        head=args.head,
-        tail=args.tail,
-        follow=args.follow,
-        agent_ids=args.agent_ids,
-        container_ids=args.container_ids,
-        rank_ids=args.rank_ids,
-        sources=args.sources,
-        stdtypes=args.stdtypes,
-        min_level=args.level,
-        timestamp_before=args.timestamp_before,
-        timestamp_after=args.timestamp_after,
-    )
-    api.pprint_trial_logs(first_trial_id, logs)
+    try:
+        logs = api.trial_logs(
+            cli.setup_session(args),
+            first_trial_id,
+            head=args.head,
+            tail=args.tail,
+            follow=args.follow,
+            agent_ids=args.agent_ids,
+            container_ids=args.container_ids,
+            rank_ids=args.rank_ids,
+            sources=args.sources,
+            stdtypes=args.stdtypes,
+            min_level=args.level,
+            timestamp_before=args.timestamp_before,
+            timestamp_after=args.timestamp_after,
+        )
+        if args.json:
+            api.print_json_logs(logs)
+        else:
+            api.pprint_logs(logs)
+    finally:
+        print(
+            termcolor.colored(
+                "Trial log stream ended. To reopen log stream, run: "
+                "det trial logs -f {}".format(first_trial_id),
+                "green",
+            )
+        )
 
 
 @authentication.required
@@ -963,8 +992,8 @@ main_cmd = Cmd(
                 Arg("experiment_ids", help="comma-separated list of experiment IDs to describe"),
                 Arg("--metrics", action="store_true", help="display full metrics"),
                 Group(
-                    Arg("--csv", action="store_true", help="print as CSV"),
-                    Arg("--json", action="store_true", help="print as JSON"),
+                    cli.output_format_args["csv"],
+                    cli.output_format_args["json"],
                     Arg("--outdir", type=Path, help="directory to save output"),
                 ),
             ],
@@ -975,6 +1004,7 @@ main_cmd = Cmd(
             "fetch logs of the first trial of an experiment",
             [
                 experiment_id_arg("experiment ID"),
+                cli.output_format_args["json"],
             ]
             + logs_args_description,
         ),

--- a/harness/determined/cli/remote.py
+++ b/harness/determined/cli/remote.py
@@ -3,6 +3,8 @@ from functools import partial
 from pathlib import Path
 from typing import Any, List
 
+from termcolor import colored
+
 from determined import cli
 from determined.cli import command, task
 from determined.common import api
@@ -28,8 +30,17 @@ def run_command(args: Namespace) -> None:
         print(resp["id"])
         return
 
-    logs = api.task_logs(cli.setup_session(args), resp["id"], follow=True)
-    api.pprint_task_logs(resp["id"], logs)
+    try:
+        logs = api.task_logs(cli.setup_session(args), resp["id"], follow=True)
+        api.pprint_logs(logs)
+    finally:
+        print(
+            colored(
+                "Task log stream ended. To reopen log stream, run: "
+                "det task logs -f {}".format(resp["id"]),
+                "green",
+            )
+        )
 
 
 # fmt: off

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -7,6 +7,8 @@ from argparse import Namespace
 from datetime import datetime
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
+from termcolor import colored
+
 from determined import cli
 from determined.cli import render
 from determined.cli.master import format_log_entry
@@ -172,22 +174,34 @@ def kill_trial(args: Namespace) -> None:
 
 @authentication.required
 def trial_logs(args: Namespace) -> None:
-    logs = api.trial_logs(
-        cli.setup_session(args),
-        args.trial_id,
-        head=args.head,
-        tail=args.tail,
-        follow=args.follow,
-        agent_ids=args.agent_ids,
-        container_ids=args.container_ids,
-        rank_ids=args.rank_ids,
-        sources=args.sources,
-        stdtypes=args.stdtypes,
-        min_level=args.level,
-        timestamp_before=args.timestamp_before,
-        timestamp_after=args.timestamp_after,
-    )
-    api.pprint_trial_logs(args.trial_id, logs)
+    try:
+        logs = api.trial_logs(
+            cli.setup_session(args),
+            args.trial_id,
+            head=args.head,
+            tail=args.tail,
+            follow=args.follow,
+            agent_ids=args.agent_ids,
+            container_ids=args.container_ids,
+            rank_ids=args.rank_ids,
+            sources=args.sources,
+            stdtypes=args.stdtypes,
+            min_level=args.level,
+            timestamp_before=args.timestamp_before,
+            timestamp_after=args.timestamp_after,
+        )
+        if args.json:
+            api.print_json_logs(logs)
+        else:
+            api.pprint_logs(logs)
+    finally:
+        print(
+            colored(
+                "Trial log stream ended. To reopen log stream, run: "
+                "det trial logs -f {}".format(args.trial_id),
+                "green",
+            )
+        )
 
 
 @authentication.required
@@ -353,8 +367,8 @@ args_description = [
                         help="display full metrics, such as batch metrics",
                     ),
                     Group(
-                        Arg("--csv", action="store_true", help="print as CSV"),
-                        Arg("--json", action="store_true", help="print JSON"),
+                        cli.output_format_args["csv"],
+                        cli.output_format_args["json"],
                     ),
                     *cli.make_pagination_args(limit=1000),
                 ],
@@ -436,6 +450,7 @@ args_description = [
                 "fetch trial logs",
                 [
                     Arg("trial_id", type=int, help="trial ID"),
+                    cli.output_format_args["json"],
                 ]
                 + logs_args_description,
             ),

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -4,8 +4,8 @@ from determined.common.api import bindings
 from determined.common.api._util import PageOpts, read_paginated, WARNING_MESSAGE_MAP
 from determined.common.api.authentication import Authentication, salt_and_hash
 from determined.common.api.logs import (
-    pprint_trial_logs,
-    pprint_task_logs,
+    pprint_logs,
+    print_json_logs,
     trial_logs,
     task_logs,
 )

--- a/harness/determined/common/api/logs.py
+++ b/harness/determined/common/api/logs.py
@@ -1,41 +1,22 @@
-from typing import Iterable, List, Optional
-
-from termcolor import colored
+import json
+from typing import Iterable, List, Optional, Union
 
 from determined.common import api
 from determined.common.api import bindings
 
 
-def pprint_task_logs(task_id: str, logs: Iterable[bindings.v1TaskLogsResponse]) -> None:
-    try:
-        for log in logs:
-            print(log.message, end="")
-    except KeyboardInterrupt:
-        pass
-    finally:
-        print(
-            colored(
-                "Task log stream ended. To reopen log stream, run: "
-                "det task logs -f {}".format(task_id),
-                "green",
-            )
-        )
+def pprint_logs(
+    logs: Iterable[Union[bindings.v1TaskLogsResponse, bindings.v1TrialLogsResponse]]
+) -> None:
+    for log in logs:
+        print(log.message, end="")
 
 
-def pprint_trial_logs(trial_id: int, logs: Iterable[bindings.v1TrialLogsResponse]) -> None:
-    try:
-        for log in logs:
-            print(log.message, end="")
-    except KeyboardInterrupt:
-        pass
-    finally:
-        print(
-            colored(
-                "Trial log stream ended. To reopen log stream, run: "
-                "det trial logs -f {}".format(trial_id),
-                "green",
-            )
-        )
+def print_json_logs(
+    logs: Iterable[Union[bindings.v1TaskLogsResponse, bindings.v1TrialLogsResponse]]
+) -> None:
+    for log in logs:
+        print(json.dumps(log.to_json(), indent=4))
 
 
 def trial_logs(


### PR DESCRIPTION
## Description
Other trial & experiment CLI commands (ex. `det trial describe`) already have a `--json` flag, so this is just a matter of extending that functionality to the `det e logs <experiment-id> --json`, `det t logs <trial-id> --json`, and `det task logs <task-id> --json`.

In doing so, I also refactored the printing functions inside logs.py to combine `pprint_task_logs` + `pprint_trial_logs` -> `pprint_logs` by moving the final print statement to original handlers for `det e|task|trial logs`. Additionally, the `--json` CLI argument (and other output formatting arguments) in `experiment.py, task.py, trial.py, task.py` were imported from `_util.py`.

## Test Plan

Simply run `det e logs <experiment-id> --json`, `det t logs <trial-id> --json`, `det task logs <task-id> --json` and confirm the output is of the format:
` [  {
        "id": ...,
        "level": ...,
        "message": ...,
        "timestamp": ...,
        "trialId": ...,
        "agentId": ...,
        "containerId": ...,
        "log": ...,
        "rankId": ...,
        "source": ...,
        "stdtype": ...,
    }, { ... }, ...]`


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-8982