### PR TITLE
fix: Append instead of replace sbatch args [DET-9263]

### DIFF
--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -134,8 +134,19 @@ func (c *TaskContainerDefaultsConfig) MergeIntoExpConfig(config *expconf.Experim
 	bindMounts := c.BindMounts.ToExpconf()
 	config.RawBindMounts = schemas.Merge(config.RawBindMounts, bindMounts)
 
+	configRawSlurmConfig := config.RawSlurmConfig
 	config.RawSlurmConfig = schemas.Merge(config.RawSlurmConfig, &c.Slurm)
+	if configRawSlurmConfig != nil {
+		config.RawSlurmConfig.RawSbatchArgs = append(
+			c.Slurm.SbatchArgs(), configRawSlurmConfig.SbatchArgs()...)
+	}
+
+	configRawPbsConfig := config.RawPbsConfig
 	config.RawPbsConfig = schemas.Merge(config.RawPbsConfig, &c.Pbs)
+	if configRawPbsConfig != nil {
+		config.RawPbsConfig.RawSbatchArgs = append(
+			c.Pbs.SbatchArgs(), configRawPbsConfig.SbatchArgs()...)
+	}
 }
 
 var mergeCopier = copier.Option{IgnoreEmpty: true, DeepCopy: true}


### PR DESCRIPTION

## Description

Expconf slurm|pbs.sbatch_args replaced task_container_defaults sbatch_args. Need to append instead.

Add unit test cases for Slurm/Pbs Config and inheritance.


## Test Plan

Validated with [Slurm inheritance slumcluster.sh config on casablanca](https://github.com/determined-ai/determined-ee/pull/762).

Submitted Configuraiton
![image](https://user-images.githubusercontent.com/84593277/231891448-52ce7d10-9c0a-45b4-97a1-21288085b28a.png)

Runtime Configuration
![image](https://user-images.githubusercontent.com/84593277/231891325-ddf22401-1e70-4624-a728-a4f1933206a7.png)


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
