### PR TITLE
fix: use onCellClicked instead of links-cell [WEB-1141]

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/linkCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/linkCell.tsx
@@ -19,7 +19,6 @@ interface LinkCellProps {
   readonly link: {
     readonly title: string;
     readonly href?: string;
-    readonly onClick?: () => void;
   };
 }
 
@@ -98,14 +97,6 @@ const renderer: CustomRenderer<LinkCell> = {
   kind: GridCellKind.Custom,
   needsHover: true,
   needsHoverPosition: true,
-  onClick: (e) => {
-    const hovered = onClickSelect(e);
-    if (hovered !== undefined) {
-      hovered.onClick?.();
-      e.preventDefault();
-    }
-    return undefined;
-  },
 
   onSelect: (e) => {
     if (onClickSelect(e) !== undefined) {


### PR DESCRIPTION
## Description

We discussed an issue with the custom links-cell opening onMouseUp even if that's not where we clicked.

On investigation, glide remembers `lastMouseDown` to detect these traveling/dragged clicks and avoids calling `onCellClicked` for them. But then it continues on to call any custom renderers' `onClick` 👿  https://github.com/glideapps/glide-data-grid/blob/main/packages/core/src/data-editor/data-editor.tsx#L2012

So my suggestion is instead of links-cell calling `useNavigate`, we use `onCellClicked`. The way I got this cell's type and links is the same as the renderer. We basically re-render the cell. If there's a better way to get the link let's find it.

## Test Plan

With flag `?f_explist_v2=on`
- Left-click a row normally to select and un-select the row
- Left-click a link normally to travel to its experiment
- Mouse-down somewhere outside the link cell, move a few rows, then lift the mouse over a link. Browser should not navigate.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.