### PR TITLE
fix: Delete multiple experiments with new call [WEB-1135]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -333,7 +333,7 @@ func (a *apiServer) DeleteExperiment(
 	go func() {
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		if _, err := a.deleteExperiments(wg, []*model.Experiment{e},
+		if _, err := a.deleteExperiments(&wg, []*model.Experiment{e},
 			&curUser); err != nil {
 			logrus.WithError(err).Errorf("deleting experiment %d", e.ID)
 			e.State = model.DeleteFailedState
@@ -365,7 +365,7 @@ func (a *apiServer) DeleteExperiments(
 			exps := experiments[i : i+10]
 			wg.Add(1)
 			go func() {
-				if expIDs, err := a.deleteExperiments(wg, exps, curUser); err != nil {
+				if expIDs, err := a.deleteExperiments(&wg, exps, curUser); err != nil {
 					for _, id := range expIDs {
 						logrus.WithError(err).Errorf("deleting experiment %d", id)
 					}
@@ -393,7 +393,7 @@ func (a *apiServer) DeleteExperiments(
 	return &apiv1.DeleteExperimentsResponse{Results: exputil.ToAPIResults(results)}, err
 }
 
-func (a *apiServer) deleteExperiments(wg sync.WaitGroup, exps []*model.Experiment,
+func (a *apiServer) deleteExperiments(wg *sync.WaitGroup, exps []*model.Experiment,
 	userModel *model.User,
 ) ([]int, error) {
 	var expIDs []int

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -353,7 +353,8 @@ func (a *apiServer) DeleteExperiments(
 		return nil, status.Errorf(codes.Internal, "failed to get the user: %s", err)
 	}
 
-	results, experiments, err := exputil.DeleteExperiments(ctx, a.m.system, req.ExperimentIds, req.Filters)
+	results, experiments, err := exputil.DeleteExperiments(ctx, a.m.system, req.ExperimentIds,
+		req.Filters)
 
 	go func() {
 		for i := 0; i < len(experiments); i += 10 {
@@ -387,10 +388,8 @@ func (a *apiServer) deleteExperiments(ctx context.Context, exps []*model.Experim
 	userModel *model.User,
 ) ([]int, error) {
 	var expIDs []int
-	var jobIDs []model.JobID
 	for _, exp := range exps {
 		expIDs = append(expIDs, exp.ID)
-		jobIDs = append(jobIDs, exp.JobID)
 	}
 
 	taskSpec := *a.m.taskSpec

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -362,7 +362,8 @@ func (a *apiServer) DeleteExperiments(
 	go func() {
 		sema := make(chan struct{}, maxConcurrentDeletes)
 		wg := sync.WaitGroup{}
-		for _, exp := range experiments {
+		for idx := range experiments {
+			exp := experiments[idx]
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -318,24 +318,19 @@ func (a *apiServer) DeleteExperiment(
 		return nil, err
 	}
 
-	switch exists, eErr := a.m.db.ExperimentHasCheckpointsInRegistry(int(req.ExperimentId)); {
-	case eErr != nil:
-		return nil, errors.New("failed to check model registry for references")
-	case exists:
-		return nil, status.Errorf(
-			codes.InvalidArgument, "checkpoints are registered as model versions")
+	results, _, err := exputil.DeleteExperiments(ctx, a.m.system,
+		[]int32{req.ExperimentId}, nil)
+
+	if err == nil {
+		if len(results) == 0 {
+			return nil, errors.Errorf("unknown error during delete query.")
+		} else if results[0].Error != nil {
+			return nil, results[0].Error
+		}
 	}
 
-	if !model.ExperimentTransitions[e.State][model.DeletingState] {
-		return nil, fmt.Errorf("cannot delete experiment in %s state", e.State)
-	}
-
-	e.State = model.DeletingState
-	if err := a.m.db.TrySaveExperimentState(e); err != nil {
-		return nil, errors.Wrapf(err, "transitioning to %s", e.State)
-	}
-	go func() {
-		if err := a.deleteExperiment(e, &curUser); err != nil {
+	// go func() {
+		if _, err := a.deleteExperiments(ctx, []*model.Experiment{e}, &curUser); err != nil {
 			logrus.WithError(err).Errorf("deleting experiment %d", e.ID)
 			e.State = model.DeleteFailedState
 			if err := a.m.db.SaveExperimentState(e); err != nil {
@@ -344,7 +339,7 @@ func (a *apiServer) DeleteExperiment(
 		} else {
 			logrus.Infof("experiment %d deleted successfully", e.ID)
 		}
-	}()
+	// }()
 
 	return &apiv1.DeleteExperimentResponse{}, nil
 }
@@ -352,70 +347,111 @@ func (a *apiServer) DeleteExperiment(
 func (a *apiServer) DeleteExperiments(
 	ctx context.Context, req *apiv1.DeleteExperimentsRequest,
 ) (*apiv1.DeleteExperimentsResponse, error) {
-	_, _, err := grpcutil.GetUser(ctx)
+	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "failed to get the user: %s", err)
 	}
 
-	return &apiv1.DeleteExperimentsResponse{}, err
+	results, experiments, err := exputil.DeleteExperiments(ctx, a.m.system, req.ExperimentIds, req.Filters)
+
+	// go func() {
+	for i := 0; i < len(experiments); i += 10 {
+		exps := experiments[i : i+10]
+		if expIDs, err := a.deleteExperiments(ctx, exps, curUser); err != nil {
+			for _, id := range expIDs {
+				logrus.WithError(err).Errorf("deleting experiment %d", id)
+			}
+			_, err = db.Bun().NewUpdate().
+				ModelTableExpr("experiments as e").
+				Set("state = ?", model.DeleteFailedState).
+				Where("id IN (?)", bun.In(expIDs)).
+				Exec(ctx)
+			if err != nil {
+				for _, id := range expIDs {
+					logrus.WithError(err).Errorf("transitioning experiment %d to %s", id, model.DeleteFailedState)
+				}
+			}
+		} else {
+			for _, id := range expIDs {
+				logrus.WithError(err).Errorf("deleting experiment %d", id)
+			}
+		}
+	}
+	// }()
+
+	return &apiv1.DeleteExperimentsResponse{Results: exputil.ToAPIResults(results)}, err
 }
 
-func (a *apiServer) deleteExperiment(exp *model.Experiment, userModel *model.User) error {
-	agentUserGroup, err := user.GetAgentUserGroup(*exp.OwnerID, exp)
-	if err != nil {
-		return err
+func (a *apiServer) deleteExperiments(ctx context.Context, exps []*model.Experiment,
+	userModel *model.User,
+) ([]int, error) {
+	var expIDs []int
+	var jobIDs []model.JobID
+	for _, exp := range exps {
+		expIDs = append(expIDs, exp.ID)
+		jobIDs = append(jobIDs, exp.JobID)
 	}
 
 	taskSpec := *a.m.taskSpec
-	checkpoints, err := a.m.db.ExperimentCheckpointsToGCRaw(
-		exp.ID,
-		0,
-		0,
-		0,
-	)
-	if err != nil {
-		return err
-	}
-	if len(checkpoints) > 0 {
-		addr := actor.Addr(fmt.Sprintf("delete-checkpoint-gc-%s", uuid.New().String()))
-		jobSubmissionTime := exp.StartTime
-		taskID := model.NewTaskID()
-		ckptGCTask := newCheckpointGCTask(
-			a.m.rm, a.m.db, a.m.taskLogger, taskID, exp.JobID, jobSubmissionTime, taskSpec, exp.ID,
-			exp.Config, checkpoints, true, agentUserGroup, userModel, nil,
+
+	for _, exp := range exps {
+		agentUserGroup, err := user.GetAgentUserGroup(*exp.OwnerID, exp)
+		if err != nil {
+			return nil, err
+		}
+
+		checkpoints, err := a.m.db.ExperimentCheckpointsToGCRaw(
+			exp.ID,
+			0,
+			0,
+			0,
 		)
-		if gcErr := a.m.system.MustActorOf(addr, ckptGCTask).AwaitTermination(); gcErr != nil {
-			return errors.Wrapf(gcErr, "failed to gc checkpoints for experiment")
+		if err != nil {
+			return nil, err
+		}
+
+		if len(checkpoints) > 0 {
+			addr := actor.Addr(fmt.Sprintf("delete-checkpoint-gc-%s", uuid.New().String()))
+			jobSubmissionTime := exp.StartTime
+			taskID := model.NewTaskID()
+			ckptGCTask := newCheckpointGCTask(
+				a.m.rm, a.m.db, a.m.taskLogger, taskID, exp.JobID, jobSubmissionTime, taskSpec, exp.ID,
+				exp.Config, checkpoints, true, agentUserGroup, userModel, nil,
+			)
+			if gcErr := a.m.system.MustActorOf(addr, ckptGCTask).AwaitTermination(); gcErr != nil {
+				return nil, errors.Wrapf(gcErr, "failed to gc checkpoints for experiment")
+			}
+		}
+
+		// delete jobs per experiment
+		resp, err := a.m.rm.DeleteJob(a.m.system, sproto.DeleteJob{
+			JobID: exp.JobID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("requesting cleanup of resource mananger resources: %w", err)
+		}
+		if err = <-resp.Err; err != nil {
+			return nil, fmt.Errorf("cleaning up resource mananger resources: %w", err)
 		}
 	}
 
-	resp, err := a.m.rm.DeleteJob(a.m.system, sproto.DeleteJob{
-		JobID: exp.JobID,
-	})
+	trialIDs, taskIDs, err := a.m.db.ExperimentsTrialAndTaskIDs(ctx, db.Bun(), expIDs)
 	if err != nil {
-		return fmt.Errorf("requesting cleanup of resource mananger resources: %w", err)
-	}
-	if err = <-resp.Err; err != nil {
-		return fmt.Errorf("cleaning up resource mananger resources: %w", err)
-	}
-
-	trialIDs, taskIDs, err := a.m.db.ExperimentTrialAndTaskIDs(exp.ID)
-	if err != nil {
-		return errors.Wrapf(err, "failed to gather trial IDs for experiment")
+		return nil, errors.Wrapf(err, "failed to gather trial IDs for experiment")
 	}
 
 	if err = a.m.trialLogBackend.DeleteTrialLogs(trialIDs); err != nil {
-		return errors.Wrapf(err, "failed to delete trial logs from backend")
+		return nil, errors.Wrapf(err, "failed to delete trial logs from backend")
 	}
 
 	if err = a.m.taskLogBackend.DeleteTaskLogs(taskIDs); err != nil {
-		return errors.Wrapf(err, "failed to delete trial logs from backend (task logs)")
+		return nil, errors.Wrapf(err, "failed to delete trial logs from backend (task logs)")
 	}
 
-	if err = a.m.db.DeleteExperiment(exp.ID); err != nil {
-		return errors.Wrapf(err, "deleting experiment from database")
+	if err = a.m.db.DeleteExperiments(expIDs); err != nil {
+		return nil, errors.Wrapf(err, "deleting experiments from database")
 	}
-	return nil
+	return expIDs, nil
 }
 
 func getExperimentColumns(q *bun.SelectQuery) *bun.SelectQuery {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -447,12 +447,14 @@ func (a *apiServer) deleteExperiments(exps []*model.Experiment, userModel *model
 		}(e)
 	}
 	wg.Wait()
+	close(successfulExpIDs)
 
-	ctx := context.Background()
 	var processExpIDs []int
 	for expID := range successfulExpIDs {
 		processExpIDs = append(processExpIDs, expID)
 	}
+
+	ctx := context.Background()
 	trialIDs, taskIDs, err := a.m.db.ExperimentsTrialAndTaskIDs(ctx, db.Bun(), processExpIDs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to gather trial IDs for experiment")

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -443,7 +443,7 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	log.Debugf("deleting project %d experiments", projectID)
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	if _, err = a.deleteExperiments(wg, expList, user); err != nil {
+	if _, err = a.deleteExperiments(&wg, expList, user); err != nil {
 		log.WithError(err).Errorf("failed to delete experiments")
 		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
 		return err

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -440,7 +440,7 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	}
 
 	log.Debugf("deleting project %d experiments", projectID)
-	if _, err = a.deleteExperiments(ctx, expList, user); err != nil {
+	if _, err = a.deleteExperiments(context.Background(), expList, user); err != nil {
 		log.WithError(err).Errorf("failed to delete experiments")
 		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
 		return err

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -440,7 +441,9 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	}
 
 	log.Debugf("deleting project %d experiments", projectID)
-	if _, err = a.deleteExperiments(context.Background(), expList, user); err != nil {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	if _, err = a.deleteExperiments(wg, expList, user); err != nil {
 		log.WithError(err).Errorf("failed to delete experiments")
 		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
 		return err

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -440,12 +440,10 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	}
 
 	log.Debugf("deleting project %d experiments", projectID)
-	for _, exp := range expList {
-		if err = a.deleteExperiment(exp, user); err != nil {
-			log.WithError(err).Errorf("failed to delete experiment %d", exp.ID)
-			_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
-			return err
-		}
+	if _, err = a.deleteExperiments(ctx, expList, user); err != nil {
+		log.WithError(err).Errorf("failed to delete experiments")
+		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
+		return err
 	}
 	log.Debugf("project %d experiments deleted successfully", projectID)
 	err = a.m.db.QueryProto("delete_project", holder, projectID)

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -433,7 +432,7 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	expList []*model.Experiment,
 ) (err error) {
 	holder := &projectv1.Project{}
-	user, _, err := grpcutil.GetUser(ctx)
+	_, _, err = grpcutil.GetUser(ctx)
 	if err != nil {
 		log.WithError(err).Errorf("failed to access user and delete project %d", projectID)
 		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
@@ -441,13 +440,12 @@ func (a *apiServer) deleteProject(ctx context.Context, projectID int32,
 	}
 
 	log.Debugf("deleting project %d experiments", projectID)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	if _, err = a.deleteExperiments(&wg, expList, user); err != nil {
-		log.WithError(err).Errorf("failed to delete experiments")
-		_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
-		return err
-	}
+	// sema := make(chan struct{}, 1)
+	// if _, err = a.deleteExperiments(expList, user, sema); err != nil {
+	// 	log.WithError(err).Errorf("failed to delete experiments")
+	// 	_ = a.m.db.QueryProto("delete_fail_project", holder, projectID, err.Error())
+	// 	return err
+	// }
 	log.Debugf("project %d experiments deleted successfully", projectID)
 	err = a.m.db.QueryProto("delete_project", holder, projectID)
 	if err != nil {

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -40,7 +40,7 @@ type DB interface {
 	SaveExperimentConfig(id int, config expconf.ExperimentConfig) error
 	SaveExperimentState(experiment *model.Experiment) error
 	SaveExperimentArchiveStatus(experiment *model.Experiment) error
-	DeleteExperiments(ids []int) error
+	DeleteExperiments(ctx context.Context, ids []int) error
 	ExperimentHasCheckpointsInRegistry(id int) (bool, error)
 	SaveExperimentProgress(id int, progress *float64) error
 	ActiveExperimentConfig(id int) (expconf.ExperimentConfig, error)
@@ -122,7 +122,9 @@ type DB interface {
 	SaveSnapshot(
 		experimentID int, version int, experimentSnapshot []byte,
 	) error
-	DeleteSnapshotsForExperiments(experimentIDs []int) error
+	DeleteSnapshotsForExperiment(experimentID int) error
+	DeleteSnapshotsForExperiments(experimentIDs []int) func(ctx context.Context,
+		tx *bun.Tx) error
 	DeleteSnapshotsForTerminalExperiments() error
 	QueryProto(queryName string, v interface{}, args ...interface{}) error
 	QueryProtof(

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -39,14 +40,14 @@ type DB interface {
 	SaveExperimentConfig(id int, config expconf.ExperimentConfig) error
 	SaveExperimentState(experiment *model.Experiment) error
 	SaveExperimentArchiveStatus(experiment *model.Experiment) error
-	DeleteExperiment(id int) error
+	DeleteExperiments(ids []int) error
 	ExperimentHasCheckpointsInRegistry(id int) (bool, error)
 	SaveExperimentProgress(id int, progress *float64) error
 	ActiveExperimentConfig(id int) (expconf.ExperimentConfig, error)
 	ExperimentTotalStepTime(id int) (float64, error)
 	ExperimentNumTrials(id int) (int64, error)
 	ExperimentTrialIDs(expID int) ([]int, error)
-	ExperimentTrialAndTaskIDs(expID int) ([]int, []model.TaskID, error)
+	ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int, []model.TaskID, error)
 	ExperimentNumSteps(id int) (int64, error)
 	ExperimentModelDefinitionRaw(id int) ([]byte, error)
 	ExperimentCheckpointsToGCRaw(
@@ -121,7 +122,7 @@ type DB interface {
 	SaveSnapshot(
 		experimentID int, version int, experimentSnapshot []byte,
 	) error
-	DeleteSnapshotsForExperiment(experimentID int) error
+	DeleteSnapshotsForExperiments(experimentIDs []int) error
 	DeleteSnapshotsForTerminalExperiments() error
 	QueryProto(queryName string, v interface{}, args ...interface{}) error
 	QueryProtof(

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -47,7 +47,8 @@ type DB interface {
 	ExperimentTotalStepTime(id int) (float64, error)
 	ExperimentNumTrials(id int) (int64, error)
 	ExperimentTrialIDs(expID int) ([]int, error)
-	ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int, []model.TaskID, error)
+	ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int,
+		[]model.TaskID, error)
 	ExperimentNumSteps(id int) (int64, error)
 	ExperimentModelDefinitionRaw(id int) ([]byte, error)
 	ExperimentCheckpointsToGCRaw(

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -876,6 +876,9 @@ WHERE id = :id`
 // DeleteExperiments deletes one or more experiments.
 func (db *PgDB) DeleteExperiments(ctx context.Context, ids []int) error {
 	tx, err := Bun().BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
 	defer func() {
 		txErr := tx.Rollback()
 		if txErr != nil && txErr != sql.ErrTxDone {
@@ -1034,7 +1037,9 @@ WHERE trials.experiment_id = $1
 }
 
 // ExperimentsTrialAndTaskIDs returns the trial and task IDs for one or more experiments.
-func (db *PgDB) ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int, []model.TaskID, error) {
+func (db *PgDB) ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int,
+	[]model.TaskID, error,
+) {
 	var trialIDRows []struct {
 		ID     int          `db:"id"`
 		TaskID model.TaskID `db:"task_id"`

--- a/master/internal/db/postgres_snapshots.go
+++ b/master/internal/db/postgres_snapshots.go
@@ -42,17 +42,17 @@ DO UPDATE SET
 	return nil
 }
 
-// DeleteSnapshotsForExperiment deletes all snapshots for the given experiment.
-func (db *PgDB) DeleteSnapshotsForExperiment(experimentID int) error {
-	return db.withTransaction("delete snapshots", db.deleteSnapshotsForExperiment(experimentID))
+// DeleteSnapshotsForExperiments deletes all snapshots for multiple given experiments.
+func (db *PgDB) DeleteSnapshotsForExperiments(experimentIDs []int) error {
+	return db.withTransaction("delete snapshots", db.deleteSnapshotsForExperiments(experimentIDs))
 }
 
-func (db *PgDB) deleteSnapshotsForExperiment(experimentID int) func(tx *sqlx.Tx) error {
+func (db *PgDB) deleteSnapshotsForExperiments(experimentIDs []int) func(tx *sqlx.Tx) error {
 	return func(tx *sqlx.Tx) error {
 		if _, err := tx.Exec(`
 DELETE FROM experiment_snapshots
-WHERE experiment_id = $1`, experimentID); err != nil {
-			return errors.Wrap(err, "failed to delete experiment snapshots")
+WHERE experiment_id IN $1`, experimentIDs); err != nil {
+			return errors.Wrap(err, "failed to delete experiments snapshots")
 		}
 		return nil
 	}

--- a/master/internal/db/postgres_snapshots_test.go
+++ b/master/internal/db/postgres_snapshots_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -58,6 +59,7 @@ func TestCustomSearcherSnapshot(t *testing.T) {
 
 	err = db.DeleteSnapshotsForExperiment(exp.ID)
 	require.NoError(t, err)
-	err = db.DeleteExperiment(exp.ID)
+	ctx := context.Background()
+	err = db.DeleteExperiments(ctx, []int{exp.ID})
 	require.NoError(t, err)
 }

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -425,7 +425,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			ctx.Self().System().ActorOf(addr, ckptGCTask)
 		}
 
-		if err := e.db.DeleteSnapshotsForExperiments([]int{e.Experiment.ID}); err != nil {
+		if err := e.db.DeleteSnapshotsForExperiment(e.Experiment.ID); err != nil {
 			ctx.Log().WithError(err).Errorf(
 				"failure to delete snapshots for experiment: %d", e.Experiment.ID)
 		}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -425,7 +425,7 @@ func (e *experiment) Receive(ctx *actor.Context) error {
 			ctx.Self().System().ActorOf(addr, ckptGCTask)
 		}
 
-		if err := e.db.DeleteSnapshotsForExperiment(e.Experiment.ID); err != nil {
+		if err := e.db.DeleteSnapshotsForExperiments([]int{e.Experiment.ID}); err != nil {
 			ctx.Log().WithError(err).Errorf(
 				"failure to delete snapshots for experiment: %d", e.Experiment.ID)
 		}

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -394,13 +394,27 @@ func (_m *DB) DeleteAllocationSession(allocationID model.AllocationID) error {
 	return r0
 }
 
-// DeleteExperiments provides a mock function with given fields: ids
-func (_m *DB) DeleteExperiments(ids []int) error {
-	ret := _m.Called(ids)
+// DeleteExperiments provides a mock function with given fields: ctx, ids
+func (_m *DB) DeleteExperiments(ctx context.Context, ids []int) error {
+	ret := _m.Called(ctx, ids)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]int) error); ok {
-		r0 = rf(ids)
+	if rf, ok := ret.Get(0).(func(context.Context, []int) error); ok {
+		r0 = rf(ctx, ids)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeleteSnapshotsForExperiment provides a mock function with given fields: experimentID
+func (_m *DB) DeleteSnapshotsForExperiment(experimentID int) error {
+	ret := _m.Called(experimentID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int) error); ok {
+		r0 = rf(experimentID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -409,14 +423,16 @@ func (_m *DB) DeleteExperiments(ids []int) error {
 }
 
 // DeleteSnapshotsForExperiments provides a mock function with given fields: experimentIDs
-func (_m *DB) DeleteSnapshotsForExperiments(experimentIDs []int) error {
+func (_m *DB) DeleteSnapshotsForExperiments(experimentIDs []int) func(context.Context, *bun.Tx) error {
 	ret := _m.Called(experimentIDs)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func([]int) error); ok {
+	var r0 func(context.Context, *bun.Tx) error
+	if rf, ok := ret.Get(0).(func([]int) func(context.Context, *bun.Tx) error); ok {
 		r0 = rf(experimentIDs)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(func(context.Context, *bun.Tx) error)
+		}
 	}
 
 	return r0

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -6,6 +6,8 @@ import (
 	api "github.com/determined-ai/determined/master/internal/api"
 	apiv1 "github.com/determined-ai/determined/proto/pkg/apiv1"
 
+	bun "github.com/uptrace/bun"
+
 	context "context"
 
 	expconf "github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -392,13 +394,13 @@ func (_m *DB) DeleteAllocationSession(allocationID model.AllocationID) error {
 	return r0
 }
 
-// DeleteExperiment provides a mock function with given fields: id
-func (_m *DB) DeleteExperiment(id int) error {
-	ret := _m.Called(id)
+// DeleteExperiments provides a mock function with given fields: ids
+func (_m *DB) DeleteExperiments(ids []int) error {
+	ret := _m.Called(ids)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int) error); ok {
-		r0 = rf(id)
+	if rf, ok := ret.Get(0).(func([]int) error); ok {
+		r0 = rf(ids)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -406,13 +408,13 @@ func (_m *DB) DeleteExperiment(id int) error {
 	return r0
 }
 
-// DeleteSnapshotsForExperiment provides a mock function with given fields: experimentID
-func (_m *DB) DeleteSnapshotsForExperiment(experimentID int) error {
-	ret := _m.Called(experimentID)
+// DeleteSnapshotsForExperiments provides a mock function with given fields: experimentIDs
+func (_m *DB) DeleteSnapshotsForExperiments(experimentIDs []int) error {
+	ret := _m.Called(experimentIDs)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int) error); ok {
-		r0 = rf(experimentID)
+	if rf, ok := ret.Get(0).(func([]int) error); ok {
+		r0 = rf(experimentIDs)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -853,41 +855,6 @@ func (_m *DB) ExperimentTotalStepTime(id int) (float64, error) {
 	return r0, r1
 }
 
-// ExperimentTrialAndTaskIDs provides a mock function with given fields: expID
-func (_m *DB) ExperimentTrialAndTaskIDs(expID int) ([]int, []model.TaskID, error) {
-	ret := _m.Called(expID)
-
-	var r0 []int
-	var r1 []model.TaskID
-	var r2 error
-	if rf, ok := ret.Get(0).(func(int) ([]int, []model.TaskID, error)); ok {
-		return rf(expID)
-	}
-	if rf, ok := ret.Get(0).(func(int) []int); ok {
-		r0 = rf(expID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]int)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(int) []model.TaskID); ok {
-		r1 = rf(expID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]model.TaskID)
-		}
-	}
-
-	if rf, ok := ret.Get(2).(func(int) error); ok {
-		r2 = rf(expID)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // ExperimentTrialIDs provides a mock function with given fields: expID
 func (_m *DB) ExperimentTrialIDs(expID int) ([]int, error) {
 	ret := _m.Called(expID)
@@ -912,6 +879,41 @@ func (_m *DB) ExperimentTrialIDs(expID int) ([]int, error) {
 	}
 
 	return r0, r1
+}
+
+// ExperimentsTrialAndTaskIDs provides a mock function with given fields: ctx, idb, expIDs
+func (_m *DB) ExperimentsTrialAndTaskIDs(ctx context.Context, idb bun.IDB, expIDs []int) ([]int, []model.TaskID, error) {
+	ret := _m.Called(ctx, idb, expIDs)
+
+	var r0 []int
+	var r1 []model.TaskID
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, bun.IDB, []int) ([]int, []model.TaskID, error)); ok {
+		return rf(ctx, idb, expIDs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, bun.IDB, []int) []int); ok {
+		r0 = rf(ctx, idb, expIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, bun.IDB, []int) []model.TaskID); ok {
+		r1 = rf(ctx, idb, expIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]model.TaskID)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, bun.IDB, []int) error); ok {
+		r2 = rf(ctx, idb, expIDs)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // GetExperimentStatus provides a mock function with given fields: experimentID


### PR DESCRIPTION
## Description

The goal is to allow concurrent deletion of multiple experiments.

- divides experiments into groups of 10 (might be better to max this out at 10 rather than batching?)
- retrieving trials, tasks for the batch and deletions use a Bun transaction and can apply to multiple experiments
- `deleteExperiments` and snapshot code need context for Bun; use `context.Background()` since this runs async and the web ctx gets cancelled
- GetAgentUserGroup / GC of checkpoints remains in a loop; if this were made concurrent we might be able to send a map of AgentUserGroups and experiment IDs to make the right queries? 

Comes after #6568

## Test Plan

Delete test experiments using the CLI; they go through the same process

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.