### PR TITLE
fix: close modal properly

### DIFF
--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
@@ -70,7 +70,7 @@ vi.mock('services/api', () => ({
       maxSlotsExceeded: false,
     }),
   ),
-  getResourcePools: () => Promise.resolve([]),
+  getResourcePools: vi.fn().mockReturnValue(Promise.resolve([])),
 }));
 
 const { experiment } = generateTestExperimentData();

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
@@ -54,6 +54,7 @@ vi.mock('stores/cluster', async (importOriginal) => {
         },
       ]),
     ),
+    fetchResourcePools: vi.fn()
   };
 
   return {

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.test.tsx
@@ -17,6 +17,7 @@ vi.mock('stores/cluster', async (importOriginal) => {
   const observable = await import('utils/observable');
 
   const store = {
+    fetchResourcePools: vi.fn(),
     resourcePools: observable.observable(
       loadable.Loaded([
         {
@@ -54,7 +55,6 @@ vi.mock('stores/cluster', async (importOriginal) => {
         },
       ]),
     ),
-    fetchResourcePools: vi.fn()
   };
 
   return {

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -122,7 +122,7 @@ const useModalHyperparameterSearch = ({
 
   useEffect(() => {
     const cancelerTemp = canceler.current;
-    clusterStore.poll();
+    clusterStore.fetchResourcePools(cancelerTemp.signal);
     return () => {
       cancelerTemp.abort();
     };

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -122,6 +122,7 @@ const useModalHyperparameterSearch = ({
 
   useEffect(() => {
     const cancelerTemp = canceler.current;
+    clusterStore.poll();
     return () => {
       cancelerTemp.abort();
     };

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
@@ -34,6 +34,7 @@ vi.mock('services/api', () => ({
   getExpTrials: vi.fn(),
   getExpValidationHistory: vi.fn(),
   getProject: vi.fn(),
+  getResourcePools: vi.fn(),
   getTrialDetails: vi.fn(),
   getWorkspace: vi.fn(),
   getWorkspaceProjects: vi.fn().mockReturnValue({ projects: [] }),

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
@@ -34,7 +34,7 @@ vi.mock('services/api', () => ({
   getExpTrials: vi.fn(),
   getExpValidationHistory: vi.fn(),
   getProject: vi.fn(),
-  getResourcePools: vi.fn(),
+  getResourcePools: vi.fn().mockReturnValue(Promise.resolve([])),
   getTrialDetails: vi.fn(),
   getWorkspace: vi.fn(),
   getWorkspaceProjects: vi.fn().mockReturnValue({ projects: [] }),


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
When go directly to experiment details page (without going to clusters page first), Hyperparameter Search modal does not close properly.
This issue is caused by `resourcePools` not available in this component so I added a poll to fetch `resourcePools`. 
cc @hkang1 to verify this is the proper way to do it. 

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Go to experiment details page, open Hyperparameter Search modal, you should be able to close it. 


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
WEB-1149

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
