### PR TITLE
fix: metrics sampling for metrics with epochs.

### DIFF
--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -461,6 +460,5 @@ func TestCompareTrialsSampling(t *testing.T) {
 
 	sampleBatches2 := compareTrialsResponseToBatches(resp)
 
-	require.True(t, reflect.DeepEqual(sampleBatches1, sampleBatches2),
-		"%s != %s", sampleBatches1, sampleBatches2)
+	require.Equal(t, sampleBatches1, sampleBatches2)
 }

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -67,6 +68,11 @@ func createTestTrialWithMetrics(
 							NumberValue: float64(i),
 						},
 					},
+					"epoch": {
+						Kind: &structpb.Value_NumberValue{
+							NumberValue: float64(i),
+						},
+					},
 				},
 			},
 		}
@@ -100,6 +106,11 @@ func createTestTrialWithMetrics(
 			AvgMetrics: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
 					"val_loss": {
+						Kind: &structpb.Value_NumberValue{
+							NumberValue: float64(i),
+						},
+					},
+					"epoch": {
 						Kind: &structpb.Value_NumberValue{
 							NumberValue: float64(i),
 						},
@@ -405,4 +416,51 @@ func TestTrialAuthZ(t *testing.T) {
 			Return(fmt.Errorf(curCase.DenyFuncName + "Error")).Once()
 		require.ErrorIs(t, curCase.IDToReqCall(trial.ID), expectedErr)
 	}
+}
+
+func compareTrialsResponseToBatches(resp *apiv1.CompareTrialsResponse) []int32 {
+	compTrial := resp.Trials[0]
+	compMetrics := compTrial.Metrics[0]
+
+	sampleBatches := []int32{}
+
+	for _, m := range compMetrics.Data {
+		sampleBatches = append(sampleBatches, m.Batches)
+	}
+
+	return sampleBatches
+}
+
+func TestCompareTrialsSampling(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+
+	trial, _, _ := createTestTrialWithMetrics(
+		ctx, t, api, curUser, false)
+
+	const DATAPOINTS = 3
+
+	req := &apiv1.CompareTrialsRequest{
+		TrialIds:      []int32{int32(trial.ID)},
+		MaxDatapoints: DATAPOINTS,
+		MetricNames:   []string{"loss"},
+		StartBatches:  0,
+		EndBatches:    1000,
+		MetricType:    apiv1.MetricType_METRIC_TYPE_TRAINING,
+		Scale:         apiv1.Scale_SCALE_LINEAR,
+		XAxis:         apiv1.XAxis_X_AXIS_BATCH,
+	}
+
+	resp, err := api.CompareTrials(ctx, req)
+	require.NoError(t, err)
+
+	sampleBatches1 := compareTrialsResponseToBatches(resp)
+	require.Equal(t, DATAPOINTS, len(sampleBatches1))
+
+	resp, err = api.CompareTrials(ctx, req)
+	require.NoError(t, err)
+
+	sampleBatches2 := compareTrialsResponseToBatches(resp)
+
+	require.True(t, reflect.DeepEqual(sampleBatches1, sampleBatches2),
+		"%s != %s", sampleBatches1, sampleBatches2)
 }

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -351,11 +351,11 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	}
 	measurements := []db.MetricMeasurements{}
 	subq := db.Bun().NewSelect().TableExpr(tableName).
-		ColumnExpr("setseed(1) as _seed").
+		ColumnExpr("(select setseed(1)) as _seed").
 		ColumnExpr("total_batches as batches").
 		ColumnExpr("trial_id").ColumnExpr("end_time as time").
 		ColumnExpr("(metrics ->'?' ->> ?)::float8 as value", bun.Safe(metricsObjectName), metricName).
-		ColumnExpr("(metrics ->'?' ->> 'epoch')::float8 as epoch", bun.Safe(metricsObjectName)).
+		ColumnExpr("(metrics ->'?' ->> 'epoch')::integer as epoch", bun.Safe(metricsObjectName)).
 		Where("metrics ->'?' ->> ? IS NOT NULL", bun.Safe(metricsObjectName), metricName).
 		Where("trial_id = ?", trialID).OrderExpr("random()").Limit(maxDatapoints)
 	switch timeSeriesFilter {


### PR DESCRIPTION
## Description

- Metrics sampling broke for trials which report "epochs" because floats couldn't be deserialized into ints: https://determined-community.slack.com/archives/C04PZL88HDL/p1681744867345819
- also change setseed usage so the samples are reproducible.
- add tests for both issues.

## Test Plan

Run any experiment which reports metrics, e.g. https://github.com/determined-ai/determined/blob/master/examples/tutorials/core_api_pytorch_mnist/model_def_metrics.py#L73

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
