### PR TITLE
chore: lazy load imports to speed up load time [MLG-455]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -17,7 +17,7 @@ import determined as det
 import determined.experimental
 import determined.load
 from determined import cli
-from determined.cli import checkpoint, proxy, render
+from determined.cli import checkpoint, render
 from determined.cli.command import CONFIG_DESC, parse_config_overrides
 from determined.cli.errors import CliError
 from determined.common import api, context, set_logger, util, yaml
@@ -293,6 +293,8 @@ def submit_experiment(args: Namespace) -> None:
 
         if not args.paused and args.follow_first_trial:
             if args.publish:
+                from determined.cli import proxy
+
                 port_map = proxy.parse_port_map_flag(args.publish)
                 with proxy.tunnel_experiment(sess, resp.experiment.id, port_map):
                     _follow_experiment_logs(sess, resp.experiment.id)

--- a/harness/determined/common/api/profiler.py
+++ b/harness/determined/common/api/profiler.py
@@ -46,12 +46,16 @@ def post_trial_profiler_metrics_batches(
                 "/api/v1/trials/profiler/metrics",
                 json={"batches": [b.__dict__ for b in batches]},
             )
+            return
         except exceptions.RequestException as e:
             if e.response is not None and e.response.status_code < 500:
                 raise e
 
-            time.sleep(backoff_interval)
             tries += 1
+            if tries == max_tries:
+                raise e
+            time.sleep(backoff_interval)
+    return
 
 
 class TrialProfilerSeriesLabels:
@@ -83,12 +87,15 @@ def get_trial_profiler_available_series(
                 path=f"/api/v1/trials/{trial_id}/profiler/available_series",
                 params={"follow": follow},
             )
+            break
         except exceptions.RequestException as e:
             if e.response is not None and e.response.status_code < 500:
                 raise e
 
-            time.sleep(backoff_interval)
             tries += 1
+            if tries == max_tries:
+                raise e
+            time.sleep(backoff_interval)
 
     assert response
     j = response.json()

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -5,8 +5,6 @@ import pathlib
 import tarfile
 from typing import Any, Dict, Iterable, List, Optional
 
-import pathspec
-
 from determined.common import constants
 from determined.common.api import bindings
 from determined.common.util import sizeof_fmt
@@ -112,6 +110,9 @@ class _Builder:
         if ignore_path.is_file():
             with ignore_path.open("r") as detignore_file:
                 ignore.extend(detignore_file)
+
+        import pathspec
+
         ignore_spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
 
         # We could use pathlib.Path.rglob for scanning the directory;

--- a/harness/determined/common/storage/hdfs.py
+++ b/harness/determined/common/storage/hdfs.py
@@ -4,8 +4,6 @@ import tempfile
 import warnings
 from typing import Optional, Union
 
-from hdfs.client import InsecureClient
-
 from determined.common import storage, util
 
 
@@ -34,7 +32,9 @@ class HDFSStorageManager(storage.CloudStorageManager):
         self.hdfs_path = hdfs_path
         self.user = user
 
-        self.client = InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
+        from hdfs import client
+
+        self.client = client.InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
 
     @util.preserve_random_state
     def upload(

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -7,8 +7,6 @@ import subprocess
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import psutil
-
 import determined as det
 
 
@@ -402,6 +400,8 @@ class PIDServer:
         """
         Any PIDs which exited without a graceful exit message indicates a crashed worker.
         """
+        import psutil
+
         for pid in self.pids:
             if pid not in self.graceful_shutdowns:
                 pid_ok = False

--- a/harness/determined/tensorboard/hdfs.py
+++ b/harness/determined/tensorboard/hdfs.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any, List, Optional
 
-from hdfs.client import InsecureClient
-
 from determined.common import util
 from determined.tensorboard import base
 
@@ -26,7 +24,9 @@ class HDFSTensorboardManager(base.TensorboardManager):
         self.hdfs_path = hdfs_path
         self.user = user
 
-        self.client = InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
+        from hdfs import client
+
+        self.client = client.InsecureClient(self.hdfs_url, root=self.hdfs_path, user=self.user)
         self.client.makedirs(str(self.sync_path))
 
     def _sync_impl(

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -24,7 +24,6 @@ setup(
         "pyzmq>=18.1.0",
         "yogadl==0.1.4",
         # Common:
-        "backoff",
         "certifi",
         "filelock",
         "google-cloud-storage",

--- a/harness/tests/test_imports.py
+++ b/harness/tests/test_imports.py
@@ -37,6 +37,10 @@ def test_import_side_effects() -> None:
             determined.cli.cli.main()
 
             bad = {
+                "^backoff\\.*",
+                "^lomond\\.*",
+                "^pathspec\\.*",
+                "^hdfs\\.*",
                 "^google\\.*",
                 "^boto3\\.*",
                 "^botocore\\.*",

--- a/harness/tests/test_imports.py
+++ b/harness/tests/test_imports.py
@@ -37,7 +37,6 @@ def test_import_side_effects() -> None:
             determined.cli.cli.main()
 
             bad = {
-                "^backoff\\.*",
                 "^lomond\\.*",
                 "^pathspec\\.*",
                 "^hdfs\\.*",

--- a/master/static/srv/check_ready_logs.py
+++ b/master/static/srv/check_ready_logs.py
@@ -6,31 +6,34 @@ import argparse
 import os
 import re
 import sys
-from time import sleep
+import time
 from typing import Pattern, Optional
 
-import backoff
 from determined.common import api
 from determined.common.api import certs
 from requests.exceptions import RequestException
 
 BACKOFF_SECONDS = 5
 
-# Since the service is virtually inaccessible by the user unless
-# the call completes, we may as well try forever or just wait for
-# them to kill us.
-@backoff.on_exception(  # type: ignore
-    lambda: backoff.constant(interval=BACKOFF_SECONDS),
-    RequestException,
-    giveup=lambda e: e.response is not None and e.response.status_code < 500,
-)
+
 def post_ready(master_url: str, cert: certs.Cert, allocation_id: str, state: str):
-    api.post(
-        master_url,
-        f"/api/v1/allocations/{allocation_id}/{state}",
-        {},
-        cert=cert,
-    )
+    # Since the service is virtually inaccessible by the user unless
+    # the call completes, we may as well try forever or just wait for
+    # them to kill us.
+    while True:
+        try:
+            api.post(
+                master_url,
+                f"/api/v1/allocations/{allocation_id}/{state}",
+                {},
+                cert=cert,
+            )
+            return
+        except RequestException as e:
+            if e.response is not None and e.response.status_code < 500:
+                raise e
+
+            time.sleep(BACKOFF_SECONDS)
 
 
 def main(ready: Pattern, waiting: Optional[Pattern] = None):

--- a/master/static/srv/enrich_task_logs.py
+++ b/master/static/srv/enrich_task_logs.py
@@ -10,7 +10,6 @@ import threading
 import time
 from typing import Any, Dict, Iterator
 
-import backoff
 from determined.common import api
 from determined.common.api import errors
 


### PR DESCRIPTION
## Description
loading harness takes around 0.75s on my machine. there's quite a few imports that can be lazily-imported to reduce load time.

**Before**
```
Program: determined.cli.cli

0.753 <module>  harness/determined/__init__.py:1
└─ 0.725 <module>  harness/determined/core/__init__.py:1
   ├─ 0.674 <module>  harness/determined/core/_checkpoint.py:1
   │  └─ 0.673 <module>  harness/determined/tensorboard/__init__.py:1
   │     └─ 0.660 <module>  harness/determined/tensorboard/metric_writers/__init__.py:1
   │        └─ 0.659 <module>  harness/determined/tensorboard/metric_writers/callback.py:1
   │           └─ 0.658 <module>  harness/determined/util.py:1
   │              └─ 0.655 <module>  harness/determined/common/__init__.py:1
   │                 ├─ 0.378 <module>  harness/determined/common/api/__init__.py:1
   │                 │  ├─ 0.199 <module>  harness/determined/common/api/authentication.py:1
   │                 │  │  ├─ 0.152 <module>  harness/determined/common/api/bindings.py:2
   │                 │  │  │  └─ 0.124 <module>  requests/__init__.py:39
   │                 │  │  │        [224 frames hidden]  requests, charset_normalizer, <built-...
   │                 │  │  └─ 0.021 <module>  filelock/__init__.py:7
   │                 │  │        [20 frames hidden]  filelock, <built-in>
   │                 │  ├─ 0.131 <module>  harness/determined/common/api/request.py:1
   │                 │  │  └─ 0.126 <module>  lomond/__init__.py:1
   │                 │  │        [79 frames hidden]  lomond, platform, os, subprocess, <bu...
   │                 │  └─ 0.034 <module>  harness/determined/common/api/profiler.py:1
   │                 │     └─ 0.026 decorate  backoff/_decorator.py:152
   │                 │           [35 frames hidden]  backoff, asyncio, <built-in>, concurrent
   │                 ├─ 0.137 <module>  harness/determined/common/util.py:1
   │                 │  └─ 0.125 <module>  urllib3/__init__.py:3
   │                 │        [266 frames hidden]  urllib3, re, sre_compile, sre_parse, ...
   │                 ├─ 0.061 <module>  ruamel/yaml/__init__.py:1
   │                 │     [67 frames hidden]  ruamel, base64, struct, <built-in>
   │                 ├─ 0.051 <module>  harness/determined/common/storage/__init__.py:1
   │                 │  └─ 0.041 <module>  harness/determined/common/storage/hdfs.py:1
   │                 │     └─ 0.037 <module>  hdfs/__init__.py:4
   │                 │           [91 frames hidden]  hdfs, multiprocessing, pickle, <built...
   │                 └─ 0.018 <module>  harness/determined/common/context.py:1
   │                    └─ 0.013 <module>  pathspec/__init__.py:30
   │                          [32 frames hidden]  pathspec, <built-in>, typing
   └─ 0.040 <module>  harness/determined/core/_distributed.py:1
      └─ 0.032 <module>  harness/determined/ipc.py:1
         └─ 0.030 <module>  psutil/__init__.py:21
               [41 frames hidden]  psutil, <built-in>, enum, collections...
```

After
```
Program: determined.cli.cli

0.487 <module>  harness/determined/__init__.py:1
├─ 0.433 <module>  harness/determined/core/__init__.py:1
│  ├─ 0.388 <module>  harness/determined/core/_distributed.py:1
│  │  ├─ 0.374 <module>  harness/determined/util.py:1
│  │  │  └─ 0.369 <module>  harness/determined/common/__init__.py:1
│  │  │     ├─ 0.248 <module>  harness/determined/common/api/__init__.py:1
│  │  │     │  ├─ 0.226 <module>  harness/determined/common/api/authentication.py:1
│  │  │     │  │  ├─ 0.136 compile  None
│  │  │     │  │  │     [2 frames hidden]  <built-in>
│  │  │     │  │  └─ 0.078 <module>  harness/determined/common/api/bindings.py:2
│  │  │     │  │     └─ 0.061 <module>  requests/__init__.py:39
│  │  │     │  │           [156 frames hidden]  requests, http, re, sre_compile, sre_...
│  │  │     │  └─ 0.009 compile  None
│  │  │     │        [2 frames hidden]  <built-in>
│  │  │     ├─ 0.071 <module>  harness/determined/common/util.py:1
│  │  │     │  └─ 0.063 <module>  urllib3/__init__.py:3
│  │  │     │        [187 frames hidden]  urllib3, re, sre_compile, sre_parse, ...
│  │  │     ├─ 0.018 <module>  ruamel/yaml/__init__.py:1
│  │  │     │     [33 frames hidden]  ruamel, base64, <built-in>, struct, abc
│  │  │     └─ 0.016 <module>  harness/determined/common/storage/__init__.py:1
│  │  └─ 0.009 compile  None
│  │        [2 frames hidden]  <built-in>
│  ├─ 0.021 <module>  harness/determined/core/_checkpoint.py:1
│  │  └─ 0.019 <module>  harness/determined/tensorboard/__init__.py:1
│  └─ 0.016 compile  None
│        [2 frames hidden]  <built-in>
├─ 0.029 <module>  harness/determined/_trial_controller.py:1
│  ├─ 0.017 <module>  harness/determined/profiler.py:1
│  │  └─ 0.012 <module>  psutil/__init__.py:21
│  │        [22 frames hidden]  psutil, <built-in>, enum, collections
│  └─ 0.010 compile  None
│        [2 frames hidden]  <built-in>
├─ 0.012 compile  None
│     [2 frames hidden]  <built-in>
└─ 0.009 <module>  harness/determined/_info.py:1

```
## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
