### PR TITLE
fix: Investigate "directory does not exist" tensorboard warning messages [DET-9166]

### DIFF
--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -59,7 +59,6 @@ class TensorboardManager(metaclass=abc.ABCMeta):
         """
 
         if not self.base_path.exists():
-            logging.warning(f"{self.base_path} directory does not exist.")
             return []
         return [
             file

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -26,12 +26,6 @@ class SharedFSTensorboardManager(base.TensorboardManager):
         # specifically should just create the storage path themselves; this will not interfere.
         old_umask = os.umask(0)
         self.shared_fs_base.mkdir(parents=True, exist_ok=True, mode=0o777)
-
-        # Create the directories contained in the "base_path" to suppress the
-        # "directory does not exist" warnings for worker nodes from
-        # "list_tb_files()" in "base.py".
-        os.makedirs(self.base_path, exist_ok=True)
-
         # Restore the original umask.
         os.umask(old_umask)
 

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -26,6 +26,12 @@ class SharedFSTensorboardManager(base.TensorboardManager):
         # specifically should just create the storage path themselves; this will not interfere.
         old_umask = os.umask(0)
         self.shared_fs_base.mkdir(parents=True, exist_ok=True, mode=0o777)
+
+        # Create the directories contained in the "base_path" to suppress the
+        # "directory does not exist" warnings for worker nodes from
+        # "list_tb_files()" in "base.py".
+        os.makedirs(self.base_path, exist_ok=True)
+
         # Restore the original umask.
         os.umask(old_umask)
 


### PR DESCRIPTION

## Description

Although a distributed experiment would successfully run to completion, there were warning messages that said "directory does not exist".

For example, I ran the following experiment.

```
(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % pwd
/Users/rcorujo/IdeaProjects/FOUNDENG-527_wckey/determined-ee/examples/computer_vision/cifar10_pytorch

(base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % cat rig_distributed.yaml
#debug: true
name: cifar10_pytorch_distributed
hyperparameters:
  learning_rate: 1.0e-4
  learning_rate_decay: 1.0e-6
  layer1_dropout: 0.25
  layer2_dropout: 0.25
  layer3_dropout: 0.5
  global_batch_size: 512 # Per-GPU batch size of 32
resources:
#  slots_per_trial: 4
  slots_per_trial: 8
records_per_epoch: 50000
max_restarts: 0
searcher:
  name: single
  metric: validation_error
  max_length:
    epochs: 2
entrypoint: model_def:CIFARTrial
min_validation_period:
  epochs: 1
```

As you can see, it completed successfully, but there were warning messages.

```
[2023-03-23 22:07:05] [cont=0] [rank=0] || INFO: [2905099] root: validated: 10000 records in 3.095s (3232.0 records/s), in 157 batches (50.73 batches/s)
<info> [2023-03-23 22:07:05] [cont=0] [rank=0] || INFO: [2905099] determined.core: report_validation_metrics(steps_completed=98, metrics={'validation_accuracy': 0.33081210191082805, 'validation_error': 0.669187898089172})
<info> [2023-03-23 22:07:07] [cont=0] [rank=0] || INFO: [2905099] determined.core: Reported checkpoint to master 8b333cf7-4da8-4acd-8147-9ed371d0828b
<warning> [2023-03-23 22:07:07] [cont=0] [rank=3] || WARNING: [2905101] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-3 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=0] [rank=1] || WARNING: [2905100] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-1 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=0] [rank=2] || WARNING: [2905102] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-2 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=1] [rank=6] || WARNING: [153631] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-6 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=1] [rank=5] || WARNING: [153626] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-5 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=1] [rank=4] || WARNING: [153629] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-4 directory does not exist.
<warning> [2023-03-23 22:07:07] [cont=1] [rank=7] || WARNING: [153630] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-7 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=1] [rank=4] || WARNING: [153629] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-4 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=1] [rank=7] || WARNING: [153630] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-7 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=1] [rank=6] || WARNING: [153631] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-6 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=1] [rank=5] || WARNING: [153626] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-5 directory does not exist.
<info> [2023-03-23 22:07:07] [cont=0] [rank=0] || INFO: [2905099] determined.core: report_training_metrics(steps_completed=100, metrics={'loss': 1.8974220752716064, 'train_error': 0.67578125, 'train_accuracy': 0.32421875})
<warning> [2023-03-23 22:07:08] [cont=0] [rank=3] || WARNING: [2905101] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-3 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=0] [rank=1] || WARNING: [2905100] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-1 directory does not exist.
<warning> [2023-03-23 22:07:08] [cont=0] [rank=2] || WARNING: [2905102] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-2 directory does not exist.
<info> [2023-03-23 22:07:10] [cont=0] [rank=0] || INFO: [2905099] determined.core: report_training_metrics(steps_completed=196, metrics={'loss': 1.8859044313430786, 'train_error': 0.6727701822916666, 'train_accuracy': 0.3272298177083333})
<warning> [2023-03-23 22:07:10] [cont=0] [rank=1] || WARNING: [2905100] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-1 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=0] [rank=3] || WARNING: [2905101] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-3 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=0] [rank=2] || WARNING: [2905102] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-2 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=1] [rank=6] || WARNING: [153631] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-6 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=1] [rank=5] || WARNING: [153626] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-5 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=1] [rank=4] || WARNING: [153629] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-4 directory does not exist.
<warning> [2023-03-23 22:07:10] [cont=1] [rank=7] || WARNING: [153630] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-7 directory does not exist.
<info> [2023-03-23 22:07:11] [cont=0] [rank=0] || INFO: [2905099] root: validated: 10000 records in 0.2171s (46058.0 records/s), in 157 batches (723.1 batches/s)
<info> [2023-03-23 22:07:11] [cont=0] [rank=0] || INFO: [2905099] determined.core: report_validation_metrics(steps_completed=196, metrics={'validation_accuracy': 0.37908041401273884, 'validation_error': 0.6209195859872612})
<warning> [2023-03-23 22:07:13] [cont=1] [rank=6] || WARNING: [153631] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-6 directory does not exist.
<warning> [2023-03-23 22:07:13] [cont=1] [rank=5] || WARNING: [153626] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-5 directory does not exist.
<warning> [2023-03-23 22:07:13] [cont=1] [rank=4] || WARNING: [153629] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-4 directory does not exist.
<warning> [2023-03-23 22:07:13] [cont=1] [rank=7] || WARNING: [153630] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-7 directory does not exist.
<info> [2023-03-23 22:07:13] [cont=0] [rank=0] || INFO: [2905099] determined.core: Reported checkpoint to master 5faee6d2-40cb-4fc4-8a50-784c94dd4f1b
<warning> [2023-03-23 22:07:13] [cont=0] [rank=1] || WARNING: [2905100] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-1 directory does not exist.
<warning> [2023-03-23 22:07:13] [cont=0] [rank=3] || WARNING: [2905101] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-3 directory does not exist.
<warning> [2023-03-23 22:07:13] [cont=0] [rank=2] || WARNING: [2905102] root: /tmp/tensorboard-3021.32690e03-7e1b-41bf-937b-e8c10bffe04f.1-2 directory does not exist.
<info> [2023-03-23 22:07:14] [cont=0] [rank=0] || INFO: [2905099] root: Waiting for Tensorboard files to finish uploading
<info> [2023-03-23 22:07:30] || INFO: resources exited successfully with a zero exit code
<info> [2023-03-23 22:07:30] || INFO: Trial (Experiment 3021) was terminated: allocation stopped after resources exited successfully with a zero exit code
```

In "harness/determined/pytorch/_pytorch_trial.py", only the chief writes the metrics to the "base_path", which, by default, is "/tmp".  The worker nodes do not.

```
def _validate(self, searcher_op: Optional[core.SearcherOperation] = None) -> Dict[str, Any]:

        ...

            if self.is_chief:
                assert input_counts is not None
                # Reshape and sum.
                num_inputs, num_batches = [sum(n) for n in zip(*input_counts)]  <-- num_batches only set for the chief
        ...

        # Report metrics.
        if self.is_chief:  <-- The writing of the metrics is only done by the chief
            # Skip reporting timings if evaluate_full_dataset() was defined.  This is far less
            # common than evaluate_batch() and we can't know how the user processed their
            # validation data.
            if self._evaluate_batch_defined():
                step_duration = time.time() - step_start_time
                logging.info(
                    det.util.make_timing_log("validated", step_duration, num_inputs, num_batches)  <-- If attempt to access num_batches for non-chief, we will get "[cont=0] [rank=3] || UnboundLocalError: local variable 'num_batches' referenced before assignment"
                )

            det.pytorch._log_tb_metrics(
                self.context.get_tensorboard_writer(), "val", self.state.batches_trained, metrics
            )

            self.core_context.train.report_validation_metrics(self.state.batches_trained, metrics)  <-- Sends metrics to the master. Only the chief sends the metrics. Otherwise, if the non-chief ranks send metrics too, we wind up with 'determined.common.api.errors.APIException: {"error":{"code":13,"reason":"Internal","error":"failed to exec transaction (add validation metrics): inserting validation metrics: ERROR: duplicate key value violates unique constraint \"validations_trial_id_total_batches_run_id_unique\" (SQLSTATE 23505)"}}'
```

The problem is that in "harness/determined/tensorboard/base.py", a warning was being issued by each worker node if the "base_path" didn't exist.

```
    def list_tb_files(
        self,
        since: float,
        selector: Callable[[pathlib.Path], bool],
    ) -> List[pathlib.Path]:
        """
        list_files returns Tensorboard-relevant file names located in the base_path directory
        and all sub-directories that have been modified since a certain time.

        If many files have been created, the syscall to stat on each of them can be quite
        expensive, taking on the order of 1ms for every 100 files. Each file gets stat'd every call
        to this function, which can be a bottleneck late in training or in local training when many
        files exist but few or none need to be re-synced.
        """

        if not self.base_path.exists():
            logging.warning(f"{self.base_path} directory does not exist.")
            return []
        return [
            file
            for file in self.base_path.rglob("*")
            if file.stat().st_mtime > since and file.is_file() and selector(file)
        ]
```

My initial attempt to address this issue in https://github.com/determined-ai/determined-ee/pull/793 was to simply only issue the warning message if the directory was missing for the chief (i.e., rank 0), since it is the only one writing to the "base_path" directory.  So I added the following check in "list_tb_files()" (base.py).

```
        if not self.base_path.exists():

            rank = int(os.getenv("HOROVOD_RANK", 0))

            # In "harness/determined/pytorch/_pytorch_trial.py", the logging of
            # the metrics is done in the "_validate()" function by the chief.
            # The workers do not log metrics, so it is expected that the
            # directory will not exist for them. Therefore, only issue a warning
            # if the directory does not exist for the chief. Otherwise, we will
            # wind up with "directory does not exist" warning messages for the
            # workers in the experiment log, which may confuse the user.
            if rank == 0:
                logging.warning(f"{self.base_path} directory does not exist.")
            return []
```

Ryan reviewed my PR and felt that the change did not belong in "base.py".

```
If I had to guess, one well-placed os.makedirs(THE_PATH, exist_ok=True) would suffice
```

```
It's slightly more involved than that, because user code can set up profiling which does write to tensorboard from all workers.

But yeah, having PyTorchTrial just create that directory seems like a much more direct fix
```

I've now made the change in "shared.py", where I have access to "base_path".

## Test Plan

Re-ran the experiment with the code changes and observed that the experiment still ran successfully to completion, but the warnings were not present.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
