### PR TITLE
chore: bumpenvs a8b9c02, remove some selective tensorflow imports [MLG-358]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,11 +182,11 @@ commands:
       - when:
           condition: <<parameters.tf1>>
           steps:
-            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b
+            - run: docker pull determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a8b9c02
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b
+            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02
 
   login-docker:
     parameters:
@@ -2007,7 +2007,7 @@ jobs:
         type: string
         default: "1"
       environment-image:
-        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2
+        default: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
         type: string
       accel-node-taints:
         type: string

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/install-gcp.rst
@@ -402,5 +402,5 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --compute-agent-instance-type a2-highgpu-1g --gpu-num 1 \
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
-      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2 \
-      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2
+      --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2 \
+      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/singularity.rst
@@ -21,15 +21,15 @@ container runtime in use.
 Each version of Determined utilizes specifically-tagged Docker containers. The image tags referenced
 by default in this version of Determined are described below.
 
-+-------------+-------------------------------------------------------------------------+
-| Environment | File Name                                                               |
-+=============+=========================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b``    |
-+-------------+-------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b`` |
-+-------------+-------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b`` |
-+-------------+-------------------------------------------------------------------------+
++-------------+--------------------------------------------------------------------------+
+| Environment | File Name                                                                |
++=============+==========================================================================+
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02``    |
++-------------+--------------------------------------------------------------------------+
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02`` |
++-------------+--------------------------------------------------------------------------+
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02``  |
++-------------+--------------------------------------------------------------------------+
 
 See :doc:`/training/setup-guide/set-environment-images` for the images Docker Hub location, and add
 each tagged image needed by your experiments to the image cache.

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/slurm-requirements.rst
@@ -387,7 +387,7 @@ platform. There may be additional per-user configuration that is required.
 
    .. code:: bash
 
-      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02
       cd /shared/enroot/images
       enroot import docker://$image
       enroot create /shared/enroot/images/${image//[\/:]/\+}.sqsh

--- a/docs/reference/reference-deploy/config/helm-config-reference.rst
+++ b/docs/reference/reference-deploy/config/helm-config-reference.rst
@@ -181,11 +181,11 @@
 
    -  ``cpuImage``: Sets the default docker image for all non-gpu tasks. If a docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2``.
+      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2``.
 
    -  ``gpuImage``: Sets the default docker image for all gpu tasks. If a docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults
-      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2``.
+      to: ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2``.
 
 -  ``enterpriseEdition``: Specifies whether to use Determined enterprise edition.
 

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -55,9 +55,9 @@ The master supports the following configuration settings:
       ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks
       using the ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2`` for NVIDIA GPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2`` for NVIDIA GPUs.
       -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2`` for CPUs.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2`` for CPUs.
 
    -  ``environment_variables``: A list of environment variables that will be set in every task
       container. Each element of the list should be a string of the form ``NAME=VALUE``. See

--- a/docs/reference/reference-interface/job-config-reference.rst
+++ b/docs/reference/reference-interface/job-config-reference.rst
@@ -45,9 +45,9 @@ The following configuration settings are supported:
       different container images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6),
       CPU tasks using ``cpu`` key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
-      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2`` for NVIDIA GPUs.
+      -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2`` for NVIDIA GPUs.
       -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2`` for CPUs.
+      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2`` for CPUs.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker registry and bypass the Docker
       cache. Defaults to ``false``.

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -1234,8 +1234,8 @@ Optional. The Docker image to use when executing the workload. This image must b
 container images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.6), CPU tasks using
 ``cpu`` key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
--  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2`` for NVIDIA GPUs.
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2`` for CPUs.
+-  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2`` for NVIDIA GPUs.
+-  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2`` for CPUs.
 -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2`` for ROCm.
 
 When the cluster is configured with :ref:`resource_manager.type: slurm

--- a/docs/training/apis-howto/overview.rst
+++ b/docs/training/apis-howto/overview.rst
@@ -68,15 +68,16 @@ TensorFlow 1 vs 2
 
 Determined supports both TensorFlow 1 and 2. The version of TensorFlow that is used for a particular
 experiment is controlled by the container image that has been configured for that experiment.
-Determined provides prebuilt Docker images that include TensorFlow 2.8, 1.15, and 2.7, respectively:
+Determined provides prebuilt Docker images that include TensorFlow 2.11, 1.15, and 2.8,
+respectively:
 
--  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2`` (default)
+-  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2`` (default)
 -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.2``
 -  ``determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.2``
 
 We also provide lightweight CPU-only counterparts:
 
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2``
+-  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2``
 -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.2``
 -  ``determinedai/environments:py-3.8-tf-2.7-cpu-0.21.2``
 
@@ -92,7 +93,7 @@ images.
 .. _rocm-support:
 
 Determined has experimental support for ROCm. Determined provides a prebuilt Docker image that
-includes ROCm 4.2, PyTorch 1.9 and Tensorflow 2.5:
+includes ROCm 5.0, PyTorch 1.10 and Tensorflow 2.7:
 
 -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2``
 

--- a/docs/training/apis-howto/overview.rst
+++ b/docs/training/apis-howto/overview.rst
@@ -73,13 +73,13 @@ respectively:
 
 -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2`` (default)
 -  ``determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.2``
--  ``determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.2``
+-  ``determinedai/environments:cuda-11.2-tf-2.8-gpu-0.21.2``
 
 We also provide lightweight CPU-only counterparts:
 
 -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2``
 -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.2``
--  ``determinedai/environments:py-3.8-tf-2.7-cpu-0.21.2``
+-  ``determinedai/environments:py-3.8-tf-2.8-cpu-0.21.2``
 
 To change the container image used for an experiment, specify :ref:`environment.image
 <exp-environment-image>` in the experiment configuration file. Please see :ref:`container-images`

--- a/docs/training/setup-guide/custom-env.rst
+++ b/docs/training/setup-guide/custom-env.rst
@@ -101,9 +101,9 @@ Default Images
 +-------------+-----------------------------------------------------------------------------------+
 | Environment | File Name                                                                         |
 +=============+===================================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2``               |
+| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2``              |
 +-------------+-----------------------------------------------------------------------------------+
-| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2``            |
+| Nvidia GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2``           |
 +-------------+-----------------------------------------------------------------------------------+
 | AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2``            |
 +-------------+-----------------------------------------------------------------------------------+
@@ -132,7 +132,7 @@ Example Dockerfile that installs custom ``conda``-, ``pip``-, and ``apt``-based 
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2
+   FROM determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
 
    # Custom Configuration
    RUN apt-get update && \
@@ -195,7 +195,7 @@ environments using :ref:`custom images <custom-docker-images>`:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2
+   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.8

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -13,12 +13,12 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b"
-DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9b5db1b"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
-DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-9b5db1b"
-DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-9b5db1b"
+DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a8b9c02"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02"
+DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a8b9c02"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
+DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-a8b9c02"
+DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-a8b9c02"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -60,7 +60,8 @@ class NoopKerasTrial(TFKerasTrial):
             ]
         )
         model = self.context.wrap_model(model)
-        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.SGD())
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.legacy.SGD())
         model.compile(
             loss=tf.keras.losses.MeanSquaredError(),
             optimizer=optimizer,

--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -61,7 +61,10 @@ class NoopKerasTrial(TFKerasTrial):
         )
         model = self.context.wrap_model(model)
         # TODO MLG-443 Migrate from legacy Keras optimizers
-        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.legacy.SGD())
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer = self.context.wrap_optimizer(tf.keras.optimizers.legacy.SGD())
+        else:
+            optimizer = self.context.wrap_optimizer(tf.keras.optimizers.SGD())
         model.compile(
             loss=tf.keras.losses.MeanSquaredError(),
             optimizer=optimizer,

--- a/e2e_tests/tests/fixtures/keras_tf2_disabled_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_tf2_disabled_no_op/model_def.py
@@ -24,7 +24,8 @@ class NoopKerasTrial(TFKerasTrial):
             ]
         )
         model = self.context.wrap_model(model)
-        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.SGD())
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.legacy.SGD())
         model.compile(
             loss=tf.keras.losses.MeanSquaredError(),
             optimizer=optimizer,

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/apex_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: apex_amp_model_def:MNistApexAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2
 

--- a/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
+++ b/e2e_tests/tests/fixtures/pytorch_lightning_amp/auto_amp.yaml
@@ -14,6 +14,6 @@ searcher:
 entrypoint: auto_amp_model_def:MNistAutoAMPTrial
 environment:
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2
-    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
+    cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2
 

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -210,6 +210,11 @@ def test_unets_tf_keras_accuracy() -> None:
 
 @pytest.mark.nightly
 def test_gbt_titanic_estimator_accuracy() -> None:
+    import tensorflow as tf
+    from packaging import version
+
+    if version.parse(tf.__version__) >= version.parse("2.11.0"):
+        pytest.skip("# TODO [MLG-442], see comment in gbt_titanic_estimator model_def")
     config = conf.load_config(conf.decision_trees_examples_path("gbt_titanic_estimator/const.yaml"))
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.decision_trees_examples_path("gbt_titanic_estimator"), 1

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -5,8 +5,8 @@ pytest-timeout
 pexpect
 torch==1.9.0
 torchvision==0.10.0
-tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.12.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow==2.11.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 pandas
 pyyaml
 docker

--- a/examples/computer_vision/cifar10_tf_keras/cifar_model.py
+++ b/examples/computer_vision/cifar10_tf_keras/cifar_model.py
@@ -12,6 +12,8 @@ from tensorflow.keras.losses import categorical_crossentropy
 from tensorflow.keras.metrics import categorical_accuracy
 from tensorflow.keras.models import Sequential
 
+# This example is used in some examples with an explicit tf1 image,
+#  so we keep backwards compatibility.
 # TODO MLG-443 Migrate from legacy Keras optimizers
 if version.parse(tf.__version__) >= version.parse("2.11.0"):
     from tensorflow.keras.optimizers.legacy import RMSprop

--- a/examples/computer_vision/iris_tf_keras/model_def.py
+++ b/examples/computer_vision/iris_tf_keras/model_def.py
@@ -13,18 +13,12 @@ from typing import List
 
 import pandas as pd
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense, Input
 from tensorflow.keras.losses import categorical_crossentropy
 from tensorflow.keras.metrics import categorical_accuracy
 from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers.legacy import RMSprop  # TODO MLG-443
 from tensorflow.keras.utils import to_categorical
-
-# TODO MLG-443 Migrate from legacy Keras optimizers
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import RMSprop
-else:
-    from tensorflow.keras.optimizers import RMSprop
 
 from determined import keras
 

--- a/examples/computer_vision/unets_tf_keras/const.yaml
+++ b/examples/computer_vision/unets_tf_keras/const.yaml
@@ -22,4 +22,4 @@ min_validation_period:
 entrypoint: model_def:UNetsTrial
 scheduling_unit: 57
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02

--- a/examples/computer_vision/unets_tf_keras/distributed.yaml
+++ b/examples/computer_vision/unets_tf_keras/distributed.yaml
@@ -25,4 +25,4 @@ min_validation_period:
 scheduling_unit: 8
 entrypoint: model_def:UNetsTrial
 environment:
-    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+    image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02

--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -104,7 +104,8 @@ class UNetsTrial(TFKerasTrial):
         model = self.context.wrap_model(model)
 
         # Create and wrap optimizer.
-        optimizer = tf.keras.optimizers.Adam()
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        optimizer = tf.keras.optimizers.legacy.Adam()
         optimizer = self.context.wrap_optimizer(optimizer)
 
         model.compile(

--- a/examples/computer_vision/unets_tf_keras/startup-hook.sh
+++ b/examples/computer_vision/unets_tf_keras/startup-hook.sh
@@ -1,2 +1,3 @@
+pip install "setuptools<66" # necessary for installing tensorflow/examples for some reason
 pip install git+https://github.com/tensorflow/examples.git
 pip install -q -U tfds-nightly

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_3_cpu_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
+++ b/examples/deepspeed/cifar10_cpu_offloading/zero_no_offload.yaml
@@ -14,7 +14,7 @@ environment:
     # You may need to modify this to match your network configuration.
     - NCCL_SOCKET_IFNAME=ens,eth,ib
   image:
-    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
+    gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02
 bind_mounts:
   - host_path: /tmp
     container_path: /data

--- a/examples/deepspeed/cifar10_moe/moe.yaml
+++ b/examples/deepspeed/cifar10_moe/moe.yaml
@@ -21,7 +21,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
+        gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/cifar10_moe/zero_stages.yaml
+++ b/examples/deepspeed/cifar10_moe/zero_stages.yaml
@@ -22,7 +22,7 @@ environment:
     #    - NCCL_BLOCKING_WAIT=1
     #    - NCCL_IB_DISABLE=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02
 bind_mounts:
     - host_path: /tmp
       container_path: /data

--- a/examples/deepspeed/gpt_neox/Dockerfile
+++ b/examples/deepspeed/gpt_neox/Dockerfile
@@ -1,4 +1,4 @@
-FROM determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-9b5db1b
+FROM determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-a8b9c02
 
 # Install deepspeed & dependencies
 RUN apt-get install -y mpich

--- a/examples/deepspeed/pipeline_parallelism/distributed.yaml
+++ b/examples/deepspeed/pipeline_parallelism/distributed.yaml
@@ -20,7 +20,7 @@ environment:
     #    - CUDA_LAUNCH_BLOCKING=1
     #    - NCCL_BLOCKING_WAIT=1
     image:
-      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
+      gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02
 resources:
   slots_per_trial: 2
 records_per_epoch: 50000

--- a/examples/gan/dcgan_tf_keras/model_def.py
+++ b/examples/gan/dcgan_tf_keras/model_def.py
@@ -26,12 +26,13 @@ class DCGanTrial(TFKerasTrial):
         model = self.context.wrap_model(model)
 
         # Create and wrap the optimizers.
-        g_optimizer = tf.keras.optimizers.Adam(
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        g_optimizer = tf.keras.optimizers.legacy.Adam(
             learning_rate=self.context.get_hparam("generator_lr")
         )
         g_optimizer = self.context.wrap_optimizer(g_optimizer)
 
-        d_optimizer = tf.keras.optimizers.Adam(
+        d_optimizer = tf.keras.optimizers.legacy.Adam(
             learning_rate=self.context.get_hparam("discriminator_lr")
         )
         d_optimizer = self.context.wrap_optimizer(d_optimizer)

--- a/examples/gan/pix2pix_tf_keras/pix2pix/discriminator.py
+++ b/examples/gan/pix2pix_tf_keras/pix2pix/discriminator.py
@@ -47,4 +47,5 @@ def loss(real_output, fake_output):
 
 
 def make_optimizer(lr=2e-4, beta_1=0.5):
-    return tf.keras.optimizers.Adam(lr, beta_1)
+    # TODO MLG-443 Migrate from legacy Keras optimizers
+    return tf.keras.optimizers.legacy.Adam(lr, beta_1)

--- a/examples/gan/pix2pix_tf_keras/pix2pix/generator.py
+++ b/examples/gan/pix2pix_tf_keras/pix2pix/generator.py
@@ -75,4 +75,5 @@ def loss(fake_output, gen_output, target, lambda_=100):
 
 
 def make_optimizer(lr=2e-4, beta_1=0.5):
-    return tf.keras.optimizers.Adam(lr, beta_1)
+    # TODO MLG-443 Migrate from legacy Keras optimizers
+    return tf.keras.optimizers.legacy.Adam(lr, beta_1)

--- a/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/adaptive.yaml
@@ -32,4 +32,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02

--- a/examples/graphs/proteins_pytorch_geometric/const.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/const.yaml
@@ -18,4 +18,4 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02

--- a/examples/graphs/proteins_pytorch_geometric/distributed.yaml
+++ b/examples/graphs/proteins_pytorch_geometric/distributed.yaml
@@ -18,6 +18,6 @@ searcher:
 entrypoint: model_def:GraphConvTrial
 environment:
   image:
-    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+    cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02
 resources:
   slots_per_trial: 4

--- a/examples/tests/requirements.txt
+++ b/examples/tests/requirements.txt
@@ -1,7 +1,7 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
-tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
-tensorflow-macos==2.12.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow==2.11.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 # torch is pinned here to maintain consistency with that specified in the root Makefile
 torch==1.9.0
 # torchvision is pinned because this is the most recent version compatible with the version of torch

--- a/examples/tests/test_official.py
+++ b/examples/tests/test_official.py
@@ -2,6 +2,8 @@ import pathlib
 import subprocess
 
 import pytest
+import tensorflow as tf
+from packaging import version
 
 official_examples = [
     (
@@ -57,8 +59,11 @@ official_examples = [
 
 @pytest.mark.parametrize("model_def,config_file", official_examples)
 def test_official(model_def: str, config_file: str) -> None:
-    if "gbt_titanic_estimator" in model_def:
-        pytest.skip("# TODO [MLG-442], see comment in {model_def}")
+    if (
+        version.parse(tf.__version__) >= version.parse("2.11.0")
+        and "gbt_titanic_estimator" in model_def
+    ):
+        pytest.skip(f"# TODO [MLG-442], see comment in {model_def}")
     examples_dir = pathlib.Path(__file__).parent.parent
     model_def_absolute = examples_dir.joinpath(model_def)
     config_file_absolute = examples_dir.joinpath(config_file)

--- a/examples/tutorials/fashion_mnist_tf_keras/model_def.py
+++ b/examples/tutorials/fashion_mnist_tf_keras/model_def.py
@@ -32,7 +32,8 @@ class FashionMNISTTrial(TFKerasTrial):
         model = self.context.wrap_model(model)
 
         # Create and wrap the optimizer.
-        optimizer = tf.keras.optimizers.Adam()
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        optimizer = tf.keras.optimizers.legacy.Adam()
         optimizer = self.context.wrap_optimizer(optimizer)
 
         model.compile(

--- a/examples/tutorials/fashion_mnist_tf_keras/model_def.py
+++ b/examples/tutorials/fashion_mnist_tf_keras/model_def.py
@@ -10,6 +10,7 @@ the number of epochs to increase accuracy.
 """
 import data
 import tensorflow as tf
+from packaging import version
 from tensorflow import keras
 
 from determined.keras import InputData, TFKerasTrial, TFKerasTrialContext
@@ -33,7 +34,11 @@ class FashionMNISTTrial(TFKerasTrial):
 
         # Create and wrap the optimizer.
         # TODO MLG-443 Migrate from legacy Keras optimizers
-        optimizer = tf.keras.optimizers.legacy.Adam()
+        # TODO Why is GKE hardcoding TF-2.4?
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer = tf.keras.optimizers.legacy.Adam()
+        else:
+            optimizer = tf.keras.optimizers.Adam()
         optimizer = self.context.wrap_optimizer(optimizer)
 
         model.compile(

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0bb9d169eea880f0c
+      Agent: ami-0ed7e09f8c0782e7a
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-04b2a73ef7923efe6
+    #   Agent: ami-047f2d8dc6874c3c4
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-024d675978237fa80
+    #   Agent: ami-0935a6fdc6a5bbbcd
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0238276397b254a83
+    #   Agent: ami-0c827da0f24b30b31
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-09506c0a6df6626bc
+      Agent: ami-01f4fccdaf0f05260
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-0e2b716415874cb07
+      Agent: ami-09e7dc0bb15d0741d
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0c8a8a8c7a2721ee7
+    #   Agent: ami-01a76da2162d5a3de
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-0b18bcecbd428ae4c
+      Agent: ami-0e8bfb0c4d4a8b023
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-00e86d39577d39acf
+      Agent: ami-0088f8c6e981955e2
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0c841a5d48a137ae2
+      Agent: ami-004cc7841b2b1216c
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0bb9d169eea880f0c
+      Agent: ami-0ed7e09f8c0782e7a
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-04b2a73ef7923efe6
+    #   Agent: ami-047f2d8dc6874c3c4
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-024d675978237fa80
+    #   Agent: ami-0935a6fdc6a5bbbcd
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0238276397b254a83
+    #   Agent: ami-0c827da0f24b30b31
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-09506c0a6df6626bc
+      Agent: ami-01f4fccdaf0f05260
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-0e2b716415874cb07
+      Agent: ami-09e7dc0bb15d0741d
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0c8a8a8c7a2721ee7
+    #   Agent: ami-01a76da2162d5a3de
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-0b18bcecbd428ae4c
+      Agent: ami-0e8bfb0c4d4a8b023
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-00e86d39577d39acf
+      Agent: ami-0088f8c6e981955e2
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0c841a5d48a137ae2
+      Agent: ami-004cc7841b2b1216c
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0bb9d169eea880f0c
+      Agent: ami-0ed7e09f8c0782e7a
       Bastion: ami-00910ef9457f0df47
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-04b2a73ef7923efe6
+    #   Agent: ami-047f2d8dc6874c3c4
     #   Bastion: ami-035e3e44dc41db6a2
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-024d675978237fa80
+    #   Agent: ami-0935a6fdc6a5bbbcd
     #   Bastion: ami-0fd1ee6c8b656f020
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0238276397b254a83
+    #   Agent: ami-0c827da0f24b30b31
     #   Bastion: ami-0b62ecd3babd1c548
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-09506c0a6df6626bc
+      Agent: ami-01f4fccdaf0f05260
       Bastion: ami-0abbe417ed83c0b29
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-0e2b716415874cb07
+      Agent: ami-09e7dc0bb15d0741d
       Bastion: ami-0e3f7dd2dc743e48a
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0c8a8a8c7a2721ee7
+    #   Agent: ami-01a76da2162d5a3de
     #   Bastion: ami-0d78429fb6af30994
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-0b18bcecbd428ae4c
+      Agent: ami-0e8bfb0c4d4a8b023
       Bastion: ami-0172070f66a8ebe63
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-00e86d39577d39acf
+      Agent: ami-0088f8c6e981955e2
       Bastion: ami-0bafa3699418551cd
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0c841a5d48a137ae2
+      Agent: ami-004cc7841b2b1216c
       Bastion: ami-0ceeab680f529cc36
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0bb9d169eea880f0c
+      Agent: ami-0ed7e09f8c0782e7a
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-04b2a73ef7923efe6
+    #   Agent: ami-047f2d8dc6874c3c4
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-024d675978237fa80
+    #   Agent: ami-0935a6fdc6a5bbbcd
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0238276397b254a83
+    #   Agent: ami-0c827da0f24b30b31
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-09506c0a6df6626bc
+      Agent: ami-01f4fccdaf0f05260
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-0e2b716415874cb07
+      Agent: ami-09e7dc0bb15d0741d
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0c8a8a8c7a2721ee7
+    #   Agent: ami-01a76da2162d5a3de
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-0b18bcecbd428ae4c
+      Agent: ami-0e8bfb0c4d4a8b023
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-00e86d39577d39acf
+      Agent: ami-0088f8c6e981955e2
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0c841a5d48a137ae2
+      Agent: ami-004cc7841b2b1216c
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -4,7 +4,7 @@ class defaults:
     DB_PASSWORD = "postgres"
     BOOT_DISK_SIZE = 200
     BOOT_DISK_TYPE = "pd-standard"
-    ENVIRONMENT_IMAGE = "det-environments-9b5db1b"
+    ENVIRONMENT_IMAGE = "det-environments-a8b9c02"
     GPU_NUM = 4
     GPU_TYPE = "nvidia-tesla-t4"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/determined/estimator/_estimator_trial.py
+++ b/harness/determined/estimator/_estimator_trial.py
@@ -818,7 +818,7 @@ class EstimatorTrial(det.Trial):
     """
     By default, experiments run with TensorFlow 1.x. To configure your trial to
     use TensorFlow 2.x, set a TF 2.x image in the experiment configuration
-    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2``).
+    (e.g. ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2``).
 
     ``EstimatorTrial`` supports TF 2.x; however it uses TensorFlow V1
     behavior. We have disabled TensorFlow V2 behavior for ``EstimatorTrial``,

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-estimator/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/code/model_def.py
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/code/model_def.py
@@ -1,16 +1,10 @@
 import numpy as np
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.losses import mean_squared_error
 from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers.legacy import SGD  # TODO MLG-443
 from tensorflow.keras.utils import Sequence
-
-# TODO MLG-443 Migrate from legacy Keras optimizers
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import SGD
-else:
-    from tensorflow.keras.optimizers import SGD
 
 from determined.keras import TFKerasTrial
 

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
@@ -38,9 +38,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.7-keras/code/model_def.py
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.7-keras/code/model_def.py
@@ -1,16 +1,10 @@
 import numpy as np
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.losses import mean_squared_error
 from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers.legacy import SGD  # TODO MLG-443
 from tensorflow.keras.utils import Sequence
-
-# TODO MLG-443 Migrate from legacy Keras optimizers
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import SGD
-else:
-    from tensorflow.keras.optimizers import SGD
 
 from determined.keras import TFKerasTrial
 

--- a/harness/tests/experiment/fixtures/ancient_keras_ckpt.py
+++ b/harness/tests/experiment/fixtures/ancient_keras_ckpt.py
@@ -6,16 +6,11 @@ be loaded in new Determined.
 from typing import Any, Dict, cast
 
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.losses import mean_squared_error
 from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers.legacy import SGD  # TODO MLG-443
 from tensorflow.raw_ops import ZipDataset
-
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import SGD
-else:
-    from tensorflow.keras.optimizers import SGD
 
 from determined import keras
 

--- a/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
+++ b/harness/tests/experiment/fixtures/tf_keras_one_var_model.py
@@ -3,16 +3,10 @@ from typing import Any, Dict, List, cast
 
 import numpy as np
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.losses import mean_squared_error
 from tensorflow.keras.models import Sequential
-
-# TODO MLG-443 Migrate from legacy Keras optimizers
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import SGD
-else:
-    from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD  # TODO MLG-443
 
 from determined import keras
 from tests.experiment.fixtures import keras_cb_checker

--- a/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
+++ b/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
@@ -23,7 +23,8 @@ class RuntimeErrorTrial(det.keras.TFKerasTrial):
         model = keras.Sequential([keras.layers.Dense(10)])
         model = self.context.wrap_model(model)
         model.compile(
-            optimizer=tf.keras.optimizers.Adam(name="Adam"),
+            # TODO MLG-443 Migrate from legacy Keras optimizers
+            optimizer=tf.keras.optimizers.legacy.Adam(name="Adam"),
             loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
             metrics=[
                 tf.keras.metrics.Accuracy()

--- a/harness/tests/experiment/fixtures/tf_keras_xor_model.py
+++ b/harness/tests/experiment/fixtures/tf_keras_xor_model.py
@@ -1,17 +1,11 @@
 from typing import Any, List, cast
 
 import tensorflow as tf
-from packaging import version
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.losses import binary_crossentropy
 from tensorflow.keras.metrics import categorical_accuracy
 from tensorflow.keras.models import Sequential
-
-# TODO MLG-443 Migrate from legacy Keras optimizers
-if version.parse(tf.__version__) >= version.parse("2.11.0"):
-    from tensorflow.keras.optimizers.legacy import SGD, Adam
-else:
-    from tensorflow.keras.optimizers import SGD, Adam
+from tensorflow.keras.optimizers.legacy import SGD, Adam  # TODO MLG-443
 
 from determined import keras
 from tests.experiment.utils import make_xor_data_sequences  # noqa: I202, I100

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -131,8 +131,8 @@ data:
       {{- toYaml .Values.resourcePools | nindent 6}}
     {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b")._1 -}}
+    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02")._1}}
+    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -49,16 +49,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0bb9d169eea880f0c",
-	"ap-northeast-2": "ami-04b2a73ef7923efe6",
-	"ap-southeast-1": "ami-024d675978237fa80",
-	"ap-southeast-2": "ami-0238276397b254a83",
-	"us-east-2":      "ami-00e86d39577d39acf",
-	"us-east-1":      "ami-0b18bcecbd428ae4c",
-	"us-west-2":      "ami-0c841a5d48a137ae2",
-	"eu-central-1":   "ami-09506c0a6df6626bc",
-	"eu-west-2":      "ami-0c8a8a8c7a2721ee7",
-	"eu-west-1":      "ami-0e2b716415874cb07",
+	"ap-northeast-1": "ami-0ed7e09f8c0782e7a",
+	"ap-northeast-2": "ami-047f2d8dc6874c3c4",
+	"ap-southeast-1": "ami-0935a6fdc6a5bbbcd",
+	"ap-southeast-2": "ami-0c827da0f24b30b31",
+	"us-east-2":      "ami-0088f8c6e981955e2",
+	"us-east-1":      "ami-0e8bfb0c4d4a8b023",
+	"us-west-2":      "ami-004cc7841b2b1216c",
+	"eu-central-1":   "ami-01f4fccdaf0f05260",
+	"eu-west-2":      "ami-01a76da2162d5a3de",
+	"eu-west-1":      "ami-09e7dc0bb15d0741d",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -55,7 +55,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-9b5db1b",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-a8b9c02",
 		BootDiskType:        "pd-standard",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b"
-	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
-	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"
+	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02"
+	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
+	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -111,7 +111,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-aaa3750"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-aaa3750"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},
@@ -245,7 +245,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"),
 					},
 					RawPodSpec: &PodSpec{
 						TypeMeta: metaV1.TypeMeta{
@@ -332,8 +332,8 @@ func TestLegacyConfig(t *testing.T) {
                     gpu: []
                   force_pull_image: false
                   image:
-                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b
-                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9b5db1b
+                    cpu: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a8b9c02
+                    gpu: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a8b9c02
                   ports: {}
                   registry_auth: null
                 hyperparameters:
@@ -410,9 +410,9 @@ func TestLegacyConfig(t *testing.T) {
 						RawROCM: []string{},
 					},
 					RawImage: &EnvironmentImageMap{
-						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b"),
-						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9b5db1b"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b"),
+						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a8b9c02"),
+						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a8b9c02"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -32,9 +32,9 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b
-        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
-        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b
+        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02
+        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02
+        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,309 +1,174 @@
-ap_northeast_1_agent_ami:
-  new: ami-0bb9d169eea880f0c
-  old: ami-00345c85c48e1b0f1
-ap_northeast_1_bastion_ami:
-  new: ami-00910ef9457f0df47
-  old: ami-0c7cb70d3eb61492b
-ap_northeast_1_master_ami:
-  new: ami-00910ef9457f0df47
-  old: ami-0c7cb70d3eb61492b
-ap_northeast_2_agent_ami:
-  new: ami-04b2a73ef7923efe6
-  old: ami-0b2642953f8f7b733
-ap_northeast_2_bastion_ami:
-  new: ami-035e3e44dc41db6a2
-  old: ami-003bb1772f36a39a3
-ap_northeast_2_master_ami:
-  new: ami-035e3e44dc41db6a2
-  old: ami-003bb1772f36a39a3
-ap_southeast_1_agent_ami:
-  new: ami-024d675978237fa80
-  old: ami-0b2e86c5b85bb79b2
-ap_southeast_1_bastion_ami:
-  new: ami-0fd1ee6c8b656f020
-  old: ami-09f03fa5572692399
-ap_southeast_1_master_ami:
-  new: ami-0fd1ee6c8b656f020
-  old: ami-09f03fa5572692399
-ap_southeast_2_agent_ami:
-  new: ami-0238276397b254a83
-  old: ami-0712786f5f4bd1960
-ap_southeast_2_bastion_ami:
-  new: ami-0b62ecd3babd1c548
-  old: ami-06139e5e22cc2f7b1
-ap_southeast_2_master_ami:
-  new: ami-0b62ecd3babd1c548
-  old: ami-06139e5e22cc2f7b1
-deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-b785d7b
-deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.21.1
-deepspeed_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-9119094
-deepspeed_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-0.19.1
-eu_central_1_agent_ami:
-  new: ami-09506c0a6df6626bc
-  old: ami-021c7d250ca573a38
-eu_central_1_bastion_ami:
-  new: ami-0abbe417ed83c0b29
-  old: ami-0b81e95bb0a06ea8c
-eu_central_1_master_ami:
-  new: ami-0abbe417ed83c0b29
-  old: ami-0b81e95bb0a06ea8c
-eu_west_1_agent_ami:
-  new: ami-0e2b716415874cb07
-  old: ami-01030a50479dcdaf2
-eu_west_1_bastion_ami:
-  new: ami-0e3f7dd2dc743e48a
-  old: ami-029cfca952b331b52
-eu_west_1_master_ami:
-  new: ami-0e3f7dd2dc743e48a
-  old: ami-029cfca952b331b52
-eu_west_2_agent_ami:
-  new: ami-0c8a8a8c7a2721ee7
-  old: ami-0c75b4a4ccfbabfb1
-eu_west_2_bastion_ami:
-  new: ami-0d78429fb6af30994
-  old: ami-035469b606478d63d
-eu_west_2_master_ami:
-  new: ami-0d78429fb6af30994
-  old: ami-035469b606478d63d
-gcp_env:
-  new: det-environments-9b5db1b
-  old: det-environments-b785d7b
-gpt_neox_deepspeed_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-b785d7b
-gpt_neox_deepspeed_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.21.1
-gpt_neox_deepspeed_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094
-gpt_neox_deepspeed_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1
-pt_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-9b5db1b
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-b785d7b
-pt_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.2
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.1
-pt_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-9b5db1b
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-b785d7b
-pt_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.2
-  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.1
-pt_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-b785d7b
-pt_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.1
-pt_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-b785d7b
-pt_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.1
-pytorch10_tf27_rocm50_0_hashed:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-b785d7b
-pytorch10_tf27_rocm50_0_versioned:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2
-  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1
-pytorch19_tf25_rocm_0_hashed:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730
-  old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-ecee7c1
-pytorch19_tf25_rocm_0_versioned:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4
-  old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-0.18.5
-pytorch19_tf25_rocm_1_hashed:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730
-pytorch19_tf25_rocm_1_versioned:
-  new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4
-tf1_cpu_0_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-b785d7b
-tf1_cpu_0_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.2
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.1
-tf1_cpu_1_hashed:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-9b5db1b
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-b785d7b
-tf1_cpu_1_versioned:
-  new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.2
-  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.1
-tf1_gpu_0_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9b5db1b
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-b785d7b
-tf1_gpu_0_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.2
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1
-tf1_gpu_1_hashed:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-9b5db1b
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-b785d7b
-tf1_gpu_1_versioned:
-  new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.2
-  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.1
-tf24_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-24586f0
-  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-1c769fb
-tf24_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.10
-  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.10
-tf24_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-24586f0
-  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-1c769fb
-tf24_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-0.19.10
-  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-0.19.10
-tf24_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-24586f0
-  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-1c769fb
-tf24_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
-  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
-tf24_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-24586f0
-  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-1c769fb
-tf24_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-0.19.10
-  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-0.19.10
-tf25_cpu_0_hashed:
-  new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-1c769fb
-  old: determinedai/environments-dev:py-3.8-tf-2.5-cpu-15f6132
-tf25_cpu_0_versioned:
-  new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-0.19.10
-  old: determinedai/environments:py-3.8-tf-2.5-cpu-0.19.4
-tf25_cpu_1_hashed:
-  new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-1c769fb
-  old: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-15f6132
-tf25_cpu_1_versioned:
-  new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-0.19.10
-  old: determinedai/environments:py-3.8-tf-2.5-cpu-mpi-0.19.4
-tf25_gpu_0_hashed:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-1c769fb
-  old: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-15f6132
-tf25_gpu_0_versioned:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-0.19.10
-  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.19.4
-tf25_gpu_1_hashed:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-1c769fb
-  old: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-15f6132
-tf25_gpu_1_versioned:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-0.19.10
-  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-mpi-0.19.4
-tf26_cpu_0_hashed:
-  new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-1c769fb
-  old: determinedai/environments-dev:py-3.8-tf-2.6-cpu-15f6132
-tf26_cpu_0_versioned:
-  new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-0.19.10
-  old: determinedai/environments:py-3.8-tf-2.6-cpu-0.19.4
-tf26_cpu_1_hashed:
-  new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-1c769fb
-  old: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-15f6132
-tf26_cpu_1_versioned:
-  new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-0.19.10
-  old: determinedai/environments:py-3.8-tf-2.6-cpu-mpi-0.19.4
-tf26_gpu_0_hashed:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-1c769fb
-  old: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-15f6132
-tf26_gpu_0_versioned:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-0.19.10
-  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.19.4
-tf26_gpu_1_hashed:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-1c769fb
-  old: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-15f6132
-tf26_gpu_1_versioned:
-  new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-0.19.10
-  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-mpi-0.19.4
-tf27_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-9b5db1b
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-b785d7b
-tf27_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.2
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.1
-tf27_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-9b5db1b
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-b785d7b
-tf27_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.2
-  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.1
-tf27_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-9b5db1b
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-b785d7b
-tf27_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.2
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.1
-tf27_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-9b5db1b
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-b785d7b
-tf27_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.2
-  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.1
-tf2_cpu_0_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-b785d7b
-tf2_cpu_0_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.1
-tf2_cpu_1_hashed:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-9b5db1b
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-b785d7b
-tf2_cpu_1_versioned:
-  new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.2
-  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.1
-tf2_gpu_0_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-b785d7b
-tf2_gpu_0_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.1
-tf2_gpu_1_hashed:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-9b5db1b
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-b785d7b
-tf2_gpu_1_versioned:
-  new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.2
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.1
-us_east_1_agent_ami:
-  new: ami-0b18bcecbd428ae4c
-  old: ami-03e48d96ecb9ad34b
-us_east_1_bastion_ami:
-  new: ami-0172070f66a8ebe63
-  old: ami-0b93ce03dcbcb10f6
-us_east_1_master_ami:
-  new: ami-0172070f66a8ebe63
-  old: ami-0b93ce03dcbcb10f6
-us_east_2_agent_ami:
-  new: ami-00e86d39577d39acf
-  old: ami-0be8cf526ed0e00dd
-us_east_2_bastion_ami:
-  new: ami-0bafa3699418551cd
-  old: ami-0cbea92f2377277a4
-us_east_2_master_ami:
-  new: ami-0bafa3699418551cd
-  old: ami-0cbea92f2377277a4
-us_gov_east_1_agent_ami:
-  new: ami-062e68b13140d6c76
-  old: ami-0e9b2643059c481db
-us_gov_east_1_master_ami:
-  new: ami-0cd066f69b98b61b2
-  old: ami-0b36c558c9dd26c75
-us_gov_west_1_agent_ami:
-  new: ami-007c01918230c876c
-  old: ami-026923c8daec86a8f
-us_gov_west_1_master_ami:
-  new: ami-0cbd5dbd94f397bdd
-  old: ami-0f1289f37e46c1eff
-us_west_2_agent_ami:
-  new: ami-0c841a5d48a137ae2
-  old: ami-09d36eb955cff67dd
-us_west_2_bastion_ami:
-  new: ami-0ceeab680f529cc36
-  old: ami-0d31d7c9fc9503726
-us_west_2_master_ami:
-  new: ami-0ceeab680f529cc36
-  old: ami-0d31d7c9fc9503726
+ap_northeast_1_agent_ami: {new: ami-0ed7e09f8c0782e7a, old: ami-0bb9d169eea880f0c}
+ap_northeast_1_bastion_ami: {new: ami-00910ef9457f0df47, old: ami-0c7cb70d3eb61492b}
+ap_northeast_1_master_ami: {new: ami-00910ef9457f0df47, old: ami-0c7cb70d3eb61492b}
+ap_northeast_2_agent_ami: {new: ami-047f2d8dc6874c3c4, old: ami-04b2a73ef7923efe6}
+ap_northeast_2_bastion_ami: {new: ami-035e3e44dc41db6a2, old: ami-003bb1772f36a39a3}
+ap_northeast_2_master_ami: {new: ami-035e3e44dc41db6a2, old: ami-003bb1772f36a39a3}
+ap_southeast_1_agent_ami: {new: ami-0935a6fdc6a5bbbcd, old: ami-024d675978237fa80}
+ap_southeast_1_bastion_ami: {new: ami-0fd1ee6c8b656f020, old: ami-09f03fa5572692399}
+ap_southeast_1_master_ami: {new: ami-0fd1ee6c8b656f020, old: ami-09f03fa5572692399}
+ap_southeast_2_agent_ami: {new: ami-0c827da0f24b30b31, old: ami-0238276397b254a83}
+ap_southeast_2_bastion_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
+ap_southeast_2_master_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
+deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-9b5db1b}
+deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.7.0-gpu-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-0.21.1}
+deepspeed_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-9119094}
+deepspeed_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-0.19.1}
+eu_central_1_agent_ami: {new: ami-01f4fccdaf0f05260, old: ami-09506c0a6df6626bc}
+eu_central_1_bastion_ami: {new: ami-0abbe417ed83c0b29, old: ami-0b81e95bb0a06ea8c}
+eu_central_1_master_ami: {new: ami-0abbe417ed83c0b29, old: ami-0b81e95bb0a06ea8c}
+eu_west_1_agent_ami: {new: ami-09e7dc0bb15d0741d, old: ami-0e2b716415874cb07}
+eu_west_1_bastion_ami: {new: ami-0e3f7dd2dc743e48a, old: ami-029cfca952b331b52}
+eu_west_1_master_ami: {new: ami-0e3f7dd2dc743e48a, old: ami-029cfca952b331b52}
+eu_west_2_agent_ami: {new: ami-01a76da2162d5a3de, old: ami-0c8a8a8c7a2721ee7}
+eu_west_2_bastion_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
+eu_west_2_master_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
+gcp_env: {new: det-environments-a8b9c02, old: det-environments-9b5db1b}
+gpt_neox_deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-9b5db1b}
+gpt_neox_deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-0.21.1}
+gpt_neox_deepspeed_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094}
+gpt_neox_deepspeed_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1}
+pt_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-a8b9c02,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-9b5db1b}
+pt_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.2,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.21.1}
+pt_cpu_1_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-a8b9c02,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-9b5db1b}
+pt_cpu_1_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.2,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.21.1}
+pt_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-9b5db1b}
+pt_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.21.1}
+pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-9b5db1b}
+pt_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.1}
+pytorch10_tf27_rocm50_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02,
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b}
+pytorch10_tf27_rocm50_0_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2,
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.1}
+pytorch19_tf25_rocm_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730,
+  old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-ecee7c1}
+pytorch19_tf25_rocm_0_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4,
+  old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-0.18.5}
+pytorch19_tf25_rocm_1_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730}
+pytorch19_tf25_rocm_1_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4}
+tf1_cpu_0_hashed: {new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-a8b9c02,
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-9b5db1b}
+tf1_cpu_0_versioned: {new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.2,
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.1}
+tf1_cpu_1_hashed: {new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-a8b9c02,
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-9b5db1b}
+tf1_cpu_1_versioned: {new: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.2,
+  old: determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-mpi-0.21.1}
+tf1_gpu_0_hashed: {new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-a8b9c02,
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-9b5db1b}
+tf1_gpu_0_versioned: {new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.2,
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-0.21.1}
+tf1_gpu_1_hashed: {new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-a8b9c02,
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-9b5db1b}
+tf1_gpu_1_versioned: {new: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.2,
+  old: determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-mpi-0.21.1}
+tf24_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-24586f0,
+  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-1c769fb}
+tf24_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.10,
+  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.10}
+tf24_cpu_1_hashed: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-24586f0,
+  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-1c769fb}
+tf24_cpu_1_versioned: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-0.19.10,
+  old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-mpi-0.19.10}
+tf24_gpu_0_hashed: {new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-24586f0,
+  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-1c769fb}
+tf24_gpu_0_versioned: {new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10,
+  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10}
+tf24_gpu_1_hashed: {new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-24586f0,
+  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-1c769fb}
+tf24_gpu_1_versioned: {new: determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-0.19.10,
+  old: determinedai/environments-dev:cuda-11.1-pytorch-1.9-tf-2.4-gpu-mpi-0.19.10}
+tf25_cpu_0_hashed: {new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-1c769fb,
+  old: determinedai/environments-dev:py-3.8-tf-2.5-cpu-15f6132}
+tf25_cpu_0_versioned: {new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-0.19.10,
+  old: determinedai/environments:py-3.8-tf-2.5-cpu-0.19.4}
+tf25_cpu_1_hashed: {new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-1c769fb,
+  old: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-15f6132}
+tf25_cpu_1_versioned: {new: determinedai/environments-dev:py-3.8-tf-2.5-cpu-mpi-0.19.10,
+  old: determinedai/environments:py-3.8-tf-2.5-cpu-mpi-0.19.4}
+tf25_gpu_0_hashed: {new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-1c769fb,
+  old: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-15f6132}
+tf25_gpu_0_versioned: {new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-0.19.10,
+  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-0.19.4}
+tf25_gpu_1_hashed: {new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-1c769fb,
+  old: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-15f6132}
+tf25_gpu_1_versioned: {new: determinedai/environments-dev:cuda-11.2-tf-2.5-gpu-mpi-0.19.10,
+  old: determinedai/environments:cuda-11.2-tf-2.5-gpu-mpi-0.19.4}
+tf26_cpu_0_hashed: {new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-1c769fb,
+  old: determinedai/environments-dev:py-3.8-tf-2.6-cpu-15f6132}
+tf26_cpu_0_versioned: {new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-0.19.10,
+  old: determinedai/environments:py-3.8-tf-2.6-cpu-0.19.4}
+tf26_cpu_1_hashed: {new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-1c769fb,
+  old: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-15f6132}
+tf26_cpu_1_versioned: {new: determinedai/environments-dev:py-3.8-tf-2.6-cpu-mpi-0.19.10,
+  old: determinedai/environments:py-3.8-tf-2.6-cpu-mpi-0.19.4}
+tf26_gpu_0_hashed: {new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-1c769fb,
+  old: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-15f6132}
+tf26_gpu_0_versioned: {new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-0.19.10,
+  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-0.19.4}
+tf26_gpu_1_hashed: {new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-1c769fb,
+  old: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-15f6132}
+tf26_gpu_1_versioned: {new: determinedai/environments-dev:cuda-11.2-tf-2.6-gpu-mpi-0.19.10,
+  old: determinedai/environments:cuda-11.2-tf-2.6-gpu-mpi-0.19.4}
+tf27_cpu_0_hashed: {new: determinedai/environments:py-3.8-tf-2.7-cpu-9b5db1b, old: determinedai/environments:py-3.8-tf-2.7-cpu-b785d7b}
+tf27_cpu_0_versioned: {new: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.2, old: determinedai/environments:py-3.8-tf-2.7-cpu-0.21.1}
+tf27_cpu_1_hashed: {new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-9b5db1b,
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-b785d7b}
+tf27_cpu_1_versioned: {new: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.2,
+  old: determinedai/environments:py-3.8-tf-2.7-cpu-mpi-0.21.1}
+tf27_gpu_0_hashed: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-9b5db1b, old: determinedai/environments:cuda-11.2-tf-2.7-gpu-b785d7b}
+tf27_gpu_0_versioned: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.2,
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-0.21.1}
+tf27_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-9b5db1b,
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-b785d7b}
+tf27_gpu_1_versioned: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.2,
+  old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.1}
+tf28_cpu_0_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-a8b9c02}
+tf28_cpu_0_versioned: {new: determinedai/environments:py-3.8-tf-2.8-cpu-0.21.2}
+tf28_cpu_1_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-a8b9c02}
+tf28_cpu_1_versioned: {new: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-0.21.2}
+tf28_gpu_0_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-a8b9c02}
+tf28_gpu_0_versioned: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-0.21.2}
+tf28_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-a8b9c02}
+tf28_gpu_1_versioned: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-0.21.2}
+tf2_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b}
+tf2_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.21.2,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-0.21.2}
+tf2_cpu_1_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-a8b9c02,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-9b5db1b}
+tf2_cpu_1_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-0.21.2,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-mpi-0.21.2}
+tf2_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b}
+tf2_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-0.21.2}
+tf2_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-a8b9c02,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-9b5db1b}
+tf2_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-0.21.2,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-mpi-0.21.2}
+us_east_1_agent_ami: {new: ami-0e8bfb0c4d4a8b023, old: ami-0b18bcecbd428ae4c}
+us_east_1_bastion_ami: {new: ami-0172070f66a8ebe63, old: ami-0b93ce03dcbcb10f6}
+us_east_1_master_ami: {new: ami-0172070f66a8ebe63, old: ami-0b93ce03dcbcb10f6}
+us_east_2_agent_ami: {new: ami-0088f8c6e981955e2, old: ami-00e86d39577d39acf}
+us_east_2_bastion_ami: {new: ami-0bafa3699418551cd, old: ami-0cbea92f2377277a4}
+us_east_2_master_ami: {new: ami-0bafa3699418551cd, old: ami-0cbea92f2377277a4}
+us_gov_east_1_agent_ami: {new: ami-0729480cbea1fed69, old: ami-062e68b13140d6c76}
+us_gov_east_1_master_ami: {new: ami-0cd066f69b98b61b2, old: ami-0b36c558c9dd26c75}
+us_gov_west_1_agent_ami: {new: ami-02d16d4cd37ae0b7d, old: ami-007c01918230c876c}
+us_gov_west_1_master_ami: {new: ami-0cbd5dbd94f397bdd, old: ami-0f1289f37e46c1eff}
+us_west_2_agent_ami: {new: ami-004cc7841b2b1216c, old: ami-0c841a5d48a137ae2}
+us_west_2_bastion_ami: {new: ami-0ceeab680f529cc36, old: ami-0d31d7c9fc9503726}
+us_west_2_master_ami: {new: ami-0ceeab680f529cc36, old: ami-0d31d7c9fc9503726}

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -39,11 +39,11 @@ BASE_URL = f"https://circleci.com/api/v1.1/project/github/{USER}/{PROJECT}"
 JOB_SUFFIXES = [
     "tf1-cpu",
     "tf2-cpu",
-    "tf27-cpu",
+    "tf28-cpu",
     "pt-cpu",
     "tf1-gpu",
     "tf2-gpu",
-    "tf27-gpu",
+    "tf28-gpu",
     "pt-gpu",
 ]
 

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
+        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
+          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
         },
         "pod_spec": {
           "metadata": {

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9b5db1b",
-      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9b5db1b"
+      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-a8b9c02",
+      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-a8b9c02"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
@@ -69,7 +69,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02',
           },
           pod_spec: null,
           ports: {},
@@ -762,7 +762,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-9b5db1b',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02',
           },
           pod_spec: null,
           ports: {},


### PR DESCRIPTION
## Description

This bumpenvs reflects the upgrade of our `environments` images to TensorFlow 2.11.0.
The example `gpt_titanic_estimator` image has been held back; it will be updated when MLG-442 is done.
Some references in the docs to specific versions of TensorFlow, ROCm, and PyTorch have been updated (not all because of this particular bumpenvs).
Selective imports of Keras optimizers - based on the installed version of TensorFlow - have been removed from many examples and test fixtures: these are cases where it is reasonable to assume that the latest version of TensorFlow we support, 2.11, is installed. This reverts some changes made in #6527.

## Test Plan

All automated tests should pass, including and especially those in `test-e2e-longrunning`.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
