### PR TITLE
fix: Workspace member modal includes users and groups

### DIFF
--- a/webui/react/src/components/WorkspaceMemberAddModal.tsx
+++ b/webui/react/src/components/WorkspaceMemberAddModal.tsx
@@ -28,7 +28,7 @@ interface FormInputs {
 interface SearchProp {
   label: {
     props: {
-      groupName?: string;
+      name?: string;
       user?: User;
     };
   };
@@ -47,7 +47,7 @@ const WorkspaceMemberAddModalComponent: React.FC<Props> = ({
     if (!option) return false;
     const label = option.label;
     return (
-      label.props.groupName?.includes(search) ||
+      label.props.name?.includes(search) ||
       label.props.user?.username?.includes(search) ||
       label.props.user?.displayName?.includes(search) ||
       false


### PR DESCRIPTION
## Description

The new standard modal for Add Member [to a workspace] recently changed the `groupName` prop to `name`. This was hiding groups when searching for users+groups by name inside the Add Member modal.

## Test Plan

In an EE / RBAC environment
Open a workspace other than Uncategorized
Go to the Members tab, and click the "Add Member" button at right
In the "User or Group" section, type the start of user or group names and confirm the name filter is focusing on them

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.