### PR TITLE
fix: launch error has no effect for k8s and slurm

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -106,7 +106,9 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	if err != nil {
 		return nil, launchWarnings, fmt.Errorf("checking resource availability: %v", err.Error())
 	}
-	if a.m.config.LaunchError && len(launchWarnings) > 0 {
+	if a.m.config.ResourceManager.AgentRM != nil &&
+		a.m.config.LaunchError &&
+		len(launchWarnings) > 0 {
 		return nil, nil, errors.New("slots requested exceeds cluster capacity")
 	}
 	// Get the base TaskSpec.

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -145,7 +145,7 @@ func newExperiment(
 	if err != nil {
 		return nil, launchWarnings, fmt.Errorf("getting resource availability: %w", err)
 	}
-	if m.config.LaunchError && len(launchWarnings) > 0 {
+	if m.config.ResourceManager.AgentRM != nil && m.config.LaunchError && len(launchWarnings) > 0 {
 		return nil, nil, errors.New("slots requested exceeds cluster capacity")
 	}
 


### PR DESCRIPTION
## Description
fixes launch error so that it has the expected behavior of not returning an error for kubernetes or slurm.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
