### PR TITLE
fix: missed updates for tensorflow 2.11.0

### DIFF
--- a/e2e_tests/tests/fixtures/keras_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_no_op/model_def.py
@@ -60,7 +60,12 @@ class NoopKerasTrial(TFKerasTrial):
             ]
         )
         model = self.context.wrap_model(model)
-        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.SGD())
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            sgd = tf.keras.optimizers.legacy.SGD()
+        else:
+            sgd = tf.keras.optimizers.SGD()
+        optimizer = self.context.wrap_optimizer(sgd)
         model.compile(
             loss=tf.keras.losses.MeanSquaredError(),
             optimizer=optimizer,

--- a/e2e_tests/tests/fixtures/keras_tf2_disabled_no_op/model_def.py
+++ b/e2e_tests/tests/fixtures/keras_tf2_disabled_no_op/model_def.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+from packaging import version
 
 from determined.keras import TFKerasTrial, TFKerasTrialContext
 
@@ -24,7 +25,12 @@ class NoopKerasTrial(TFKerasTrial):
             ]
         )
         model = self.context.wrap_model(model)
-        optimizer = self.context.wrap_optimizer(tf.keras.optimizers.SGD())
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            sgd = tf.keras.optimizers.legacy.SGD()
+        else:
+            sgd = tf.keras.optimizers.SGD()
+        optimizer = self.context.wrap_optimizer(sgd)
         model.compile(
             loss=tf.keras.losses.MeanSquaredError(),
             optimizer=optimizer,

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -210,6 +210,11 @@ def test_unets_tf_keras_accuracy() -> None:
 
 @pytest.mark.nightly
 def test_gbt_titanic_estimator_accuracy() -> None:
+    import tensorflow as tf
+    from packaging import version
+
+    if version.parse(tf.__version__) >= version.parse("2.11.0"):
+        pytest.skip("# TODO [MLG-442], see comment in {model_def}")
     config = conf.load_config(conf.decision_trees_examples_path("gbt_titanic_estimator/const.yaml"))
     experiment_id = exp.run_basic_test_with_temp_config(
         config, conf.decision_trees_examples_path("gbt_titanic_estimator"), 1

--- a/examples/computer_vision/unets_tf_keras/model_def.py
+++ b/examples/computer_vision/unets_tf_keras/model_def.py
@@ -12,6 +12,7 @@ import filelock
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
+from packaging import version
 from tensorflow import keras
 from tensorflow_examples.models.pix2pix import pix2pix
 
@@ -104,7 +105,11 @@ class UNetsTrial(TFKerasTrial):
         model = self.context.wrap_model(model)
 
         # Create and wrap optimizer.
-        optimizer = tf.keras.optimizers.Adam()
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer = tf.keras.optimizers.legacy.Adam()
+        else:
+            optimizer = tf.keras.optimizers.Adam()
         optimizer = self.context.wrap_optimizer(optimizer)
 
         model.compile(

--- a/examples/gan/dcgan_tf_keras/model_def.py
+++ b/examples/gan/dcgan_tf_keras/model_def.py
@@ -8,7 +8,7 @@ defines a custom `train_step()` and `test_step()`.
 import tensorflow as tf
 from data import get_train_dataset, get_validation_dataset
 from dc_gan import DCGan
-from packaing import version
+from packaging import version
 
 from determined.keras import InputData, TFKerasTrial, TFKerasTrialContext
 

--- a/examples/gan/dcgan_tf_keras/model_def.py
+++ b/examples/gan/dcgan_tf_keras/model_def.py
@@ -8,6 +8,7 @@ defines a custom `train_step()` and `test_step()`.
 import tensorflow as tf
 from data import get_train_dataset, get_validation_dataset
 from dc_gan import DCGan
+from packaing import version
 
 from determined.keras import InputData, TFKerasTrial, TFKerasTrialContext
 
@@ -25,15 +26,16 @@ class DCGanTrial(TFKerasTrial):
         # Wrap the model.
         model = self.context.wrap_model(model)
 
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer_type = tf.keras.optimizers.legacy.Adam
+        else:
+            optimizer_type = tf.keras.optimizers.Adam
         # Create and wrap the optimizers.
-        g_optimizer = tf.keras.optimizers.Adam(
-            learning_rate=self.context.get_hparam("generator_lr")
-        )
+        g_optimizer = optimizer_type(learning_rate=self.context.get_hparam("generator_lr"))
         g_optimizer = self.context.wrap_optimizer(g_optimizer)
 
-        d_optimizer = tf.keras.optimizers.Adam(
-            learning_rate=self.context.get_hparam("discriminator_lr")
-        )
+        d_optimizer = optimizer_type(learning_rate=self.context.get_hparam("discriminator_lr"))
         d_optimizer = self.context.wrap_optimizer(d_optimizer)
 
         model.compile(

--- a/examples/gan/pix2pix_tf_keras/pix2pix/discriminator.py
+++ b/examples/gan/pix2pix_tf_keras/pix2pix/discriminator.py
@@ -2,6 +2,7 @@
 Implement Pix2Pix discriminator model based on: https://www.tensorflow.org/tutorials/generative/pix2pix
 """
 import tensorflow as tf
+from packaging import version
 
 from .sampling import downsample
 
@@ -47,4 +48,8 @@ def loss(real_output, fake_output):
 
 
 def make_optimizer(lr=2e-4, beta_1=0.5):
-    return tf.keras.optimizers.Adam(lr, beta_1)
+    # TODO MLG-443 Migrate from legacy Keras optimizers
+    if version.parse(tf.__version__) >= version.parse("2.11.0"):
+        return tf.keras.optimizers.legacy.Adam(lr, beta_1)
+    else:
+        return tf.keras.optimizers.Adam(lr, beta_1)

--- a/examples/gan/pix2pix_tf_keras/pix2pix/generator.py
+++ b/examples/gan/pix2pix_tf_keras/pix2pix/generator.py
@@ -2,6 +2,7 @@
 Implement Pix2Pix generator model based on: https://www.tensorflow.org/tutorials/generative/pix2pix
 """
 import tensorflow as tf
+from packaging import version
 
 from .sampling import downsample, upsample
 
@@ -75,4 +76,8 @@ def loss(fake_output, gen_output, target, lambda_=100):
 
 
 def make_optimizer(lr=2e-4, beta_1=0.5):
-    return tf.keras.optimizers.Adam(lr, beta_1)
+    # TODO MLG-443 Migrate from legacy Keras optimizers
+    if version.parse(tf.__version__) >= version.parse("2.11.0"):
+        return tf.keras.optimizers.legacy.Adam(lr, beta_1)
+    else:
+        return tf.keras.optimizers.Adam(lr, beta_1)

--- a/examples/tutorials/fashion_mnist_tf_keras/model_def.py
+++ b/examples/tutorials/fashion_mnist_tf_keras/model_def.py
@@ -10,6 +10,7 @@ the number of epochs to increase accuracy.
 """
 import data
 import tensorflow as tf
+from packaging import version
 from tensorflow import keras
 
 from determined.keras import InputData, TFKerasTrial, TFKerasTrialContext
@@ -32,7 +33,11 @@ class FashionMNISTTrial(TFKerasTrial):
         model = self.context.wrap_model(model)
 
         # Create and wrap the optimizer.
-        optimizer = tf.keras.optimizers.Adam()
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer = tf.keras.optimizers.legacy.Adam()
+        else:
+            optimizer = tf.keras.optimizers.Adam()
         optimizer = self.context.wrap_optimizer(optimizer)
 
         model.compile(

--- a/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
+++ b/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
@@ -2,8 +2,8 @@ from typing import Any
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 from packaging import version
+from tensorflow import keras
 
 import determined as det
 import determined.keras

--- a/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
+++ b/harness/tests/experiment/fixtures/tf_keras_runtime_error.py
@@ -3,6 +3,7 @@ from typing import Any
 import numpy as np
 import tensorflow as tf
 from tensorflow import keras
+from packaging import version
 
 import determined as det
 import determined.keras
@@ -22,8 +23,13 @@ class RuntimeErrorTrial(det.keras.TFKerasTrial):
     def build_model(self) -> Any:
         model = keras.Sequential([keras.layers.Dense(10)])
         model = self.context.wrap_model(model)
+        # TODO MLG-443 Migrate from legacy Keras optimizers
+        if version.parse(tf.__version__) >= version.parse("2.11.0"):
+            optimizer = tf.keras.optimizers.legacy.Adam(name="Adam")
+        else:
+            optimizer = tf.keras.optimizers.Adam(name="Adam")
         model.compile(
-            optimizer=tf.keras.optimizers.Adam(name="Adam"),
+            optimizer=optimizer,
             loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
             metrics=[
                 tf.keras.metrics.Accuracy()


### PR DESCRIPTION
## Description

These selective imports of (legacy) optimizers were missed in #6527.

## Test Plan

Selected jobs in `test-e2e-longrunning` should pass - this will test the selective import logic, _not_ the legacy optimizer itself (TF 2.8 will be used). The legacy optimizer has already been successfully tested in #6595 (which should rebase after this PR is merged).


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
