### PR TITLE
chore: cleanup our setup.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,17 @@ commands:
                   echo 'export PATH=/tmp/venv/bin:$PATH' >> $BASH_ENV
                   /tmp/venv/bin/python -m pip install --upgrade pip wheel setuptools
 
+      # Either of make -C {harness,model_hub} build require pypa's build module.
+      - when:
+          condition:
+            or:
+              - <<parameters.determined>>
+              - <<parameters.model-hub>>
+          steps:
+            - run:
+                name: Install pypa builder
+                command: python3 -m pip install build
+
       - run:
           name: Write cache key
           command: |

--- a/harness/MANIFEST.in
+++ b/harness/MANIFEST.in
@@ -1,3 +1,4 @@
+include determined/py.typed
 include determined/deploy/aws/templates/*.yaml
 include determined/deploy/aws/vcpu_mapping.yaml
 recursive-include determined/deploy/gcp/terraform *

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -3,7 +3,8 @@ cuda_available=$(shell python -c "import torch; print(torch.cuda.is_available())
 
 .PHONY: build
 build:
-	python -W ignore:Normalizing:UserWarning:setuptools.dist setup.py -q bdist_wheel
+	PYTHONWARNINGS=ignore:Normalizing:UserWarning:setuptools.dist \
+		python -m build -nxw >/dev/null
 
 .PHONY: publish
 publish:

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -1,6 +1,6 @@
-from setuptools import find_packages, setup
+import setuptools
 
-setup(
+setuptools.setup(
     name="determined",
     version="0.21.3-dev0",
     author="Determined AI",
@@ -10,11 +10,12 @@ setup(
     long_description="See https://docs.determined.ai/ for more information.",
     license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
-    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    # Use find_namespace_packages because it will include data-only packages (that is, directories
+    # containing only non-python files, like our gcp terraform directory).
+    packages=setuptools.find_namespace_packages(include=["determined*"]),
     # Technically, we haven't supported 3.6 or tested against it since it went EOL. But some users
     # are still using it successfully so there's hardly a point in breaking them.
     python_requires=">=3.6",
-    package_data={"determined": ["py.typed"]},
     include_package_data=True,
     install_requires=[
         "matplotlib",

--- a/model_hub/MANIFEST.in
+++ b/model_hub/MANIFEST.in
@@ -1,0 +1,1 @@
+include model_hub/py.typed

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -43,7 +43,8 @@ clean:
 
 .PHONY: build
 build:
-	python setup.py -q bdist_wheel
+	PYTHONWARNINGS=ignore:Normalizing:UserWarning:setuptools.dist \
+		python -m build -nxw >/dev/null
 
 build-examples/stamp: $(HF_EXAMPLES_DIRS) $(MMDET_EXAMPLE_DIR)
 	touch $@

--- a/model_hub/setup.py
+++ b/model_hub/setup.py
@@ -1,6 +1,6 @@
-from setuptools import find_packages, setup
+import setuptools
 
-setup(
+setuptools.setup(
     name="model-hub",
     version="0.21.3-dev0",
     author="Determined AI",
@@ -10,9 +10,9 @@ setup(
     long_description="See https://docs.determined.ai/ for more information.",
     license="Apache License 2.0",
     classifiers=["License :: OSI Approved :: Apache Software License"],
-    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    packages=setuptools.find_packages(include=["model_hub*"]),
     python_requires=">=3.6",
-    package_data={"model_hub": ["py.typed"]},
+    include_package_data=True,
     # Versions of model-hub will correspond to specific versions of third party
     # libraries that are guaranteed to work with our code.  Other versions
     # may work with model-hub as well but are not officially supported.
@@ -20,5 +20,4 @@ setup(
         "attrdict",
         "determined>=0.13.11",  # We require custom reducers for PyTorchTrial.
     ],
-    zip_safe=False,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@
 -r e2e_tests/tests/requirements.txt
 -r bindings/requirements.txt
 
+build
 black==23.3.0 # Note: this should be kept in sync with the version in `.pre-commit-config.yaml`.
 click<=8.0.4  # Unpin click after tensorflow update.
 flake8>=3.8.0 # Note: this should be kept in sync with the version in `.pre-commit-config.yaml`.


### PR DESCRIPTION
First, use find_namespace_packages instead of find_packages because it
includes directories containing only data files (non-python files) as
"packages".  We were seeing deprecation warnings during `make build`
with recent versions of setuptools for not doing that.  Although it
seems odd, that is what setuptools maintainers recommend [1].

Second, use an `include` pattern to find packages, rather than `exclude`
patterns.  The exclude pattern list was needlessly long and we only ship
one package so include makes more sense.

Third, include `py.typed` in MANIFEST.in.  MANIFEST.in is what controls
what goes into source distributions, and there's no reason py.typed
shouldn't be included.

Fourth, eliminate the package_data from our setup() call.  Having
include_package_data=True is sufficient to include all data files
included by MANIFEST.in

Fifth, stop calling setup.py directly (which is deprecated) and use
python -m build instead.  `build` is PyPA's PEP517-compliant package
builder, and seems to be the go-to build tool from what I've seen.

Sixth, make many of the same changes in model_hub.

[1] https://github.com/pypa/setuptools/issues/3340#issuecomment-1146678086

## Test Plan

- install an old version of determined
- find installation path: `python -c 'import determined; print(determined.__file__)'`
- `find path/to/install | sort > old-files.txt`
- install this version of determined
- `find path/to/install | sort > new-files.txt`
- ensure there are no differences: `diff old-files.txt new-files.txt` (except the new py.typed file in model hub)