### PR TITLE
ci: fully quarantine `test-det-deploy-local` and `test-stress`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2575,6 +2575,21 @@ workflows:
               slot-resource-requests-cpu: [7]
               accel-node-taints: ["accel=truth:NoSchedule"]
 
+  test-e2e-quarantined:
+    jobs:
+      - build-proto
+      - build-helm
+      - build-react:
+          dev-mode: true
+      - build-docs:
+          requires:
+            - build-helm
+            - build-proto
+      - package-and-push-system-local:
+          requires:
+            - build-react
+            - build-docs
+
       - test-stress:
           name: test-stress
           filters: *any-upstream
@@ -2594,31 +2609,6 @@ workflows:
             parameters:
               parallelism: [2]
               mark: ["det_deploy_local"]
-              det-version: [$CIRCLE_SHA1]
-
-  test-e2e-quarantined:
-    jobs:
-      - build-proto
-      - build-helm
-      - build-react:
-          dev-mode: true
-      - build-docs:
-          requires:
-            - build-helm
-            - build-proto
-      - package-and-push-system-local:
-          requires:
-            - build-react
-            - build-docs
-
-      - test-det-deploy:
-          name: test-det-deploy-local-quarantine
-          requires:
-            - package-and-push-system-local
-          matrix:
-            parameters:
-              parallelism: [1]
-              mark: ["det_deploy_local_quarantine"]
               det-version: [$CIRCLE_SHA1]
 
   test-e2e-longrunning:

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -137,7 +137,7 @@ def test_custom_etc() -> None:
     cluster_down(["--cluster-name", name])
 
 
-@pytest.mark.det_deploy_local_quarantine
+@pytest.mark.det_deploy_local
 def test_agent_config_path() -> None:
     master_host = "localhost"
     master_port = "8080"
@@ -182,7 +182,7 @@ def test_agent_config_path() -> None:
     master_down(["--master-name", master_name])
 
 
-@pytest.mark.det_deploy_local_quarantine
+@pytest.mark.det_deploy_local
 def test_custom_port() -> None:
     name = "port_test"
     master_host = "localhost"


### PR DESCRIPTION
## Description

Bit of a heavy hammer, but the issue with these tests appears to not be specific to any particular test: after some specific tests in `test-det-deploy-local` were quarantined, other tests that were left behind started failing in the same way. And now `test-stress` seems to be showing the same thing as well.

## Test Plan

## Commentary (optional)

@azhou-determined is working on the underlying issue, so ideally we'll be able to unquarantine these entirely soon..