### PR TITLE
chore: refactor PermissionDenied RBAC errors [DET-8946]

### DIFF
--- a/e2e_tests/tests/cluster/test_groups.py
+++ b/e2e_tests/tests/cluster/test_groups.py
@@ -31,7 +31,7 @@ def det_cmd_expect_error(cmd: List[str], expected: str) -> None:
 
 @pytest.mark.e2e_cpu
 @pytest.mark.parametrize("add_users", [[], ["admin", "determined"]])
-def test_group_creation(add_users: List[str]) -> None:
+def test_group_creation(add_users: List[str]) -> None:  # TODO CAROLINA
     with logged_in_user(ADMIN_CREDENTIALS):
         group_name = get_random_string()
         create_group_cmd = ["user-group", "create", group_name]

--- a/e2e_tests/tests/cluster/test_groups.py
+++ b/e2e_tests/tests/cluster/test_groups.py
@@ -31,7 +31,7 @@ def det_cmd_expect_error(cmd: List[str], expected: str) -> None:
 
 @pytest.mark.e2e_cpu
 @pytest.mark.parametrize("add_users", [[], ["admin", "determined"]])
-def test_group_creation(add_users: List[str]) -> None:  # TODO CAROLINA
+def test_group_creation(add_users: List[str]) -> None:
     with logged_in_user(ADMIN_CREDENTIALS):
         group_name = get_random_string()
         create_group_cmd = ["user-group", "create", group_name]

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -451,13 +451,11 @@ def test_login_with_environment_variables(clean_auth: None, login_admin: None) -
         del os.environ["DET_PASS"]
 
 
-@pytest.mark.e2e_cpu  # TODO CAROLINA
+@pytest.mark.e2e_cpu
 def test_auth_inside_shell(clean_auth: None, login_admin: None) -> None:
     creds = api_utils.create_test_user(True)
 
     with logged_in_user(creds):
-        return
-        """
         # start a shell
         child = det_spawn(["shell", "start"])
         child.setecho(True)
@@ -497,7 +495,6 @@ def test_auth_inside_shell(clean_auth: None, login_admin: None) -> None:
         child.read()
         child.wait()
         assert child.exitstatus == 0
-        """
 
 
 @pytest.mark.e2e_cpu
@@ -667,11 +664,11 @@ def kill_tensorboards(*tensorboard_ids: str) -> None:
         tids.remove(tensorboard_id)
 
 
-@pytest.mark.e2e_cpu  # TODO CAROLINA
+@pytest.mark.e2e_cpu
 def test_notebook_creation_and_listing(clean_auth: None, login_admin: None) -> None:
     creds1 = api_utils.create_test_user(True)
     creds2 = api_utils.create_test_user(True)
-    """
+
     with logged_in_user(creds1):
         notebook_id1 = start_notebook()
 
@@ -693,7 +690,6 @@ def test_notebook_creation_and_listing(clean_auth: None, login_admin: None) -> N
 
     # Clean up, killing experiments.
     kill_notebooks(notebook_id1, notebook_id2)
-    """
 
 
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -451,11 +451,13 @@ def test_login_with_environment_variables(clean_auth: None, login_admin: None) -
         del os.environ["DET_PASS"]
 
 
-@pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu  # TODO CAROLINA
 def test_auth_inside_shell(clean_auth: None, login_admin: None) -> None:
     creds = api_utils.create_test_user(True)
 
     with logged_in_user(creds):
+        return
+        """
         # start a shell
         child = det_spawn(["shell", "start"])
         child.setecho(True)
@@ -495,6 +497,7 @@ def test_auth_inside_shell(clean_auth: None, login_admin: None) -> None:
         child.read()
         child.wait()
         assert child.exitstatus == 0
+        """
 
 
 @pytest.mark.e2e_cpu
@@ -664,11 +667,11 @@ def kill_tensorboards(*tensorboard_ids: str) -> None:
         tids.remove(tensorboard_id)
 
 
-@pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu  # TODO CAROLINA
 def test_notebook_creation_and_listing(clean_auth: None, login_admin: None) -> None:
     creds1 = api_utils.create_test_user(True)
     creds2 = api_utils.create_test_user(True)
-
+    """
     with logged_in_user(creds1):
         notebook_id1 = start_notebook()
 
@@ -690,6 +693,7 @@ def test_notebook_creation_and_listing(clean_auth: None, login_admin: None) -> N
 
     # Clean up, killing experiments.
     kill_notebooks(notebook_id1, notebook_id2)
+    """
 
 
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/command/test_notebook.py
+++ b/e2e_tests/tests/command/test_notebook.py
@@ -7,10 +7,9 @@ from tests import command as cmd
 
 
 @pytest.mark.slow
-@pytest.mark.e2e_cpu  # TODO CAROLINA
+@pytest.mark.e2e_cpu
 def test_basic_notebook_start_and_kill() -> None:
     lines = []  # type: List[str]
-    """
     with cmd.interactive_command("notebook", "start") as notebook:
         for line in notebook.stdout:
             if re.search("Jupyter Notebook .*is running at", line) is not None:
@@ -18,4 +17,3 @@ def test_basic_notebook_start_and_kill() -> None:
             lines.append(line)
 
     raise ValueError(lines)
-    """

--- a/e2e_tests/tests/command/test_notebook.py
+++ b/e2e_tests/tests/command/test_notebook.py
@@ -7,9 +7,10 @@ from tests import command as cmd
 
 
 @pytest.mark.slow
-@pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu  # TODO CAROLINA
 def test_basic_notebook_start_and_kill() -> None:
     lines = []  # type: List[str]
+    """
     with cmd.interactive_command("notebook", "start") as notebook:
         for line in notebook.stdout:
             if re.search("Jupyter Notebook .*is running at", line) is not None:
@@ -17,3 +18,4 @@ def test_basic_notebook_start_and_kill() -> None:
             lines.append(line)
 
     raise ValueError(lines)
+    """

--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -39,11 +39,12 @@ def test_experiment_capture() -> None:
     assert len(matches) >= 1, f"could not find any rows for experiment {experiment_id}"
 
 
-@pytest.mark.e2e_cpu
+@pytest.mark.e2e_cpu  # TODO CAROLINA
 def test_notebook_capture() -> None:
     start_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     task_id = None
+    """
     with cmd.interactive_command("notebook", "start") as notebook:
         task_id = notebook.task_id
 
@@ -60,6 +61,7 @@ def test_notebook_capture() -> None:
     assert r.status_code == requests.codes.ok, r.text
 
     assert re.search(f"{task_id},NOTEBOOK", r.text) is not None
+    """
 
 
 # Create a No_Op Experiment/Tensorboard & Confirm Tensorboard task is captured

--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -39,12 +39,11 @@ def test_experiment_capture() -> None:
     assert len(matches) >= 1, f"could not find any rows for experiment {experiment_id}"
 
 
-@pytest.mark.e2e_cpu  # TODO CAROLINA
+@pytest.mark.e2e_cpu
 def test_notebook_capture() -> None:
     start_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     task_id = None
-    """
     with cmd.interactive_command("notebook", "start") as notebook:
         task_id = notebook.task_id
 
@@ -61,7 +60,6 @@ def test_notebook_capture() -> None:
     assert r.status_code == requests.codes.ok, r.text
 
     assert re.search(f"{task_id},NOTEBOOK", r.text) is not None
-    """
 
 
 # Create a No_Op Experiment/Tensorboard & Confirm Tensorboard task is captured

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
@@ -147,13 +148,9 @@ func processProxyAuthentication(c echo.Context) (done bool, err error) {
 			return true, fmt.Errorf("error looking up task experiment: %w", err)
 		}
 
-		if ok, err := expauth.AuthZProvider.Get().CanGetExperiment(ctx, *user, e); err != nil {
-			return true, err
-		} else if !ok {
-			return true, echo.NewHTTPError(http.StatusNotFound, "service not found: "+taskID)
-		}
-
-		return false, nil
+		err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *user, e)
+		return err != nil, authz.SubIfUnauthorized(err,
+			echo.NewHTTPError(http.StatusNotFound, "service not found: "+taskID))
 	}
 
 	if err != nil {
@@ -161,19 +158,13 @@ func processProxyAuthentication(c echo.Context) (done bool, err error) {
 	}
 
 	// Continue NTSC task checks.
-	var ok bool
 	if spec.TaskType == model.TaskTypeTensorboard {
-		ok, err = command.AuthZProvider.Get().CanGetTensorboard(
+		err = command.AuthZProvider.Get().CanGetTensorboard(
 			ctx, *user, spec.WorkspaceID, spec.ExperimentIDs, spec.TrialIDs)
 	} else {
-		ok, err = command.AuthZProvider.Get().CanGetNSC(
+		err = command.AuthZProvider.Get().CanGetNSC(
 			ctx, *user, spec.WorkspaceID)
 	}
-	if err != nil {
-		return true, err
-	} else if !ok {
-		return true, echo.NewHTTPError(http.StatusNotFound, "service not found: "+taskID)
-	}
-
-	return false, nil
+	return err != nil, authz.SubIfUnauthorized(err,
+		echo.NewHTTPError(http.StatusNotFound, "service not found: "+taskID))
 }

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -127,7 +128,7 @@ func TestCheckpointAuthZ(t *testing.T) {
 			}
 
 			authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
-				Return(false, nil).Once()
+				Return(authz2.PermissionDeniedError{}).Once()
 			if curCase.UseMultiCheckpointError {
 				require.Equal(t, errCheckpointsNotFound([]string{checkpointID}),
 					curCase.IDToReqCall(checkpointID))
@@ -138,12 +139,12 @@ func TestCheckpointAuthZ(t *testing.T) {
 
 			expectedErr := fmt.Errorf("canGetExperimentError")
 			authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
-				Return(false, expectedErr).Once()
+				Return(expectedErr).Once()
 			require.Equal(t, expectedErr, curCase.IDToReqCall(checkpointID))
 
 			expectedErr = status.Error(codes.PermissionDenied, curCase.DenyFuncName+"Error")
 			authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
-				Return(true, nil).Once()
+				Return(nil).Once()
 			authZExp.On(curCase.DenyFuncName, mock.Anything, curUser, mock.Anything).
 				Return(fmt.Errorf(curCase.DenyFuncName + "Error")).Once()
 			require.Equal(t, expectedErr, curCase.IDToReqCall(checkpointID))

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/api/apiutils"
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
 	mconfig "github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -264,11 +265,9 @@ func (a *apiServer) GetCommand(
 		return nil, err
 	}
 
-	if ok, err := command.AuthZProvider.Get().CanGetNSC(
+	if err := command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Command.WorkspaceId)); err != nil {
-		return nil, err
-	} else if !ok {
-		return nil, errActorNotFound(addr)
+		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
 	}
 	return resp, nil
 }

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -194,7 +194,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 	if spec.TaskType == model.TaskTypeTensorboard {
 		if err := command.AuthZProvider.Get().CanGetTensorboard(
 			ctx, *user, workspaceID, spec.Metadata.ExperimentIDs, spec.Metadata.TrialIDs,
-		); err != nil || authz.IsPermissionDenied(err) {
+		); err != nil {
 			return err
 		}
 	} else {

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -194,7 +194,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 	if spec.TaskType == model.TaskTypeTensorboard {
 		if err := command.AuthZProvider.Get().CanGetTensorboard(
 			ctx, *user, workspaceID, spec.Metadata.ExperimentIDs, spec.Metadata.TrialIDs,
-		); err != nil {
+		); err != nil || authz.IsPermissionDenied(err) {
 			return err
 		}
 	} else {
@@ -224,7 +224,7 @@ func (a *apiServer) LaunchNotebook(
 	if req.WorkspaceId != 0 {
 		spec.Metadata.WorkspaceID = model.AccessScopeID(req.WorkspaceId)
 	}
-	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil {
+	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { //TODO CAROLINA
 		return nil, err
 	}
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -224,11 +224,11 @@ func (a *apiServer) LaunchNotebook(
 	if req.WorkspaceId != 0 {
 		spec.Metadata.WorkspaceID = model.AccessScopeID(req.WorkspaceId)
 	}
-	/*
-		if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { // TODO CAROLINA
-			return nil, err
-		}
-	*/
+
+	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { // TODO CAROLINA
+		return nil, err
+	}
+
 	spec.WatchProxyIdleTimeout = true
 	spec.WatchRunnerIdleTimeout = true
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -224,10 +224,11 @@ func (a *apiServer) LaunchNotebook(
 	if req.WorkspaceId != 0 {
 		spec.Metadata.WorkspaceID = model.AccessScopeID(req.WorkspaceId)
 	}
-	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { //TODO CAROLINA
-		return nil, err
-	}
-
+	/*
+		if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { // TODO CAROLINA
+			return nil, err
+		}
+	*/
 	spec.WatchProxyIdleTimeout = true
 	spec.WatchRunnerIdleTimeout = true
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -199,8 +199,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 		}
 	} else {
 		if err := command.AuthZProvider.Get().CanCreateNSC(
-			ctx, *user, workspaceID,
-		); err != nil {
+			ctx, *user, workspaceID); err != nil {
 			return apiutils.MapAndFilterErrors(err, nil, nil)
 		}
 	}
@@ -225,7 +224,7 @@ func (a *apiServer) LaunchNotebook(
 		spec.Metadata.WorkspaceID = model.AccessScopeID(req.WorkspaceId)
 	}
 
-	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil { // TODO CAROLINA
+	if err = a.isNTSCPermittedToLaunch(ctx, spec); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -99,7 +99,7 @@ func (a *apiServer) GetNotebook(
 
 	if err = command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Notebook.WorkspaceId)); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errActorNotFound((addr)))
+		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
 	}
 	return resp, nil
 }

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -132,8 +132,7 @@ func TestCanGetNTSC(t *testing.T) {
 
 	// check permission errors are returned with not found status and follow the same pattern.
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		false, nil,
-	).Times(3)
+		authz2.PermissionDeniedError{}).Times(3)
 
 	invalidID := "non-existing"
 
@@ -170,7 +169,7 @@ func TestCanGetNTSC(t *testing.T) {
 	// Tensorboards.
 	// check permission errors are returned with not found status and follow the same pattern.
 	authz.On("CanGetTensorboard", mock.Anything, curUser, mock.Anything, mock.Anything,
-		mock.Anything).Return(false, nil).Once()
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 
 	tbID := setupMockTensorboardActor(t, api.m)
 	tbActor := actor.Addr(command.TensorboardActorPath)
@@ -183,7 +182,7 @@ func TestCanGetNTSC(t *testing.T) {
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		false, errors.New("other error"),
+		errors.New("other error"),
 	).Times(3)
 	_, err = api.GetNotebook(ctx, &apiv1.GetNotebookRequest{NotebookId: string(nbID)})
 	require.NotNil(t, err)
@@ -201,7 +200,7 @@ func TestCanGetNTSC(t *testing.T) {
 	require.NotEqual(t, codes.NotFound, status.Code(err))
 
 	authz.On("CanGetTensorboard", mock.Anything, curUser, mock.Anything, mock.Anything,
-		mock.Anything).Return(false, errors.New("other error")).Once()
+		mock.Anything).Return(errors.New("other error")).Once()
 
 	_, err = api.GetTensorboard(ctx, &apiv1.GetTensorboardRequest{TensorboardId: string(tbID)})
 	require.NotNil(t, err)
@@ -213,10 +212,10 @@ func TestAuthZCanTerminateNSC(t *testing.T) {
 	api, authz, curUser, ctx := setupNTSCAuthzTest(t)
 	var err error
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		true, nil,
+		nil,
 	)
 	authz.On("CanGetTensorboard", mock.Anything, curUser, mock.Anything, mock.Anything,
-		mock.Anything).Return(true, nil)
+		mock.Anything).Return(nil)
 
 	// check permission errors are returned with permission denied status.
 	authz.On("CanTerminateNSC", mock.Anything, curUser, mock.Anything).Return(
@@ -275,10 +274,10 @@ func TestAuthZCanSetNSCsPriority(t *testing.T) {
 	api, authz, curUser, ctx := setupNTSCAuthzTest(t)
 	var err error
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		true, nil,
+		nil,
 	)
 	authz.On("CanGetTensorboard", mock.Anything, curUser, mock.Anything, mock.Anything,
-		mock.Anything).Return(true, nil)
+		mock.Anything).Return(nil)
 
 	// check permission errors are returned with permission denied status.
 	authz.On("CanSetNSCsPriority", mock.Anything, curUser, mock.Anything, mock.Anything).Return(

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -11,6 +11,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -21,11 +27,6 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 	"github.com/determined-ai/determined/proto/pkg/rbacv1"
 	"github.com/determined-ai/determined/proto/pkg/userv1"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"github.com/uptrace/bun"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var pAuthZ *mocks.ProjectAuthZ

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/api/apiutils"
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
@@ -107,11 +108,9 @@ func (a *apiServer) GetShell(
 		return nil, err
 	}
 
-	if ok, err := command.AuthZProvider.Get().CanGetNSC(
+	if err = command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Shell.WorkspaceId)); err != nil {
-		return nil, err
-	} else if !ok {
-		return nil, errActorNotFound(addr)
+		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
 	}
 	return resp, nil
 }

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -109,7 +109,7 @@ func (a *apiServer) canDoActionsOnTask(
 	default: // NTSC case + checkpointGC.
 		if ok, err := canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
 			return err
-		} else if !ok {
+		} else if ok {
 			return errTaskNotFound
 		}
 	}

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -383,12 +383,13 @@ func (a *apiServer) GetTasks(
 			return nil, err
 		}
 
+		var ok bool
 		if !isExp {
-			_, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
+			ok, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
-		if !authz.IsPermissionDenied(err) {
+		if !authz.IsPermissionDenied(err) || ok {
 			pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 		} else if err != nil {
 			return nil, err

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -67,7 +67,7 @@ func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.Tas
 	}
 	err = command.AuthZProvider.Get().CanGetNSC(
 		ctx, curUser, spec.WorkspaceID)
-	return authz.IsPermissionDenied(err), err
+	return !authz.IsPermissionDenied(err), err
 }
 
 func (a *apiServer) canDoActionsOnTask(
@@ -109,7 +109,7 @@ func (a *apiServer) canDoActionsOnTask(
 	default: // NTSC case + checkpointGC.
 		if ok, err := canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
 			return err
-		} else if ok {
+		} else if !ok {
 			return errTaskNotFound
 		}
 	}

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -389,7 +389,7 @@ func (a *apiServer) GetTasks(
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
-		if !authz.IsPermissionDenied(err) || ok {
+		if !authz.IsPermissionDenied(err) || !ok {
 			pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 		} else if err != nil {
 			return nil, err

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -67,7 +67,7 @@ func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.Tas
 	}
 	err = command.AuthZProvider.Get().CanGetNSC(
 		ctx, curUser, spec.WorkspaceID)
-	return err != nil, err
+	return authz.IsPermissionDenied(err), err
 }
 
 func (a *apiServer) canDoActionsOnTask(

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -247,7 +247,8 @@ func TestAuthzGetUser(t *testing.T) {
 	_, notFoundError := api.GetUser(ctx, &apiv1.GetUserRequest{UserId: -999})
 	require.Equal(t, errUserNotFound.Error(), notFoundError.Error())
 
-	authzUsers.On("CanGetUser", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authzUsers.On("CanGetUser", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	_, err = api.GetUser(ctx, &apiv1.GetUserRequest{UserId: 1})
 	require.Equal(t, notFoundError.Error(), err.Error())
 
@@ -306,7 +307,8 @@ func TestAuthzSetUserPassword(t *testing.T) {
 
 	authzUsers.On("CanSetUsersPassword", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canSetUsersPassword")).Once()
-	authzUsers.On("CanGetUser", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authzUsers.On("CanGetUser", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	_, err = api.SetUserPassword(ctx, &apiv1.SetUserPasswordRequest{UserId: int32(curUser.ID)})
 	require.Equal(t, errUserNotFound.Error(), err.Error())
 
@@ -350,7 +352,8 @@ func TestAuthzPatchUser(t *testing.T) {
 	// If we can't view the user get the same as passing in user not found.
 	authzUsers.On("CanSetUsersDisplayName", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canSetUsersDisplayName")).Once()
-	authzUsers.On("CanGetUser", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authzUsers.On("CanGetUser", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	_, err = api.PatchUser(ctx, req)
 	require.Equal(t, errUserNotFound.Error(), err.Error())
 

--- a/master/internal/authz/permission_denied_error.go
+++ b/master/internal/authz/permission_denied_error.go
@@ -26,3 +26,19 @@ func (p PermissionDeniedError) Error() string {
 	return fmt.Sprintf("access denied; required permissions: %s", strings.Join(
 		permissions, ", "))
 }
+
+// IsPermissionDenied checks if err is of type PermissionDeniedError.
+func IsPermissionDenied(err error) bool {
+	if _, ok := err.(PermissionDeniedError); ok {
+		return true
+	}
+	return false
+}
+
+// SubIfUnauthorized substitutes an error if it is of type PermissionDeniedError.
+func SubIfUnauthorized(err error, sub error) error {
+	if IsPermissionDenied(err) {
+		return sub
+	}
+	return err
+}

--- a/master/internal/command/authz_basic_impl.go
+++ b/master/internal/command/authz_basic_impl.go
@@ -15,8 +15,8 @@ type NSCAuthZBasic struct{}
 // CanGetNSC returns true and nil error.
 func (a *NSCAuthZBasic) CanGetNSC(
 	ctx context.Context, curUser model.User, workspaceID model.AccessScopeID,
-) (canGetCmd bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // CanGetActiveTasksCount always returns a nil error.
@@ -81,8 +81,8 @@ func (a *NSCAuthZBasic) FilterTensorboards(
 func (a *NSCAuthZBasic) CanGetTensorboard(
 	ctx context.Context, curUser model.User, workspaceID model.AccessScopeID,
 	experimentIDs []int32, trialIDs []int32,
-) (canGetTensorboards bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // CanTerminateTensorboard always returns nil.

--- a/master/internal/command/authz_iface.go
+++ b/master/internal/command/authz_iface.go
@@ -16,7 +16,7 @@ type NSCAuthZ interface {
 	// GET /tasks
 	CanGetNSC(
 		ctx context.Context, curUser model.User, workspaceID model.AccessScopeID,
-	) (canGetNsc bool, serverError error)
+	) error
 
 	// GET /api/v1/tasks/count
 	CanGetActiveTasksCount(ctx context.Context, curUser model.User) error
@@ -52,7 +52,7 @@ type NSCAuthZ interface {
 	CanGetTensorboard(
 		ctx context.Context, curUser model.User, workspaceID model.AccessScopeID,
 		experimentIDs []int32, trialIDs []int32,
-	) (canGetTensorboard bool, serverError error)
+	) error
 
 	// POST /api/v1/tensorboards/:tb_id/kill
 	CanTerminateTensorboard(

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -267,7 +267,8 @@ func TestAuthZCheckpointsEcho(t *testing.T) {
 
 	addMockCheckpointDB(t, api.m.db, checkpointUUID)
 
-	authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authZExp.On("CanGetExperiment", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	require.Equal(t, echo.NewHTTPError(http.StatusNotFound,
 		fmt.Sprintf("checkpoint not found: %s", checkpointUUID)), api.m.getCheckpoint(ctx))
 

--- a/master/internal/core_experiment_intg_test.go
+++ b/master/internal/core_experiment_intg_test.go
@@ -86,7 +86,8 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 	ctx := newTestEchoContext(curUser)
 
 	// Can't view project passed in.
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	err := echoPostExperiment(ctx, api, t, CreateExperimentParams{
 		ConfigBytes: minExpConfToYaml(t),
 		ProjectID:   &projectID,
@@ -95,7 +96,8 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 		fmt.Sprintf("project (%d) not found", projectID)).Error(), err.Error())
 
 	// Can't view project passed in from config.
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	err = echoPostExperiment(ctx, api, t, CreateExperimentParams{
 		ConfigBytes: minExpConfToYaml(t) + "project: Uncategorized\nworkspace: Uncategorized",
 	})

--- a/master/internal/core_experiment_intg_test.go
+++ b/master/internal/core_experiment_intg_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/etc"
@@ -85,7 +86,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 	ctx := newTestEchoContext(curUser)
 
 	// Can't view project passed in.
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(false, nil).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	err := echoPostExperiment(ctx, api, t, CreateExperimentParams{
 		ConfigBytes: minExpConfToYaml(t),
 		ProjectID:   &projectID,
@@ -94,7 +95,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 		fmt.Sprintf("project (%d) not found", projectID)).Error(), err.Error())
 
 	// Can't view project passed in from config.
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(false, nil).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	err = echoPostExperiment(ctx, api, t, CreateExperimentParams{
 		ConfigBytes: minExpConfToYaml(t) + "project: Uncategorized\nworkspace: Uncategorized",
 	})
@@ -110,7 +111,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 
 	// Can't create experiment deny.
 	expectedErr := echo.NewHTTPError(http.StatusForbidden, "canCreateExperimentError")
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(true, nil).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
 	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("canCreateExperimentError")).Once()
 	err = echoPostExperiment(ctx, api, t, CreateExperimentParams{
@@ -120,7 +121,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 
 	// Can't activate experiment deny.
 	expectedErr = echo.NewHTTPError(http.StatusForbidden, "canActivateExperimentError")
-	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(true, nil).Once()
+	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
 	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
 		Return(nil).Once()
 	authZExp.On("CanEditExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
@@ -224,19 +225,19 @@ func TestAuthZGetExperimentAndCanDoActionsEcho(t *testing.T) {
 		require.Equal(t, expNotFoundErrEcho(-999), curCase.IDToReqCall(-999))
 
 		authZExp.On("CanGetExperiment", mock.Anything, mock.Anything, mock.Anything).
-			Return(false, nil).Once()
+			Return(authz2.PermissionDeniedError{}).Once()
 		require.Equal(t, expNotFoundErrEcho(exp.ID), curCase.IDToReqCall(exp.ID))
 
 		// CanGetExperiment error returns unmodified.
 		expectedErr := fmt.Errorf("canGetExperimentError")
 		authZExp.On("CanGetExperiment", mock.Anything, mock.Anything, mock.Anything).
-			Return(false, expectedErr).Once()
+			Return(expectedErr).Once()
 		require.Equal(t, expectedErr, curCase.IDToReqCall(exp.ID))
 
 		// Deny returns error with Forbidden.
 		expectedErr = echo.NewHTTPError(http.StatusForbidden, curCase.DenyFuncName+"Error")
 		authZExp.On("CanGetExperiment", mock.Anything, mock.Anything, mock.Anything).
-			Return(true, nil).Once()
+			Return(nil).Once()
 		authZExp.On(curCase.DenyFuncName, curCase.Params...).
 			Return(fmt.Errorf(curCase.DenyFuncName + "Error")).Once()
 		require.Equal(t, expectedErr.Error(), curCase.IDToReqCall(exp.ID).Error())

--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"github.com/labstack/echo/v4"
 
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/context"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -22,18 +23,15 @@ func (m *Master) getTasks(c echo.Context) (interface{}, error) {
 			return nil, err
 		}
 
-		var ok bool
 		if !isExp {
-			ok, err = canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID)
+			_, err = canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID)
 		} else {
-			ok, err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp)
+			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp)
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		if !ok {
+		if authz.IsPermissionDenied(err) {
 			delete(summary, allocationID)
+		} else if err != nil {
+			return nil, err
 		}
 	}
 	return summary, nil

--- a/master/internal/core_trial_intg_test.go
+++ b/master/internal/core_trial_intg_test.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	authz2 "github.com/determined-ai/determined/master/internal/authz"
 )
 
 func trialNotFoundErrEcho(id int) error {

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -17,8 +17,8 @@ type ExperimentAuthZBasic struct{}
 // CanGetExperiment always returns true and a nill error.
 func (a *ExperimentAuthZBasic) CanGetExperiment(
 	ctx context.Context, curUser model.User, e *model.Experiment,
-) (canGetExp bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // CanGetExperimentArtifacts always returns a nil error.

--- a/master/internal/experiment/authz_iface.go
+++ b/master/internal/experiment/authz_iface.go
@@ -17,7 +17,7 @@ type ExperimentAuthZ interface {
 	// GET /tasks
 	CanGetExperiment(
 		ctx context.Context, curUser model.User, e *model.Experiment,
-	) (canGetExp bool, serverError error)
+	) error
 
 	// GET /api/v1/experiments/:exp_id/file_tree
 	// POST /api/v1/experiments/{experimentId}/file

--- a/master/internal/mocks/authz_experiment_iface.go
+++ b/master/internal/mocks/authz_experiment_iface.go
@@ -92,27 +92,17 @@ func (_m *ExperimentAuthZ) CanForkFromExperiment(ctx context.Context, curUser mo
 }
 
 // CanGetExperiment provides a mock function with given fields: ctx, curUser, e
-func (_m *ExperimentAuthZ) CanGetExperiment(ctx context.Context, curUser model.User, e *model.Experiment) (bool, error) {
+func (_m *ExperimentAuthZ) CanGetExperiment(ctx context.Context, curUser model.User, e *model.Experiment) error {
 	ret := _m.Called(ctx, curUser, e)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *model.Experiment) (bool, error)); ok {
-		return rf(ctx, curUser, e)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *model.Experiment) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *model.Experiment) error); ok {
 		r0 = rf(ctx, curUser, e)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, *model.Experiment) error); ok {
-		r1 = rf(ctx, curUser, e)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanGetExperimentArtifacts provides a mock function with given fields: ctx, curUser, e

--- a/master/internal/mocks/authz_model_iface.go
+++ b/master/internal/mocks/authz_model_iface.go
@@ -62,37 +62,26 @@ func (_m *ModelAuthZ) CanEditModel(ctx context.Context, curUser model.User, m *m
 }
 
 // CanGetModel provides a mock function with given fields: ctx, curUser, m, workspaceID
-func (_m *ModelAuthZ) CanGetModel(ctx context.Context, curUser model.User, m *modelv1.Model, workspaceID int32) (bool, error) {
+func (_m *ModelAuthZ) CanGetModel(ctx context.Context, curUser model.User, m *modelv1.Model, workspaceID int32) error {
 	ret := _m.Called(ctx, curUser, m, workspaceID)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *modelv1.Model, int32) (bool, error)); ok {
-		return rf(ctx, curUser, m, workspaceID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *modelv1.Model, int32) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *modelv1.Model, int32) error); ok {
 		r0 = rf(ctx, curUser, m, workspaceID)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, *modelv1.Model, int32) error); ok {
-		r1 = rf(ctx, curUser, m, workspaceID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanGetModels provides a mock function with given fields: ctx, curUser, workspaceIDs
-func (_m *ModelAuthZ) CanGetModels(ctx context.Context, curUser model.User, workspaceIDs []int32) ([]int32, bool, error) {
+func (_m *ModelAuthZ) CanGetModels(ctx context.Context, curUser model.User, workspaceIDs []int32) ([]int32, error) {
 	ret := _m.Called(ctx, curUser, workspaceIDs)
 
 	var r0 []int32
-	var r1 bool
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, []int32) ([]int32, bool, error)); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, []int32) ([]int32, error)); ok {
 		return rf(ctx, curUser, workspaceIDs)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, model.User, []int32) []int32); ok {
@@ -103,19 +92,13 @@ func (_m *ModelAuthZ) CanGetModels(ctx context.Context, curUser model.User, work
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, []int32) bool); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, model.User, []int32) error); ok {
 		r1 = rf(ctx, curUser, workspaceIDs)
 	} else {
-		r1 = ret.Get(1).(bool)
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, model.User, []int32) error); ok {
-		r2 = rf(ctx, curUser, workspaceIDs)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // CanMoveModel provides a mock function with given fields: ctx, curUser, _a2, fromWorkspaceID, toWorkspaceID

--- a/master/internal/mocks/nsc_authz_iface.go
+++ b/master/internal/mocks/nsc_authz_iface.go
@@ -72,51 +72,31 @@ func (_m *NSCAuthZ) CanGetActiveTasksCount(ctx context.Context, curUser model.Us
 }
 
 // CanGetNSC provides a mock function with given fields: ctx, curUser, workspaceID
-func (_m *NSCAuthZ) CanGetNSC(ctx context.Context, curUser model.User, workspaceID model.AccessScopeID) (bool, error) {
+func (_m *NSCAuthZ) CanGetNSC(ctx context.Context, curUser model.User, workspaceID model.AccessScopeID) error {
 	ret := _m.Called(ctx, curUser, workspaceID)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID) (bool, error)); ok {
-		return rf(ctx, curUser, workspaceID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID) error); ok {
 		r0 = rf(ctx, curUser, workspaceID)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, model.AccessScopeID) error); ok {
-		r1 = rf(ctx, curUser, workspaceID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanGetTensorboard provides a mock function with given fields: ctx, curUser, workspaceID, experimentIDs, trialIDs
-func (_m *NSCAuthZ) CanGetTensorboard(ctx context.Context, curUser model.User, workspaceID model.AccessScopeID, experimentIDs []int32, trialIDs []int32) (bool, error) {
+func (_m *NSCAuthZ) CanGetTensorboard(ctx context.Context, curUser model.User, workspaceID model.AccessScopeID, experimentIDs []int32, trialIDs []int32) error {
 	ret := _m.Called(ctx, curUser, workspaceID, experimentIDs, trialIDs)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID, []int32, []int32) (bool, error)); ok {
-		return rf(ctx, curUser, workspaceID, experimentIDs, trialIDs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID, []int32, []int32) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.AccessScopeID, []int32, []int32) error); ok {
 		r0 = rf(ctx, curUser, workspaceID, experimentIDs, trialIDs)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, model.AccessScopeID, []int32, []int32) error); ok {
-		r1 = rf(ctx, curUser, workspaceID, experimentIDs, trialIDs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanSetNSCsPriority provides a mock function with given fields: ctx, curUser, workspaceID, priority

--- a/master/internal/mocks/project_authz_iface.go
+++ b/master/internal/mocks/project_authz_iface.go
@@ -62,27 +62,17 @@ func (_m *ProjectAuthZ) CanDeleteProject(ctx context.Context, curUser model.User
 }
 
 // CanGetProject provides a mock function with given fields: ctx, curUser, _a2
-func (_m *ProjectAuthZ) CanGetProject(ctx context.Context, curUser model.User, _a2 *projectv1.Project) (bool, error) {
+func (_m *ProjectAuthZ) CanGetProject(ctx context.Context, curUser model.User, _a2 *projectv1.Project) error {
 	ret := _m.Called(ctx, curUser, _a2)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *projectv1.Project) (bool, error)); ok {
-		return rf(ctx, curUser, _a2)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *projectv1.Project) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *projectv1.Project) error); ok {
 		r0 = rf(ctx, curUser, _a2)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, *projectv1.Project) error); ok {
-		r1 = rf(ctx, curUser, _a2)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanMoveProject provides a mock function with given fields: ctx, curUser, _a2, from, to

--- a/master/internal/mocks/user_authz_iface.go
+++ b/master/internal/mocks/user_authz_iface.go
@@ -44,27 +44,17 @@ func (_m *UserAuthZ) CanCreateUsersOwnSetting(ctx context.Context, curUser model
 }
 
 // CanGetUser provides a mock function with given fields: ctx, curUser, targetUser
-func (_m *UserAuthZ) CanGetUser(ctx context.Context, curUser model.User, targetUser model.User) (bool, error) {
+func (_m *UserAuthZ) CanGetUser(ctx context.Context, curUser model.User, targetUser model.User) error {
 	ret := _m.Called(ctx, curUser, targetUser)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.User) (bool, error)); ok {
-		return rf(ctx, curUser, targetUser)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.User) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, model.User) error); ok {
 		r0 = rf(ctx, curUser, targetUser)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, model.User) error); ok {
-		r1 = rf(ctx, curUser, targetUser)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanGetUsersImage provides a mock function with given fields: ctx, curUser, targetUsername

--- a/master/internal/mocks/workspace_authz_iface.go
+++ b/master/internal/mocks/workspace_authz_iface.go
@@ -90,27 +90,17 @@ func (_m *WorkspaceAuthZ) CanDeleteWorkspace(ctx context.Context, curUser model.
 }
 
 // CanGetWorkspace provides a mock function with given fields: ctx, curUser, _a2
-func (_m *WorkspaceAuthZ) CanGetWorkspace(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) (bool, error) {
+func (_m *WorkspaceAuthZ) CanGetWorkspace(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) error {
 	ret := _m.Called(ctx, curUser, _a2)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *workspacev1.Workspace) (bool, error)); ok {
-		return rf(ctx, curUser, _a2)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *workspacev1.Workspace) bool); ok {
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *workspacev1.Workspace) error); ok {
 		r0 = rf(ctx, curUser, _a2)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, model.User, *workspacev1.Workspace) error); ok {
-		r1 = rf(ctx, curUser, _a2)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // CanPinWorkspace provides a mock function with given fields: ctx, curUser, _a2

--- a/master/internal/model/authz_basic_impl.go
+++ b/master/internal/model/authz_basic_impl.go
@@ -16,15 +16,15 @@ type ModelAuthZBasic struct{}
 // CanGetModels always returns true and a nil error.
 func (a *ModelAuthZBasic) CanGetModels(ctx context.Context,
 	curUser model.User, workspaceIDs []int32,
-) (workspaceIDsWithPermsFilter []int32, canGetModels bool, serverError error) {
-	return workspaceIDs, true, nil
+) (workspaceIDsWithPermsFilter []int32, serverError error) {
+	return workspaceIDs, nil
 }
 
 // CanGetModel always returns true and a nil error.
 func (a *ModelAuthZBasic) CanGetModel(ctx context.Context, curUser model.User,
 	m *modelv1.Model, workspaceID int32,
-) (canGetModel bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // CanEditModel always returns true and a nil error.

--- a/master/internal/model/authz_iface.go
+++ b/master/internal/model/authz_iface.go
@@ -14,14 +14,14 @@ import (
 type ModelAuthZ interface {
 	// GET /api/v1/models
 	CanGetModels(ctx context.Context, curUser model.User, workspaceIDs []int32,
-	) (workspaceIDsWithPermsFilter []int32, canGetModels bool, serverError error)
+	) (workspaceIDsWithPermsFilter []int32, serverError error)
 	// GET /api/v1/checkpoints/{checkpoint_uuid}
 	// GET /api/v1/models/{model_name}
 	// GET /api/v1/models/{model_name}/versions/{model_version_num}
 	// GET /api/v1/models/{model_name}/versions
 	CanGetModel(ctx context.Context, curUser model.User,
 		m *modelv1.Model, workspaceID int32,
-	) (canGetModel bool, serverError error)
+	) error
 	// PATCH /api/v1/models/{model_name}
 	// PATCH /api/v1/models/{model_name}/versions/{model_version_num}
 	// POST /api/v1/models/{model_name}/versions

--- a/master/internal/project/authz_basic_impl.go
+++ b/master/internal/project/authz_basic_impl.go
@@ -18,8 +18,8 @@ type ProjectAuthZBasic struct{}
 // CanGetProject always return true and a nil error for basic auth.
 func (a *ProjectAuthZBasic) CanGetProject(
 	ctx context.Context, curUser model.User, project *projectv1.Project,
-) (canGetProject bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // CanCreateProject always returns true and a nil error for basic auth.

--- a/master/internal/project/authz_iface.go
+++ b/master/internal/project/authz_iface.go
@@ -12,9 +12,7 @@ import (
 // ProjectAuthZ is the interface for project authorization.
 type ProjectAuthZ interface {
 	// GET /api/v1/projects/:project_id
-	CanGetProject(ctx context.Context, curUser model.User, project *projectv1.Project) (
-		canGetProject bool, serverError error,
-	)
+	CanGetProject(ctx context.Context, curUser model.User, project *projectv1.Project) error
 
 	// POST /api/v1/workspaces/:workspace_id/projects
 	CanCreateProject(

--- a/master/internal/trials/api_trials.go
+++ b/master/internal/trials/api_trials.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -235,8 +236,8 @@ func (a *TrialsAPIServer) CreateTrialsCollection(
 	if req.ProjectId == 0 {
 		return nil, errors.New("failed to create trials collection: must specify project_id")
 	}
-	canCreate, err := AuthZProvider.Get().CanCreateTrialCollection(ctx, curUser, req.ProjectId)
-	if !canCreate {
+	err = AuthZProvider.Get().CanCreateTrialCollection(ctx, curUser, req.ProjectId)
+	if authz.IsPermissionDenied(err) {
 		return nil, status.Error(
 			codes.PermissionDenied,
 			"unable to create collection",

--- a/master/internal/trials/authz_basic_impl.go
+++ b/master/internal/trials/authz_basic_impl.go
@@ -63,8 +63,8 @@ func (a *TrialAuthZBasic) AuthFilterCollectionsDeleteQuery(
 // CanCreateTrialCollection indicates whether a user can create a collection in a project.
 func (a *TrialAuthZBasic) CanCreateTrialCollection(
 	ctx context.Context, curUser *model.User, projectID int32,
-) (canCreateTrialCollection bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // AuthFilterTrialsQuery filters a trials SelectQuery to those the user is authorized for.

--- a/master/internal/trials/authz_iface.go
+++ b/master/internal/trials/authz_iface.go
@@ -14,7 +14,7 @@ type TrialAuthZ interface {
 	// POST /trial-comparison/collections
 	CanCreateTrialCollection(
 		ctx context.Context, curUser *model.User, projectID int32,
-	) (canGetCollections bool, serverError error)
+	) error
 
 	// POST /trial-comparison/query
 	// POST /trial-comparison/update-trial-tags

--- a/master/internal/user/authz_basic_impl.go
+++ b/master/internal/user/authz_basic_impl.go
@@ -10,7 +10,7 @@ import (
 // UserAuthZBasic is basic OSS controls.
 type UserAuthZBasic struct{}
 
-// CanGetUser always returns true.
+// CanGetUser always returns nil.
 func (a *UserAuthZBasic) CanGetUser(
 	ctx context.Context, curUser, targetUser model.User,
 ) error {

--- a/master/internal/user/authz_basic_impl.go
+++ b/master/internal/user/authz_basic_impl.go
@@ -13,8 +13,8 @@ type UserAuthZBasic struct{}
 // CanGetUser always returns true.
 func (a *UserAuthZBasic) CanGetUser(
 	ctx context.Context, curUser, targetUser model.User,
-) (canGetUser bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // FilterUserList always returns the input user list and does not filtering.

--- a/master/internal/user/authz_iface.go
+++ b/master/internal/user/authz_iface.go
@@ -19,8 +19,7 @@ type UserAuthZ interface {
 	// GET /api/v1/users/:user_id
 	// Denying a user shouldn't return an error. Only a server error that needs to be
 	// reported to the user should return an errr.
-	CanGetUser(ctx context.Context, curUser, targetUser model.User) (
-		canGetUser bool, serverError error)
+	CanGetUser(ctx context.Context, curUser, targetUser model.User) error
 
 	// GET /users
 	// GET /api/v1/users

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -317,8 +317,10 @@ func (s *Service) getUsers(c echo.Context) (interface{}, error) {
 
 func canViewUserErrorHandle(currUser, user model.User, actionErr, notFoundErr error) error {
 	ctx := context.TODO()
-	err := AuthZProvider.Get().CanGetUser(ctx, currUser, user)
-	return authz.SubIfUnauthorized(err, notFoundErr)
+	if err := AuthZProvider.Get().CanGetUser(ctx, currUser, user); err != nil {
+		return authz.SubIfUnauthorized(err, notFoundErr)
+	}
+	return actionErr
 }
 
 func (s *Service) patchUser(c echo.Context) (interface{}, error) {

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/api"
+	"github.com/determined-ai/determined/master/internal/authz"
 	detContext "github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/telemetry"
@@ -316,12 +317,8 @@ func (s *Service) getUsers(c echo.Context) (interface{}, error) {
 
 func canViewUserErrorHandle(currUser, user model.User, actionErr, notFoundErr error) error {
 	ctx := context.TODO()
-	if ok, err := AuthZProvider.Get().CanGetUser(ctx, currUser, user); err != nil {
-		return err
-	} else if !ok {
-		return notFoundErr
-	}
-	return actionErr
+	err := AuthZProvider.Get().CanGetUser(ctx, currUser, user)
+	return authz.SubIfUnauthorized(err, notFoundErr)
 }
 
 func (s *Service) patchUser(c echo.Context) (interface{}, error) {

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
-	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/pkg/errors"
 
+	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -149,10 +149,9 @@ func TestAuthzPatchUser(t *testing.T) {
 		authzUser.On(testCase.expectedCall, testCase.args...).
 			Return(fmt.Errorf(testCase.expectedCall + "Error")).Once()
 		authzUser.On("CanGetUser", mock.Anything, model.User{}, mock.Anything).
-			Return(nil).Once() //TODO CAROLINA
+			Return(nil).Once()
 
-		_, err := svc.patchUser(ctx) //TODO: add logging -- is it returning early/why not returning an error ??
-		require.Error(t, err, "expected patchUser to return non-nil error")
+		_, err := svc.patchUser(ctx)
 		require.Equal(t, expectedErr.Error(), err.Error())
 
 		// If CanGetUser returns an error we get that error.
@@ -164,7 +163,7 @@ func TestAuthzPatchUser(t *testing.T) {
 			Return(fmt.Errorf(testCase.expectedCall + "Error")).Once()
 		cantGetUserError := fmt.Errorf("cantGetUserError")
 		authzUser.On("CanGetUser", mock.Anything, model.User{}, mock.Anything).
-			Return(cantGetUserError).Once() //TODO CAROLINA
+			Return(cantGetUserError).Once()
 
 		_, err = svc.patchUser(ctx)
 		require.Equal(t, cantGetUserError, err)
@@ -175,7 +174,7 @@ func TestAuthzPatchUser(t *testing.T) {
 		authzUser.On(testCase.expectedCall, testCase.args...).
 			Return(fmt.Errorf(testCase.expectedCall + "Error")).Once()
 		authzUser.On("CanGetUser", mock.Anything, model.User{}, mock.Anything).
-			Return(authz2.PermissionDeniedError{}).Once() //TODO CAROLINA
+			Return(authz2.PermissionDeniedError{}).Once()
 
 		_, err = svc.patchUser(ctx)
 		require.Equal(t,

--- a/master/internal/usergroup/api_groups.go
+++ b/master/internal/usergroup/api_groups.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/api/apiutils"
+	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -125,11 +126,8 @@ func (a *UserGroupAPIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRe
 
 	gid := int(req.GroupId)
 
-	canGet, err := AuthZProvider.Get().CanGetGroup(ctx, *curUser, gid)
-	if err != nil {
-		return nil, err
-	} else if !canGet {
-		return nil, errors.Wrapf(db.ErrNotFound, "Error getting group %d", gid)
+	if err := AuthZProvider.Get().CanGetGroup(ctx, *curUser, gid); err != nil {
+		return nil, authz.SubIfUnauthorized(err, errors.Wrapf(db.ErrNotFound, "Error getting group %d", gid))
 	}
 
 	g, err := GroupByIDTx(ctx, nil, gid)

--- a/master/internal/usergroup/api_groups.go
+++ b/master/internal/usergroup/api_groups.go
@@ -127,7 +127,8 @@ func (a *UserGroupAPIServer) GetGroup(ctx context.Context, req *apiv1.GetGroupRe
 	gid := int(req.GroupId)
 
 	if err := AuthZProvider.Get().CanGetGroup(ctx, *curUser, gid); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errors.Wrapf(db.ErrNotFound, "Error getting group %d", gid))
+		return nil, authz.SubIfUnauthorized(err,
+			errors.Wrapf(db.ErrNotFound, "Error getting group %d", gid))
 	}
 
 	g, err := GroupByIDTx(ctx, nil, gid)

--- a/master/internal/usergroup/authz_basic_impl.go
+++ b/master/internal/usergroup/authz_basic_impl.go
@@ -13,10 +13,8 @@ import (
 type UserGroupAuthZBasic struct{}
 
 // CanGetGroup always returns nil.
-func (a *UserGroupAuthZBasic) CanGetGroup(ctx context.Context, curUser model.User, gid int) (
-	bool, error,
-) {
-	return true, nil
+func (a *UserGroupAuthZBasic) CanGetGroup(ctx context.Context, curUser model.User, gid int) error {
+	return nil
 }
 
 // FilterGroupsList returns the list it was given and a nil error.

--- a/master/internal/usergroup/authz_iface.go
+++ b/master/internal/usergroup/authz_iface.go
@@ -13,7 +13,7 @@ import (
 type UserGroupAuthZ interface {
 	// CanGetGroup checks whether a user can get a group.
 	// GET /api/v1/groups/{group_id}
-	CanGetGroup(ctx context.Context, curUser model.User, gid int) (bool, error)
+	CanGetGroup(ctx context.Context, curUser model.User, gid int) error
 
 	// FilterGroupsList checks what groups a user can get.
 	// POST /api/v1/groups/search

--- a/master/internal/workspace/authz_basic_impl.go
+++ b/master/internal/workspace/authz_basic_impl.go
@@ -15,8 +15,8 @@ type WorkspaceAuthZBasic struct{}
 // CanGetWorkspace always return true and a nil error.
 func (a *WorkspaceAuthZBasic) CanGetWorkspace(
 	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) (canGetWorkspace bool, serverError error) {
-	return true, nil
+) error {
+	return nil
 }
 
 // FilterWorkspaceProjects always returns the list provided and a nil error.

--- a/master/internal/workspace/authz_iface.go
+++ b/master/internal/workspace/authz_iface.go
@@ -14,7 +14,7 @@ type WorkspaceAuthZ interface {
 	// GET /api/v1/workspaces/:workspace_id
 	CanGetWorkspace(
 		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-	) (canGetWorkspace bool, serverError error)
+	) error
 
 	// GET /api/v1/workspaces/:workspace_id/projects
 	FilterWorkspaceProjects(


### PR DESCRIPTION
## Description
These changes modify the RBAC interfaces to return just `err`and let `PermissionDeniedError` through for the `CanGetNSC` and `CanGetTensorboard` functions. The `PermissionDeniedError` is checked in other functions to return detailed, relevant error messages.

## Test Plan

I tested the endpoints affected following the test plan from https://github.com/determined-ai/determined-ee/pull/823.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-8946
