### PR TITLE
ci: auto-scrape algolia records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,15 @@ parameters:
     type: string
     default: xlarge
 
+main-and-release-and-rc-filters: &main-and-release-and-rc-filters
+  branches:
+    only:
+      - main
+  tags:
+    only:
+      - /(\d)+(\.(\d)+)+/
+      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
+
 release-and-rc-filters: &release-and-rc-filters
   branches:
     ignore:
@@ -1066,6 +1075,22 @@ jobs:
       - run: tar czf docs.tgz docs/site/html
       - store_artifacts:
           path: docs.tgz
+
+  scrape-docs:
+    docker:
+      - image: <<pipeline.parameters.docker-image>>
+    steps:
+      - checkout
+      - setup-python-venv:
+          install-python: false
+          determined: true
+          extras-requires: "tensorflow==2.12.0 torch==1.9.0 torchvision==0.10.0"
+          model-hub: true
+          extra-requirements-file: "docs/requirements.txt"
+          executor: <<pipeline.parameters.docker-image>>
+      - attach_workspace:
+          at: .
+      - run: make -C docs upload-search-index
 
   publish-docs:
     docker:
@@ -3108,6 +3133,12 @@ workflows:
             - build-docs
           context: determined-production
           filters: *release-filters
+
+      - scrape-docs:
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *main-and-release-and-rc-filters
 
       - publish-helm:
           requires:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -61,6 +61,10 @@ build: build/stamp
 .PHONY: xml
 xml: build/sp-xml.stamp
 
+.PHONY: upload-search-index
+upload-search-index: xml
+	python3 deploy/scrape.py --upload
+
 .PHONY: clean
 clean:
 	rm -rf site build attributions.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ project = "Determined"
 html_title = "Determined AI Documentation"
 copyright = "2023, Determined AI"
 author = "hello@determined.ai"
-version = pathlib.Path(__file__).parents[1].joinpath("VERSION").read_text()
+version = pathlib.Path(__file__).parents[1].joinpath("VERSION").read_text().strip()
 release = version
 language = "en"
 

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -263,12 +263,15 @@ if __name__ == "__main__":
 
     if args.json:
         json.dump(records, sys.stdout, indent="  ")
+        print()
+        print(f"{len(records)} records for version={version} dumped to stdout")
 
     if args.upload:
         if not args.api_key:
             print("--api-key or ALGOLIA_API_KEY required for upload", file=sys.stderr)
             exit(1)
         upload(args.app_id, args.api_key, records, version)
+        print(f"{len(records)} records uploaded for version={version}")
 
     if not args.upload and not args.json:
-        print("scrape was successful, try --json or --upload", file=sys.stderr)
+        print(f"scrape of version={version} succeeded, try --json or --upload", file=sys.stderr)


### PR DESCRIPTION
Scrape + upload Aloglia records of the "dev" version on every commit that lands on main.  The dev index is used by source builds of the docs. This implies that old source build won't have a functional search bar, but that seems fine.

Scrape + upload Alogila records for the official version on every commit that is either tagged as a release or a release candidate.  There's no point in keeping extra release-candidate search indices.