### PR TITLE
ci: reduce overly long CloudFormation stack name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3033,7 +3033,7 @@ workflows:
           context: aws
           matrix:
             parameters:
-              cluster-id-prefix: ["mmdetection"]
+              cluster-id-prefix: ["mmdet"]
               mark: ["model_hub_mmdetection"]
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
@@ -3043,7 +3043,7 @@ workflows:
           context: aws
           matrix:
             parameters:
-              cluster-id-prefix: ["mmdetection-quarantine"]
+              cluster-id-prefix: ["mmdet-quarantine"]
               mark: ["model_hub_mmdetection_quarantine"]
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]


### PR DESCRIPTION
## Description

With a prefix of `mmdetection-quarantine`, an S3 bucket in the stack would try to have a name longer than the maximum of 63 characters, so stack creation would always fail.

The original `mmdetection` doesn't need to be shortened to work, of course, but I figure both of them ought to be the same.

## Test Plan

- [x] use `det deploy aws` locally to check that stack creation with this name prefix will succeed