### PR TITLE
test: fix test_experiment_api_determined_disabled flake

### DIFF
--- a/e2e_tests/tests/cluster/test_users_experiment_api.py
+++ b/e2e_tests/tests/cluster/test_users_experiment_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from determined.common.api import bindings
+from determined.common.api import bindings, errors
 from determined.experimental import client
 from tests import api_utils
 from tests import config as conf
@@ -15,13 +15,21 @@ def test_experiment_api_determined_disabled() -> None:
     determined_master = conf.make_master_url()
     user_creds = api_utils.create_test_user(add_password=True)
 
-    test_users.det_spawn(["user", "deactivate", "determined"])
+    child = test_users.det_spawn(["user", "deactivate", "determined"])
+    child.wait()
+    child.close()
+    assert child.exitstatus == 0
     try:
         d = client.Determined(determined_master, user_creds.username, user_creds.password)
         e = d.create_experiment(
             config=conf.fixtures_path("no_op/single-medium-train-step.yaml"),
             model_dir=conf.fixtures_path("no_op"),
         )
-        exp.wait_for_experiment_state(e.id, bindings.experimentv1State.COMPLETED)
+
+        # Determined shouldn't be able to view the experiment since it is deactivated.
+        with pytest.raises(errors.ForbiddenException):
+            exp.wait_for_experiment_state(e.id, bindings.experimentv1State.COMPLETED)
+
+        assert e.wait() == client.ExperimentState.COMPLETED
     finally:
         test_users.det_spawn(["user", "activate", "determined"])

--- a/e2e_tests/tests/cluster/test_users_experiment_api.py
+++ b/e2e_tests/tests/cluster/test_users_experiment_api.py
@@ -32,4 +32,7 @@ def test_experiment_api_determined_disabled() -> None:
 
         assert e.wait() == client.ExperimentState.COMPLETED
     finally:
-        test_users.det_spawn(["user", "activate", "determined"])
+        child = test_users.det_spawn(["user", "activate", "determined"])
+        child.wait()
+        child.close()
+        assert child.exitstatus == 0


### PR DESCRIPTION
## Description

Fix test flake that occurred here

https://app.circleci.com/pipelines/github/determined-ai/determined/37363/workflows/df112a8d-6f8f-41c6-89e9-db0e31d05826/jobs/1355952

## Test Plan

e2e_cpu passes

## Commentary (optional)

My running assumption is the reason why it has been passing was a race between spawning the process and master deactivating determined.

If it instead it was an error that happened when deactivating the user or a legitimate bug in deactivating users added two asserts to catch that.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
