### PR TITLE
refactor: clean up a bit of logic in `test_core.py`

### DIFF
--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -512,10 +512,11 @@ def test_experiment_list_columns() -> None:
     exp_metrics = ["validation.validation_error"]
     columns = bindings.get_GetProjectColumns(api_utils.determined_test_session(), id=1)
 
+    column_values = {c.column for c in columns.columns}
     for hp in exp_hyperparameters:
-        assert next((c for c in columns.columns if c.column == "hp." + hp), None) is not None
+        assert "hp." + hp in column_values
     for mc in exp_metrics:
-        assert next((c for c in columns.columns if c.column == mc), None) is not None
+        assert mc in column_values
 
 
 @pytest.mark.e2e_cpu


### PR DESCRIPTION
## Description

Just a spot refactor of something I happened across.

## Test Plan

- [x] CI

## Commentary
Another version that would be closer to the original would be
```python
    for hp in exp_hyperparameters:
        assert any(c.column == "hp." + hp for c in columns.columns)
    for mc in exp_metrics:
        assert any(c.column == mc for c in columns.columns)
```
but I figured what I have in the PR is the clearest overall.