### PR TITLE
fix: Metadata card can view and preserve JSON values [WEB-1183]

### DIFF
--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -62,21 +62,17 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
           <Form.List name="metadata">
             {(fields, { add, remove }) => (
               <>
-                {fields.map((field, idx) => (typeof metadataList[idx].value !== 'object') ? (
+                {fields.map((field, idx) => (
                   <EditableRow
+                    jsonValue={
+                      typeof metadataList[idx].value === 'object'
+                        ? JSON.stringify(metadataList[idx].value)
+                        : undefined
+                    }
                     key={field.key}
                     name={field.name}
                     onDelete={fields.length > 1 ? () => remove(field.name) : undefined}
                   />
-                ) : (
-                    <Input.Group className={rowcss.row} compact>
-                      <Form.Item noStyle>
-                        <Input disabled placeholder={String(metadataList[idx].key)} />
-                      </Form.Item>
-                      <Form.Item noStyle>
-                        <Input disabled placeholder={JSON.stringify(metadataList[idx].value)} />
-                      </Form.Item>
-                    </Input.Group>
                 ))}
                 <Button type="link" onClick={() => add({ key: '', value: '' })}>
                   {ADD_ROW_TEXT}

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -20,8 +20,9 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
   const [metadataRows, metadataList] = useMemo(() => {
     const { rows, list } = Object.entries(metadata).reduce(
       (acc, [key, value]) => {
-        acc.rows.push({ content: value, label: key });
-        acc.list.push({ key, value });
+        const stringedValue = typeof value === 'object' ? JSON.stringify(value) : value;
+        acc.rows.push({ content: stringedValue, label: key });
+        acc.list.push({ key, value: stringedValue });
         return acc;
       },
       { list: [] as { key: string; value: string }[], rows: [] as InfoRow[] },

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -22,10 +22,10 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
       (acc, [key, value]) => {
         const stringedValue = typeof value === 'object' ? JSON.stringify(value) : value;
         acc.rows.push({ content: stringedValue, label: key });
-        acc.list.push({ key, value: stringedValue });
+        acc.list.push({ key, value });
         return acc;
       },
-      { list: [] as { key: string; value: string }[], rows: [] as InfoRow[] },
+      { list: [] as { key: string; value: string | object }[], rows: [] as InfoRow[] },
     );
     if (list.length === 0) list.push({ key: '', value: '' });
     return [rows, list];
@@ -39,7 +39,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
           if (row.value === undefined) {
             row.value = '';
           }
-          if (row?.key) acc[row.key] = row.value;
+          if (typeof row?.key === 'string') acc[row.key] = row.value;
           return acc;
         }, {} as Metadata);
 
@@ -62,12 +62,21 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
           <Form.List name="metadata">
             {(fields, { add, remove }) => (
               <>
-                {fields.map((field) => (
+                {fields.map((field, idx) => (typeof metadataList[idx].value !== 'object') ? (
                   <EditableRow
                     key={field.key}
                     name={field.name}
                     onDelete={fields.length > 1 ? () => remove(field.name) : undefined}
                   />
+                ) : (
+                    <Input.Group className={rowcss.row} compact>
+                      <Form.Item noStyle>
+                        <Input disabled placeholder={String(metadataList[idx].key)} />
+                      </Form.Item>
+                      <Form.Item noStyle>
+                        <Input disabled placeholder={JSON.stringify(metadataList[idx].value)} />
+                      </Form.Item>
+                    </Input.Group>
                 ))}
                 <Button type="link" onClick={() => add({ key: '', value: '' })}>
                   {ADD_ROW_TEXT}

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -65,8 +65,8 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
                 {fields.map((field, idx) => (
                   <EditableRow
                     jsonValue={
-                      typeof metadataList[idx].value === 'object'
-                        ? JSON.stringify(metadataList[idx].value)
+                      typeof metadataList[idx]?.value === 'object'
+                        ? JSON.stringify(metadataList[idx]?.value || '')
                         : undefined
                     }
                     key={field.key}

--- a/webui/react/src/components/Metadata/EditableRow.tsx
+++ b/webui/react/src/components/Metadata/EditableRow.tsx
@@ -18,11 +18,12 @@ interface Props {
   field?: FormListFieldData;
   initialKey?: string;
   initialValue?: string;
+  jsonValue?: string;
   name: string | number;
   onDelete?: () => void;
 }
 
-const EditableRow: React.FC<Props> = ({ name, onDelete, field }: Props) => {
+const EditableRow: React.FC<Props> = ({ jsonValue, name, onDelete, field }: Props) => {
   const menu: DropDownProps['menu'] = useMemo(() => {
     const MenuKey = {
       DeleteMetadataRow: 'delete-metadata-row',
@@ -49,10 +50,10 @@ const EditableRow: React.FC<Props> = ({ name, onDelete, field }: Props) => {
     <Form.Item {...field} name={name} noStyle>
       <Input.Group className={css.row} compact>
         <Form.Item name={[name, 'key']} noStyle>
-          <Input placeholder={METADATA_KEY_PLACEHOLDER} />
+          <Input disabled={!!jsonValue} placeholder={METADATA_KEY_PLACEHOLDER} />
         </Form.Item>
-        <Form.Item name={[name, 'value']} noStyle>
-          <Input placeholder={METADATA_VALUE_PLACEHOLDER} />
+        <Form.Item name={jsonValue ? '' : [name, 'value']} noStyle>
+          <Input disabled={!!jsonValue} placeholder={jsonValue || METADATA_VALUE_PLACEHOLDER} />
         </Form.Item>
         {onDelete && (
           <Dropdown

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -205,7 +205,7 @@ export interface PatchModelParams {
   body: {
     description?: string;
     labels?: string[];
-    metadata?: Record<RecordKey, string|object>;
+    metadata?: Record<RecordKey, string | object>;
     name: string;
     notes?: string;
   };
@@ -216,7 +216,7 @@ export interface PatchModelVersionParams {
   body: {
     comment?: string;
     labels?: string[];
-    metadata?: Record<RecordKey, string|object>;
+    metadata?: Record<RecordKey, string | object>;
     modelName: string;
     name?: string;
     notes?: string;

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -205,7 +205,7 @@ export interface PatchModelParams {
   body: {
     description?: string;
     labels?: string[];
-    metadata?: Record<RecordKey, string>;
+    metadata?: Record<RecordKey, string|object>;
     name: string;
     notes?: string;
   };
@@ -216,7 +216,7 @@ export interface PatchModelVersionParams {
   body: {
     comment?: string;
     labels?: string[];
-    metadata?: Record<RecordKey, string>;
+    metadata?: Record<RecordKey, string|object>;
     modelName: string;
     name?: string;
     notes?: string;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -420,7 +420,7 @@ export interface Metrics extends Api.V1Metrics {
   batchMetrics?: Array<MetricStruct>;
 }
 
-export type Metadata = Record<RecordKey, string>;
+export type Metadata = Record<RecordKey, string|object>;
 
 export interface CoreApiGenericCheckpoint {
   allocationId?: string;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -420,7 +420,7 @@ export interface Metrics extends Api.V1Metrics {
   batchMetrics?: Array<MetricStruct>;
 }
 
-export type Metadata = Record<RecordKey, string|object>;
+export type Metadata = Record<RecordKey, string | object>;
 
 export interface CoreApiGenericCheckpoint {
   allocationId?: string;


### PR DESCRIPTION
## Description

Models and ModelVersions have editable Metadata which can accept JSON values. This causes an error on the Model Details page.

This PR makes JSON metadata visible when viewing and editing.
JSON rows are disabled from editing, because saving in the text editor would convert the value to a string.
We don't have a design or component to create and edit indefinitely nested JSON so we can't as quickly fix creating and editing JSON metadata

## Test Plan

Use `/det/models/397` with latest-master as an example model; otherwise to prepare a model in the database you can `SET metadata = '{ "sample": "data" }'::json WHERE id = ?`

On the model details page:

- JSON row appears string-ified

<img width="426" alt="Screen Shot 2023-04-26 at 1 16 24 PM" src="https://user-images.githubusercontent.com/643918/234654929-d5e88168-a1ae-4b1b-815f-6802f1a591bf.png">

- During edit, form is disabled to protect JSON value, and is string-ified for display

<img width="713" alt="Screen Shot 2023-04-26 at 1 16 32 PM" src="https://user-images.githubusercontent.com/643918/234655495-e4592ddb-fbfa-434f-b7aa-3090c9f32875.png">

- Editing another row's metadata, then saving, does not change content or type of the JSON row
- Adding and deleting other rows, then saving, does not change the JSON row

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.