### PR TITLE
fix: cache k8s summarize for performance

### DIFF
--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"path/filepath"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -93,7 +95,15 @@ type pods struct {
 
 	podInterfaces       map[string]typedV1.PodInterface
 	configMapInterfaces map[string]typedV1.ConfigMapInterface
-	quotaInterfaces     map[string]typedV1.ResourceQuotaInterface
+
+	summarizeCacheLock sync.RWMutex
+	summarizeCache     summarizeResult
+	summarizeCacheTime time.Time
+}
+
+type summarizeResult struct {
+	summary map[string]model.AgentSummary
+	err     error
 }
 
 // PodsInfo contains information for pods.
@@ -174,7 +184,6 @@ func Initialize(
 		nodeToSystemResourceRequests: make(map[string]int64),
 		podInterfaces:                make(map[string]typedV1.PodInterface),
 		configMapInterfaces:          make(map[string]typedV1.ConfigMapInterface),
-		quotaInterfaces:              make(map[string]typedV1.ResourceQuotaInterface),
 	})
 	check.Panic(check.True(ok, "pods address already taken"))
 	s.Ask(podsActor, actor.Ping{}).Get()
@@ -348,7 +357,6 @@ func (p *pods) startClientSet(ctx *actor.Context) error {
 	}
 
 	for _, ns := range append(maps.Keys(p.namespaceToPoolName), p.namespace) {
-		p.quotaInterfaces[ns] = p.clientSet.CoreV1().ResourceQuotas(ns)
 		p.podInterfaces[ns] = p.clientSet.CoreV1().Pods(ns)
 		p.configMapInterfaces[ns] = p.clientSet.CoreV1().ConfigMaps(ns)
 	}
@@ -939,8 +947,27 @@ func (p *pods) handleGetAgentsRequest(ctx *actor.Context) {
 
 // summarize describes pods' available resources. When there's exactly one resource pool, it uses
 // the whole cluster's info. Otherwise, it matches nodes to resource pools using taints and
-// tolerations to derive that info.
-func (p *pods) summarize(ctx *actor.Context) (map[string]model.AgentSummary, error) {
+// tolerations to derive that info. This may be cached, so don't use this for decisions
+// that require up-to-date information.
+func (p *pods) summarize(ctx *actor.Context) (summary map[string]model.AgentSummary, err error) {
+	p.summarizeCacheLock.Lock()
+	defer p.summarizeCacheLock.Unlock()
+
+	if time.Since(p.summarizeCacheTime) < 5*time.Second {
+		return p.summarizeCache.summary, p.summarizeCache.err
+	}
+
+	// Keep the cache up to date. Note: since this only gets deferred when the cache is expired,
+	// we won't update the time unless we're generating a new value.
+	defer func() {
+		p.summarizeCacheTime = time.Now()
+
+		p.summarizeCache = summarizeResult{
+			summary: summary,
+			err:     err,
+		}
+	}()
+
 	nodeSummaries := p.summarizeClusterByNodes(ctx)
 
 	poolTaskContainerDefaults := extractTCDs(p.resourcePoolConfigs)


### PR DESCRIPTION
## Description

@stoksc and I talked it through and decided that `summarize` itself was an expensive operation, and users wouldn't be bothered by it being only a few seconds out of date. Further, it could be a problem if some API operations were cached and not others, since that could lead to inconsistency. So we just cached the result of the `summarize` operation for now until we can come up with a longer-term fix for the k8s API rate limiting.

## Test Plan

Tests like those described in [this Slack thread](https://determined-ai.slack.com/archives/C0147SMJQQY/p1682016860926639) should be faster.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
