### PR TITLE
docs: add meta descriptions

### DIFF
--- a/docs/architecture/index.rst
+++ b/docs/architecture/index.rst
@@ -18,9 +18,11 @@ so you can spend your time building models instead of managing infrastructure.
 
 .. image:: /assets/images/det-ai-sys-arch-01-start-dark.png
    :class: only-dark
+   :alt: Determined AI system architecture diagram dark mode
 
 .. image:: /assets/images/det-ai-sys-arch-01-start-light.png
    :class: only-light
+   :alt: Determined AI system architecture diagram light mode
 
 Learn more:
 

--- a/docs/architecture/introduction.rst
+++ b/docs/architecture/introduction.rst
@@ -31,10 +31,10 @@ Determined CLI
 One of the key components of the Determined platform is the :ref:`command-line interface (CLI)
 <cli-ug>`. The CLI serves as a primary entry point for interacting with Determined, providing a way
 to efficiently manage and control various aspects of the system. The following list describes some
-of the tasks users can perform with the Determined CLI:
+of the tasks you can perform with the Determined CLI:
 
 -  Experiment management: Running experiments is a fundamental part of the machine learning process.
-   With the CLI, users can effortlessly create, list, and manage experiments, as well as access
+   With the CLI, you can effortlessly create, list, and manage experiments, as well as access
    important experiment metrics and logs.
 
 -  Queue management: The CLI enables users to manage their job queues, monitor the progress of
@@ -69,8 +69,8 @@ Configuration Templates
 At a typical organization, many Determined configuration files will contain similar settings. For
 example, all of the training workloads run at a given organization might use the same checkpoint
 storage configuration. One way to reduce this redundancy is to use *configuration templates*. With
-this feature, users can move settings that are shared by many experiments into a single YAML file
-that can then be referenced by configurations that require those settings.
+this feature, you can move settings that are shared by many experiments into a single YAML file that
+can then be referenced by configurations that require those settings.
 
 Each configuration template has a unique name and is stored by the Determined master. If a
 configuration specifies a template, the effective configuration of the task will be the result of
@@ -247,6 +247,7 @@ instances as the set of deep learning workloads on the cluster changes. This cap
 The diagram below outlines the high-level system architecture when using dynamic agents:
 
 .. image:: /assets/images/det-arch-elastic-infra.png
+   :alt: Determined AI system architecture when using dynamic agents
 
 Following the diagram, the execution would be:
 

--- a/docs/architecture/system-architecture.rst
+++ b/docs/architecture/system-architecture.rst
@@ -22,9 +22,11 @@ agent has no state and only communicates with the master. Each agent is responsi
 
 .. image:: /assets/images/det-ai-sys-arch-01-dark.png
    :class: only-dark
+   :alt: Determined AI system architecture diagram describing master and agent components in dark mode
 
 .. image:: /assets/images/det-ai-sys-arch-01-light.png
    :class: only-light
+   :alt: Determined AI system architecture diagram describing master and agent components in light mode
 
 The **task container** runs a training task or other task(s) in a containerized environment.
 Training tasks are expected to have access to the data that will be used in training. The **agents**

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-aws/overview.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-aws/overview.rst
@@ -15,6 +15,7 @@ Virtual Private Cloud (VPC); users interact with the master via a designated ext
 configured during installation.
 
 .. image:: /assets/images/det-cloud-architecture.png
+   :alt: Diagram showing Determined Cloud Deployment Architecture on AWS
 
 Following the diagram, a standard execution would be:
 

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/overview.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-gcp/overview.rst
@@ -21,6 +21,7 @@ with the master via a designated port configured during installation.
 The diagram below outlines the high level architecture of a Determined cluster in GCP.
 
 .. image:: /assets/images/det-cloud-architecture.png
+   :alt: Diagram showing Determined Cloud Deployment Architecture on GCP
 
 Following the diagram, a standard execution would be:
 
@@ -32,7 +33,7 @@ Following the diagram, a standard execution would be:
 
 There are two types of resources used to run Determined: core resources that enable the Determined
 platform, and periphery resources that add optional functionality. The section below provides
-additional detail on these resources, and users can deploy these resources in GCP by following the
+additional detail on these resources. You can deploy these resources in GCP by following the
 :ref:`install-gcp` guide.
 
 ****************

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/custom-pod-specs.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/custom-pod-specs.rst
@@ -5,7 +5,7 @@
 #################
 
 In a :ref:`Determined cluster running on Kubernetes <determined-on-kubernetes>`, tasks (e.g.,
-experiments, notebooks) are executed by launching one or more Kubernetes pods. Users can customize
+experiments, notebooks) are executed by launching one or more Kubernetes pods. You can customize
 these pods by providing custom `pod specs
 <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core>`__. Common use
 cases include assigning pods to specific nodes, specifying additional volume mounts, and attaching
@@ -35,7 +35,7 @@ some of the fields for the ``determined-container``.
 
 Determined provides two ways to configure pod specs. When Determined is installed, the system
 administrator can configure pod specs that are used by default for all GPU and CPU tasks. In
-addition, users can specify a custom pod spec for individual tasks (e.g., for an experiment by
+addition, you can specify a custom pod spec for individual tasks (e.g., for an experiment by
 specifying ``environment.pod_spec`` in the :ref:`experiment configuration
 <experiment-config-reference>`). If a custom pod spec is specified for a task, it overrides the
 default pod spec (if any).

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/overview.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-k8s/overview.rst
@@ -20,7 +20,7 @@ In this topic guide, we will cover:
 
 :ref:`Installing Determined on Kubernetes <install-on-kubernetes>` deploys an instance of the
 Determined master and a Postgres database in the Kubernetes cluster. Once the master is up and
-running, users can launch :ref:`experiments <experiments>`, :ref:`notebooks <notebooks>`,
+running, you can launch :ref:`experiments <experiments>`, :ref:`notebooks <notebooks>`,
 :ref:`TensorBoards <tensorboards>`, :ref:`commands <commands-and-shells>`, and :ref:`shells
 <commands-and-shells>`. When new workloads are submitted to the Determined master, the master
 launches pods and configMaps on the Kubernetes cluster to execute those workloads. Users of

--- a/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/hpc-launching-architecture.rst
+++ b/docs/cluster-setup-guide/deploy-cluster/sysadmin-deploy-on-slurm/hpc-launching-architecture.rst
@@ -11,6 +11,7 @@ any Determined Agents. Instead, Determined interfaces with the workload managers
 HPC launcher component.
 
 .. image:: hpc-launching-arch-diagram.png
+   :alt: Diagram showing how Determined interfaces with the workload managers
 
 **************
  HPC Launcher
@@ -198,10 +199,10 @@ provided that they do not conflict with Determined-controlled settings.
 Slurm Resource Calculations
 ---------------------------
 
-Resource requirements for Slurm jobs submitted by Determined are generated as per the table below.
-Users can specify a ``--gres`` expression via ``slurm.sbatch_args`` as long as it does not reference
-a GPU resource. All other ``--gres`` options from the ``slurm.sbatch_args`` will be generated into
-the generated batch script.
+Resource requirements for Slurm jobs submitted by Determined are generated according to the table
+below. You can specify a ``--gres`` expression via ``slurm.sbatch_args`` as long as it does not
+reference a GPU resource. All other ``--gres`` options from the ``slurm.sbatch_args`` will be
+generated into the generated batch script.
 
 .. table::
    :width: 1000px
@@ -307,9 +308,9 @@ provided that they do not conflict with Determined-controlled settings.
 PBS Resource Calculations
 -------------------------
 
-Resource requirements for PBS jobs submitted by Determined are generated as per the table below.
-Users can specify a ``-l select`` expression via ``pbs.pbsbatch_args``, however chunk count, chunk
-arrangement, and GPU or CPU counts per chunk (depending on the value of ``slot_type``) are
+Resource requirements for PBS jobs submitted by Determined are generated according to the table
+below. You can specify a ``-l select`` expression via ``pbs.pbsbatch_args``, however chunk count,
+chunk arrangement, and GPU or CPU counts per chunk (depending on the value of ``slot_type``) are
 controlled by Determined; any values specified for these quantities will be ignored. All other
 resource requests from the ``pbs.pbsbatch_args`` will be appended to the select expression generated
 into the generated batch script.

--- a/docs/cluster-setup-guide/historical-cluster-usage-data.rst
+++ b/docs/cluster-setup-guide/historical-cluster-usage-data.rst
@@ -30,6 +30,7 @@ We build WebUI visualizations for a quick snapshot of the historical cluster usa
 
 .. image:: /assets/images/historical-cluster-usage-data.png
    :width: 100%
+   :alt: WebUI showing historical cluster usage data
 
 ************************
  Command-line Interface

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,9 @@
  *Welcome to Determined!*
 ##########################
 
+.. meta::
+   :description: Visit the Determined AI documentation home page and get quick access to information, tutorials, quickstarts, user guides, and reference material.
+
 You can quickly train almost any deep learning model using Determined.
 
 .. raw:: html

--- a/docs/integrations/notification/index.rst
+++ b/docs/integrations/notification/index.rst
@@ -121,6 +121,7 @@ side menu, and click on the top right corner button "New Webhook"
 
 .. image:: /assets/images/webhook.png
    :width: 100%
+   :alt: Det Webhooks interface showing New Webhook button
 
 .. note::
 
@@ -136,6 +137,7 @@ At the modal input:
 
 .. image:: /assets/images/webhook_modal.png
    :width: 100%
+   :alt: New Webhook user interface showing the fields you will interact with.
 
 Once created, your webhook will begin executing for the chosen events.
 
@@ -148,6 +150,7 @@ actions.
 
 .. image:: /assets/images/webhook_action.png
    :width: 100%
+   :alt: Webhooks interface showing where to find the actions menu
 
 Clicking on "Test Webhook" will trigger a test event to be sent to the defined webhook URL with a
 mock payload as stated below:

--- a/docs/integrations/notification/slack.rst
+++ b/docs/integrations/notification/slack.rst
@@ -23,10 +23,11 @@ First, we need to create a Slack application and give the application permission
 appropriate Slack channel. Visit the `Slack App Managment page <https://api.slack.com/apps>`_ and
 click on the **Create New App** button.
 
-In the pop window asking for the app configuration choose the **From scratch** option.
+In app configuration, select **From scratch**.
 
 .. image:: /assets/images/slack-app-configuration.jpeg
    :width: 100%
+   :alt: Create an app showing the From Scratch option
 
 In the next window you will input an "App Name" and select the Workspace for the application.
 
@@ -42,6 +43,7 @@ Incoming Webhooks** as shown below.
 
 .. image:: /assets/images/slack-incoming-webhooks-page.jpeg
    :width: 100%
+   :alt: Slack API showing the Add New Webhook to Workspace option
 
 Now that webhooks are enabled we can set up a new webhook integration. Click the **Add New Webhook
 to Workspace** button at the bottom of the page. On the next page you will be asked to select the
@@ -77,11 +79,13 @@ If the **Base URL** is set correctly then Slack messages will include links as s
 
 .. image:: /assets/images/slack-message-with-links.png
    :width: 40%
+   :alt: Test Webhook Service when Base URL is set correctly
 
 If no **Base URL** is set then links will not be present in Slack messages.
 
 .. image:: /assets/images/slack-message-without-links.png
    :width: 40%
+   :alt: Test Webhook Service when no Base URL is set
 
 .. _setting-up-webhook-in-determined:
 
@@ -100,6 +104,7 @@ page.
 
 .. image:: /assets/images/slack-webhook-creation-in-determined.jpeg
    :width: 100%
+   :alt: Webhooks page displaying New Webhook fields you will interact with.
 
 In the pop up, paste the **Webhook URL** that was copied from Slack in the **URL** field. Choose
 **Slack** for the webhook type and then choose the triggers that you want to receive notifications
@@ -116,6 +121,7 @@ dots on the right side of any of the listed webhooks.
 
 .. image:: /assets/images/test-webhook.png
    :width: 100%
+   :alt: Webhooks page displaying where to find the Test Webhook action.
 
 If everything has been configured correctly you should receive a message from the Slack application
 you created with the message "test" as shown above.

--- a/docs/integrations/notification/zapier.rst
+++ b/docs/integrations/notification/zapier.rst
@@ -32,6 +32,7 @@ intead of **Catch Hook** because headers are needed to verify each webhook reque
 
 .. image:: /assets/images/zapier_webhook.png
    :width: 100%
+   :alt: Zapier Webhooks page displaying Catch Raw Hook event selected
 
 .. _webhook-in-determined:
 
@@ -43,12 +44,14 @@ Then, you need to create a webhook in Determined using the **Webhook URL** from 
 
 .. image:: /assets/images/zapier_webhook_url.png
    :width: 100%
+   :alt: This is where your webhook URL displays in Zapier
 
 Navigate to ``/det/webhooks`` or click on the "Webhooks" item in navigation side menu, then click
 the **New Webhook** button in the top right corner of the page.
 
 .. image:: /assets/images/zapier_new_webhook.png
    :width: 100%
+   :alt: Webhooks page displaying New Webhook fields including triggers.
 
 Paste the **Webhook URL** that was copied from Zapier in the **URL** field. Select **Default** for
 the webhook type and then select the triggers that you want to receive notifications for. Finally,
@@ -65,12 +68,14 @@ Webhook**.
 
 .. image:: /assets/images/zapier_test.png
    :width: 100%
+   :alt: Webhooks page displaying where to find the Test Webhook action.
 
 Then navigate back to Zapier and click on **Test Trigger**, then you should be able to see the test
 request.
 
 .. image:: /assets/images/zapier_request_found.png
    :width: 100%
+   :alt: Zapier Webhooks request page showing that your request was found.
 
 .. _verification:
 
@@ -88,6 +93,7 @@ Add a new action and choose **Code by Zapier**, select **Run Python** as an exam
 
 .. image:: /assets/images/zapier_python.png
    :width: 100%
+   :alt: Code by Zapier action with a Run Python event
 
 Construct input data as following:
 
@@ -98,6 +104,7 @@ Construct input data as following:
 
 .. image:: /assets/images/zapier_code_input.png
    :width: 100%
+   :alt: Code by Zapier showing set up action input data like webhook_signing_key
 
 Input code as following:
 
@@ -120,6 +127,7 @@ Under **Test Action**, test the code above, you should be able to see that verif
 
 .. image:: /assets/images/zapier_code_result.png
    :width: 100%
+   :alt: Code by Zapier showing that a Run Python event was sent
 
 .. _configuring_destination:
 

--- a/docs/interfaces/index.rst
+++ b/docs/interfaces/index.rst
@@ -2,6 +2,9 @@
  Tools
 #######
 
+.. meta::
+   :description: Get links to info about Determined AI tools such as the CLI User Guide, Commands and Shells, WebUI, Jupyter Notebooks, TensorBoard, and Exposing Custom Ports.
+
 .. raw:: html
 
    <div class="landing">

--- a/docs/interfaces/notebooks.rst
+++ b/docs/interfaces/notebooks.rst
@@ -116,6 +116,7 @@ the tasks currently running on the cluster.
 
 .. image:: /assets/images/task-list@2x.jpg
    :width: 100%
+   :alt: Determined AI model training interactive WebUI where you can visualize your cluster tasks.
 
 |
 
@@ -126,6 +127,7 @@ click the dropdown arrow and select "Launch CPU-only Notebook".
 
 .. image:: /assets/images/launch-cpu-notebook@2x.jpg
    :width: 100%
+   :alt: Determined AI model training interactive WebUI where you can launch a new Jupyter Notebook.
 
 .. _notebook-configuration:
 

--- a/docs/model-hub-library/index.rst
+++ b/docs/model-hub-library/index.rst
@@ -2,6 +2,9 @@
  Model Hub Library
 ###################
 
+.. meta::
+   :description: The Model Hub Library page contains info about Transformers and MMDetection where you can access the benefits of using Determined.
+
 +------------------------------+----------------------------------------------------------------+
 | Title                        | Description                                                    |
 +==============================+================================================================+

--- a/docs/reference/cli-reference.rst
+++ b/docs/reference/cli-reference.rst
@@ -4,6 +4,9 @@
  Determined CLI Reference
 ##########################
 
+.. meta::
+   :description: Browse this complete description of the Determined command-line interface that tells you how to print the built-in documentation and formulate your cli commands.
+
 +-----------------------------------------------+
 | User Guide                                    |
 +===============================================+

--- a/docs/reference/overview.rst
+++ b/docs/reference/overview.rst
@@ -2,6 +2,9 @@
  Reference
 ###########
 
+.. meta::
+   :description: Get links to Determined AI reference pages such as the Python SDK, the REST API, the Training API Reference pages, tools, and more.
+
 .. raw:: html
 
    <div class="landing">

--- a/docs/reference/reference-deploy/config/master-config-reference.rst
+++ b/docs/reference/reference-deploy/config/master-config-reference.rst
@@ -95,7 +95,7 @@ values:
 A list of environment variables that will be set in every task container. Each element of the list
 should be a string of the form ``NAME=VALUE``. See :ref:`environment-variables` for more details.
 Environment variables specified in experiment config will override default values specified here.
-Users can customize environment variables for CUDA (NVIDIA GPU), CPU, and ROCm (AMD GPU) tasks
+You can customize environment variables for CUDA (NVIDIA GPU), CPU, and ROCm (AMD GPU) tasks
 differently by specifying a dict with ``cuda`` (``gpu`` prior to 0.17.6), ``cpu``, and ``rocm``
 keys.
 
@@ -659,10 +659,10 @@ tools that summarize usage by each WCKey/Project value.
  ``resource_pools``
 ********************
 
-A list of resource pools. A resource pool is a collection of identical computational resources.
-Users can specify which resource pool a job should be assigned to when the job is submitted. Refer
-to the documentation on :ref:`resource-pools` for more information. Defaults to a resource pool with
-a name ``default``.
+A list of resource pools. A resource pool is a collection of identical computational resources. You
+can specify which resource pool a job should be assigned to when the job is submitted. Refer to the
+documentation on :ref:`resource-pools` for more information. Defaults to a resource pool with a name
+``default``.
 
 ``pool_name``
 =============

--- a/docs/reference/reference-training/experiment-config-reference.rst
+++ b/docs/reference/reference-training/experiment-config-reference.rst
@@ -6,6 +6,9 @@
  Experiment Configuration Reference
 ####################################
 
+.. meta::
+   :description: Browse this complete description of the experiment configuration reference or YAML file, including metadata, entrypoint, basic behaviors, validation policy, checkpoint policy, checkpoint storage, and so on.
+
 The behavior of an experiment is configured via a YAML file. A configuration file is typically
 passed as a command-line argument when an experiment is created with the Determined CLI. For
 example:
@@ -167,7 +170,7 @@ object delimited by a period (``.``).
 
 Examples:
 
--  ``:MnistTrial`` expects an *MnistTrial* class exposed in a ``__init__.py`` file at the top level
+-  ``MnistTrial`` expects an *MnistTrial* class exposed in a ``__init__.py`` file at the top level
    of the context directory.
 -  ``model_def:CIFAR10Trial`` expects a *CIFAR10Trial* class defined in the ``model_def.py`` file at
    the top level of the context directory.
@@ -1298,7 +1301,7 @@ base Docker image, if needed. Credentials are specified as the following nested 
 
 Optional. A list of environment variables that will be set in every trial container. Each element of
 the list should be a string of the form ``NAME=VALUE``. See :ref:`environment-variables` for more
-details. Users can customize environment variables for CUDA (NVIDIA GPU), CPU, and ROCm (AMD GPU)
+details. You can customize environment variables for CUDA (NVIDIA GPU), CPU, and ROCm (AMD GPU)
 tasks differently by specifying a dict with ``cuda`` (``gpu`` prior to 0.17.6), ``cpu``, and
 ``rocm`` keys.
 

--- a/docs/reference/reference-training/index.rst
+++ b/docs/reference/reference-training/index.rst
@@ -6,6 +6,9 @@
  Python Modules APIs
 *********************
 
+.. meta::
+   :description: Discover reference guides and resources for Python modules APIs and the experiment configuration YAML file.
+
 -  :doc:`det <training/api-det-reference>`
 -  :doc:`det.core <training/api-core-reference>`
 -  :doc:`det.pytorch <training/api-pytorch-reference>`

--- a/docs/reference/reference-training/training/api-core-reference.rst
+++ b/docs/reference/reference-training/training/api-core-reference.rst
@@ -4,6 +4,9 @@
  ``det.core`` API Reference
 ############################
 
+.. meta::
+   :description: Familiarize yourself with the det.core API by visiting this reference page on the determined.core.init module, its configuration parameters, classes, methods, and practical examples.
+
 +-----------------------------------------------+
 | User Guide                                    |
 +===============================================+

--- a/docs/reference/reference-training/training/api-pytorch-reference.rst
+++ b/docs/reference/reference-training/training/api-pytorch-reference.rst
@@ -2,6 +2,9 @@
  ``det.pytorch`` API Reference
 ###############################
 
+.. meta::
+   :description: Familiarize yourself with the det.pytorch API. This PyTorch-based training loop includes the PyTorchTrial class, the PyTorchTrialContext class, and the Trainer class.
+
 +--------------------------------------------+
 | User Guide                                 |
 +============================================+

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -909,8 +909,10 @@ Version 0.18.1
    column in the `Trials` table.
 
    .. image:: https://user-images.githubusercontent.com/220971/169450333-c3dde9f4-abc0-4f8b-9e83-216e13ee2ca0.png
+      :alt: Trial restart counter
 
    .. image:: https://user-images.githubusercontent.com/220971/169450323-d169f4ee-2698-4ae8-9b1a-c04460751310.png
+      :alt: Restarts column in the Trials table
 
 **Improvements**
 
@@ -1218,8 +1220,10 @@ Version 0.17.9
    to display.
 
    .. image:: https://user-images.githubusercontent.com/15078396/152874244-51e0d84a-3678-4427-b082-ccc0c865200f.png
+      :alt: Customize columns picker
 
    .. image:: https://user-images.githubusercontent.com/15078396/152874240-6365b276-3f3e-4fb6-aa2b-0cedc7451b12.png
+      :alt: Customize columns picker displaying columns matching search criteria
 
 -  Notebooks: Add a config field ``notebook_idle_type`` that changes how the idleness of a notebook
    is determined for the idle timeout feature. If the value is different from the default, users do
@@ -1378,10 +1382,13 @@ Version 0.17.5
    or on the Model Registry page.
 
    .. image:: https://user-images.githubusercontent.com/15078396/144926870-bb93d587-f7ad-4052-a338-6fc000bd2ed9.png
+      :alt: Model Registry page
 
    .. image:: https://user-images.githubusercontent.com/15078396/144926881-98aeb187-aa3f-4e40-b502-d7af624573db.png
+      :alt: Register Checkpoint page
 
    .. image:: https://user-images.githubusercontent.com/15078396/144926889-eec0216a-dacc-4fe5-ac28-858ea6587d04.png
+      :alt: Create Model page
 
 -  API: Add a method for listing trials within an experiment.
 
@@ -1496,6 +1503,7 @@ Version 0.17.1
    experiment.
 
    .. image:: https://user-images.githubusercontent.com/15078396/136809928-11c815cc-3751-4908-8c6e-34fef3b9858d.png
+      :alt: Notes tab in the WebUI
 
 **Improvements**
 
@@ -1585,13 +1593,16 @@ Version 0.17.0
 -  WebUI: Allow experiment owners to delete their own experiments, singly or in batches.
 
    .. image:: https://user-images.githubusercontent.com/220971/134048799-cd663a75-cb24-4f44-9a8a-c2ff23222cef.png
+      :alt: WebUI showing Delete action
 
    .. image:: https://user-images.githubusercontent.com/220971/133659677-aea0d1bc-95ce-4652-8218-92b97d114358.png
+      :alt: WebUI showing action dropdown selector
 
 -  WebUI: Display the latest log entry available for a trial at the bottom of the trial's page. This
    works for both single-trial experiments and trials within a multi-trial experiment.
 
    .. image:: https://user-images.githubusercontent.com/220971/131391658-4be1a1f4-1d46-4766-a737-7eb8efcb65b4.png
+      :alt: WebUI displaying the latest log entry
 
 -  WebUI: Add support for displaying NaN and Infinity metric values.
 

--- a/docs/training/apis-howto/api-core-ug.rst
+++ b/docs/training/apis-howto/api-core-ug.rst
@@ -2,6 +2,9 @@
  Core API
 ##########
 
+.. meta::
+   :description: Learn how to use the Core API. With the Core API you can train arbitrary models on the Determined platform with seamless access to the following capabilities: metrics tracking, checkpoint tracking and preemption support, hyperparameter search, distributing work across multiple GPUs or nodes.
+
 In this guide, you'll learn how to use the Core API.
 
 +------------------------------------------------------------------+
@@ -11,7 +14,7 @@ In this guide, you'll learn how to use the Core API.
 +------------------------------------------------------------------+
 
 With the Core API you can train arbitrary models on the Determined platform with seamless access to
-the the following capabilities:
+the following capabilities:
 
 -  metrics tracking
 -  checkpoint tracking and preemption support

--- a/docs/training/apis-howto/api-core-ug.rst
+++ b/docs/training/apis-howto/api-core-ug.rst
@@ -3,7 +3,7 @@
 ##########
 
 .. meta::
-   :description: Learn how to use the Core API. With the Core API you can train arbitrary models on the Determined platform with seamless access to the following capabilities: metrics tracking, checkpoint tracking and preemption support, hyperparameter search, distributing work across multiple GPUs or nodes.
+   :description: Learn how to train almost any machine learning model using Determined AI's Core API. This guide covers metrics tracking, checkpoint tracking and preemption support, hyperparameter search, and distributing work across multiple GPUs or nodes.
 
 In this guide, you'll learn how to use the Core API.
 

--- a/docs/training/apis-howto/api-estimator-ug.rst
+++ b/docs/training/apis-howto/api-estimator-ug.rst
@@ -2,6 +2,9 @@
  Estimator API
 ###############
 
+.. meta::
+   :description: Learn how to use the Estimator API to train an Estimator model in Determined. Steps include defining an optimizer and datasets, defining custom reducers, checkpointing, and callbacks.
+
 In this guide, you'll learn how to use the Estimator API.
 
 +-----------------------------------------------------------------------+
@@ -28,7 +31,7 @@ To learn about this API, you can start by reading the trial definitions from the
    Before loading data, read this document :doc:`/training/load-model-data` to understand how to
    work with different sources of data.
 
-To use ``tf.estimator`` models with Determined, users need to wrap their optimizer and datasets
+To use ``tf.estimator`` models with Determined, you'll need to wrap your optimizer and datasets
 using :meth:`~determined.estimator.EstimatorTrialContext.wrap_optimizer` and
 :meth:`~determined.estimator.EstimatorTrialContext.wrap_dataset`. Note that the concrete context
 object where these functions will be found will be in
@@ -54,7 +57,7 @@ details.
 A checkpoint includes the model definition (Python source code), experiment configuration file,
 network architecture, and the values of the model's parameters (i.e., weights) and hyperparameters.
 When using a stateful optimizer during training, checkpoints will also include the state of the
-optimizer (i.e., learning rate). Users can also embed arbitrary metadata in checkpoints via the
+optimizer (i.e., learning rate). You can also embed arbitrary metadata in checkpoints via the
 :ref:`Python SDK <store-checkpoint-metadata>`.
 
 TensorFlow Estimator trials are checkpointed using the `SavedModel

--- a/docs/training/apis-howto/api-keras-ug.rst
+++ b/docs/training/apis-howto/api-keras-ug.rst
@@ -2,6 +2,9 @@
  Keras API
 ###########
 
+.. meta::
+   :description: Learn how to use the Keras API to train a Keras model. This user guide walks you through loading your data, defining the model, customizing how the model.fit function is called, checkpointing, and callbacks.
+
 In this guide, you'll learn how to use the Keras API.
 
 +---------------------------------------------------------------------+
@@ -25,7 +28,7 @@ To learn about this API, you can start by reading the trial definitions from the
 
 .. note::
 
-   Before loading data, read :doc:`/training/load-model-data` to understand how to work with
+   Before loading data, visit :doc:`/training/load-model-data` to understand how to work with
    different sources of data.
 
 Loading data is done by defining :meth:`~determined.keras.TFKerasTrial.build_training_data_loader`
@@ -72,7 +75,7 @@ is called by calling :meth:`self.context.configure_fit()
 A checkpoint includes the model definition (Python source code), experiment configuration file,
 network architecture, and the values of the model's parameters (i.e., weights) and hyperparameters.
 When using a stateful optimizer during training, checkpoints will also include the state of the
-optimizer (i.e., learning rate). Users can also embed arbitrary metadata in checkpoints via a
+optimizer (i.e., learning rate). You can also embed arbitrary metadata in checkpoints via a
 :ref:`Python SDK <store-checkpoint-metadata>`.
 
 TensorFlow Keras trials are checkpointed to a file named ``determined-keras-model.h5`` using

--- a/docs/training/apis-howto/api-pytorch-lightning-ug.rst
+++ b/docs/training/apis-howto/api-pytorch-lightning-ug.rst
@@ -2,6 +2,9 @@
  PyTorch Lightning API
 #######################
 
+.. meta::
+   :description: Discover how to use the PyTorch Lightning API to train a PyTorch Lightning model in Determined. It includes step-by-step instructions for installation and usage, as well as sample code snippets and tips.
+
 In this guide, you'll learn how to use the PyTorch Lightning API.
 
 +-------------------------------------------------------------------------------+

--- a/docs/training/apis-howto/api-pytorch-ug.rst
+++ b/docs/training/apis-howto/api-pytorch-ug.rst
@@ -2,6 +2,9 @@
  PyTorch API
 #############
 
+.. meta::
+   :description: Learn how to train a PyTorch model in Determined. This user guide covers everything from PyTorch's tensor operations, data loading, and preprocessing techniques, to how to train and evaluate your models using Determined AI's PyTorch Trial and PyTorch Trainer.
+
 In this guide, you'll learn how to use :ref:`pytorch_trial_ug` and :ref:`pytorch_trainer_ug`.
 
 +---------------------------------------------------------------------+
@@ -322,7 +325,7 @@ Checkpointing
 A checkpoint includes the model definition (Python source code), experiment configuration file,
 network architecture, and the values of the model's parameters (i.e., weights) and hyperparameters.
 When using a stateful optimizer during training, checkpoints will also include the state of the
-optimizer (i.e., learning rate). Users can also embed arbitrary metadata in checkpoints via a
+optimizer (i.e., learning rate). You can also embed arbitrary metadata in checkpoints via a
 :ref:`Python SDK <store-checkpoint-metadata>`.
 
 PyTorch trials are checkpointed as a ``state-dict.pth`` file. This file is created in a similar

--- a/docs/training/apis-howto/deepspeed/advanced.rst
+++ b/docs/training/apis-howto/deepspeed/advanced.rst
@@ -4,6 +4,9 @@
  Advanced Usage
 ################
 
+.. meta::
+   :description: This article covers advanced usage of the DeepSpeed API including model parallelism and pipeline parallelism, gradient accumulation, zero-offloading, and more.
+
 *********************************
  Training Multiple Model Engines
 *********************************

--- a/docs/training/apis-howto/deepspeed/deepspeed.rst
+++ b/docs/training/apis-howto/deepspeed/deepspeed.rst
@@ -4,7 +4,10 @@
  Usage Guide
 #############
 
-This document introduces DeepSpeed and guides you through how to train a PyTorch model with the
+.. meta::
+   :description: This comprehensive guide explains the DeepSpeed API and provides step-by-step instructions for getting started. Learn how to use the DeepSpeed API by training a PyTorch model with the DeepSpeed engine.
+
+This usage guide introduces DeepSpeed and guides you through how to train a PyTorch model with the
 DeepSpeed engine. To implement :class:`~determined.pytorch.deepspeed.DeepSpeedTrial`, you need to
 overwrite specific functions corresponding to common training aspects. It is helpful to work from a
 skeleton trial to keep track of what is required, as the following example template shows:

--- a/docs/training/apis-howto/deepspeed/overview.rst
+++ b/docs/training/apis-howto/deepspeed/overview.rst
@@ -2,6 +2,9 @@
  DeepSpeed API
 ###############
 
+.. meta::
+   :description: Learn how you can train your model in Determined using the DeepSpeed engine.
+
 In this guide, you'll learn how to use the DeepSpeed API.
 
 +-----------------------------------------------------------------------+

--- a/docs/training/apis-howto/deepspeed/pytorch2deepspeed.rst
+++ b/docs/training/apis-howto/deepspeed/pytorch2deepspeed.rst
@@ -4,6 +4,9 @@
  ``PyTorchTrial`` to ``DeepSpeedTrial``
 ########################################
 
+.. meta::
+   :description: Learn how to adapt an existing PyTorchTrial to use DeepSpeed. This article explains how adapting an existing PyTorchTrial to use DeepSpeed mirrors the process for adapting existing code to use DeepSpeed outside of Determined.
+
 Adapting an existing :class:`~determined.pytorch.PyTorchTrial` to use DeepSpeed mirrors the process
 for adapting existing code to use DeepSpeed outside of Determined.
 

--- a/docs/training/apis-howto/overview.rst
+++ b/docs/training/apis-howto/overview.rst
@@ -2,6 +2,9 @@
  Training APIs
 ###############
 
+.. meta::
+   :description: You can train almost any deep learning model using the Determined Training APIs. By using the Training API guides, you'll discover how to take your existing model code and train your model in Determined. Each API guide contains a link to its corresponding API reference.
+
 You can train almost any deep learning model using the Determined Training APIs. The Training API
 guides describe how to take your existing model code and train your model in Determined. Each API
 guide contains a link to its corresponding API reference.

--- a/docs/training/hyperparameter/search-methods/hp-adaptive-asha.rst
+++ b/docs/training/hyperparameter/search-methods/hp-adaptive-asha.rst
@@ -112,8 +112,10 @@ the desired number of trials is reached.
 See the difference in asynchronous vs. synchronous promotions in the two animated GIFs below:
 
 .. image:: /assets/images/sha.gif
+   :alt: Determined AI successive halving (SHA) animation showing how each rung waits to complete before performing promotions.
 
 .. image:: /assets/images/asha.gif
+   :alt: Determined AI asynchronous successive halving (ASHA) animation showing how each trials are continuously added to the bottom rung until the desired number is reached.
 
 Adaptive over ASHA
 ==================

--- a/docs/training/hyperparameter/search-methods/overview.rst
+++ b/docs/training/hyperparameter/search-methods/overview.rst
@@ -24,12 +24,13 @@ simultaneously:
 For details on the supported searchers and their respective configuration options, refer to
 :ref:`hyperparameter-tuning`.
 
-That's it! After submitting an experiment, users can easily see the best validation metric observed
-across all trials over time in the WebUI. After the experiment has completed, they can view the
+That's it! After submitting an experiment, you can easily see the best validation metric observed
+across all trials over time in the WebUI. After the experiment has completed, you can view the
 hyperparameter values for the best-performing trials and then export the associated model
 checkpoints for downstream serving.
 
 .. image:: /assets/images/adaptive-asha-experiment-detail.png
+   :alt: You can use the Determined WebUI to see the best validation metric observed across all trials over time.
 
 *****************
  Adaptive Search

--- a/docs/training/index.rst
+++ b/docs/training/index.rst
@@ -2,6 +2,9 @@
  Model Developer Guide
 #######################
 
+.. meta::
+   :description: The Model Developer Guide to using Determined AI including core concepts, resources for preparing your environment, using a training API, submitting an experiment, and best practices.
+
 .. raw:: html
 
    <div class="landing">

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -2,8 +2,8 @@
  Tutorials
 ###########
 
-Learn the basics of working with Determined and how to port your existing code to the Determined
-environment.
+.. meta::
+   :description: Choose a tutorial to help you get started training machine learning models. You'll find beginner level and more advanced tutorials with links to user guides and examples.
 
 ************
  Quickstart

--- a/docs/tutorials/pytorch-mnist-local-qs.rst
+++ b/docs/tutorials/pytorch-mnist-local-qs.rst
@@ -5,7 +5,7 @@
 #########################################
 
 .. meta::
-   :description: Learn how to integrate the PyTorch MNIST model into Determined AI using only a single CPU or GPU.
+   :description: Learn how to run your first experiment in Determined by working with the PyTorch MNIST model. You'll need only a single CPU or GPU.
    :keywords: PyTorch API,MNIST,model developer,quickstart
 
 In this tutorial, we’ll show you how to integrate a training example with the Determined

--- a/docs/tutorials/pytorch-mnist-tutorial.rst
+++ b/docs/tutorials/pytorch-mnist-tutorial.rst
@@ -4,6 +4,10 @@
  PyTorch MNIST Tutorial
 ########################
 
+.. meta::
+   :description: Using a simple image classification model for the MNIST dataset, you'll Learn how to port an existing PyTorch model to Determined.
+   :keywords: PyTorch API,MNIST,model developer,quickstart
+
 This tutorial describes how to port an existing PyTorch model to Determined. We will port a simple
 image classification model for the MNIST dataset. This tutorial is based on the official `PyTorch
 MNIST example <https://github.com/PyTorch/examples/blob/master/mnist/main.py>`_.

--- a/docs/tutorials/pytorch-porting-tutorial.rst
+++ b/docs/tutorials/pytorch-porting-tutorial.rst
@@ -2,6 +2,9 @@
  PyTorch Porting Tutorial
 ##########################
 
+.. meta::
+   :description: By walking through this simple example, you'll learn how to organize your PyTorch code into Determined's PyTorch Trial API.
+
 Determined provides a high-level framework APIs for PyTorch, Keras, and Estimators that let users
 describe their model without boilerplate code. Determined reduces boilerplate by providing a
 state-of-the-art training loop that provides distributed training, hyperparameter search, automatic

--- a/docs/tutorials/tf-mnist-tutorial.rst
+++ b/docs/tutorials/tf-mnist-tutorial.rst
@@ -2,6 +2,9 @@
  TensorFlow Keras Fashion MNIST Tutorial
 #########################################
 
+.. meta::
+   :description: Learn how to use a TensorFlow model in Determined by porting an existing tf.keras model. We'll use a simple image classification model for the Fashion MNIST dataset.
+
 This tutorial describes how to port an existing ``tf.keras`` model to Determined. We will port a
 simple image classification model for the Fashion MNIST dataset. This tutorial is based on the
 official `TensorFlow Basic Image Classification Tutorial


### PR DESCRIPTION
for compliance and SEO purposes, 

- add meta descriptions to main index pages, api user guide pages, main reference pages, tutorials
- add alt tags to images


Tests
- [x] each meta description should strive to meet 150-170 characters
- [x] each meta description represents the content on the page
- [x] each meta description is unique
- [x] each description includes a call to action where possible