### PR TITLE
chore: add warning to det auth login flow

### DIFF
--- a/harness/determined/cli/sso.py
+++ b/harness/determined/cli/sso.py
@@ -83,7 +83,7 @@ def sso(parsed_args: Namespace) -> None:
                 "Your browser should open and prompt you to sign on;"
                 " if it did not, please visit {}".format(sso_url)
             )
-            print("Killing this process before signing on will cancel authentication")
+            print("Killing this process before signing on will cancel authentication.")
             with HTTPServer(
                 ("localhost", CLI_REDIRECT_PORT),
                 make_handler(parsed_args.master, lambda code: sys.exit(code)),

--- a/harness/determined/cli/sso.py
+++ b/harness/determined/cli/sso.py
@@ -83,6 +83,7 @@ def sso(parsed_args: Namespace) -> None:
                 "Your browser should open and prompt you to sign on;"
                 " if it did not, please visit {}".format(sso_url)
             )
+            print("Killing this process before signing on will cancel authentication")
             with HTTPServer(
                 ("localhost", CLI_REDIRECT_PORT),
                 make_handler(parsed_args.master, lambda code: sys.exit(code)),


### PR DESCRIPTION
## Description

SaaS has had a few users report issues with `det auth login` printing the wrong URL. I've validated that the URL that is printed is correct; I suspect the issue here is that users are killing the CLI process before visiting the link, which closes the `localhost` port and gives a connection refused error when visiting the printed link. I've added a print statement warning about this.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9117

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
