### PR TITLE
refactor: simplify config handling in `AddExperiment`.

### DIFF
--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -204,7 +204,8 @@ func compareMetrics(
 }
 
 func isMultiTrialSampleCorrect(expectedMetrics []*commonv1.Metrics,
-	actualMetrics *apiv1.DownsampledMetrics) bool {
+	actualMetrics *apiv1.DownsampledMetrics,
+) bool {
 	// Checking if metric names and their values are equal.
 	for i := 0; i < len(actualMetrics.Data); i++ {
 		allActualAvgMetrics := actualMetrics.Data
@@ -284,6 +285,7 @@ func TestMultiTrialSampleMetrics(t *testing.T) {
 	require.True(t, isMultiTrialSampleCorrect(expectedTrainMetrics, actualAllMetrics[0]))
 	require.True(t, isMultiTrialSampleCorrect(expectedValMetrics, actualAllMetrics[1]))
 }
+
 func TestStreamTrainingMetrics(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
 

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1331,7 +1331,8 @@ func extractSlotInfo(node model.AgentSummary) (numSlots int, devType device.Type
 }
 
 func extractTolerations(tcd *model.TaskContainerDefaultsConfig) (
-	cpuTolerations, gpuTolerations []k8sV1.Toleration) {
+	cpuTolerations, gpuTolerations []k8sV1.Toleration,
+) {
 	if tcd != nil {
 		if tcd.GPUPodSpec != nil {
 			gpuTolerations = tcd.GPUPodSpec.Spec.Tolerations

--- a/master/internal/rm/kubernetesrm/pods_test.go
+++ b/master/internal/rm/kubernetesrm/pods_test.go
@@ -40,7 +40,8 @@ func TestTaintTolerated(t *testing.T) {
 					Key:      "baz",
 					Value:    "qux",
 					Operator: k8sV1.TolerationOpEqual,
-				}},
+				},
+			},
 		}, {
 			expected: false,
 			taint:    taintFooBar,
@@ -99,10 +100,8 @@ func TestAllTaintsTolerated(t *testing.T) {
 	}
 }
 
-var (
-	taintFooBar = k8sV1.Taint{
-		Key:    "foo",
-		Value:  "bar",
-		Effect: k8sV1.TaintEffectNoSchedule,
-	}
-)
+var taintFooBar = k8sV1.Taint{
+	Key:    "foo",
+	Value:  "bar",
+	Effect: k8sV1.TaintEffectNoSchedule,
+}


### PR DESCRIPTION
## Description

The reason for separate `UPDATE` added in https://github.com/determined-ai/determined/pull/5294/files#r1036537936 got lost to the bun-ification.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

Also there're formatting changes because someone did not run `make fmt`. Same as https://github.com/determined-ai/determined/pull/6650/files.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
