### PR TITLE
perf: add latest_validation_id to trials

### DIFF
--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -446,6 +446,21 @@ FROM validation_training_combined_json vtcj WHERE vtcj.trial_id = trials.id;
 	return nil
 }
 
+// updateLatestValidationID updates latest validation based on validations table.
+func (db *PgDB) updateLatestValidationID(ctx context.Context, tx *sqlx.Tx, trialID int) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE trials SET latest_validation_id = (
+			SELECT id
+			FROM validations
+			WHERE trial_id = $1
+			ORDER BY end_time DESC
+			LIMIT 1
+		) WHERE id = $1`, trialID); err != nil {
+		return fmt.Errorf("updating latest validation id for trial %d: %w", trialID, err)
+	}
+	return nil
+}
+
 // updateTotalBatches update precomputed total_batches based on existing steps and validations.
 func (db *PgDB) updateTotalBatches(ctx context.Context, tx *sqlx.Tx, trialID int) error {
 	if _, err := tx.ExecContext(ctx, `
@@ -528,23 +543,27 @@ WHERE trial_id = $1
 			return fmt.Errorf("error getting summary metrics from trials: %w", err)
 		}
 
-		if _, err := tx.NamedExecContext(ctx, fmt.Sprintf(`
+		var metricRowID int
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 INSERT INTO %s
 	(trial_id, trial_run_id, end_time, metrics, total_batches)
 VALUES
-	(:trial_id, :trial_run_id, now(), :metrics, :total_batches)
-`, targetTable), model.TrialMetrics{
-			TrialID:      int(m.TrialId),
-			TrialRunID:   int(m.TrialRunId),
-			Metrics:      metricsBody,
-			TotalBatches: int(m.StepsCompleted),
-		}); err != nil {
+	($1, $2, now(), $3, $4)
+RETURNING id
+`, targetTable),
+			int(m.TrialId), int(m.TrialRunId), metricsBody, int(m.StepsCompleted),
+		).Scan(&metricRowID); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("inserting metrics into %s", targetTable))
 		}
 
 		if rollbackHappened {
 			if err := db.updateTotalBatches(ctx, tx, int(m.TrialId)); err != nil {
 				return errors.Wrap(err, "rollback")
+			}
+
+			if err := db.updateLatestValidationID(ctx, tx, int(m.TrialId)); err != nil {
+				return fmt.Errorf(
+					"rollback updating latest validation ID for trial %d: %w", m.TrialId, err)
 			}
 
 			if err := db.fullTrialSummaryMetricsRecompute(ctx, tx, int(m.TrialId)); err != nil {
@@ -559,11 +578,17 @@ VALUES
 				m.Metrics.AvgMetrics,
 			)
 
+			var latestValidationID *int
+			if isValidation {
+				latestValidationID = &metricRowID
+			}
+
 			if _, err := tx.ExecContext(ctx, `
 UPDATE trials SET total_batches = GREATEST(total_batches, $2),
-summary_metrics = $3, summary_metrics_timestamp = NOW()
+summary_metrics = $3, summary_metrics_timestamp = NOW(),
+latest_validation_id = coalesce($4, latest_validation_id)
 WHERE id = $1;
-`, m.TrialId, m.StepsCompleted, summaryMetrics); err != nil {
+`, m.TrialId, m.StepsCompleted, summaryMetrics, latestValidationID); err != nil {
 				return errors.Wrap(err, "updating trial total batches")
 			}
 		}

--- a/master/static/migrations/20230428102519_add-last-validation-id.tx.down.sql
+++ b/master/static/migrations/20230428102519_add-last-validation-id.tx.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.trials DROP latest_validation_id;

--- a/master/static/migrations/20230428102519_add-last-validation-id.tx.up.sql
+++ b/master/static/migrations/20230428102519_add-last-validation-id.tx.up.sql
@@ -1,0 +1,14 @@
+ALTER TABLE public.trials
+    ADD COLUMN latest_validation_id int REFERENCES public.raw_validations(id) NULL;
+
+UPDATE trials SET latest_validation_id = sub.id
+FROM (
+    SELECT id, trial_id, ROW_NUMBER() OVER(
+        PARTITION BY trial_id
+        ORDER BY end_time DESC
+    ) AS rank
+    FROM validations
+) sub
+WHERE
+  rank = 1 AND
+  sub.trial_id = trials.id;


### PR DESCRIPTION
## Description

Adds ```latest_validation_id``` to optimize experiments search query.

## Test Plan

Integration test

## Commentary (optional)

We can't update `proto_get_trials_plus` to use this column since `proto_get_trials_plus` only considered metrics with the searcher metric reported. 

Experiment search doesn't have this consideration. Going to check with WEB on this being intended.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
