### PR TITLE
chore: add a util for testing migrations

### DIFF
--- a/tools/scripts/test-reversability.py
+++ b/tools/scripts/test-reversability.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+"""
+test the reversibility of a migration by running it in a transaction both ways and
+timing it.
+"""
+
+import contextlib
+import os
+import pathlib
+import time
+from typing import Dict, Generator, List, Sequence, Set, Tuple
+
+import psycopg  # pip install "psycopg[binary]"
+
+DB_NAME = os.environ.get("DET_DB_NAME", "determined")
+DB_USERNAME = os.environ.get("DET_DB_USERNAME", "postgres")
+DB_PASSWORD = os.environ.get("DET_DB_PASSWORD", "postgres")
+DB_HOST = os.environ.get("DET_DB_HOST", "localhost")
+DB_PORT = os.environ.get("DET_DB_PORT", "5432")
+
+MIGRATIONS_DIR = pathlib.Path("master/static/migrations")
+
+
+@contextlib.contextmanager
+def db_cursor() -> Generator[psycopg.Cursor, None, None]:
+    conn = psycopg.connect(
+        dbname=DB_NAME,
+        user=DB_USERNAME,
+        password=DB_PASSWORD,
+        host=DB_HOST,
+        port=DB_PORT,
+    )
+    cur = conn.cursor()
+    yield cur
+    conn.close()
+
+
+@contextlib.contextmanager
+def db_transaction():
+    with db_cursor() as cur:
+        try:
+            cur.execute("BEGIN")
+            yield cur
+        except Exception:
+            print("rolling back")
+            cur.execute("ROLLBACK")
+            raise
+        else:
+            cur.execute("COMMIT")
+
+
+# query the current db schemas for all tables into a dict
+def get_db_schemas() -> Dict[str, Set[str]]:
+    with db_cursor() as cur:
+        cur.execute(
+            """
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+            """
+        )
+        rows = cur.fetchall()
+        schemas = {}
+        for table_name, column_name in rows:
+            if table_name not in schemas:
+                schemas[table_name] = set()
+            schemas[table_name].add(column_name)
+        return schemas
+
+
+def run_migration(name: str, statements: str) -> None:
+    with db_transaction() as cur:
+        start = time.time()
+        cur.execute(statements)  # type: ignore
+        end = time.time()
+        print(f"Ran {name} in {end - start:.2f}s")
+
+
+def run_sql_file(file_path: pathlib.Path) -> None:
+    """
+    run a set of sql statements from a file in a transaction
+    and time it.
+    """
+    with file_path.open("r") as f:
+        sql_statements = f.read()
+    run_migration(file_path.name, sql_statements)
+
+
+def get_migration_paths(query: str) -> List[Tuple[pathlib.Path, pathlib.Path]]:
+    migration_files = list(MIGRATIONS_DIR.glob(f"*{query}*"))
+    assert len(migration_files) % 2 == 0, f"expected even files for {query} got {migration_files}"
+    up_files = [f for f in migration_files if "up" in f.name]
+    down_files = [f for f in migration_files if "down" in f.name]
+    return list(zip(sorted(up_files), sorted(down_files)))
+
+
+def diff_dicts(old: Dict[str, Set[str]], new: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
+    """
+    return a dict of table names to the set of changes
+    """
+    diff = {}
+    for table_name, old_columns in old.items():
+        if table_name not in new:
+            diff[table_name] = old_columns
+        else:
+            new_columns = new[table_name]
+            if old_columns != new_columns:
+                diff[table_name] = old_columns ^ new_columns
+    return diff
+
+
+def test_det_migration(name: str, reverse: bool = False):
+    """
+    given a migration name:
+    - construct the file path to up and down directions
+    - get the current schema
+    - run the up migration and time it
+    - run the down migration and time it
+    - get the new schema
+    - compare the new schema to the old schema
+    """
+    migration_files = get_migration_paths(name)
+    assert len(migration_files) == 1, f"expected one migration for {name} got {migration_files}"
+    up_file, down_file = migration_files[0]
+    assert up_file.exists(), f"{up_file} does not exist"
+    assert down_file.exists(), f"{down_file} does not exist"
+    name = up_file.name.split(".up")[0]
+    migration_files = [up_file, down_file] if not reverse else [down_file, up_file]
+    statements = "\n".join([f.read_text() for f in migration_files])
+
+    old_schema = get_db_schemas()
+    run_migration(name + "-merged", statements)
+    # for file in migration_files:
+    #     print(f"Running migration {file}")
+    #     run_sql_file(file)
+    new_schema = get_db_schemas()
+    assert (
+        old_schema == new_schema
+    ), f"{up_file} is not reversible, {diff_dicts(old_schema, new_schema)}"
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="test timing and reversibility of migrations")
+    parser.add_argument("name", type=str, help="name of migration to test")
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="run the migration in reverse",
+    )
+    args = parser.parse_args()
+
+    test_det_migration(args.name, args.reverse)


### PR DESCRIPTION
## Description

- test reversibility
- timing
- attempt to detect differences in schema after and rollback and rollforward

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

sample issue caught (an existing issue in `main`)
(https://www.postgresql.org/docs/11/sql-altertable.html dropping the column drops the index as well)
```
hbp ➜ determined git:(test-migration-reverse) ✗ py tools/scripts/test-reversability.py add-searcher-me --reverse
rolling back
Traceback (most recent call last):
  File "/Users/hmd/projects/da/determined/tools/scripts/test-reversability.py", line 155, in <module>
    test_det_migration(args.name, args.reverse)
  File "/Users/hmd/projects/da/determined/tools/scripts/test-reversability.py", line 133, in test_det_migration
    run_migration(name + "-merged", statements)
  File "/Users/hmd/projects/da/determined/tools/scripts/test-reversability.py", line 75, in run_migration
    cur.execute(statements)  # type: ignore
  File "/Users/hmd/.pyenv/versions/3.10.1/lib/python3.10/site-packages/psycopg/cursor.py", line 723, in execute
    raise ex.with_traceback(None)
psycopg.errors.UndefinedObject: index "ix_trials_metric_value" does not exist

```

could use a more robust way of detecting changes between before and after.

we're using go-migrate. maybe using their cli tool to run a particular migration is a better idea? https://github.com/golang-migrate/migrate/tree/master/cmd/migrate . not sure if we want to add that as a binary dependency here although it would help if we needed to migrate up or down multiple versions.

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
