### PR TITLE
fix: GC jobs do not inherit sbatch_args from custom resource_pool [DET-9363]

### DIFF
--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -120,8 +121,7 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 		t.Base.TaskContainerDefaults, err = t.rm.TaskContainerDefaults(
 			ctx,
 			rp,
-			model.TaskContainerDefaultsConfig{})
-
+			config.GetMasterConfig().TaskContainerDefaults)
 		if err != nil {
 			return fmt.Errorf("creating task container defaults: %v", err)
 		}

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -116,6 +116,12 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 		}, t.db, t.rm, t.taskLogger)
 
 		t.allocation, _ = ctx.ActorOf(t.allocationID, allocation)
+
+		t.Base.TaskContainerDefaults, err = t.rm.TaskContainerDefaults(ctx, rp, model.TaskContainerDefaultsConfig{})
+
+		if err != nil {
+			return fmt.Errorf("creating task container defaults: %v", err)
+		}
 	case task.BuildTaskSpec:
 		if ctx.ExpectingResponse() {
 			ctx.Respond(t.ToTaskSpec())

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -117,7 +117,10 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 
 		t.allocation, _ = ctx.ActorOf(t.allocationID, allocation)
 
-		t.Base.TaskContainerDefaults, err = t.rm.TaskContainerDefaults(ctx, rp, model.TaskContainerDefaultsConfig{})
+		t.Base.TaskContainerDefaults, err = t.rm.TaskContainerDefaults(
+			ctx,
+			rp,
+			model.TaskContainerDefaultsConfig{})
 
 		if err != nil {
 			return fmt.Errorf("creating task container defaults: %v", err)

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -118,6 +118,8 @@ func (t *checkpointGCTask) Receive(ctx *actor.Context) error {
 
 		t.allocation, _ = ctx.ActorOf(t.allocationID, allocation)
 
+		// t.Base is just a shallow copy of the m.taskSpec on the master, so
+		// use caution when mutating it.
 		t.Base.TaskContainerDefaults, err = t.rm.TaskContainerDefaults(
 			ctx,
 			rp,

--- a/master/pkg/tasks/task_gc.go
+++ b/master/pkg/tasks/task_gc.go
@@ -46,6 +46,8 @@ func (g GCCkptSpec) ToTaskSpec() TaskSpec {
 	res.Environment = schemas.WithDefaults(env)
 	res.ExtraEnvVars = map[string]string{"DET_TASK_TYPE": string(model.TaskTypeCheckpointGC)}
 	res.ResourcesConfig = schemas.WithDefaults(res.ResourcesConfig)
+	res.SlurmConfig = defaultConfig.SlurmConfig()
+	res.PbsConfig = defaultConfig.PbsConfig()
 
 	res.WorkDir = DefaultWorkDir
 


### PR DESCRIPTION
## Description

These code changes allow the "sbatch_args" and "pbsbatch_args" defined in the resource pool or partition overrides section of the "master.yaml" to be consumed and passed to the Workload Manager (i.e., "Slurm" or "PBS") for GC tasks.

## Test Plan

See "Test Plan" for "determined-ee" in pull request https://github.com/determined-ai/determined-ee/pull/827

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
