### PR TITLE
fix: metricName escaping using bun.Ident

### DIFF
--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -356,8 +356,8 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		ColumnExpr("(metrics ->'?' ->> 'epoch')::float8 as epoch", bun.Safe(metricsObjectName))
 
 	for _, metricName := range metricNames {
-		subq = subq.ColumnExpr("(metrics ->'?' ->> ?)::float8 as "+metricName,
-			bun.Safe(metricsObjectName), metricName)
+		subq = subq.ColumnExpr("(metrics ->'?' ->> ?)::float8 as ?",
+			bun.Safe(metricsObjectName), metricName, bun.Ident(metricName))
 	}
 
 	subq = subq.Where("trial_id = ?", trialID).OrderExpr("random()").


### PR DESCRIPTION
## Description

On a decision tree demo, we have unusual metric names which are not handled well by our metrics API. Traced error to how these are queried from the JSONB column in the DB.  The new code will use `bun.Ident`

## Test Plan

`cd examples/decision_trees`
`det e create gbt_titanic_estimator/const.yaml gbt_titanic_estimator`

When the experiment completes, look for a chart with a point from validation metrics

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.