### PR TITLE
docs: summary metric migration downtime

### DIFF
--- a/docs/release-notes/summary_metrics.rst
+++ b/docs/release-notes/summary_metrics.rst
@@ -8,7 +8,7 @@
    This has the effect of causing upgrades from a previous version to this version or a future
    version to take an extended period of time for clusters to upgrade with a large amount of trials
    and training steps reported. An example database with 10,000 trials with 125 million training
-   metrics can have 6+ hours of downtime upgrading.
+   metrics on a small instance can have 6+ hours of downtime upgrading.
 
    As an optional mitigation users with large databases can choose to manually run the `this sql
    file

--- a/docs/release-notes/summary_metrics.rst
+++ b/docs/release-notes/summary_metrics.rst
@@ -1,0 +1,17 @@
+:orphan:
+
+**Improvements**
+
+-  Trials: Metric storage has been optimized for reading summaries of metrics reported during a
+   trial.
+
+   This has the effect of causing upgrades from a previous version to this version or a future
+   version to take an extended period of time for clusters to upgrade with a large amount of trials
+   and training steps reported. An example database with 10,000 trials with 125 million training
+   metrics can have 6+ hours of downtime upgrading.
+
+   As an optional mitigation users with large databases can choose to manually run the `this sql
+   file
+   <https://github.com/determined-ai/determined/blob/main/master/static/migrations/20230425100036_add-summary-metrics.tx.up.sql>`__
+   against their cluster's database in advance of a version upgrade while it is still running to
+   minimize downtime. This is purely optional and only recommended for sufficiently large databases.


### PR DESCRIPTION
## Description

Document summary metrics migration.



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
