### PR TITLE
docs: Help users find exp conf ref

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@
    Python SDK <reference/python-sdk>
    REST API <reference/rest-api>
    Training Reference <reference/reference-training/index>
+   Experiment Configuration Reference <reference/reference-training/experiment-config-reference>
    Model Hub Reference <reference/reference-model-hub/index>
    Deployment Reference <reference/reference-deploy/index>
    Job Configuration Reference <reference/reference-interface/job-config-reference>


### PR DESCRIPTION
Help users find the experiment configuration reference by adding the link to the top level left side navigation