### PR TITLE
chore: release note on breaking TF changes to Keras optimizers

### DIFF
--- a/docs/release-notes/legacy-optimizers.rst
+++ b/docs/release-notes/legacy-optimizers.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+**Breaking Changes**
+
+-  Experiment: Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11
+      -  Experiments now use images with TensorFlow 2.11 by default. TensorFlow users who are not
+         explicitly configuring their training image(s) will need to adapt their model code to
+         reflect these changes. Users will likely need to use Keras optimizers located in
+         ``tensorflow.keras.optimizers.legacy``. Depending on the sophistication of users' model
+         code, there may be other breaking changes. Determined is not responsible for these
+         breakages. See the `TensorFlow release notes
+         <https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0>`_ for more details.
+
+      -  PyTorch users and users who specify custom images should not be affected.


### PR DESCRIPTION
## Description

**Breaking Changes**

-  Experiment: Optimizer has to be an instance of tensorflow.keras.optimizers.legacy.Optimizer starting from Keras 2.11
      -  Experiments now use images with TensorFlow 2.11 by default. TensorFlow users who are not
         explicitly configuring their training image(s) will need to adapt their model code to
         reflect these changes. Users will likely need to use Keras optimizers located in
         ``tensorflow.keras.optimizers.legacy``. Depending on the sophistication of users' model
         code, there may be other breaking changes. Determined is not responsible for these
         breakages. See the `TensorFlow release notes
         <https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0>`_ for more details.

      -  PyTorch users and users who specify custom images should not be affected.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

This note is somewhat redundant with (but takes priority over) the one in #6681.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
