### PR TITLE
fix: dataloader skip on resume

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -426,7 +426,7 @@ class _PyTorchTrialController:
         return util.is_overridden(self.trial.evaluate_full_dataset, PyTorchTrial)
 
     def _set_data_loaders(self) -> None:
-        skip_batches = self.state.batches_trained
+        skip_batches = self.start_from_batch
 
         num_replicas = self.context.distributed.size
         rank = self.context.distributed.rank


### PR DESCRIPTION
## Description

Dataloaders are created before state is loaded. The state variable at this moment is invalid, and `state.batches_trained` is not a proper value for the skip argument of `get_data_loader` . 
This should be changed to use the same value that the `training_enumerator` sees.

## Checklist

- [X] Changes have been manually QA'd

## Ticket

No Ticket