### PR TITLE
ci: make custom searcher dump failed trial logs

### DIFF
--- a/e2e_tests/tests/experiment/__init__.py
+++ b/e2e_tests/tests/experiment/__init__.py
@@ -10,6 +10,7 @@ from .experiment import (
     kill_experiments,
     kill_single,
     kill_trial,
+    print_trial_logs,
     check_if_string_present_in_trial_logs,
     assert_patterns_in_trial_logs,
     create_experiment,

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -20,6 +20,14 @@ from tests.fixtures.custom_searcher import searchers
 TIMESTAMP = int(time.time())
 
 
+def check_trial_state(trial: bindings.trialv1Trial, expect: bindings.experimentv1State) -> bool:
+    """If the trial is in an unexpected state, dump logs and return False."""
+    if trial.state == expect:
+        return True
+    exp.print_trial_logs(trial.id)
+    return False
+
+
 @pytest.fixture
 def client_login() -> Iterator[None]:
     client.login(master=conf.make_master_url())
@@ -154,8 +162,13 @@ def test_run_random_searcher_exp_core_api(
     assert experiment.numTrials == 5
 
     trials = bindings.get_GetExperimentTrials(session, experimentId=experiment.id).trials
+
+    ok = True
     for trial in trials:
-        assert trial.state == bindings.experimentv1State.COMPLETED
+        ok = ok and check_trial_state(trial, bindings.experimentv1State.COMPLETED)
+    assert ok, "some trials failed"
+
+    for trial in trials:
         assert trial.totalBatchesProcessed == 500
 
     # check logs to ensure failures actually happened
@@ -219,8 +232,13 @@ def test_pause_multi_trial_random_searcher_core_api() -> None:
     trials = bindings.get_GetExperimentTrials(
         api_utils.determined_test_session(), experimentId=experiment.id
     ).trials
+
+    ok = True
     for trial in trials:
-        assert trial.state == bindings.experimentv1State.COMPLETED
+        ok = ok and check_trial_state(trial, bindings.experimentv1State.COMPLETED)
+    assert ok, "some trials failed"
+
+    for trial in trials:
         assert trial.totalBatchesProcessed == 500
 
 
@@ -348,8 +366,10 @@ def test_run_asha_batches_exp(tmp_path: pathlib.Path, client_login: None) -> Non
     # at least 1 trial in rung 3 (#batches = 2000)
     assert sum(t.totalBatchesProcessed == 2000 for t in response_trials) >= 1
 
+    ok = True
     for trial in response_trials:
-        assert trial.state == bindings.experimentv1State.COMPLETED
+        ok = ok and check_trial_state(trial, bindings.experimentv1State.COMPLETED)
+    assert ok, "some trials failed"
 
 
 @pytest.mark.e2e_cpu_2a


### PR DESCRIPTION
Failing tests should always be debuggable from the failed test logs, but that doesn't work if the failed test logs don't contain what happened inside training.

## Test Plan

- [x] manually force failure and verify it prints logs

## Commentary

[example of unhelpful failure](https://app.circleci.com/pipelines/github/determined-ai/determined/38009/workflows/ec106894-d444-4c64-8bea-90fdde83ab90/jobs/1390142)