### PR TITLE
fix: Remove canCreateExperiment experiment param [WEB-1205]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1255,7 +1255,7 @@ func (a *apiServer) CreateExperiment(
 		}
 		return nil, status.Errorf(codes.InvalidArgument, "invalid experiment: %s", err)
 	}
-	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *user, p, dbExp); err != nil {
+	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *user, p); err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
@@ -1830,9 +1830,7 @@ func (a *apiServer) MoveExperiment(
 		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments.",
 			req.DestinationProjectId)
 	}
-	// need to update CanCreateExperiment to check project when experiment is nil
-	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, curUser, destProject,
-		nil); err != nil {
+	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, curUser, destProject); err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 
@@ -1867,9 +1865,7 @@ func (a *apiServer) MoveExperiments(
 		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments.",
 			req.DestinationProjectId)
 	}
-	// need to update CanCreateExperiment to check project when experiment is nil
-	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *curUser, destProject,
-		nil); err != nil {
+	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *curUser, destProject); err != nil {
 		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -973,7 +973,7 @@ func TestAuthZCreateExperiment(t *testing.T) {
 	// Can't create experiment deny.
 	expectedErr = status.Errorf(codes.PermissionDenied, "canCreateExperimentError")
 	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
+	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canCreateExperimentError")).Once()
 	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
 		ProjectId: int32(projectID),
@@ -984,7 +984,7 @@ func TestAuthZCreateExperiment(t *testing.T) {
 	// Can't activate experiment deny.
 	expectedErr = status.Errorf(codes.PermissionDenied, "canActivateExperimentError")
 	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
+	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything).
 		Return(nil).Once()
 	authZExp.On("CanEditExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
 		fmt.Errorf("canActivateExperimentError")).Once()

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -597,7 +597,7 @@ func (m *Master) postExperiment(c echo.Context) (interface{}, error) {
 	}
 
 	// Can we create the experiment?
-	if err = expauth.AuthZProvider.Get().CanCreateExperiment(ctx, user, p, dbExp); err != nil {
+	if err = expauth.AuthZProvider.Get().CanCreateExperiment(ctx, user, p); err != nil {
 		return nil, echo.NewHTTPError(http.StatusForbidden, err.Error())
 	}
 	if validateOnly {

--- a/master/internal/core_experiment_intg_test.go
+++ b/master/internal/core_experiment_intg_test.go
@@ -114,7 +114,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 	// Can't create experiment deny.
 	expectedErr := echo.NewHTTPError(http.StatusForbidden, "canCreateExperimentError")
 	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
+	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canCreateExperimentError")).Once()
 	err = echoPostExperiment(ctx, api, t, CreateExperimentParams{
 		ConfigBytes: minExpConfToYaml(t),
@@ -124,7 +124,7 @@ func TestAuthZPostExperimentEcho(t *testing.T) {
 	// Can't activate experiment deny.
 	expectedErr = echo.NewHTTPError(http.StatusForbidden, "canActivateExperimentError")
 	pAuthZ.On("CanGetProject", mock.Anything, curUser, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
+	authZExp.On("CanCreateExperiment", mock.Anything, curUser, mock.Anything).
 		Return(nil).Once()
 	authZExp.On("CanEditExperiment", mock.Anything, curUser, mock.Anything, mock.Anything).
 		Return(fmt.Errorf("canActivateExperimentError")).Once()

--- a/master/internal/experiment/authz_basic_impl.go
+++ b/master/internal/experiment/authz_basic_impl.go
@@ -78,7 +78,7 @@ func (a *ExperimentAuthZBasic) CanEditExperimentsMetadata(
 
 // CanCreateExperiment always returns a nil error.
 func (a *ExperimentAuthZBasic) CanCreateExperiment(
-	ctx context.Context, curUser model.User, proj *projectv1.Project, e *model.Experiment,
+	ctx context.Context, curUser model.User, proj *projectv1.Project,
 ) error {
 	return nil
 }

--- a/master/internal/experiment/authz_iface.go
+++ b/master/internal/experiment/authz_iface.go
@@ -93,7 +93,7 @@ type ExperimentAuthZ interface {
 
 	// POST /api/v1/experiments
 	CanCreateExperiment(
-		ctx context.Context, curUser model.User, proj *projectv1.Project, e *model.Experiment,
+		ctx context.Context, curUser model.User, proj *projectv1.Project,
 	) error
 	CanForkFromExperiment(ctx context.Context, curUser model.User, e *model.Experiment) error
 

--- a/master/internal/mocks/authz_experiment_iface.go
+++ b/master/internal/mocks/authz_experiment_iface.go
@@ -21,13 +21,13 @@ type ExperimentAuthZ struct {
 	mock.Mock
 }
 
-// CanCreateExperiment provides a mock function with given fields: ctx, curUser, proj, e
-func (_m *ExperimentAuthZ) CanCreateExperiment(ctx context.Context, curUser model.User, proj *projectv1.Project, e *model.Experiment) error {
-	ret := _m.Called(ctx, curUser, proj, e)
+// CanCreateExperiment provides a mock function with given fields: ctx, curUser, proj
+func (_m *ExperimentAuthZ) CanCreateExperiment(ctx context.Context, curUser model.User, proj *projectv1.Project) error {
+	ret := _m.Called(ctx, curUser, proj)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, model.User, *projectv1.Project, *model.Experiment) error); ok {
-		r0 = rf(ctx, curUser, proj, e)
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *projectv1.Project) error); ok {
+		r0 = rf(ctx, curUser, proj)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
## Description

This is a longer-term fix for the EE update begun in https://github.com/determined-ai/determined-ee/pull/832

We will determine `canCreateExperiment` permission from the context project, not the experiment (the experiment might not be created, or might be moving into a new project and workspace).  The experiment parameter is no longer needed.

There should be no effect in OSS

## Test Plan

- Create an experiment from the CLI
- Move an experiment between projects from the CLI or WebUI

## Commentary

I looked into an unrelated WebUI issue where the current project is an option in MoveExperimentModal. This modal can sometimes be used with multiple experiments. Even when a single experiment / `sourceProjectId` is provided, it's the default value of the destination project dropdown.  So filtering out this project only replaces the current project name with the current project id (e.g. 202).

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.