### PR TITLE
fix: Remove redundant scroll bar for new experiment list

### DIFF
--- a/webui/react/src/components/Markdown.tsx
+++ b/webui/react/src/components/Markdown.tsx
@@ -3,6 +3,7 @@ import { default as MarkdownViewer } from 'markdown-to-jsx';
 import React, { useMemo } from 'react';
 
 import Pivot from 'components/kit/Pivot';
+import useResize from 'hooks/useResize';
 import Spinner from 'shared/components/Spinner/Spinner';
 
 import css from './Markdown.module.scss';
@@ -48,6 +49,7 @@ const Markdown: React.FC<Props> = ({
   onChange,
   onClick,
 }: Props) => {
+  const resize = useResize();
   const tabItems: TabsProps['items'] = useMemo(() => {
     return [
       {
@@ -61,6 +63,7 @@ const Markdown: React.FC<Props> = ({
               }>
               <MonacoEditor
                 defaultValue={markdown}
+                height={resize.height - 420}
                 language="markdown"
                 options={{
                   folding: false,
@@ -87,7 +90,7 @@ const Markdown: React.FC<Props> = ({
         label: 'Preview',
       },
     ];
-  }, [markdown, onChange, onClick]);
+  }, [markdown, onChange, onClick, resize]);
 
   return (
     <div aria-label="markdown-editor" className={css.base} tabIndex={0}>

--- a/webui/react/src/components/Navigation.module.scss
+++ b/webui/react/src/components/Navigation.module.scss
@@ -1,6 +1,8 @@
 .base {
   display: flex;
   flex-grow: 1;
+  height: calc(var(--vh, 1vh) * 100);
+  overflow: hidden;
 
   [class*='NavigationSideBar_base_'] {
     flex-grow: 0;
@@ -18,7 +20,7 @@
   }
   & > main {
     flex-grow: 1;
-    height: calc(var(--vh, 1vh) * 100);
+    height: 100%;
     overflow: auto;
   }
 

--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -135,6 +135,7 @@ const LogViewer: React.FC<Props> = ({
   const [showButtons, setShowButtons] = useState<boolean>(false);
   const [logs, setLogs] = useState<ViewerLog[]>([]);
   const containerSize = useResize(logsRef);
+  const pageSize = useResize();
   const charMeasures = useGetCharMeasureInContainer(logsRef);
 
   const { dateTimeWidth, maxCharPerLine } = useMemo(() => {
@@ -578,7 +579,7 @@ const LogViewer: React.FC<Props> = ({
         <div className={css.container}>
           <div className={css.logs} ref={logsRef}>
             <VariableSizeList
-              height={containerSize.height}
+              height={pageSize.height - 200}
               itemCount={logs.length}
               itemData={logs}
               itemSize={getItemHeight}

--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -579,7 +579,7 @@ const LogViewer: React.FC<Props> = ({
         <div className={css.container}>
           <div className={css.logs} ref={logsRef}>
             <VariableSizeList
-              height={pageSize.height - 200}
+              height={pageSize.height - 240}
               itemCount={logs.length}
               itemData={logs}
               itemSize={getItemHeight}

--- a/webui/react/src/components/kit/Pivot.module.scss
+++ b/webui/react/src/components/kit/Pivot.module.scss
@@ -13,8 +13,7 @@
     text-shadow: none;
   }
   &:global(.ant-tabs > .ant-tabs-content-holder > .ant-tabs-content) {
-    height: 100%;
-    overflow: auto;
+    height: auto;
   }
   &:global(.ant-tabs-top > .ant-tabs-nav::before),
   &:global(.ant-tabs-bottom > .ant-tabs-nav::before),

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -525,7 +525,7 @@ const CodeViewer: React.FC<Props> = ({
             <h5>Please, choose a file to preview.</h5>
           ) : editorMode === 'monaco' ? (
             <MonacoEditor
-              height={resize.height - 320}
+              height={resize.height - 240}
               language={getSyntaxHighlight()}
               options={{
                 minimap: {

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -525,7 +525,7 @@ const CodeViewer: React.FC<Props> = ({
             <h5>Please, choose a file to preview.</h5>
           ) : editorMode === 'monaco' ? (
             <MonacoEditor
-              height="100%"
+              height={resize.height - 240}
               language={getSyntaxHighlight()}
               options={{
                 minimap: {

--- a/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/CodeViewer/CodeViewer.tsx
@@ -525,7 +525,7 @@ const CodeViewer: React.FC<Props> = ({
             <h5>Please, choose a file to preview.</h5>
           ) : editorMode === 'monaco' ? (
             <MonacoEditor
-              height={resize.height - 240}
+              height={resize.height - 320}
               language={getSyntaxHighlight()}
               options={{
                 minimap: {

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -60,8 +60,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const colorMap = useGlasbey(selectedExperimentIds);
   const pageRef = useRef<HTMLElement>(null);
-  const { width, height } = useResize(pageRef);
-
+  const { width } = useResize(pageRef);
+  const { height: wholePageHeight } = useResize();
   const [scrollPositionSetCount] = useState(observable(0));
 
   const handleScroll = useCallback(
@@ -234,7 +234,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         ) : error ? (
           <Error />
         ) : (
-          <>
+          <div>
             <TableActionBar
               experiments={experiments}
               filters={experimentFilters}
@@ -255,7 +255,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               fetchExperiments={fetchExperiments}
               handleScroll={handleScroll}
               handleUpdateExperimentList={handleUpdateExperimentList}
-              height={height - 20}
+              height={wholePageHeight - 140}
               page={page}
               project={project}
               projectColumns={projectColumns}
@@ -267,7 +267,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               setSortableColumnIds={setVisibleColumns}
               sortableColumnIds={settings.columns}
             />
-          </>
+          </div>
         )}
       </>
     </Page>

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -255,7 +255,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               fetchExperiments={fetchExperiments}
               handleScroll={handleScroll}
               handleUpdateExperimentList={handleUpdateExperimentList}
-              height={height}
+              height={height - 20}
               page={page}
               project={project}
               projectColumns={projectColumns}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -234,7 +234,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         ) : error ? (
           <Error />
         ) : (
-          <div>
+          <>
             <TableActionBar
               experiments={experiments}
               filters={experimentFilters}
@@ -267,7 +267,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               setSortableColumnIds={setVisibleColumns}
               sortableColumnIds={settings.columns}
             />
-          </div>
+          </>
         )}
       </>
     </Page>

--- a/webui/react/src/pages/F_ExpList/glide-table/exceptions.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/exceptions.tsx
@@ -93,7 +93,7 @@ export const Error: React.FC<{ fetchExperiments?: () => void }> = ({ fetchExperi
 
 export const Loading: React.FC<{ width: number }> = ({ width }) => (
   <>
-    {[...Array(22)].map((x, i) => (
+    {[...Array(21)].map((x, i) => (
       <Row key={i} style={{ paddingBottom: '4px' }}>
         <SkeletonButton style={{ width: width - 20 }} />
       </Row>


### PR DESCRIPTION
This PR duplicates the https://github.com/determined-ai/determined/pull/6699, which get merged then accidentally removed.  

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
-  New experiment list page should have only 1 scroll bar.
- Trials page should have only 1 scroll bar.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Navigate to `/det/projects/{pro_id}/experiments?f_explist_v2=on`
Verify that there is only one scroll bar vertically 

Before:
<img width="1908" alt="Screen Shot 2023-05-02 at 7 09 33 PM" src="https://user-images.githubusercontent.com/40620519/235811531-a5994cfd-cae7-4ff3-8244-0c9ac8dada8b.png">


After:
<img width="1910" alt="Screen Shot 2023-05-02 at 7 03 03 PM" src="https://user-images.githubusercontent.com/40620519/235811524-258c80ca-1e90-4210-80a5-129f2a030af2.png">

Navigate to `/det/experiments/{exp_id}/trials`
Verify that there is only one scroll bar vertically 

Before:
<img width="1594" alt="Screen Shot 2023-05-03 at 11 57 31 AM" src="https://user-images.githubusercontent.com/40620519/236042717-3eafcc24-7f67-4736-b446-52aa531a54f8.png">

After:
<img width="1598" alt="Screen Shot 2023-05-03 at 12 10 54 PM" src="https://user-images.githubusercontent.com/40620519/236042742-bb6ddafa-f70d-408d-a64c-2d08c1c0d6aa.png">

Since this PR changes UI kit style of Pivot, verify that any related pages look reasonable.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->
When we zoom in a lot to like 175%, there won't be multiple scroll bar, but the navigation sidebar may not be as functional.

Before:
<img width="1675" alt="Screen Shot 2023-05-04 at 2 01 45 PM" src="https://user-images.githubusercontent.com/40620519/236303381-889efb04-0188-4cd1-b4a2-c2dccf5643b0.png">


After:
<img width="1714" alt="Screen Shot 2023-05-04 at 1 51 01 PM" src="https://user-images.githubusercontent.com/40620519/236301104-a35583e5-a7b5-4415-b478-750e089efad6.png">


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
WEB-1181

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
