### PR TITLE
chore: support non numeric metrics in CompareTrials, SummarizeTrials, and TrialsSample [DET-9384]

### DIFF
--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -366,6 +366,19 @@ func TestStreamTrainingMetrics(t *testing.T) {
 	}
 }
 
+func TestCompareTrialsNonNumeric(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+	trial0, _, _ := createTestTrialWithMetrics(ctx, t, api, curUser, true)
+	trial1, _, _ := createTestTrialWithMetrics(ctx, t, api, curUser, true)
+
+	resp, err := api.CompareTrials(ctx, &apiv1.CompareTrialsRequest{
+		TrialIds:    []int32{int32(trial0.ID), int32(trial1.ID)},
+		MetricNames: []string{"loss", "textMetric"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 func TestTrialAuthZ(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
 	authZNSC := setupNSCAuthZ()

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -352,13 +352,39 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	subq := db.Bun().NewSelect().TableExpr(tableName).
 		ColumnExpr("(select setseed(1)) as _seed").
 		ColumnExpr("total_batches as batches").
-		ColumnExpr("trial_id").ColumnExpr("end_time as time").
-		ColumnExpr("(metrics ->'?' ->> 'epoch')::float8 as epoch", bun.Safe(metricsObjectName))
+		ColumnExpr("trial_id").ColumnExpr("end_time as time")
 
-	for _, metricName := range metricNames {
-		// TODO: This cast is wrong?!
-		subq = subq.ColumnExpr("(metrics ->'?' ->> ?)::float8 as ?",
-			bun.Safe(metricsObjectName), metricName, bun.Ident(metricName))
+	type summary struct {
+		bun.BaseModel `bun:"table:trials"`
+		Metrics       map[string]any
+	}
+	var summaryMetrics summary
+	if err := db.Bun().NewSelect().Table("trials").
+		ColumnExpr("summary_metrics->? AS metrics", metricsObjectName).
+		Where("id = ?", trialID).
+		Scan(context.TODO(), &summaryMetrics); err != nil {
+		return nil, fmt.Errorf("getting summary metrics for trial %d: %w", trialID, err)
+	}
+
+	for _, metricName := range append(metricNames, "epoch") {
+		metricType := db.MetricTypeString
+		if curSummary, ok := summaryMetrics.Metrics[metricName].(map[string]any); ok {
+			if m, ok := curSummary["type"].(string); ok {
+				metricType = m
+			}
+		}
+
+		cast := "text"
+		switch metricType {
+		case db.MetricTypeNumber:
+			cast = "float8"
+		case db.MetricTypeDate:
+			cast = "timestamp"
+		case db.MetricTypeBool:
+			cast = "boolean"
+		}
+		subq = subq.ColumnExpr("(metrics->?->>?)::? as ?",
+			metricsObjectName, metricName, bun.Safe(cast), bun.Ident(metricName))
 	}
 
 	subq = subq.Where("trial_id = ?", trialID).OrderExpr("random()").
@@ -400,6 +426,8 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		}
 		epoch := new(int32)
 		if results[i]["epoch"] != nil {
+			// ERROR here
+			fmt.Printf("%v %T\n", results[i]["epoch"], results[i]["epoch"])
 			*epoch = int32(results[i]["epoch"].(float64))
 		}
 		var endTime time.Time

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -356,6 +356,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		ColumnExpr("(metrics ->'?' ->> 'epoch')::float8 as epoch", bun.Safe(metricsObjectName))
 
 	for _, metricName := range metricNames {
+		// TODO: This cast is wrong?!
 		subq = subq.ColumnExpr("(metrics ->'?' ->> ?)::float8 as ?",
 			bun.Safe(metricsObjectName), metricName, bun.Ident(metricName))
 	}

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -378,8 +378,6 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		switch metricType {
 		case db.MetricTypeNumber:
 			cast = "float8"
-		case db.MetricTypeDate:
-			cast = "timestamp"
 		case db.MetricTypeBool:
 			cast = "boolean"
 		}
@@ -426,9 +424,12 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		}
 		epoch := new(int32)
 		if results[i]["epoch"] != nil {
-			// ERROR here
-			fmt.Printf("%v %T\n", results[i]["epoch"], results[i]["epoch"])
-			*epoch = int32(results[i]["epoch"].(float64))
+			if e, ok := results[i]["epoch"].(float64); ok {
+				*epoch = int32(e)
+			} else {
+				return nil, fmt.Errorf(
+					"metric 'epoch' has nonnumeric value reported value='%v'", results[i]["epoch"])
+			}
 		}
 		var endTime time.Time
 		if results[i]["time"] == nil {


### PR DESCRIPTION
## Description

Previously these endpoints would error with a non numeric metric reported. Now these will return the values without error.

## Test Plan

Integration test.



## Commentary (optional)

There is a webui aspect to this that will need to be done to update the ui to handle cases of these previously always numeric values that may now be non numeric. 

Release note I think is okay to add on the web aspect? 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
