### PR TITLE
fix: Cluster stats chart displays with single day result [WEB-1206]

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -68,6 +68,7 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
         width: 2,
       });
     });
+    const singlePoint = Object.keys(hoursByLabel).length + (hoursTotal?.length || 0) <= 1;
 
     return {
       axes: [
@@ -90,6 +91,17 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
       ],
       height,
       key: chartKey,
+      scales: {
+        x: {
+          auto: !singlePoint,
+          range: singlePoint
+            ? [
+                new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
+                new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
+              ]
+            : undefined,
+        },
+      },
       series,
       tzDate: (ts) => uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'),
     };

--- a/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
+++ b/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
@@ -20,11 +20,9 @@ const ClustersQueuedChart: React.FC<Props> = ({ poolStats }: Props) => {
   const queuedStats = useMemo(() => {
     if (!poolStats?.aggregates) return;
     const { aggregates } = poolStats;
-    const agg = aggregates.filter(
+    const aggd = aggregates.filter(
       (item) => Date.parse(item.periodStart) >= Date.now() - viewDays * DURATION_DAY,
     );
-    // If aggregates only has one record of today, then do not display.
-    const aggd = agg.length > 1 ? agg : [];
     return {
       hoursAverage: { average: aggd.map((item) => item.seconds / 60) },
       time: aggd.map((item) => item.periodStart),
@@ -49,7 +47,7 @@ const ClustersQueuedChart: React.FC<Props> = ({ poolStats }: Props) => {
         <ClusterHistoricalUsageChart
           chartKey={viewDays}
           hoursByLabel={queuedStats.hoursAverage}
-          label="Queued Minuts"
+          label="Queued Minutes"
           time={queuedStats.time}
         />
       </Section>


### PR DESCRIPTION
## Description

Fixes an issue where the cluster stats 7 day chart was not appearing for a single point. Displays chart with one point and x-axis range of Jan 1 - Dec 31 of same year (I can modify this to be +/- 30 days)

Note: the previous code intentionally avoided making a chart in this case, so confirm if we do want this chart

## Test Plan

On Cluster, select a resource pool card, then the Stats tab

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.