### PR TITLE
fix: allow 0 metrics on old and new charts [WEB-1216]

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -81,7 +81,7 @@ const TrialChart: React.FC<Props> = ({
       }
 
       mWrapper.data.forEach((avgMetrics) => {
-        if (avgMetrics.values[metric.name]) {
+        if (avgMetrics.values[metric.name] || avgMetrics.values[metric.name] === 0) {
           if (!xValues.includes(avgMetrics.batches)) {
             xValues.push(avgMetrics.batches);
           }

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -34,7 +34,7 @@ const summarizedMetricToSeries = (
 
         if (!rawBatchEpochMap[metric.name]) rawBatchEpochMap[metric.name] = [];
 
-        if (value) {
+        if (value || value === 0) {
           rawBatchValuesMap[metric.name]?.push([avgMetrics.batches, value]);
           if (avgMetrics.time)
             rawBatchTimesMap[metric.name]?.push([


### PR DESCRIPTION
## Description

Metrics which were precisely 0 were being treated like other falsey values, not being shown on the chart

These changes affect the current trial metrics chart, and the future one

## Test Plan

Ilia shared a python file where one metric (x2) alternates between 0 and 1, and the other (x3) logs 0.01 and 1.01

For testing I ran the experiment here: http://latest-main.determined.ai:8080/det/experiments/2747/overview

We should see a zig-zag line alternating between 0 and 1 for the metrics: x2 and x3

This should fix the current trial metric chart and the next-gen chart enabled with `f_chart=on`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.