### PR TITLE
chore: test RBAC transfers permission from group to users [WEB-1172]

### DIFF
--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -560,11 +560,13 @@ def test_rbac_describe_role() -> None:
 @pytest.mark.e2e_cpu
 @pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_group_access() -> None:
-    # create relevant workspace, with group having access
+    # create relevant workspace and project, with group having access
     group_name = get_random_string()
     workspace_name = get_random_string()
+    project_name = get_random_string()
     with logged_in_user(ADMIN_CREDENTIALS):
         det_cmd(["workspace", "create", workspace_name], check=True)
+        det_cmd(["project", "create", workspace_name, project_name], check=True)
         det_cmd(["user-group", "create", group_name], check=True)
         det_cmd(
             ["rbac", "assign-role", "WorkspaceAdmin", "-w", workspace_name, "-g", group_name],
@@ -585,3 +587,5 @@ def test_group_access() -> None:
     # with user now in group, access possible
     with logged_in_user(creds1):
         det_cmd(["workspace", "describe", workspace_name], check=True)
+        # test code from https://github.com/determined-ai/determined/pull/6503
+        det_cmd(["project", "list-experiments", workspace_name, project_name], check=True)


### PR DESCRIPTION
## Description

In https://github.com/determined-ai/determined-ee/pull/809 we fixed RBAC logic to make sure users inherit permissions from their groups

This adds an RBAC-only e2e_test where user doesn't have access to a workspace until added to a group

The project / list-experiments code is based on another PR fix

## Test Plan

Needs to be tested in EE.
If you're using devcluster, enable RBAC
In e2e_tests, run `pytest tests/cluster/test_rbac.py::test_group_access`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.