### PR TITLE
chore: porting EE PermissionDenied changes back to OSS [DET-9468]

### DIFF
--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -195,7 +195,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 		if err := command.AuthZProvider.Get().CanGetTensorboard(
 			ctx, *user, workspaceID, spec.Metadata.ExperimentIDs, spec.Metadata.TrialIDs,
 		); err != nil {
-			return err
+			return authz.SubIfUnauthorized(err, apiutils.MapAndFilterErrors(err, nil, nil))
 		}
 	} else {
 		if err := command.AuthZProvider.Get().CanCreateNSC(

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -108,9 +108,10 @@ func (a *apiServer) canDoActionsOnTask(
 		}
 	default: // NTSC case + checkpointGC.
 		if ok, err := canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
+			if !ok || authz.IsPermissionDenied(err) {
+				return errTaskNotFound
+			}
 			return err
-		} else if !ok {
-			return errTaskNotFound
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description

Cherrypicking some changes back into OSS from EE https://github.com/determined-ai/determined-ee/pull/836.

## Test Plan
Make sure CircleCI tests pass, but also manually verify endpoints `POST /api/v1/NSCs` (through `CanCreateNSC()`, launching notebooks/shells/commands/tensorboards) and `GET /api/v1/experiments/:exp_id, GET /tasks, GET /api/v1/NSCs/:nsc_id`.

## Checklist

- [ X] Changes have been manually QA'd
- [ X] User-facing API changes need the "User-facing API Change" label.
- [ X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9468