### PR TITLE
fix: add correct experiment filter grouping

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2015,7 +2015,7 @@ func (a *apiServer) SearchExperiments(
 			return nil, err
 		}
 		experimentQuery = experimentQuery.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
-			_, err = efr.toSQL(experimentQuery)
+			_, err = efr.toSQL(q)
 			return q
 		})
 		if err != nil {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2014,7 +2014,10 @@ func (a *apiServer) SearchExperiments(
 		if err != nil {
 			return nil, err
 		}
-		experimentQuery, err = efr.toSQL(experimentQuery)
+		experimentQuery = experimentQuery.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
+			_, err = efr.toSQL(experimentQuery)
+			return q
+		})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Related comment: 

Currently, the resulting query from the expertiment filter in some cases is joined with other queries using an `OR` operator, which causes incorrect queries. The update here ensures that the resulting experiment filter query is always joined with the rest of the query with an `AND` operator i.e 
```
(project_id = 3) AND // non-filter sql
(((((SELECT COUNT(*) FROM trials t WHERE e.id = t.experiment_id) = 0))) OR ((true)) AND (e.archived = false)) // filter sql
```

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
1. Using the `search-experiments` API supply a `project id` argument and `filter` argument that contains `OR` conjunctions between the  `condition groups`, choose filter options that will always return true. An example from the UI: 
<img width="686" alt="Screen Shot 2023-05-08 at 12 37 12 PM" src="https://user-images.githubusercontent.com/103522725/236892319-295a9dee-82f7-4258-8658-6384e54d7626.png">


Resulting filter expression:

```
{"filterGroup":{"children":[{"children":[{"columnName":"name","kind":"field","location":"LOCATION_TYPE_EXPERIMENT","operator":"contains","type":"COLUMN_TYPE_TEXT","value":null},{"children":[],"conjunction":"and","kind":"group"}],"conjunction":"or","kind":"group"},{"children":[{"columnName":"name","kind":"field","location":"LOCATION_TYPE_EXPERIMENT","operator":"contains","type":"COLUMN_TYPE_TEXT","value":null},{"children":[],"conjunction":"and","kind":"group"}],"conjunction":"or","kind":"group"}],"conjunction":"or","kind":"group"},"showArchived":false}
```
ensure that only experiments within the supplied project ID are returned. 

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
