### PR TITLE
fix: Use position: fixed to replace sticky TrialLogPreview

### DIFF
--- a/webui/react/src/components/TrialLogPreview.module.scss
+++ b/webui/react/src/components/TrialLogPreview.module.scss
@@ -11,10 +11,11 @@ $preview-transition-out: height 0s;
     bottom: 0;
     cursor: pointer;
     height: $preview-height;
+    left: calc(var(--nav-side-bar-width-max) + 32px - 0.1rem);
     overflow: hidden;
     position: fixed;
     transition: $preview-transition-in;
-    width: calc(100% - 63px - var(--nav-side-bar-width-max));
+    width: calc(100vw - var(--nav-side-bar-width-max) - 60px);
     z-index: 99;
   }
   .preview:hover {

--- a/webui/react/src/components/TrialLogPreview.module.scss
+++ b/webui/react/src/components/TrialLogPreview.module.scss
@@ -3,19 +3,19 @@ $preview-transition-in: height 0.2s ease-in-out;
 $preview-transition-out: height 0s;
 
 .base {
-  height: calc(100% - #{$preview-height});
   transition: $preview-transition-in;
 
   .preview {
     background-color: var(--theme-surface);
     border-top: solid var(--theme-stroke-width) var(--theme-surface-border);
+    bottom: 0;
     cursor: pointer;
     height: $preview-height;
     overflow: hidden;
-    position: sticky;
-    top: 100%;
+    position: fixed;
     transition: $preview-transition-in;
-    width: 100%;
+    width: calc(100% - 63px - var(--nav-side-bar-width-max));
+    z-index: 99;
   }
   .preview:hover {
     background-color: var(--theme-surface-strong);


### PR DESCRIPTION
## Description

When the Ant Tabs component height + overflow behavior changed (which removes an extra scrollbar), it affected the TrialLogPreview (the ticker at the bottom of the TrialDetails page which shows the latest logs)

To fix without a regression, this uses `position: fixed` and sets width to the original containing element. This is calculated as 100% - Sidebar width, -32px for Page element padding, -32px for the gap between Sidebar and Page. This needs +1px to cover the border

Other `position: sticky` elements are at the top of the pages and work OK.

## Test Plan

Original behavior
- Fork a recent experiment and note logs appearing at the bottom of the page / viewport
- Wait for the metric chart to appear
- Scroll up and down the page to confirm that the TrialLogPreview stays at the bottom of the browser

Width issue
- Check that shrinking window width keeps the TrialLogPreview aligned with the content inside the tab
- Check that TrialLogPreview is wide enough to cover the full content (including left and right borders) of the lower elements when scrolling past

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.