### PR TITLE
chore: Quarantine select React test(s)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1497,7 +1497,7 @@ jobs:
       - checkout-with-sm
       - skip-if-docs-only
       - react-get-deps
-      - run: make -C webui/react test-ci-quarantined
+      - run: make -C webui/react test-ci-flaky
 
   test-unit-react-screenshot:
     docker:

--- a/webui/react/Makefile
+++ b/webui/react/Makefile
@@ -112,9 +112,12 @@ test:
 test-ci:
 	VITEST_MAX_THREADS=6 VITEST_MIN_THREADS=1 npm run test:coverage -- --reporter=junit --reporter=default --outputFile.junit=coverage/junit.xml
 
-.PHONY: test-ci-quarantined
-test-ci-quarantined:
-	QUARANTINED=true VITEST_MAX_THREADS=6 VITEST_MIN_THREADS=1 npm run test -- LogViewer --reporter=default
+# INCLUDE_FLAKY runs all tests even if they use flakyIt.
+# By default this would run ALL tests.
+# To avoid duplication, I use a filename (LogViewer) here to specify which group of tests to run.
+.PHONY: test-ci-flaky
+test-ci-flaky:
+	INCLUDE_FLAKY=true VITEST_MAX_THREADS=6 VITEST_MIN_THREADS=1 npm run test -- LogViewer --reporter=default
 
 .PHONY: visual-test-deps
 visual-test-deps: node_modules/playwright-core/.local-browsers

--- a/webui/react/src/components/kit/LogViewer/LogViewer.test.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { quarantinedIt } from 'quarantineTests';
+import { flakyIt } from 'quarantineTests';
 import { FetchArgs } from 'services/api-ts-sdk';
 import { mapV1LogsResponse } from 'services/decoder';
 import { StoreProvider as UIProvider } from 'shared/contexts/stores/UI';
@@ -282,7 +282,7 @@ describe('LogViewer', () => {
       });
     });
 
-    quarantinedIt(
+    flakyIt(
       'should render logs with streaming',
       async () => {
         setup({ decoder, onFetch });

--- a/webui/react/src/quarantineTests.ts
+++ b/webui/react/src/quarantineTests.ts
@@ -1,3 +1,3 @@
-export const quarantinedIt = (name: string, fn?: jest.ProvidesCallback, timeout?: number): void => {
-  return (process.env.QUARANTINED ? it : it.skip)(name, fn, timeout);
+export const flakyIt = (name: string, fn?: jest.ProvidesCallback, timeout?: number): void => {
+  return (process.env.INCLUDE_FLAKY ? it : it.skip)(name, fn, timeout);
 };


### PR DESCRIPTION
## Description

We're seeing a streaming logs test in `LogViewer.test.tsx` become especially flaky again, so our procedure is to put it into the quarantined tests runner. We haven't done this to react tests before, so def. open to iterating and improving on this for future flexibility.

Method: uses a QUARANTINED env variable. The standard job will skip quarantined tests
The quarantine job will only run tests in files named in `webui/react/Makefile`.

## Test Plan

Tests pass, and the quarantined react job shows that it's run only LogViewer-related tests

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.