### PR TITLE
fix: Core api pytorch mnist update2

### DIFF
--- a/examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
+++ b/examples/tutorials/core_api_pytorch_mnist/model_def_distributed.py
@@ -4,9 +4,10 @@
 from __future__ import print_function
 
 import argparse
+import os
 import pathlib
 
-# NEW: Import torch distributed libraries.
+import filelock
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -215,8 +216,9 @@ def main(core_context):
         [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
     )
 
-    dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
-    dataset2 = datasets.MNIST("../data", train=False, transform=transform)
+    with filelock.FileLock(os.path.join(os.getcwd(), "lock")):
+        dataset1 = datasets.MNIST("../data", train=True, download=True, transform=transform)
+        dataset2 = datasets.MNIST("../data", train=False, transform=transform)
 
     # NEW: Create DistributedSampler object for sharding data into core_context.distributed.size parts.
     sampler1 = DistributedSampler(

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -475,7 +475,7 @@ class CheckpointContext:
 
         .. note::
             metadata must include a 'steps_completed' key in the current implementation.
-            Raises ValueError if the 'steps_completed' key is not present in the metadata 
+            Raises ValueError if the 'steps_completed' key is not present in the metadata
             dictionary.
 
 

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -473,6 +473,12 @@ class CheckpointContext:
         you should save your model to.  When the context manager exits, the model is automatically
         uploaded (at least, for cloud-backed checkpoint storage backends).
 
+        .. note::
+            metadata must include a 'steps_completed' key in the current implementation.
+            Raises ValueError if the 'steps_completed' key is not present in the metadata 
+            dictionary.
+
+
         When ``shard=False``, only the chief worker (``distributed.rank==0``) may call
         ``store_path()``.
 


### PR DESCRIPTION
## Description

fix: Core api pytorch mnist update2

added filelock in model_def_distributed.py to avoid downloading files from multiple ranks to fix corrupted file error which occurs on some machines 
