### PR TITLE
ci: Schedule search indexing with release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,15 +55,6 @@ parameters:
     type: string
     default: xlarge
 
-main-and-release-and-rc-filters: &main-and-release-and-rc-filters
-  branches:
-    only:
-      - main
-  tags:
-    only:
-      - /(\d)+(\.(\d)+)+/
-      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
-
 release-and-rc-filters: &release-and-rc-filters
   branches:
     ignore:
@@ -1132,7 +1123,7 @@ jobs:
       - store_artifacts:
           path: docs.tgz
 
-  scrape-docs:
+  upload-docs-search-index:
     docker:
       - image: <<pipeline.parameters.docker-image>>
     steps:
@@ -2497,11 +2488,14 @@ workflows:
             - build-docs
           filters: *any-upstream
 
-      - scrape-docs:
+      - upload-docs-search-index:
           requires:
             - build-docs
           context: determined-production
-          filters: *main-and-release-and-rc-filters
+          filters:
+            branches:
+              only:
+                - main
 
       - test-debian-packaging:
           requires:
@@ -3281,6 +3275,12 @@ workflows:
           requires:
             - build-helm
             - build-proto
+
+      - upload-docs-search-index:
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *release-and-rc-filters
 
       - package-and-push-system-rc:
           requires:


### PR DESCRIPTION
* Renames `scrape-docs` to `upload-docs-search-index`. The former name obscures the stage's purpose. The latter name describes its effect.

* Moves the tagged execution to the release workflow. The old execution (both branch and tag) was at the end of `test-e2e`. This worked fine for the branch filter, but didn't ever execute on the tag filter because it had a dependency that wasn't also tag filtered. This change keeps official release activity in the release workflow while still maintaining the indexing/uploading to Algolia of the `determined-dev` index.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

Check that `upload-docs-search-index` has run in CircleCI and that a corresponding index has been uploaded to Algolia after a release has been cut. https://hpe-aiatscale.atlassian.net/wiki/spaces/DOC/pages/1328414765/Algolia+search has more information (including how to log into Algolia).

Run a search on the release candidate's docs website.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
