### PR TITLE
docs: correct the cloud shared fs information.

### DIFF
--- a/docs/interfaces/notebooks.rst
+++ b/docs/interfaces/notebooks.rst
@@ -197,9 +197,6 @@ To ensure that your work is saved even if your notebook gets terminated, it is r
 all notebooks with a shared filesystem directory *bind-mounted* into the notebook container and work
 on files inside of the bind mounted directory.
 
-By default, clusters that are launched by ``det deploy aws/gcp up`` create a Network file system
-that is shared by all the agents and automatically mounted into Notebook containers.
-
 For example, a user ``jimmy`` with a shared filesystem home directory at ``/shared/home/jimmy``
 could use the following configuration to launch a notebook:
 
@@ -211,6 +208,11 @@ could use the following configuration to launch a notebook:
        container_path: /shared/home/jimmy
    EOL
    $ det notebook start --config-file config.yaml
+
+By default, clusters that are launched by ``det deploy gcp up``, ``det deploy aws --deployment-type
+efs``, or ``det deploy aws --deployment-type fsx`` will create a Network file system that is shared
+by all the agents and automatically mounted into Notebook containers at
+``/run/determined/workdir/shared_fs/``.
 
 To launch a notebook with ``det deploy local cluster-up``, a user can add the ``--auto-bind-mount``
 flag, which mounts the user's home directory into the task containers by default:


### PR DESCRIPTION
## Description

Current information is not correct.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
