### PR TITLE
chore: review use of singularity pull in the agent

### DIFF
--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -97,22 +97,13 @@ func (s *SingularityClient) Close() error {
 	return nil
 }
 
-func getPullCommand(req docker.PullImage, image string) (string, []string) {
-	args := []string{"pull"}
-	if req.ForcePull {
-		args = append(args, "--force")
-	}
-	args = append(args, image)
-	return "singularity", args
-}
-
 // PullImage implements container.ContainerRuntime.
 func (s *SingularityClient) PullImage(
 	ctx context.Context,
 	req docker.PullImage,
 	p events.Publisher[docker.Event],
 ) (err error) {
-	return cruntimes.PullImage(ctx, req, p, &s.wg, s.log, getPullCommand)
+	return nil // 'singularity run' will pull the image & cache the result for reuse
 }
 
 // CreateContainer implements container.ContainerRuntime.


### PR DESCRIPTION
## Description

From a performance perspective, is not desirable to pull the container image with every experiment, as the singularity run command will pull the image and make the result available for reuse in the users cache. 

We therefor make the PullImage() method a no-op.

Here's an example. Let's start with an empty cache:
```
[gaisford@node003 ~]$ singularity cache clean --force
INFO:    Removing blob cache entry: blobs
INFO:    Removing blob cache entry: index.json
INFO:    Removing blob cache entry: oci-layout
INFO:    No cached files to remove at /home/users/gaisford/.apptainer/cache/library
INFO:    Removing oci-tmp cache entry: 124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
INFO:    No cached files to remove at /home/users/gaisford/.apptainer/cache/shub
INFO:    No cached files to remove at /home/users/gaisford/.apptainer/cache/oras
INFO:    No cached files to remove at /home/users/gaisford/.apptainer/cache/net
[gaisford@node003 ~]$
```
Now we'll run a container image (using a small image for speed):

```
[gaisford@node003 ~]$ singularity run docker://alpine hostname
INFO:    Converting OCI blobs to SIF format
INFO:    Starting build...
Getting image source signatures
Copying blob f56be85fc22e done 
Copying config 4798f93a2c done 
Writing manifest to image destination
Storing signatures
2023/05/05 10:17:09  info unpack layer: sha256:f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09
INFO:    Creating SIF file...
node003
[gaisford@node003 ~]$
```
Now we run the image again, and see that the cached result from the prior run is reused:

```
[gaisford@node003 ~]$ singularity run docker://alpine hostname
INFO:    Using cached SIF image
node003
```

_Possible con: the first time a DAI environment container is referenced, the experiments state will show as running, even though it may initially be pulling._

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
