### PR TITLE
fix: det e download auth issue [MLG-526]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -644,6 +644,7 @@ def download_model_def(args: Namespace) -> None:
         f.write(base64.b64decode(resp.b64Tgz))
 
 
+@authentication.required
 def download(args: Namespace) -> None:
     exp = client.ExperimentReference(args.experiment_id, cli.setup_session(args))
     checkpoints = exp.top_n_checkpoints(


### PR DESCRIPTION
## Test Plan

1. Login on the CLI as a user.
2. Make sure there is at least one successful experiment.
3. Run `det e download [expid]`
^ this should work.