### PR TITLE
feat: add selection menu to glide table

### DIFF
--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -1,5 +1,6 @@
 import { Popover as AntdPopover, Dropdown as AntDropdown } from 'antd';
 import { MenuProps as AntdMenuProps } from 'antd/es/menu/menu';
+import { MenuClickEventHandler } from 'rc-menu/lib/interface';
 import { PropsWithChildren, useMemo } from 'react';
 import * as React from 'react';
 
@@ -15,7 +16,7 @@ export interface MenuOption {
   key: number | string;
   label?: React.ReactNode;
   icon?: React.ReactNode;
-  onClick?: React.MouseEventHandler;
+  onClick?: MenuClickEventHandler;
 }
 
 export interface MenuOptionGroup {

--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -12,8 +12,8 @@ export interface MenuDivider {
 export interface MenuOption {
   danger?: boolean;
   disabled?: boolean;
-  key: string;
-  label: React.ReactNode;
+  key: number | string;
+  label?: React.ReactNode;
   icon?: React.ReactNode;
 }
 
@@ -23,7 +23,7 @@ export interface MenuOptionGroup {
   type: 'group';
 }
 
-export type MenuItem = MenuDivider | MenuOption | MenuOptionGroup;
+export type MenuItem = MenuDivider | MenuOption | MenuOptionGroup | null;
 
 export type Placement = 'bottomLeft' | 'bottomRight';
 

--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -35,6 +35,7 @@ interface BaseProps {
   isContextMenu?: boolean;
   menu?: MenuItem[];
   open?: boolean;
+  overlayStyle?: React.CSSProperties;
   placement?: Placement;
   onClick?: (key: string, e: DropdownEvent) => void | Promise<void>;
 }
@@ -62,6 +63,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
   isContextMenu,
   menu = [],
   open,
+  overlayStyle,
   placement = 'bottomLeft',
   onClick,
   selectable,
@@ -88,6 +90,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       className={css.base}
       content={content}
       open={open}
+      overlayStyle={overlayStyle}
       placement={placement}
       showArrow={false}
       trigger="click">
@@ -99,6 +102,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       disabled={disabled}
       menu={antdMenu}
       open={open}
+      overlayStyle={overlayStyle}
       placement={placement}
       trigger={[isContextMenu ? 'contextMenu' : 'click']}>
       {children}

--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -37,7 +37,7 @@ interface BaseProps {
   isContextMenu?: boolean;
   menu?: MenuItem[];
   open?: boolean;
-  overlayStyle?: React.CSSProperties;
+  autoWidthOverlay?: boolean;
   placement?: Placement;
   onClick?: (key: string, e: DropdownEvent) => void | Promise<void>;
 }
@@ -65,7 +65,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
   isContextMenu,
   menu = [],
   open,
-  overlayStyle,
+  autoWidthOverlay,
   placement = 'bottomLeft',
   onClick,
   selectable,
@@ -82,6 +82,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       selectedKeys,
     };
   }, [menu, onClick, selectable, selectedKeys]);
+  const overlayStyle = autoWidthOverlay ? { minWidth: 'auto' } : undefined;
 
   /**
    * Using `dropdownRender` for Dropdown causes some issues with triggering the dropdown.

--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -15,6 +15,7 @@ export interface MenuOption {
   key: number | string;
   label?: React.ReactNode;
   icon?: React.ReactNode;
+  onClick?: React.MouseEventHandler;
 }
 
 export interface MenuOptionGroup {

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -35,6 +35,7 @@ import {
   Operator,
   SpecialColumnNames,
 } from 'components/FilterForm/components/type';
+import { MenuItem } from 'components/kit/Dropdown';
 import usePrevious from 'hooks/usePrevious';
 import { handlePath } from 'routes/utils';
 import { V1ColumnType, V1LocationType } from 'services/api-ts-sdk';
@@ -323,7 +324,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       const columnId = columnIds[col];
 
       if (columnId === 'selected') {
-        const items: ItemType[] = [
+        const items: MenuItem[] = [
           selection.rows.length > 0
             ? {
                 key: 'select-none',

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -16,7 +16,6 @@ import DataEditor, {
   Theme,
 } from '@glideapps/glide-data-grid';
 import { DrawHeaderCallback } from '@glideapps/glide-data-grid/dist/ts/data-grid/data-grid-types';
-import { ItemType } from 'antd/es/menu/hooks/useItems';
 import React, {
   Dispatch,
   SetStateAction,
@@ -393,7 +392,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         setMenuIsOpen(false);
       };
 
-      const items: ItemType[] = [
+      const items: MenuItem[] = [
         ...(BANNED_FILTER_COLUMNS.includes(column.column)
           ? []
           : [

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -327,35 +327,45 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       const y = bounds.y + bounds.height;
 
       if (columnId === 'selected') {
-        if ((selectAll && excludedExperimentIds.size) || selection.rows.length !== data.length) {
-          const items: ItemType[] = [
-            ...[5, 10, 25, 50].map((n) => ({
-              key: `select-${n}`,
-              label: `Select ${n}`,
-              onClick: () => {
-                setSelection((s) => ({
-                  ...s,
-                  rows: CompactSelection.fromSingleSelection([0, n]),
-                }));
-                setMenuIsOpen(false);
-              },
-            })),
-            {
-              key: 'select-all',
-              label: 'Select all',
-              onClick: () => {
-                selectAllRows();
-                setMenuIsOpen(false);
-              },
+        const items: ItemType[] = [
+          ...[5, 10, 25, 50].map((n) => ({
+            key: `select-${n}`,
+            label: `Select ${n}`,
+            onClick: () => {
+              setSelection((s) => ({
+                ...s,
+                rows: CompactSelection.fromSingleSelection([0, n]),
+              }));
+              if (gridRef.current) {
+                // scroll first row into view for feedback
+                gridRef.current.scrollTo(0, 0);
+              }
+              setMenuIsOpen(false);
             },
-          ];
-          setTimeout(() => {
-            setMenuProps((prev) => ({ ...prev, items, title: 'Selection menu', x, y }));
-            setMenuIsOpen(true);
-          });
-        } else {
-          deselectAllRows();
-        }
+          })),
+          {
+            disabled: selectAll && excludedExperimentIds.size === 0,
+            key: 'select-all',
+            label: 'Select all',
+            onClick: () => {
+              selectAllRows();
+              setMenuIsOpen(false);
+            },
+          },
+          {
+            disabled: selection.rows.length === 0,
+            key: 'select-none',
+            label: 'Select none',
+            onClick: () => {
+              deselectAllRows();
+              setMenuIsOpen(false);
+            },
+          },
+        ];
+        setTimeout(() => {
+          setMenuProps((prev) => ({ ...prev, items, title: 'Selection menu', x, y }));
+          setMenuIsOpen(true);
+        });
         return;
       }
       const column = Loadable.getOrElse([], projectColumns).find((c) => c.column === columnId);
@@ -435,25 +445,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       setMenuProps((prev) => ({ ...prev, items, title: `${columnId} menu`, x, y }));
       setMenuIsOpen(true);
     },
-    [
-      columnIds,
-      projectColumns,
-      sorts,
-      onSortChange,
-      staticColumns,
-      pinnedColumnsCount,
-      selectAll,
-      excludedExperimentIds.size,
-      selectAllRows,
-      deselectAllRows,
-      selection.rows.length,
-      data.length,
-      formStore,
-      onIsOpenFilterChange,
-      sortableColumnIds,
-      setSortableColumnIds,
-      setPinnedColumnsCount,
-    ],
+    [columnIds, projectColumns, sorts, onSortChange, staticColumns, pinnedColumnsCount, selectAll, excludedExperimentIds.size, selectAllRows, deselectAllRows, selection.rows.length, formStore, gridRef, onIsOpenFilterChange, sortableColumnIds, setSortableColumnIds, setPinnedColumnsCount],
   );
 
   const getCellContent: DataEditorProps['getCellContent'] = React.useCallback(

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -327,7 +327,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           selection.rows.length > 0
             ? {
                 key: 'select-none',
-                label: 'Clear selection',
+                label: 'Clear selected',
                 onClick: () => {
                   deselectAllRows();
                   setMenuIsOpen(false);

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -16,7 +16,7 @@ import DataEditor, {
   Theme,
 } from '@glideapps/glide-data-grid';
 import { DrawHeaderCallback } from '@glideapps/glide-data-grid/dist/ts/data-grid/data-grid-types';
-import { MenuProps } from 'antd';
+import { ItemType } from 'antd/es/menu/hooks/useItems';
 import React, {
   Dispatch,
   SetStateAction,
@@ -321,20 +321,37 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, args: HeaderClickedEventArgs) => {
       const columnId = columnIds[col];
+      const { bounds } = args;
+      const x = bounds.x;
+      const y = bounds.y + bounds.height;
 
       if (columnId === 'selected') {
-        if (selectAll) {
-          if (excludedExperimentIds.size) {
-            selectAllRows();
-          } else {
-            deselectAllRows();
-          }
+        if ((selectAll && excludedExperimentIds.size) || selection.rows.length !== data.length) {
+          const items: ItemType[] = [
+            ...[5, 10, 25, 50].map((n) => ({
+              key: `select-${n}`,
+              label: `Select ${n}`,
+              onClick: () => {
+                setSelection((s) => ({
+                  ...s,
+                  rows: CompactSelection.empty().add([0, n]),
+                }));
+                setMenuIsOpen(false);
+              },
+            })),
+            {
+              key: 'select-all',
+              label: 'Select all',
+              onClick: () => {
+                selectAllRows();
+                setMenuIsOpen(false);
+              },
+            },
+          ];
+          setMenuProps((prev) => ({ ...prev, items, title: 'Selection menu', x, y }));
+          setMenuIsOpen(true);
         } else {
-          if (selection.rows.length === data.length) {
-            deselectAllRows();
-          } else {
-            selectAllRows();
-          }
+          deselectAllRows();
         }
         return;
       }
@@ -368,8 +385,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         setMenuIsOpen(false);
       };
 
-      const { bounds } = args;
-      const items: MenuProps['items'] = [
+      const items: ItemType[] = [
         ...(BANNED_FILTER_COLUMNS.includes(column.column)
           ? []
           : [
@@ -413,8 +429,6 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               },
             },
       ];
-      const x = bounds.x;
-      const y = bounds.y + bounds.height;
       setMenuProps((prev) => ({ ...prev, items, title: `${columnId} menu`, x, y }));
       setMenuIsOpen(true);
     },

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -334,7 +334,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               onClick: () => {
                 setSelection((s) => ({
                   ...s,
-                  rows: CompactSelection.empty().add([0, n]),
+                  rows: CompactSelection.fromSingleSelection([0, n]),
                 }));
                 setMenuIsOpen(false);
               },

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -320,6 +320,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, args: HeaderClickedEventArgs) => {
+      args.preventDefault();
       const columnId = columnIds[col];
       const { bounds } = args;
       const x = bounds.x;
@@ -348,8 +349,10 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               },
             },
           ];
-          setMenuProps((prev) => ({ ...prev, items, title: 'Selection menu', x, y }));
-          setMenuIsOpen(true);
+          setTimeout(() => {
+            setMenuProps((prev) => ({ ...prev, items, title: 'Selection menu', x, y }));
+            setMenuIsOpen(true);
+          });
         } else {
           deselectAllRows();
         }

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -439,7 +439,23 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       setMenuProps((prev) => ({ ...prev, bounds, items, title: `${columnId} menu` }));
       setMenuIsOpen(true);
     },
-    [columnIds, projectColumns, sorts, onSortChange, staticColumns, pinnedColumnsCount, selectAllRows, deselectAllRows, selection.rows.length, formStore, gridRef, onIsOpenFilterChange, sortableColumnIds, setSortableColumnIds, setPinnedColumnsCount],
+    [
+      columnIds,
+      projectColumns,
+      sorts,
+      onSortChange,
+      staticColumns,
+      pinnedColumnsCount,
+      selectAllRows,
+      deselectAllRows,
+      selection.rows.length,
+      formStore,
+      gridRef,
+      onIsOpenFilterChange,
+      sortableColumnIds,
+      setSortableColumnIds,
+      setPinnedColumnsCount,
+    ],
   );
 
   const getCellContent: DataEditorProps['getCellContent'] = React.useCallback(

--- a/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
@@ -1,8 +1,8 @@
 import { Popover } from 'antd';
-import { ItemType } from 'antd/es/menu/hooks/useItems';
 import * as io from 'io-ts';
 
 import Button from 'components/kit/Button';
+import { MenuItem } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import Select from 'components/kit/Select';
 import { V1ColumnType } from 'services/api-ts-sdk';
@@ -105,7 +105,7 @@ export const sortMenuItemsForColumn = (
   column: ProjectColumn,
   sorts: Sort[],
   onSortChange: (sorts: Sort[]) => void,
-): ItemType[] => {
+): MenuItem[] => {
   if (BANNED_SORT_COLUMNS.has(column.column)) {
     return [];
   }

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -16,10 +16,10 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void)
       }
     }
     // Bind the event listener
-    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('mouseup', handleClickOutside);
     return () => {
       // Unbind the event listener on clean up
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('mouseup', handleClickOutside);
     };
   }, [ref, handler]);
 }

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -27,7 +27,7 @@ export interface TableActionMenuProps {
   bounds: Rectangle;
   open: boolean;
   handleClose: () => void;
-  items: MenuItem[];
+  items?: MenuItem[];
 }
 
 export const TableActionMenu: React.FC<TableActionMenuProps> = ({

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -1,7 +1,8 @@
-import { Menu, MenuProps } from 'antd';
+import { MenuProps } from 'antd';
+import { ItemType } from 'antd/es/menu/hooks/useItems';
 import React, { MutableRefObject, useEffect, useRef } from 'react';
 
-import useResize from 'hooks/useResize';
+import Dropdown, { MenuItem } from 'components/kit/Dropdown';
 
 // eslint-disable-next-line
 function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void) {
@@ -15,10 +16,10 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void)
       }
     }
     // Bind the event listener
-    document.addEventListener('mouseup', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
     return () => {
       // Unbind the event listener on clean up
-      document.removeEventListener('mouseup', handleClickOutside);
+      document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [ref, handler]);
 }
@@ -29,6 +30,8 @@ export interface TableActionMenuProps extends MenuProps {
   open: boolean;
   handleClose: () => void;
 }
+const isMenuItem = (val: ItemType): val is MenuItem =>
+  val === null || !!val?.key || ('type' in val && val.type === 'divider');
 
 export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   x,
@@ -37,24 +40,18 @@ export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   handleClose,
   items,
 }) => {
-  const menuWidth = 220;
-  const containerRef = useRef(null);
-  useOutsideClickHandler(containerRef, handleClose);
-  const { width } = useResize();
-
+  const divRef = useRef<HTMLDivElement | null>(null);
+  useOutsideClickHandler(divRef, handleClose);
   return (
-    <div
-      ref={containerRef}
-      style={{
-        border: 'solid 1px gray',
-        display: !open ? 'none' : undefined,
-        left: width - x < menuWidth ? width - menuWidth : x,
-        position: 'fixed',
-        top: y,
-        width: menuWidth,
-        zIndex: 100,
-      }}>
-      <Menu items={items} selectable={false} />
-    </div>
+    <Dropdown menu={items?.filter(isMenuItem)} open={open} placement="bottomLeft">
+      <div
+        ref={divRef}
+        style={{
+          left: x,
+          position: 'fixed',
+          top: y,
+        }}
+      />
+    </Dropdown>
   );
 };

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -1,3 +1,4 @@
+import { Rectangle } from '@glideapps/glide-data-grid';
 import { MenuProps } from 'antd';
 import { ItemType } from 'antd/es/menu/hooks/useItems';
 import React, { MutableRefObject, useEffect, useRef } from 'react';
@@ -25,8 +26,7 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void)
 }
 
 export interface TableActionMenuProps extends MenuProps {
-  x: number;
-  y: number;
+  bounds: Rectangle;
   open: boolean;
   handleClose: () => void;
 }
@@ -34,8 +34,7 @@ const isMenuItem = (val: ItemType): val is MenuItem =>
   val === null || !!val?.key || ('type' in val && val.type === 'divider');
 
 export const TableActionMenu: React.FC<TableActionMenuProps> = ({
-  x,
-  y,
+  bounds,
   open,
   handleClose,
   items,
@@ -43,14 +42,24 @@ export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   const divRef = useRef<HTMLDivElement | null>(null);
   useOutsideClickHandler(divRef, handleClose);
   return (
-    <Dropdown menu={items?.filter(isMenuItem)} open={open} placement="bottomLeft">
+    <Dropdown
+      menu={items?.filter(isMenuItem)}
+      open={open}
+      overlayStyle={{ minWidth: 'auto' }}
+      placement="bottomLeft">
       <div
         ref={divRef}
-        style={{
-          left: x,
-          position: 'fixed',
-          top: y,
-        }}
+        style={
+          open
+            ? {
+                height: bounds.height,
+                left: bounds.x,
+                position: 'fixed',
+                top: bounds.y,
+                width: bounds.width,
+              }
+            : {}
+        }
       />
     </Dropdown>
   );

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -60,6 +60,7 @@ export const TableActionMenu: React.FC<TableActionMenuProps> = ({
               }
             : {}
         }
+        onClick={handleClose}
       />
     </Dropdown>
   );

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -39,7 +39,7 @@ export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   const divRef = useRef<HTMLDivElement | null>(null);
   useOutsideClickHandler(divRef, handleClose);
   return (
-    <Dropdown menu={items} open={open} overlayStyle={{ minWidth: 'auto' }} placement="bottomLeft">
+    <Dropdown autoWidthOverlay menu={items} open={open} placement="bottomLeft">
       <div
         ref={divRef}
         style={

--- a/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/menu.tsx
@@ -1,6 +1,4 @@
 import { Rectangle } from '@glideapps/glide-data-grid';
-import { MenuProps } from 'antd';
-import { ItemType } from 'antd/es/menu/hooks/useItems';
 import React, { MutableRefObject, useEffect, useRef } from 'react';
 
 import Dropdown, { MenuItem } from 'components/kit/Dropdown';
@@ -25,13 +23,12 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: () => void)
   }, [ref, handler]);
 }
 
-export interface TableActionMenuProps extends MenuProps {
+export interface TableActionMenuProps {
   bounds: Rectangle;
   open: boolean;
   handleClose: () => void;
+  items: MenuItem[];
 }
-const isMenuItem = (val: ItemType): val is MenuItem =>
-  val === null || !!val?.key || ('type' in val && val.type === 'divider');
 
 export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   bounds,
@@ -42,11 +39,7 @@ export const TableActionMenu: React.FC<TableActionMenuProps> = ({
   const divRef = useRef<HTMLDivElement | null>(null);
   useOutsideClickHandler(divRef, handleClose);
   return (
-    <Dropdown
-      menu={items?.filter(isMenuItem)}
-      open={open}
-      overlayStyle={{ minWidth: 'auto' }}
-      placement="bottomLeft">
+    <Dropdown menu={items} open={open} overlayStyle={{ minWidth: 'auto' }} placement="bottomLeft">
       <div
         ref={divRef}
         style={

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import InfoBox, { InfoRow } from 'components/InfoBox';
 import Button from 'components/kit/Button';
 import ClipboardButton from 'components/kit/ClipboardButton';
-import Dropdown, { MenuItem, MenuOption } from 'components/kit/Dropdown';
+import Dropdown, { MenuOption } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import { useModal } from 'components/kit/Modal';
 import Tags, { tagsActionHelper } from 'components/kit/Tags';
@@ -129,7 +129,7 @@ with det.import_from_path(path + "/code"):
   }, [modelVersion]);
 
   const menu = useMemo(() => {
-    const items: MenuItem[] = [
+    const items: MenuOption[] = [
       {
         key: MenuKey.DownloadModel,
         label: MenuKey.DownloadModel,
@@ -155,7 +155,7 @@ with det.import_from_path(path + "/code"):
   }, [canDeleteModelVersion, canModifyModelVersion, modelVersion]);
 
   const handleDropdown = useCallback(
-    (key: string) => {
+    (key: string | number) => {
       switch (key) {
         case MenuKey.DeregisterVersion:
           modelVersionDeleteModal.open();
@@ -185,18 +185,15 @@ with det.import_from_path(path + "/code"):
             </h1>
           </div>
           <div className={css.buttons}>
-            {menu.slice(0, 2).map((item) => {
-              const option = item as MenuOption;
-              return (
-                <Button
-                  danger={option.danger}
-                  disabled={option.disabled}
-                  key={option.key}
-                  onClick={() => handleDropdown(option.key)}>
-                  {option.label}
-                </Button>
-              );
-            })}
+            {menu.slice(0, 2).map((item) => (
+              <Button
+                danger={item.danger}
+                disabled={item.disabled}
+                key={item.key}
+                onClick={() => handleDropdown(item.key)}>
+                {item.label}
+              </Button>
+            ))}
             <Dropdown menu={menu.slice(2)} onClick={handleDropdown}>
               <Button
                 icon={<Icon name="overflow-horizontal" size="small" title="Action menu" />}

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -169,6 +169,8 @@ with det.import_from_path(path + "/code"):
         case MenuKey.UseInNotebook:
           setShowUseInNotebook(true);
           break;
+        default:
+          return;
       }
     },
     [modelDownloadModal, modelVersionEditModal, modelVersionDeleteModal],


### PR DESCRIPTION
## Description

This updates the select all functionality in the glide table by allowing automatic selection of the top 5, 10, 25, and 50 rows of the table. When a selection is active, clicking the select all column resets the selection. 


## Test Plan

With the glide table active:
* click the select all button
* The selection menu should appear
* When clicking on an item in the menu, the appropriate number of rows should be selected
* clicking on the select all button with an active selection clears the selection.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1188

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
