### PR TITLE
feat: mask token det auth login [MLG-540]

### DIFF
--- a/harness/determined/cli/sso.py
+++ b/harness/determined/cli/sso.py
@@ -1,6 +1,7 @@
 import sys
 import webbrowser
 from argparse import Namespace
+from getpass import getpass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Callable, List
 from urllib.parse import parse_qs, urlparse
@@ -101,12 +102,12 @@ def sso(parsed_args: Namespace) -> None:
     )
     token = None
     while not token:
-        user_input_url = input("\nlocalhost URL? ")
+        user_input_url = getpass(prompt="\n(hidden) localhost URL? ")
         try:
             token = parse_qs(urlparse(user_input_url).query)["token"][0]
             handle_token(parsed_args.master, token)
         except (KeyError, IndexError):
-            print("Could not extract token from localhost URL. {example_url}")
+            print(f"Could not extract token from localhost URL. {example_url}")
 
 
 def list_providers(parsed_args: Namespace) -> None:


### PR DESCRIPTION
## Description

feat: Turn off echo'ing of the localhost URL as it contains a secure token.
fix: there was a printf bug.

## Test Plan

1. `det auth login`, fudge the localhost URL, and make sure the error message correctly shows the example URL.
2. `det auth login` -> make sure that you can login.
