### PR TITLE
fix: 'det e list' and 'det e list -a' behavior was switched DET-9480

### DIFF
--- a/docs/release-notes/fix-det-e-list-cli.rst
+++ b/docs/release-notes/fix-det-e-list-cli.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+**Bug Fixes**
+
+-  CLI: ``det e list`` and ``det e list -a`` behaviors were erroneously switched.
+      -  Earlier, ``det e list`` was showing both archived and unarchived experiments, and ``det e
+         list -a`` was showing only unarchived experiments. This has now been fixed - ``det e list``
+         will show only unarchived experiments and ``det e list -a`` will show both archived and
+         unarchived experiments.

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -684,7 +684,7 @@ def list_experiments(args: Namespace) -> None:
         return bindings.get_GetExperiments(
             session,
             offset=offset,
-            archived=False if args.all else None,
+            archived=None if args.all else False,
             limit=args.limit,
             users=None if args.all else [authentication.must_cli_auth().get_session_user()],
         )


### PR DESCRIPTION
'det e list -a' was showing only non-archived experiments and 'det e list' was showing both archived and non-archived experiments Fixed it by changing the 'archived' argument of the API call under the GetExperiments CLI function
