### PR TITLE
feat: Hide experiments from archived projects in `GetExperiments` DET-9381

### DIFF
--- a/docs/release-notes/feat-GetExperiments.rst
+++ b/docs/release-notes/feat-GetExperiments.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+**New Features**
+
+-  API: Earlier GetExperiments(archived = False) used to list experiments from both archived and
+   unarchived projects and workspaces. Now when GetExperiments(archived = False) is called, it will
+   only list unarchived experiments from unarchived projects and workspaces. This will also affect
+   the CLI command ``det e list`` which also used to list unarchived experiments from both archived
+   and unarchived projects and workspaces. Now, it will only list unarchived experiments from
+   unarchived projects and workspaces.

--- a/e2e_tests/tests/experiment/test_api.py
+++ b/e2e_tests/tests/experiment/test_api.py
@@ -96,32 +96,39 @@ def test_archived_proj_exp_list() -> None:
     archived_exp.append(experiments[2])
     archived_exp.append(experiments[4])
 
-    # test2: GetExperiments shouldn't return experiements from archived projects when archived flag is False
+    # test2: GetExperiments shouldn't return experiements from archived projects when
+    # archived flag is False
     r2 = bindings.get_GetExperiments(session, archived=False)
     for e in r2.experiments:
         assert e.id not in archived_exp
-
-    # test3: GetExperiments should return both archived and unarchived experiments within an archived project
-    r3 = bindings.get_GetExperiments(session, archived=False, projectId=projects[1])
-    r3_correct_exp = [experiments[2], experiments[3]]
-    assert len(r3.experiments) == len(r3_correct_exp)
-    for e in r3.experiments:
-        assert e.id in r3_correct_exp
 
     bindings.post_ArchiveWorkspace(session, id=workspaces[1].id)
 
     archived_exp.append(experiments[7])
 
-    # test4: GetExperiments shouldn't return experiements from archived workspaces when archived flag is False
-    r4 = bindings.get_GetExperiments(session, archived=False)
-    for e in r4.experiments:
+    # test3: GetExperiments shouldn't return experiements from archived workspaces when
+    # archived flag is False
+    r3 = bindings.get_GetExperiments(session, archived=False)
+    for e in r3.experiments:
         assert e.id not in archived_exp
 
-    # test5: GetExperiments should return both archived and unarchived experiments when archived flag is unspecified
+    # test4: GetExperiments should return only unarchived experiments within an
+    # archived project when archived flag is false
+    r4 = bindings.get_GetExperiments(session, archived=False, projectId=projects[2])
+    r4_correct_exp = [experiments[4]]
+    assert len(r4.experiments) == len(r4_correct_exp)
+    for e in r4.experiments:
+        assert e.id in r4_correct_exp
+
+    # test5: GetExperiments should return both archived and unarchived experiments when
+    # archived flag is unspecified
     r5 = bindings.get_GetExperiments(session)
-    assert len(r5.experiments) == len(experiments)
+    returned_e_id = []
     for e in r5.experiments:
-        assert e.id in experiments
+        returned_e_id.append(e.id)
+
+    for e_id in experiments:
+        assert e_id in returned_e_id
 
     for w in workspaces:
         bindings.delete_DeleteWorkspace(session, id=w.id)

--- a/e2e_tests/tests/experiment/test_api.py
+++ b/e2e_tests/tests/experiment/test_api.py
@@ -1,0 +1,127 @@
+import uuid
+from typing import List
+
+import pytest
+
+from determined.common.api import bindings
+from determined.common.api.bindings import experimentv1State
+from tests import api_utils
+from tests import config as conf
+from tests import experiment as exp
+
+
+@pytest.mark.e2e_cpu
+def test_archived_proj_exp_list() -> None:
+    session = api_utils.determined_test_session(admin=True)
+    workspaces: List[bindings.v1Workspace] = []
+    count = 2
+
+    for _ in range(count):
+        body = bindings.v1PostWorkspaceRequest(name=f"workspace_{uuid.uuid4().hex[:8]}")
+        workspaces.append(bindings.post_PostWorkspace(session, body=body).workspace)
+
+    projects = []
+    experiments = []
+    for wrkspc in workspaces:
+        body1 = bindings.v1PostProjectRequest(
+            name=f"p_{uuid.uuid4().hex[:8]}", workspaceId=wrkspc.id
+        )
+        pid1 = bindings.post_PostProject(
+            session,
+            body=body1,
+            workspaceId=wrkspc.id,
+        ).project.id
+
+        body2 = bindings.v1PostProjectRequest(
+            name=f"p_{uuid.uuid4().hex[:8]}", workspaceId=wrkspc.id
+        )
+        pid2 = bindings.post_PostProject(
+            session,
+            body=body2,
+            workspaceId=wrkspc.id,
+        ).project.id
+
+        projects.append(pid1)
+        projects.append(pid2)
+
+        experiments.append(
+            exp.create_experiment(
+                conf.fixtures_path("no_op/single.yaml"),
+                conf.fixtures_path("no_op"),
+                ["--project_id", str(pid1), ("--paused")],
+            )
+        )
+        experiments.append(
+            exp.create_experiment(
+                conf.fixtures_path("no_op/single.yaml"),
+                conf.fixtures_path("no_op"),
+                ["--project_id", str(pid1), ("--paused")],
+            )
+        )
+        experiments.append(
+            exp.create_experiment(
+                conf.fixtures_path("no_op/single.yaml"),
+                conf.fixtures_path("no_op"),
+                ["--project_id", str(pid2), ("--paused")],
+            )
+        )
+        experiments.append(
+            exp.create_experiment(
+                conf.fixtures_path("no_op/single.yaml"),
+                conf.fixtures_path("no_op"),
+                ["--project_id", str(pid2), ("--paused")],
+            )
+        )
+
+    bindings.post_KillExperiments(
+        session, body=bindings.v1KillExperimentsRequest(experimentIds=experiments)
+    )
+
+    for x in experiments:
+        exp.wait_for_experiment_state(experiment_id=x, target_state=experimentv1State.CANCELED)
+
+    archived_exp = [experiments[0], experiments[3], experiments[5], experiments[6]]
+
+    for arch_exp in archived_exp:
+        bindings.post_ArchiveExperiment(session, id=arch_exp)
+
+    # test1: GetExperiments shouldn't return archived experiments when archived flag is False
+    r1 = bindings.get_GetExperiments(session, archived=False)
+    for e in r1.experiments:
+        assert e.id not in archived_exp
+
+    bindings.post_ArchiveProject(session, id=projects[1])
+    bindings.post_ArchiveProject(session, id=projects[2])
+
+    archived_exp.append(experiments[2])
+    archived_exp.append(experiments[4])
+
+    # test2: GetExperiments shouldn't return experiements from archived projects when archived flag is False
+    r2 = bindings.get_GetExperiments(session, archived=False)
+    for e in r2.experiments:
+        assert e.id not in archived_exp
+
+    # test3: GetExperiments should return both archived and unarchived experiments within an archived project
+    r3 = bindings.get_GetExperiments(session, archived=False, projectId=projects[1])
+    r3_correct_exp = [experiments[2], experiments[3]]
+    assert len(r3.experiments) == len(r3_correct_exp)
+    for e in r3.experiments:
+        assert e.id in r3_correct_exp
+
+    bindings.post_ArchiveWorkspace(session, id=workspaces[1].id)
+
+    archived_exp.append(experiments[7])
+
+    # test4: GetExperiments shouldn't return experiements from archived workspaces when archived flag is False
+    r4 = bindings.get_GetExperiments(session, archived=False)
+    for e in r4.experiments:
+        assert e.id not in archived_exp
+
+    # test5: GetExperiments should return both archived and unarchived experiments when archived flag is unspecified
+    r5 = bindings.get_GetExperiments(session)
+    assert len(r5.experiments) == len(experiments)
+    for e in r5.experiments:
+        assert e.id in experiments
+
+    for w in workspaces:
+        bindings.delete_DeleteWorkspace(session, id=w.id)

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -3,7 +3,6 @@ import pathlib
 import subprocess
 import tempfile
 import time
-import uuid
 from typing import Iterator, List, Optional
 
 import pytest
@@ -12,7 +11,6 @@ from urllib3 import connectionpool
 from determined import searcher
 from determined.common import yaml
 from determined.common.api import bindings
-from determined.common.api.bindings import experimentv1State
 from determined.experimental import client
 from tests import api_utils
 from tests import config as conf
@@ -584,102 +582,3 @@ class FallibleSearchRunner(searcher.LocalSearchRunner):
                 connectionpool.HTTPConnectionPool(host="dummyhost", port=8080), "http://dummyurl"
             )
             raise ex
-
-
-@pytest.mark.e2e_cpu
-def test_archived_proj_exp_list() -> None:
-    session = api_utils.determined_test_session(admin=True)
-    workspaces: List[bindings.v1Workspace] = []
-    count = 2
-
-    for _ in range(count):
-        body = bindings.v1PostWorkspaceRequest(name=f"workspace_{uuid.uuid4().hex[:8]}")
-        workspaces.append(bindings.post_PostWorkspace(session, body=body).workspace)
-
-    projects = []
-    experiments = []
-    for i in workspaces:
-        body1 = bindings.v1PostProjectRequest(name=f"p_{uuid.uuid4().hex[:8]}", workspaceId=i.id)
-        pid1 = bindings.post_PostProject(
-            session,
-            body=body1,
-            workspaceId=i.id,
-        ).project.id
-
-        body2 = bindings.v1PostProjectRequest(name=f"p_{uuid.uuid4().hex[:8]}", workspaceId=i.id)
-        pid2 = bindings.post_PostProject(
-            session,
-            body=body2,
-            workspaceId=i.id,
-        ).project.id
-
-        projects.append(pid1)
-        projects.append(pid2)
-
-        experiments.append(
-            exp.create_experiment(
-                conf.fixtures_path("no_op/single.yaml"),
-                conf.fixtures_path("no_op"),
-                ["--project_id", str(pid1)],
-            )
-        )
-        experiments.append(
-            exp.create_experiment(
-                conf.fixtures_path("no_op/single.yaml"),
-                conf.fixtures_path("no_op"),
-                ["--project_id", str(pid1)],
-            )
-        )
-        experiments.append(
-            exp.create_experiment(
-                conf.fixtures_path("no_op/single.yaml"),
-                conf.fixtures_path("no_op"),
-                ["--project_id", str(pid2)],
-            )
-        )
-        experiments.append(
-            exp.create_experiment(
-                conf.fixtures_path("no_op/single.yaml"),
-                conf.fixtures_path("no_op"),
-                ["--project_id", str(pid2)],
-            )
-        )
-
-    for x in experiments:
-        exp.wait_for_experiment_state(experiment_id=x, target_state=experimentv1State.COMPLETED)
-    bindings.post_KillExperiments(
-        session, body=bindings.v1KillExperimentsRequest(experimentIds=experiments)
-    )
-
-    bindings.post_ArchiveExperiment(session, id=experiments[0])
-    bindings.post_ArchiveExperiment(session, id=experiments[3])
-    bindings.post_ArchiveExperiment(session, id=experiments[5])
-    bindings.post_ArchiveExperiment(session, id=experiments[6])
-
-    archived_exp = [experiments[0], experiments[3], experiments[5], experiments[6]]
-
-    r1 = bindings.get_GetExperiments(session, archived=False)
-
-    for e in r1.experiments:
-        assert e.id not in archived_exp
-
-    bindings.post_ArchiveProject(session, id=projects[1])
-    bindings.post_ArchiveProject(session, id=projects[2])
-
-    archived_exp.append(experiments[2])
-    archived_exp.append(experiments[4])
-
-    r2 = bindings.get_GetExperiments(session, archived=False)
-    for e in r2.experiments:
-        assert e.id not in archived_exp
-
-    bindings.post_ArchiveWorkspace(session, id=workspaces[1].id)
-
-    archived_exp.append(experiments[7])
-
-    r3 = bindings.get_GetExperiments(session, archived=False)
-    for e in r3.experiments:
-        assert e.id not in archived_exp
-
-    for w in workspaces:
-        bindings.delete_DeleteWorkspace(session, id=w.id)

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -606,11 +606,11 @@ func (a *apiServer) GetExperiments(
 				ELSE e.config->'labels' END
 			))`, strings.Join(req.Labels, ",")) // Trying bun.In doesn't work.
 	}
-	if req.Archived != nil && req.ProjectId == 0 {
+	if req.Archived != nil {
 		query = query.Where("e.archived = ?", req.Archived.Value)
-		if !req.Archived.Value {
-			query = query.Where("w.archived= ?", false)
-			query = query.Where("p.archived= ?", false)
+		if req.ProjectId == 0 && !req.Archived.Value {
+			query = query.Where("w.archived= ?", req.Archived.Value)
+			query = query.Where("p.archived= ?", req.Archived.Value)
 		}
 	}
 	if len(req.States) > 0 {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -608,6 +608,10 @@ func (a *apiServer) GetExperiments(
 	}
 	if req.Archived != nil {
 		query = query.Where("e.archived = ?", req.Archived.Value)
+		if req.ProjectId == 0 {
+			query = query.Where("w.archived= ?", false)
+			query = query.Where("p.archived= ?", false)
+		}
 	}
 	if len(req.States) > 0 {
 		var allStates []string

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -606,9 +606,9 @@ func (a *apiServer) GetExperiments(
 				ELSE e.config->'labels' END
 			))`, strings.Join(req.Labels, ",")) // Trying bun.In doesn't work.
 	}
-	if req.Archived != nil {
+	if req.Archived != nil && req.ProjectId == 0 {
 		query = query.Where("e.archived = ?", req.Archived.Value)
-		if req.ProjectId == 0 {
+		if !req.Archived.Value {
 			query = query.Where("w.archived= ?", false)
 			query = query.Where("p.archived= ?", false)
 		}


### PR DESCRIPTION
Added a condition that filters sql results when parent workspace or project is archived and wrote a test to verify