### PR TITLE
ci: bump GKE Kubernetes version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ parameters:
     default: v1dev23
   gke-version:
     type: string
-    default: "1.23.16"
+    default: "1.25.8"
   master-build-resource-class:
     type: string
     default: xlarge


### PR DESCRIPTION
CI run: https://app.circleci.com/pipelines/github/determined-ai/determined/38681/workflows/3b7e2c2a-2285-4d44-ae8a-ff0126c876cb.