### PR TITLE
fix: Dashboard shows workspace name and link for tasks [WEB-1136]

### DIFF
--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -32,6 +32,7 @@ import usePolling from 'shared/hooks/usePolling';
 import { ErrorType } from 'shared/utils/error';
 import { dateTimeStringSorter } from 'shared/utils/sort';
 import userStore from 'stores/users';
+import workspaceStore from 'stores/workspaces';
 import { CommandTask, DetailedUser, ExperimentItem, Project } from 'types';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
@@ -52,6 +53,7 @@ const Dashboard: React.FC = () => {
   const [submissionsLoading, setSubmissionsLoading] = useState<boolean>(true);
   const [projectsLoading, setProjectsLoading] = useState<boolean>(true);
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
+  const workspaces = Loadable.getOrElse([], useObservable(workspaceStore.workspaces));
   const { canCreateNSC } = usePermissions();
   type Submission = ExperimentItem & CommandTask;
 
@@ -239,7 +241,19 @@ const Dashboard: React.FC = () => {
               {
                 dataIndex: 'projectId',
                 render: (projectId, row) => {
-                  if (row.workspaceId && row.projectId !== 1) {
+                  if (row.workspaceId && !row.projectId) {
+                    // Tasks
+                    return (
+                      <Breadcrumb>
+                        <Breadcrumb.Item>
+                          <Link path={paths.workspaceDetails(row.workspaceId)}>
+                            {workspaces.find((w) => w.id === row.workspaceId)?.name ||
+                              String(row.workspaceId)}
+                          </Link>
+                        </Breadcrumb.Item>
+                      </Breadcrumb>
+                    );
+                  } else if (row.workspaceId && row.projectId !== 1) {
                     return (
                       <Breadcrumb>
                         <Breadcrumb.Item>


### PR DESCRIPTION
## Description

As requested in ticket, instead of "/" the Dashboard page should show a link with workspace name for a recent task

Frontend uses store for workspace names because these are not included in the task info. If workspace names haven't loaded yet, you would momentarily see the workspace ID instead of the name

<img width="704" alt="Screen Shot 2023-05-16 at 10 13 18 AM" src="https://github.com/determined-ai/determined/assets/643918/aab91300-0fe3-498c-83c5-69689d52382b">

## Test Plan

On `/det/dashboard` these recent rows should appear with a link.  If you use the latest-main db then it will have the tasks as recent examples

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.