### PR TITLE
test: fix TestNonNumericEpochMetric test

### DIFF
--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -389,13 +389,7 @@ func TestNonNumericEpochMetric(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	_, err = api.CompareTrials(ctx, &apiv1.CompareTrialsRequest{
-		TrialIds:    []int32{int32(trial.ID)},
-		MetricNames: maps.Keys(expectedMetricsMap),
-	})
-	require.ErrorContains(t, err, "metric 'epoch' has nonnumeric value reported value='x'")
+	require.Equal(t, fmt.Errorf("cannot add metric with non numeric 'epoch' value got x"), err)
 }
 
 func TestTrialsNonNumericMetrics(t *testing.T) {


### PR DESCRIPTION
## Description

Merged two PRs that conflicted with this test. The earlier PR merged made reporting "epoch" and error so the test errored earlier than expected. This is the correct behavior we want.


## Test Plan

Integration tests pass



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
