### PR TITLE
ci: install `build` when publishing Python packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1348,7 +1348,7 @@ jobs:
       - checkout
       - setup-python-venv:
           install-python: false
-          extras-requires: "twine"
+          extras-requires: "build twine"
           executor: <<pipeline.parameters.docker-image>>
       - run: make -C <<parameters.path>> build
       - run: make -C <<parameters.path>> publish


### PR DESCRIPTION
## Description

In #6602, `build` was added as a dependency and set to install in some other places, but not for the publishing jobs.

## Test Plan

Hope for the best, merge this, and push a tag.
