### PR TITLE
ci: track merged PRs in a GitHub project

### DIFF
--- a/.github/workflows/track-prs-for-release.yml
+++ b/.github/workflows/track-prs-for-release.yml
@@ -1,0 +1,33 @@
+---
+name: "Track PRs for release"
+
+on:  # yamllint disable-line rule:truthy
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  add_merged_pr_to_release_project:
+    if: github.base_ref == 'main' && github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.base_ref }}
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+        with:
+          app_id: ${{ secrets.RELEASE_APP_ID }}
+          private_key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      - name: Add PR to release project
+        env:
+          # Since we want to access org-level projects, the normal GITHUB_TOKEN
+          # won't work -- it only has access to this repository.
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          PR_NUM: ${{ github.event.number }}
+          PR_REPO: ${{ github.event.repository.name }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: tools/scripts/add-pr-to-release-project.sh

--- a/tools/scripts/add-pr-to-release-project.sh
+++ b/tools/scripts/add-pr-to-release-project.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -eux
+exec 2>&1
+
+case "$PR_TITLE" in
+    fix:* | feat:*)
+        echo "fix or feat, adding to release list"
+        ;;
+    [a-z]*:*)
+        echo "not fix or feat, skipping"
+        exit
+        ;;
+    *)
+        echo "unknown, adding to release list to be safe"
+        ;;
+esac
+
+# Fetch various IDs.
+repo_id="$(gh api graphql -f query='
+query {
+  repository(owner:"determined-ai", name:"release-party-issues") {
+    id
+  }
+}
+' --jq '.data.repository.id')"
+
+project_id="$(gh api graphql -f query='
+query {
+  organization(login: "determined-ai") {
+    projectsV2(query: "Next release", first: 100) {
+      nodes {
+        id
+        title
+      }
+    }
+  }
+}
+' --jq '.data.organization.projectsV2.nodes | map(select(.title=="Next release")) | .[0].id')"
+
+status_json="$(gh api graphql -f query='
+query($project: ID!) {
+  node(id: $project) {
+    ... on ProjectV2 {
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}
+' -f project="$project_id" --jq '.data.node.field')"
+
+status_id="$(jq .id <<<"$status_json")"
+needs_testing_id="$(jq -r '.options | map(select(.name == "Needs testing")) | .[0].id' <<<"$status_json")"
+
+# Create new issue.
+issue_id="$(gh api graphql -f query='
+mutation($repo: ID!, $title: String!, $body: String!) {
+  createIssue(input: {repositoryId: $repo, title: $title, body: $body}) {
+    issue {
+      id
+    }
+  }
+}
+' -f repo="$repo_id" -f title="Test $PR_REPO#$PR_NUM ($PR_TITLE)" -f body="$PR_URL" --jq '.data.createIssue.issue.id')"
+
+# Add issue to project.
+item_id="$(gh api graphql -f query='
+mutation($project: ID!, $item: ID!) {
+  addProjectV2ItemById(input: {projectId: $project, contentId: $item}) {
+    item {
+      id
+    }
+  }
+}
+' -f project="$project_id" -f item="$issue_id" --jq '.data.addProjectV2ItemById.item.id')"
+
+# Set status of item in project.
+gh api graphql -f query='
+mutation($project: ID!, $item: ID!, $field: ID!, $value: String) {
+  updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, fieldId: $field, value: {singleSelectOptionId: $value}}) {
+    projectV2Item {
+     id
+   }
+  }
+}
+' -f project="$project_id" -f item="$item_id" -f field="$status_id" -f value="$needs_testing_id"


### PR DESCRIPTION
## Description

As a first step toward exploring a new release process, this creates a GitHub action that adds each merged fix/feat PR to an organization-level GitHub project for tracking during the release party.

The PRs are not added directly to the project; instead, new issues linking to them are created in a separate repo. It would be possible and a bit simpler to add them directly, but I felt that it was preferable to have a separate place specifically for release-related discussion that was not appending onto the already closed PRs.

## Test Plan

Did a bunch of iteration on a private test repo. There's some chance that something will go wrong on the transfer to this one, but I think I've done the best I can do. And it's not like anything terrible will happen if something is off.
