### PR TITLE
chore: Add ordered map (orderedmapx) to allow for queuing of job cancelations [DET-9465]

### DIFF
--- a/master/pkg/syncx/orderedmapx/orderedmapx.go
+++ b/master/pkg/syncx/orderedmapx/orderedmapx.go
@@ -1,0 +1,152 @@
+// Package orderedmapx is a thread safe and ordered implementation of a standard
+// map. The elements can be retrieved in the same order in which they were
+// added. orderedmapx allows elements to be located without having to
+// sequentially search the list to find the element we're looking for.
+package orderedmapx
+
+import (
+	"container/list"
+	"sync"
+)
+
+type mapElement[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+// Map is a thread safe and ordered implementation of standard map.
+// K is the type of key and V is the type of value.
+type Map[K comparable, V any] struct {
+	mp   map[K]*list.Element
+	mu   sync.RWMutex
+	dll  *list.List
+	cond *sync.Cond
+}
+
+// New returns an initialized Map[K, V].
+func New[K comparable, V any]() *Map[K, V] {
+	m := new(Map[K, V])
+	m.mp = make(map[K]*list.Element)
+	m.dll = list.New()
+	m.cond = sync.NewCond(&m.mu)
+	return m
+}
+
+// Put adds a key to the map with the specified value.  If the key already
+// exists, then the existing key's value is replaced with the new value.
+func (m *Map[K, V]) Put(key K, val V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var e *list.Element
+	var ok bool
+
+	if e, ok = m.mp[key]; ok {
+		// Replace existing key's value with the new value.
+		e.Value = mapElement[K, V]{key: key, value: val}
+		return
+	}
+
+	// Add the new key and its value.
+	m.mp[key] = m.dll.PushFront(mapElement[K, V]{key: key, value: val})
+	m.cond.Signal()
+}
+
+// PutIfAbsent returns the existing value if the key already exists in the map
+// and sets the second return value to false to indicate that the value was not
+// updated because the key already existed in the map. Otherwise, if the key
+// did not already exist in the map, it returns the new value and sets the
+// second return value to true to indicate that the key and its value were
+// added to the map.
+func (m *Map[K, V]) PutIfAbsent(key K, value V) (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if e, ok := m.mp[key]; ok {
+		me := e.Value.(mapElement[K, V])
+		return me.value, false
+	}
+
+	m.mp[key] = m.dll.PushFront(mapElement[K, V]{key: key, value: value})
+	m.cond.Signal()
+
+	return value, true
+}
+
+// Delete deletes the entry for the specified key from the map. Returns true
+// if the key existed in the map and was deleted; false otherwise.
+func (m *Map[K, V]) Delete(key K) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	e, ok := m.mp[key]
+	if !ok {
+		return false
+	}
+
+	m.dll.Remove(e)
+	delete(m.mp, key)
+	return true
+}
+
+// Length will return the length of Map.
+func (m *Map[k, V]) Length() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.dll.Len()
+}
+
+// Get returns the value for the specified key if the key exists in the map.
+// The second return value is a boolean, which will be set to true if the key
+// was found in the map, or false if the key was not found in the map.
+func (m *Map[K, V]) Get(key K) (V, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	v, ok := m.mp[key]
+	if !ok {
+		var value V
+		return value, ok
+	}
+
+	me := v.Value.(mapElement[K, V])
+	return me.value, ok
+}
+
+// GetAndDelete removes the first (i.e., oldest) element from the list and
+// returns it. If the list is empty, the call will block until a new element
+// is added.  The second return value will be set to true if the list was not
+// empty; otherwise it will be set to false if the list is empty.
+func (m *Map[K, V]) GetAndDelete() (V, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Wait for "Put()" or "PutIfAbsent()" to add an element to the list.
+	// As per https://pkg.go.dev/sync#Cond.Wait, Wait atomically unlocks
+	// m.mu and suspends execution of the calling goroutine. After later
+	// resuming execution, Wait locks m.mu before returning.
+	for m.dll.Len() == 0 {
+		m.cond.Wait()
+	}
+
+	// Get the first element from the list. "Back()" returns the oldest
+	// element in the list and "Front()" returns the newest.
+	firstElement := m.dll.Back()
+
+	if firstElement == nil {
+		var value V
+		return value, false
+	}
+
+	// The value that we store in the list is the key to the map.
+	mapElem := firstElement.Value.(mapElement[K, V])
+
+	// Remove the first element from the list.
+	m.dll.Remove(firstElement)
+
+	// Delete the entry from the map.
+	delete(m.mp, mapElem.key)
+
+	return mapElem.value, true
+}

--- a/master/pkg/syncx/orderedmapx/orderedmapx.go
+++ b/master/pkg/syncx/orderedmapx/orderedmapx.go
@@ -38,10 +38,7 @@ func (m *Map[K, V]) Put(key K, val V) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var e *list.Element
-	var ok bool
-
-	if e, ok = m.mp[key]; ok {
+	if e, ok := m.mp[key]; ok {
 		// Replace existing key's value with the new value.
 		e.Value = mapElement[K, V]{key: key, value: val}
 		return

--- a/master/pkg/syncx/orderedmapx/orderedmapx_test.go
+++ b/master/pkg/syncx/orderedmapx/orderedmapx_test.go
@@ -1,0 +1,136 @@
+package orderedmapx
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type KeyAndValue struct {
+	key   string
+	value string
+}
+
+var testData = []KeyAndValue{
+	{
+		key:   "key1",
+		value: "value1",
+	},
+	{
+		key:   "key2",
+		value: "value2",
+	},
+	{
+		key:   "key3",
+		value: "value3",
+	},
+	{
+		key:   "key4",
+		value: "value4",
+	},
+}
+
+func Test_GetAndDelete(t *testing.T) {
+	m := New[string, string]()
+
+	// Add some data to the map.
+	for _, data := range testData {
+		m.Put(data.key, data.value)
+	}
+
+	// Verify the map contains expected number of items.
+	assert.Equal(t, m.Length(), len(testData))
+
+	// Verify that "GetFirst()" returns the first (i.e., oldest) element in the
+	// map.
+	for index, data := range testData {
+		assert.Equal(t, m.Length() > 0, true, "List is empty")
+
+		val, ok := m.GetAndDelete()
+
+		assert.Equal(t, ok, true, fmt.Sprintf("Element #%d was not found", index))
+
+		assert.Equal(t, val, data.value)
+
+		assert.Equal(t, m.Length(), len(testData)-(index+1))
+	}
+
+	assert.Equal(t, m.Length(), 0, "Expected map length to be zero")
+}
+
+func Test_Put(t *testing.T) {
+	m := New[string, string]()
+
+	assert.Equal(t, m.Length(), 0, "Expected map length to be zero")
+
+	// Add the key in the map for the first time.
+	m.Put("key", "value")
+
+	assert.Equal(t, m.Length(), 1, "Expected map length to be one")
+
+	val, ok := m.Get("key")
+
+	// Should be "true" since the key exists in the map.
+	assert.Equal(t, ok, true)
+
+	// Should have returned the value that we added to the map.
+	assert.Equal(t, val, "value")
+
+	// Try to add the same key to the map with a different value.
+	m.Put("key", "new value")
+
+	assert.Equal(t, m.Length(), 1, "Expected map length to be one")
+
+	val, ok = m.Get("key")
+
+	// Should be "true" since the key exists in the map.
+	assert.Equal(t, ok, true)
+
+	// Should have returned the new value.
+	assert.Equal(t, val, "new value")
+
+	// Delete the key from the map.
+	ok = m.Delete("key")
+
+	assert.Equal(t, m.Length(), 0, "Expected map length to be zero")
+
+	// Should be "true" since the key exists in the map.
+	assert.Equal(t, ok, true)
+
+	// Delete the key from the map again.
+	ok = m.Delete("key")
+
+	// Should be "false" since the should no longer be in the map.
+	assert.Equal(t, ok, false)
+}
+
+func Test_PutIfAbsent(t *testing.T) {
+	m := New[string, string]()
+
+	assert.Equal(t, m.Length(), 0, "Expected map length to be zero")
+
+	// Add the key in the map for the first time.
+	val, ok := m.PutIfAbsent("key", "value")
+
+	assert.Equal(t, m.Length(), 1, "Expected map length to be one")
+
+	// Should be "true", since the key and its value were added to the map,
+	// because the key did not already exist in the map.
+	assert.Equal(t, ok, true)
+
+	// Should have returned the value that we added to the map.
+	assert.Equal(t, val, "value")
+
+	// Try to add the same key to the map.
+	val, ok = m.PutIfAbsent("key", "new value")
+
+	assert.Equal(t, m.Length(), 1, "Expected map length to be one")
+
+	// Should be "false", since the key already existed in the map and its
+	// value was not updated.
+	assert.Equal(t, ok, false)
+
+	// Should have returned the value that was already in the map.
+	assert.Equal(t, val, "value")
+}


### PR DESCRIPTION
## Description

Add a thread safe ordered map, in which the elements can be retrieved in the order in which they were added, to implement the queuing functionality needed for pull request https://github.com/determined-ai/determined-ee/pull/849


## Test Plan

See testing section for pull request https://github.com/determined-ai/determined-ee/pull/849


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
