### PR TITLE
fix: trials created by paused experiments should be paused [DET-9493]

### DIFF
--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -244,6 +244,7 @@ func (t *trial) Receive(ctx *actor.Context) error {
 
 func (t *trial) create(ctx *actor.Context) error {
 	m := model.NewTrial(
+		t.state,
 		t.jobID,
 		t.taskID,
 		t.searcher.Create.RequestID,

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -457,9 +457,10 @@ type Trial struct {
 	JobID JobID
 }
 
-// NewTrial creates a new trial in the active state.  Note that the trial ID
+// NewTrial creates a new trial in the specified state.  Note that the trial ID
 // will not be set.
 func NewTrial(
+	state State,
 	jobID JobID,
 	taskID TaskID,
 	requestID RequestID,
@@ -476,7 +477,7 @@ func NewTrial(
 		TaskID:                taskID,
 		RequestID:             &requestID,
 		ExperimentID:          experimentID,
-		State:                 ActiveState,
+		State:                 state,
 		StartTime:             time.Now().UTC(),
 		HParams:               hparams,
 		WarmStartCheckpointID: warmStartCheckpointID,


### PR DESCRIPTION
## Description

NewTrial was hardcoded to state:ActiveState even if the trial.state
was PAUSED, so depending upon timing new trials may show as Active/Queued
when the experiment is actually paused.  Pass the initial state to
NewTrial such that it can be persisted in the DB matching the actual
state in memory.

## Test Plan

Verified manually by pausing/resuming no_op adaptive.   No longer able to see newly created trials queued after pause.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
