### PR TITLE
fix: add canDoActionOnCheckpointThroughModel to core_checkpoint 

### DIFF
--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -90,11 +90,9 @@ func (m *Master) canDoActionOnCheckpointThroughModel(
 	if len(modelIDs) == 0 {
 		// if length of model ids is zero then permission denied
 		// so return checkpoitn not found.
-		fmt.Println("number of model IDS is zero")
 		return errCheckpointNotFound(ckptID)
 	}
 
-	fmt.Println("before for loop")
 	var errCanGetModel error
 	for _, modelID := range modelIDs {
 		model := &modelv1.Model{}
@@ -102,18 +100,14 @@ func (m *Master) canDoActionOnCheckpointThroughModel(
 		if err != nil {
 			return err
 		}
-		fmt.Println(" through model CanGetModel")
 		if errCanGetModel = modelauth.AuthZProvider.Get().CanGetModel(
-			ctx, curUser, model, model.WorkspaceId); err == nil {
-			fmt.Println("errCanGetModel is nil")
+			ctx, curUser, model, model.WorkspaceId); errCanGetModel == nil {
 			return nil
 		}
+
 	}
 	// we get to this return when there are no models belonging
 	// to a workspace where user has permissions.
-	fmt.Println("get here at the end model registry")
-	fmt.Println("errCanGetModel")
-	fmt.Println(errCanGetModel.Error())
 	return authz.SubIfUnauthorized(errCanGetModel, errCheckpointNotFound(ckptID))
 }
 

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -94,12 +94,13 @@ func (m *Master) canDoActionOnCheckpointThroughModel(
 			return err
 		}
 		if err := modelauth.AuthZProvider.Get().CanGetModel(
-			ctx, curUser, model, model.WorkspaceId); err != nil {
-			return authz.SubIfUnauthorized(err, errCheckpointNotFound(ckptID))
+			ctx, curUser, model, model.WorkspaceId); err == nil {
+			return nil
 		}
 	}
-	return status.Error(codes.PermissionDenied,
-		fmt.Sprintf("cannot access checkpoint: %s", ckptID))
+	// we get to this return when there are no models belonging
+	// to a workspace where user has permissions.
+	return authz.SubIfUnauthorized(err, errCheckpointNotFound(ckptID))
 }
 
 func (a *apiServer) GetCheckpoint(

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -104,7 +104,6 @@ func (m *Master) canDoActionOnCheckpointThroughModel(
 			ctx, curUser, model, model.WorkspaceId); errCanGetModel == nil {
 			return nil
 		}
-
 	}
 	// we get to this return when there are no models belonging
 	// to a workspace where user has permissions.
@@ -124,7 +123,7 @@ func (a *apiServer) GetCheckpoint(
 	if errE != nil {
 		errM := a.m.canDoActionOnCheckpointThroughModel(ctx, *curUser, req.CheckpointUuid)
 		if errM != nil {
-			return nil, errM
+			return nil, errE
 		}
 	}
 

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -87,6 +87,7 @@ func createVersionTwoCheckpoint(
 
 func TestCheckpointAuthZ(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
+	authZModel := getMockModelAuth()
 
 	cases := []struct {
 		DenyFuncName            string
@@ -140,11 +141,15 @@ func TestCheckpointAuthZ(t *testing.T) {
 			expectedErr := fmt.Errorf("canGetExperimentError")
 			authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
 				Return(expectedErr).Once()
+			authZModel.On("CanGetModel", mock.Anything, mock.Anything,
+				mock.Anything, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 			require.Equal(t, expectedErr, curCase.IDToReqCall(checkpointID))
 
 			expectedErr = status.Error(codes.PermissionDenied, curCase.DenyFuncName+"Error")
 			authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
 				Return(nil).Once()
+			authZModel.On("CanGetModel", mock.Anything, mock.Anything,
+				mock.Anything, mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 			authZExp.On(curCase.DenyFuncName, mock.Anything, curUser, mock.Anything).
 				Return(fmt.Errorf(curCase.DenyFuncName + "Error")).Once()
 			require.Equal(t, expectedErr, curCase.IDToReqCall(checkpointID))

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -31,8 +31,8 @@ import (
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
-	modelauth "github.com/determined-ai/determined/master/internal/model"
 	"github.com/determined-ai/determined/master/internal/mocks"
+	modelauth "github.com/determined-ai/determined/master/internal/model"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -67,8 +67,10 @@ func expNotFoundErr(expID int) error {
 	return status.Errorf(codes.NotFound, "experiment not found: %d", expID)
 }
 
-var authZExp *mocks.ExperimentAuthZ
-var authzModel *mocks.ModelAuthZ
+var (
+	authZExp   *mocks.ExperimentAuthZ
+	authzModel *mocks.ModelAuthZ
+)
 
 // pgdb can be nil to use the singleton database for testing.
 func setupExpAuthTest(t *testing.T, pgdb *db.PgDB) (
@@ -82,7 +84,7 @@ func setupExpAuthTest(t *testing.T, pgdb *db.PgDB) (
 	return api, authZExp, projectAuthZ, user, ctx
 }
 
-func getMockModelAuth() *mocks.ModelAuthZ{
+func getMockModelAuth() *mocks.ModelAuthZ {
 	if authzModel == nil {
 		authzModel = &mocks.ModelAuthZ{}
 		modelauth.AuthZProvider.Register("mock", authzModel)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -31,6 +31,7 @@ import (
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
+	modelauth "github.com/determined-ai/determined/master/internal/model"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -67,6 +68,7 @@ func expNotFoundErr(expID int) error {
 }
 
 var authZExp *mocks.ExperimentAuthZ
+var authzModel *mocks.ModelAuthZ
 
 // pgdb can be nil to use the singleton database for testing.
 func setupExpAuthTest(t *testing.T, pgdb *db.PgDB) (
@@ -78,6 +80,15 @@ func setupExpAuthTest(t *testing.T, pgdb *db.PgDB) (
 		expauth.AuthZProvider.Register("mock", authZExp)
 	}
 	return api, authZExp, projectAuthZ, user, ctx
+}
+
+func getMockModelAuth() *mocks.ModelAuthZ{
+	if authzModel == nil {
+		authzModel = &mocks.ModelAuthZ{}
+		modelauth.AuthZProvider.Register("mock", authzModel)
+	}
+
+	return authzModel
 }
 
 func createTestExp(

--- a/master/internal/core_checkpoint.go
+++ b/master/internal/core_checkpoint.go
@@ -160,19 +160,24 @@ func (m *Master) getCheckpoint(c echo.Context) error {
 	}
 
 	curUser := c.(*detContext.DetContext).MustGetUser()
-	if err := m.canDoActionOnCheckpoint(c.Request().Context(), curUser, args.CheckpointUUID,
-		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
-		s, ok := status.FromError(err)
-		if !ok {
-			return err
-		}
-		switch s.Code() {
-		case codes.NotFound:
-			return echo.NewHTTPError(http.StatusNotFound, s.Message())
-		case codes.PermissionDenied:
-			return echo.NewHTTPError(http.StatusForbidden, s.Message())
-		default:
-			return fmt.Errorf(s.Message())
+	errE := m.canDoActionOnCheckpoint(c.Request().Context(), curUser, args.CheckpointUUID,
+		expauth.AuthZProvider.Get().CanGetExperimentArtifacts)
+
+	if errE != nil {
+		errM := m.canDoActionOnCheckpointThroughModel(c.Request().Context(), curUser, args.CheckpointUUID)
+		if errM != nil {
+			s, ok := status.FromError(errM)
+			if !ok {
+				return errM
+			}
+			switch s.Code() {
+			case codes.NotFound:
+				return echo.NewHTTPError(http.StatusNotFound, s.Message())
+			case codes.PermissionDenied:
+				return echo.NewHTTPError(http.StatusForbidden, s.Message())
+			default:
+				return fmt.Errorf(s.Message())
+			}
 		}
 	}
 

--- a/master/internal/core_checkpoint.go
+++ b/master/internal/core_checkpoint.go
@@ -8,12 +8,13 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/determined-ai/determined/master/pkg/checkpoints"
-	"github.com/determined-ai/determined/master/pkg/checkpoints/archive"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/determined-ai/determined/master/pkg/checkpoints"
+	"github.com/determined-ai/determined/master/pkg/checkpoints/archive"
 
 	"github.com/determined-ai/determined/master/internal/api"
 	detContext "github.com/determined-ai/determined/master/internal/context"
@@ -176,7 +177,6 @@ func (m *Master) getCheckpoint(c echo.Context) error {
 			default:
 				return fmt.Errorf(s.Message())
 			}
-
 		}
 	}
 	c.Response().Header().Set(echo.HeaderContentType, mimeType)

--- a/master/internal/core_checkpoint.go
+++ b/master/internal/core_checkpoint.go
@@ -161,13 +161,10 @@ func (m *Master) getCheckpoint(c echo.Context) error {
 	curUser := c.(*detContext.DetContext).MustGetUser()
 	errE := m.canDoActionOnCheckpoint(c.Request().Context(), curUser, args.CheckpointUUID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts)
-	fmt.Println("errE")
 	if errE != nil {
 		errM := m.canDoActionOnCheckpointThroughModel(c.Request().Context(), curUser, args.CheckpointUUID)
 		if errM != nil {
-			fmt.Println("errM is not nil")
-			fmt.Println(errM.Error())
-			s, ok := status.FromError(errM)
+			s, ok := status.FromError(errE)
 			if !ok {
 				return errE
 			}
@@ -182,7 +179,6 @@ func (m *Master) getCheckpoint(c echo.Context) error {
 
 		}
 	}
-	fmt.Println("not returned")
 	c.Response().Header().Set(echo.HeaderContentType, mimeType)
 	return m.getCheckpointImpl(c.Request().Context(), id, mimeType, c.Response())
 }

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,9 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
+	"github.com/determined-ai/determined/proto/pkg/modelv1"
+
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
@@ -249,8 +253,54 @@ func TestGetCheckpointEchoExpErr(t *testing.T) {
 	}
 }
 
+// TODO: nikita make this a utility and use it everywhere in intg tests etc.
+func registerCheckpointAsModelVersion(t *testing.T, pgDB *db.PgDB, ckptID uuid.UUID) {
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	var retCkpt checkpointv1.Checkpoint
+	err := pgDB.QueryProto("get_checkpoint", &retCkpt, ckptID.String())
+	require.NoError(t, err)
+	user := db.RequireMockUser(t, pgDB)
+	// Insert a model.
+	now := time.Now()
+	mdl := model.Model{
+		Name:            uuid.NewString(),
+		Description:     "some important model",
+		CreationTime:    now,
+		LastUpdatedTime: now,
+		Labels:          []string{"some other label"},
+		Username:        user.Username,
+		WorkspaceID:     1,
+	}
+	var pmdl modelv1.Model
+	var emptyMetadata = []byte(`{}`)
+	mdlNotes := "some notes"
+	err = pgDB.QueryProto(
+		"insert_model", &pmdl, mdl.Name, mdl.Description, emptyMetadata,
+		strings.Join(mdl.Labels, ","), mdlNotes, user.ID, mdl.WorkspaceID,
+	)
+	require.NoError(t, err)
+
+	// Register checkpoint as a model version.
+	expected := &modelv1.ModelVersion{
+		Model:      &pmdl,
+		Checkpoint: &retCkpt,
+		Name:       "some name",
+		Comment:    "empty",
+		Username:   user.Username,
+		Labels:     []string{"some label"},
+		Notes:      "some notes",
+	}
+	var mv modelv1.ModelVersion
+	err = pgDB.QueryProto(
+		"insert_model_version", &mv, pmdl.Id, ckptID, expected.Name, expected.Comment,
+		emptyMetadata, strings.Join(expected.Labels, ","), expected.Notes, user.ID,
+	)
+	require.NoError(t, err)
+}
+
 func TestAuthZCheckpointsEcho(t *testing.T) {
 	api, authZExp, _, curUser, _ := setupExpAuthTest(t, nil)
+	authZModel := getMockModelAuth()
 	ctx := newTestEchoContext(curUser)
 
 	checkpointUUID := uuid.New()
@@ -266,25 +316,28 @@ func TestAuthZCheckpointsEcho(t *testing.T) {
 		fmt.Sprintf("checkpoint not found: %s", checkpointUUID)), api.m.getCheckpoint(ctx))
 
 	addMockCheckpointDB(t, api.m.db, checkpointUUID)
+	registerCheckpointAsModelVersion(t, api.m.db, checkpointUUID)
 
+	fmt.Println("start")
 	authZExp.On("CanGetExperiment", mock.Anything, curUser,
 		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
-	authZExp.On("CanGetModel", mock.Anything, curUser,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authZModel.On("CanGetModel", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything).Run(func(args mock.Arguments) { debug.PrintStack() }).Return(authz2.PermissionDeniedError{}).Once()
 	require.Equal(t, echo.NewHTTPError(http.StatusNotFound,
 		fmt.Sprintf("checkpoint not found: %s", checkpointUUID)), api.m.getCheckpoint(ctx))
+	fmt.Println("end")
 
 	expectedErr := fmt.Errorf("canGetExperimentError")
 	authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
 		Return(expectedErr).Once()
-	authZExp.On("CanGetModel", mock.Anything, curUser,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authZModel.On("CanGetModel", mock.Anything, curUser,
+		mock.Anything, mock.Anything).Return(authz2.PermissionDeniedError{})
 	require.Equal(t, expectedErr, api.m.getCheckpoint(ctx))
 
 	expectedErr = echo.NewHTTPError(http.StatusForbidden, "canGetArtifactsError")
 	authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).Return(nil).Once()
-	authZExp.On("CanGetModel", mock.Anything, curUser,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authZModel.On("CanGetModel", mock.Anything, curUser,
+		mock.Anything, mock.Anything).Return(nil)
 	authZExp.On("CanGetExperimentArtifacts", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canGetArtifactsError")).Once()
 	require.Equal(t, expectedErr, api.m.getCheckpoint(ctx))

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -254,7 +254,7 @@ func TestGetCheckpointEchoExpErr(t *testing.T) {
 
 // TODO: nikita make this a utility and use it everywhere in intg tests etc.
 func registerCheckpointAsModelVersion(t *testing.T, pgDB *db.PgDB, ckptID uuid.UUID) {
-	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	require.NoError(t, etc.SetRootPath("../../master/static/srv"))
 	var retCkpt checkpointv1.Checkpoint
 	err := pgDB.QueryProto("get_checkpoint", &retCkpt, ckptID.String())
 	require.NoError(t, err)

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -271,7 +271,7 @@ func registerCheckpointAsModelVersion(t *testing.T, pgDB *db.PgDB, ckptID uuid.U
 		WorkspaceID:     1,
 	}
 	var pmdl modelv1.Model
-	var emptyMetadata = []byte(`{}`)
+	emptyMetadata := []byte(`{}`)
 	mdlNotes := "some notes"
 	err = pgDB.QueryProto(
 		"insert_model", &pmdl, mdl.Name, mdl.Description, emptyMetadata,

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -269,16 +269,22 @@ func TestAuthZCheckpointsEcho(t *testing.T) {
 
 	authZExp.On("CanGetExperiment", mock.Anything, curUser,
 		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+	authZExp.On("CanGetModel", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	require.Equal(t, echo.NewHTTPError(http.StatusNotFound,
 		fmt.Sprintf("checkpoint not found: %s", checkpointUUID)), api.m.getCheckpoint(ctx))
 
 	expectedErr := fmt.Errorf("canGetExperimentError")
 	authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
 		Return(expectedErr).Once()
+	authZExp.On("CanGetModel", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	require.Equal(t, expectedErr, api.m.getCheckpoint(ctx))
 
 	expectedErr = echo.NewHTTPError(http.StatusForbidden, "canGetArtifactsError")
 	authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).Return(nil).Once()
+	authZExp.On("CanGetModel", mock.Anything, curUser,
+		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	authZExp.On("CanGetExperimentArtifacts", mock.Anything, curUser, mock.Anything).
 		Return(fmt.Errorf("canGetArtifactsError")).Once()
 	require.Equal(t, expectedErr, api.m.getCheckpoint(ctx))

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// RootFromDB returns the relative path from db to root.
-	RootFromDB = "../../static/srv"
+	RootFromDB = "../../master/static/srv"
 	// MigrationsFromDB returns the relative path to migrations folder.
 	MigrationsFromDB      = "file://../../static/migrations"
 	defaultSearcherMetric = "okness"

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	// RootFromDB returns the relative path from db to root.
-	RootFromDB = "../../master/static/srv"
+	RootFromDB = "../../static/srv"
 	// MigrationsFromDB returns the relative path to migrations folder.
 	MigrationsFromDB      = "file://../../static/migrations"
 	defaultSearcherMetric = "okness"


### PR DESCRIPTION
## Description

fix: add canDoActionOnCheckpointThroughModel to core_checkpoint 



## Test Plan
Do the following with EE version 
- [x]  Follow the steps to create a GKE cluster and go to a k8s pod. ([carolina's doc](https://stump-antlion-1c2.notion.site/GKE-Notes-5569a2342af1490caad022ced1453558)) 
- [x]  Ensure to run determined-ee migrations (TODO (nikita) put this in a doc somewhere) 
- [x]  have rbac on in .devcluster.yaml 
- [x] login as admin 
- [x]  create workspace 
- [x]  create model in above workspace 
- [x]  create user with ModelRegistryViewer role 
- [x] create experiment (can use a simple one such as tutorials/examples/mnist_pytorch det e create const.yaml .) 
- [x]  get checkpoint UUID from the experiment
- [x] det user login with created user that has ModelRegistryViewer role 
- [x]  det checkpoint download checkpoint_uuid 
- [x]  It should work! no errors 