### PR TITLE
fix: Full height on code editor [WEB-1258]

### DIFF
--- a/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
+++ b/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
@@ -11,10 +11,6 @@
     height: 100%;
     padding: 0.5em;
 
-    span {
-      white-space: nowrap;
-    }
-
     @media screen and (max-width: 1024px) {
       border-right: none;
       grid-column: 1 / 3;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
@@ -1,3 +1,7 @@
 .codeContainer {
   height: calc(100vh - 220px);
+
+  &.multitrialContainer {
+    height: calc(100vh - 270px);
+  }
 }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
@@ -1,3 +1,3 @@
 .codeContainer {
-  height: calc(100vh - 180px);
+  height: calc(100vh - 220px);
 }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
@@ -1,0 +1,3 @@
+.codeContainer {
+  height: calc(100vh - 180px);
+}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
@@ -8,6 +8,7 @@ import { V1FileNode } from 'services/api-ts-sdk';
 import Spinner from 'shared/components/Spinner/Spinner';
 import { RawJson } from 'shared/types';
 import { ExperimentBase, TreeNode } from 'types';
+import { isSingleTrialExperiment } from 'utils/experiment';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
 import css from './ExperimentCodeViewer.module.scss';
@@ -91,10 +92,15 @@ const ExperimentCodeViewer: React.FC<Props> = ({
     ...Loadable.getOrElse([], expFiles),
   ].filter((valid) => !!valid) as TreeNode[];
 
+  const cssClasses = [
+    css.codeContainer,
+    isSingleTrialExperiment(experiment) || css.multitrialContainer,
+  ];
+
   return (
     <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
       <Spinner spinning={expFiles === NotLoaded} tip="Loading file tree...">
-        <div className={css.codeContainer}>
+        <div className={cssClasses.join(' ')}>
           <CodeEditor
             files={fileOpts}
             readonly={true}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
@@ -10,6 +10,8 @@ import { RawJson } from 'shared/types';
 import { ExperimentBase, TreeNode } from 'types';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
+import css from './ExperimentCodeViewer.module.scss';
+
 const CodeEditor = React.lazy(() => import('components/kit/CodeEditor'));
 
 const configIcon = <Icon name="settings" title="settings" />;
@@ -92,7 +94,7 @@ const ExperimentCodeViewer: React.FC<Props> = ({
   return (
     <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
       <Spinner spinning={expFiles === NotLoaded} tip="Loading file tree...">
-        <div style={{ height: 'calc(100vh - 180px)' }}>
+        <div className={css.codeContainer}>
           <CodeEditor
             files={fileOpts}
             readonly={true}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
@@ -92,12 +92,14 @@ const ExperimentCodeViewer: React.FC<Props> = ({
   return (
     <React.Suspense fallback={<Spinner tip="Loading code viewer..." />}>
       <Spinner spinning={expFiles === NotLoaded} tip="Loading file tree...">
-        <CodeEditor
-          files={fileOpts}
-          readonly={true}
-          selectedFilePath={selectedFilePath}
-          onSelectFile={onSelectFile}
-        />
+        <div style={{ height: 'calc(100vh - 180px)' }}>
+          <CodeEditor
+            files={fileOpts}
+            readonly={true}
+            selectedFilePath={selectedFilePath}
+            onSelectFile={onSelectFile}
+          />
+        </div>
       </Spinner>
     </React.Suspense>
   );


### PR DESCRIPTION
## Description

Two fixes for code editor release:
- Make the container around the experiment code viewer fit the window height
- Removed `white-space: nowrap` CSS rule so file names wrap, instead of overlapping code editor

## Test Plan

Checkpoint file names with latest-main data, `/det/experiments/2744/code`
<img width="669" alt="Screen Shot 2023-05-19 at 9 50 47 AM" src="https://github.com/determined-ai/determined/assets/643918/3d1fd564-1d91-4ad8-aab6-c114f373249c">

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.