### PR TITLE
fix: Test runs dirs

### DIFF
--- a/harness/tests/experiment/integrations/test_pytorch_lightning.py
+++ b/harness/tests/experiment/integrations/test_pytorch_lightning.py
@@ -77,7 +77,7 @@ class TestLightningAdapter:
             max_batches=2,
             min_validation_batches=1,
             checkpoint_dir=str(tmp_path),
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller.run()
 
@@ -88,7 +88,6 @@ class TestLightningAdapter:
                     assert self.last_lr > self.read_lr_value()
                 else:
                     assert self.last_lr == self.read_lr_value()
-
 
         tensorboard_path = tmp_path.joinpath("tensorboard")
 
@@ -102,7 +101,7 @@ class TestLightningAdapter:
             trial_seed=self.trial_seed,
             max_batches=2,
             min_validation_batches=1,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller.run()
 
@@ -129,7 +128,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[0],
             min_checkpoint_batches=steps[0],
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         trial_controller_A.run()
@@ -177,7 +176,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[0] + steps[1],
             min_checkpoint_batches=sys.maxsize,
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_B.run()
 
@@ -367,7 +366,9 @@ def create_trial_and_trial_controller(
         trial_seed = random.randint(0, 1 << 31)
 
     checkpoint_dir = checkpoint_dir or "/tmp"
-    with det.core._dummy_init(checkpoint_storage=checkpoint_dir, tensorboard_path=tensorboard_path) as core_context:
+    with det.core._dummy_init(
+        checkpoint_storage=checkpoint_dir, tensorboard_path=tensorboard_path
+    ) as core_context:
         core_context.train._trial_id = "1"
         distributed_backend = det._DistributedBackend()
         if expose_gpus:

--- a/harness/tests/experiment/integrations/test_pytorch_lightning.py
+++ b/harness/tests/experiment/integrations/test_pytorch_lightning.py
@@ -68,6 +68,8 @@ class TestLightningAdapter:
             def check_lr_value(self, batch_idx: int):
                 assert self.last_lr > self.read_lr_value()
 
+        tensorboard_path = tmp_path.joinpath("tensorboard")
+
         trial, trial_controller = create_trial_and_trial_controller(
             trial_class=OneVarLAFreq1,
             hparams=self.hparams,
@@ -75,16 +77,20 @@ class TestLightningAdapter:
             max_batches=2,
             min_validation_batches=1,
             checkpoint_dir=str(tmp_path),
+            tensorboard_path=tensorboard_path
         )
         trial_controller.run()
 
-    def test_lr_scheduler_frequency(self) -> None:
+    def test_lr_scheduler_frequency(self, tmp_path: pathlib.Path) -> None:
         class OneVarLAFreq2(la_model.OneVarTrialLRScheduler):
             def check_lr_value(self, batch_idx: int):
                 if batch_idx % 2 == 0:
                     assert self.last_lr > self.read_lr_value()
                 else:
                     assert self.last_lr == self.read_lr_value()
+
+
+        tensorboard_path = tmp_path.joinpath("tensorboard")
 
         updated_params = {
             **self.hparams,
@@ -96,6 +102,7 @@ class TestLightningAdapter:
             trial_seed=self.trial_seed,
             max_batches=2,
             min_validation_batches=1,
+            tensorboard_path=tensorboard_path
         )
         trial_controller.run()
 
@@ -109,6 +116,7 @@ class TestLightningAdapter:
         typing.Sequence[typing.Dict[str, typing.Any]], typing.Sequence[typing.Dict[str, typing.Any]]
     ]:
         checkpoint_dir = str(tmp_path.joinpath("checkpoint"))
+        tensorboard_path = tmp_path.joinpath("tensorboard")
         training_metrics = {"A": [], "B": []}
         validation_metrics = {"A": [], "B": []}
 
@@ -121,6 +129,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[0],
             min_checkpoint_batches=steps[0],
             checkpoint_dir=checkpoint_dir,
+            tensorboard_path=tensorboard_path
         )
 
         trial_controller_A.run()
@@ -145,6 +154,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[1],
             min_checkpoint_batches=sys.maxsize,
             checkpoint_dir=checkpoint_dir,
+            tensorboard_path=tensorboard_path,
             latest_checkpoint=checkpoint_callback.uuids[0],
             steps_completed=trial_controller_A.state.batches_trained,
         )
@@ -167,6 +177,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[0] + steps[1],
             min_checkpoint_batches=sys.maxsize,
             checkpoint_dir=checkpoint_dir,
+            tensorboard_path=tensorboard_path
         )
         trial_controller_B.run()
 
@@ -193,6 +204,7 @@ class TestLightningAdapter:
         steps: typing.Tuple[int, int] = (1, 1),
     ) -> None:
         checkpoint_dir = str(tmp_path.joinpath("checkpoint"))
+        tensorboard_path = tmp_path.joinpath("tensorboard")
 
         # Trial A: train 100 batches and checkpoint
         trial_A, trial_controller_A = create_trial_and_trial_controller(
@@ -204,6 +216,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[0],
             min_checkpoint_batches=steps[0],
             checkpoint_dir=checkpoint_dir,
+            tensorboard_path=tensorboard_path,
             expose_gpus=expose_gpus,
         )
 
@@ -221,6 +234,7 @@ class TestLightningAdapter:
             min_validation_batches=steps[1],
             min_checkpoint_batches=sys.maxsize,
             checkpoint_dir=checkpoint_dir,
+            tensorboard_path=tensorboard_path,
             latest_checkpoint=os.listdir(checkpoint_dir)[0],
             steps_completed=trial_controller_A.state.batches_trained,
             expose_gpus=True,
@@ -328,6 +342,7 @@ def create_trial_and_trial_controller(
     trial_seed: int = None,
     exp_config: typing.Optional[typing.Dict] = None,
     checkpoint_dir: typing.Optional[str] = None,
+    tensorboard_path: typing.Optional[pathlib.Path] = None,
     latest_checkpoint: typing.Optional[str] = None,
     steps_completed: int = 0,
     expose_gpus: bool = True,
@@ -352,7 +367,7 @@ def create_trial_and_trial_controller(
         trial_seed = random.randint(0, 1 << 31)
 
     checkpoint_dir = checkpoint_dir or "/tmp"
-    with det.core._dummy_init(checkpoint_storage=checkpoint_dir) as core_context:
+    with det.core._dummy_init(checkpoint_storage=checkpoint_dir, tensorboard_path=tensorboard_path) as core_context:
         core_context.train._trial_id = "1"
         distributed_backend = det._DistributedBackend()
         if expose_gpus:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -6,11 +6,11 @@ import random
 import sys
 import typing
 from unittest import mock
-from _pytest import monkeypatch
 
 import numpy as np
 import pytest
 import torch
+from _pytest import monkeypatch
 
 import determined as det
 from determined import gpu, pytorch
@@ -74,7 +74,7 @@ class TestPyTorchTrial:
             trial_class=pytorch_onevar_model.OneVarTrial,
             hparams=self.hparams,
             trial_seed=self.trial_seed,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         train_steps, metrics = trial_controller._train_with_boundaries(
@@ -106,7 +106,7 @@ class TestPyTorchTrial:
             trial_class=pytorch_onevar_model.OneVarTrialWithTrainingMetrics,
             hparams=self.hparams,
             trial_seed=self.trial_seed,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         train_steps, metrics = trial_controller._train_with_boundaries(
@@ -132,7 +132,7 @@ class TestPyTorchTrial:
             hparams=self.hparams,
             expose_gpus=True,
             trial_seed=self.trial_seed,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         val_metrics = trial_controller._validate()
@@ -196,7 +196,7 @@ class TestPyTorchTrial:
             min_validation_batches=100,
             min_checkpoint_batches=100,
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         trial_controller_A.run()
@@ -236,7 +236,7 @@ class TestPyTorchTrial:
             max_batches=1000,
             min_validation_batches=100,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_A.run()
 
@@ -252,7 +252,7 @@ class TestPyTorchTrial:
             max_batches=1000,
             min_validation_batches=100,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_B.run()
 
@@ -281,7 +281,7 @@ class TestPyTorchTrial:
             max_batches=900,
             min_validation_batches=100,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_A.run()
 
@@ -298,7 +298,7 @@ class TestPyTorchTrial:
             max_batches=900,
             min_validation_batches=100,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_B.run()
 
@@ -325,7 +325,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
 
@@ -342,7 +342,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
 
@@ -366,7 +366,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
 
@@ -392,7 +392,7 @@ class TestPyTorchTrial:
             max_batches=2,
             min_validation_batches=1,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller.run()
 
@@ -516,7 +516,7 @@ class TestPyTorchTrial:
             max_batches=1,
             min_validation_batches=1,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
 
@@ -530,7 +530,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         training_metrics = []
@@ -566,7 +566,7 @@ class TestPyTorchTrial:
             min_validation_batches=30,
             min_checkpoint_batches=sys.maxsize,
             scheduling_unit=10,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
         metrics_callback = trial.metrics_callback
@@ -599,7 +599,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         def reducer_fn(_):
@@ -624,7 +624,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         def reducer_fn(_):
@@ -651,7 +651,7 @@ class TestPyTorchTrial:
                 max_batches=100,
                 min_validation_batches=10,
                 min_checkpoint_batches=sys.maxsize,
-                tensorboard_path=tensorboard_path
+                tensorboard_path=tensorboard_path,
             )
             controller.run()
 
@@ -669,7 +669,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         controller.run()
 
@@ -713,7 +713,7 @@ class TestPyTorchTrial:
             max_batches=100,
             min_validation_batches=10,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         controller.run()
@@ -752,7 +752,7 @@ class TestPyTorchTrial:
             "apex-with-noop-scaler",
         ],
     )
-    def test_amp(self, tmp_path:pathlib.Path, trial_class) -> None:
+    def test_amp(self, tmp_path: pathlib.Path, trial_class) -> None:
         """Train a linear model using Determined with Automated Mixed Precision in three ways:
         Using Apex and using PyTorch AMP both "automatically" and "manually". In the "manual" case,
         we use the context manager ``autoscale`` in the model's training and
@@ -776,7 +776,7 @@ class TestPyTorchTrial:
             max_batches=20,
             min_validation_batches=1,
             min_checkpoint_batches=sys.maxsize,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         controller.run()
@@ -837,13 +837,14 @@ class TestPyTorchTrial:
 
         amp_metrics_test(trial_class, training_metrics, agg_freq=aggregation_frequency)
 
-    def test_trainer(self, monkeypatch:monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
-
+    def test_trainer(self, monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
         # there is no direct way to set tensorboard path in Trainer API
         def mock_get_tensorboard_path(dummy: typing.Dict[str, typing.Any]) -> pathlib.Path:
             return tmp_path.joinpath("tensorboard")
 
-        monkeypatch.setattr(pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path)
+        monkeypatch.setattr(
+            pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path
+        )
 
         # Train for 100 batches, checkpoint and validate every 50 batches
         max_batches = 100
@@ -870,13 +871,16 @@ class TestPyTorchTrial:
             len(checkpoint_callback.uuids) == 2
         ), "checkpoint callback did not return expected length of uuids"
 
-    def test_trainer_callbacks(self, monkeypatch:monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
-
+    def test_trainer_callbacks(
+        self, monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path
+    ) -> None:
         # there is no direct way to set tensorboard path in Trainer API
         def mock_get_tensorboard_path(dummy: typing.Dict[str, typing.Any]) -> pathlib.Path:
             return tmp_path.joinpath("tensorboard")
 
-        monkeypatch.setattr(pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path)
+        monkeypatch.setattr(
+            pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path
+        )
 
         max_epochs = 2
         checkpoint_batches = 5
@@ -939,7 +943,7 @@ class TestPyTorchTrial:
             min_validation_batches=steps[0],
             min_checkpoint_batches=steps[0],
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         trial_controller_A.run()
@@ -987,7 +991,7 @@ class TestPyTorchTrial:
             min_validation_batches=steps[0],
             min_checkpoint_batches=sys.maxsize,
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
         trial_controller_B.run()
 
@@ -1060,7 +1064,7 @@ class TestPyTorchTrial:
             hparams=self.hparams,
             trial_seed=self.trial_seed,
             max_batches=100,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         # Checkpoint only if the following conditions are met:
@@ -1114,7 +1118,7 @@ class TestPyTorchTrial:
             "0.20.0-pytorch",
         ],
     )
-    def test_legacy_checkpoint_loading(self,tmp_path: pathlib.Path, ckpt: str):
+    def test_legacy_checkpoint_loading(self, tmp_path: pathlib.Path, ckpt: str):
         """
         This test exists to validate the checkpoint load path from older checkpoints into
         post-Trainer API checkpoints. Trainer API deprecated workload_sequencer.pkl and
@@ -1131,7 +1135,7 @@ class TestPyTorchTrial:
             min_validation_batches=1,
             min_checkpoint_batches=1,
             checkpoint_dir=checkpoint_dir,
-            tensorboard_path=tensorboard_path
+            tensorboard_path=tensorboard_path,
         )
 
         # Manually set trial ID to match checkpoint.
@@ -1307,7 +1311,9 @@ def create_trial_and_trial_controller(
         trial_seed = random.randint(0, 1 << 31)
 
     checkpoint_dir = checkpoint_dir or "/tmp"
-    with det.core._dummy_init(checkpoint_storage=checkpoint_dir, tensorboard_path=tensorboard_path) as core_context:
+    with det.core._dummy_init(
+        checkpoint_storage=checkpoint_dir, tensorboard_path=tensorboard_path
+    ) as core_context:
         core_context.train._trial_id = "1"
         distributed_backend = det._DistributedBackend()
         if expose_gpus:

--- a/harness/tests/experiment/test_local.py
+++ b/harness/tests/experiment/test_local.py
@@ -3,6 +3,7 @@ import typing
 
 import pytest
 import tensorflow as tf
+from _pytest import monkeypatch
 
 import determined as det
 from determined import estimator, experimental, keras, pytorch
@@ -11,15 +12,15 @@ from tests.experiment.fixtures import (
     pytorch_onevar_model,
     tf_keras_one_var_model,
 )
-from _pytest import monkeypatch
 
 
 def test_test_one_batch(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
-
     def mock_get_tensorboard_path(dummy: typing.Dict[str, typing.Any]) -> pathlib.Path:
         return tmp_path.joinpath("tensorboard")
 
-    monkeypatch.setattr(pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path)
+    monkeypatch.setattr(
+        pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path
+    )
 
     with det._local_execution_manager(pathlib.Path(pytorch_onevar_model.__file__).parent):
         experimental.test_one_batch(
@@ -32,10 +33,7 @@ def test_test_one_batch(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.
                     "dataloader_type": "determined",
                 },
                 "searcher": {"metric": "loss"},
-                "checkpoint_storage": {
-                    "type": "shared_fs",
-                    "host_path": str(tmp_path)
-                }
+                "checkpoint_storage": {"type": "shared_fs", "host_path": str(tmp_path)},
             },
         )
 

--- a/harness/tests/experiment/test_local.py
+++ b/harness/tests/experiment/test_local.py
@@ -33,7 +33,6 @@ def test_test_one_batch(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.
                     "dataloader_type": "determined",
                 },
                 "searcher": {"metric": "loss"},
-                "checkpoint_storage": {"type": "shared_fs", "host_path": str(tmp_path)},
             },
         )
 

--- a/harness/tests/experiment/test_local.py
+++ b/harness/tests/experiment/test_local.py
@@ -1,18 +1,26 @@
 import pathlib
+import typing
 
 import pytest
 import tensorflow as tf
 
 import determined as det
-from determined import estimator, experimental, keras
+from determined import estimator, experimental, keras, pytorch
 from tests.experiment.fixtures import (
     estimator_linear_model,
     pytorch_onevar_model,
     tf_keras_one_var_model,
 )
+from _pytest import monkeypatch
 
 
-def test_test_one_batch() -> None:
+def test_test_one_batch(monkeypatch: monkeypatch.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+
+    def mock_get_tensorboard_path(dummy: typing.Dict[str, typing.Any]) -> pathlib.Path:
+        return tmp_path.joinpath("tensorboard")
+
+    monkeypatch.setattr(pytorch.PyTorchTrialContext, "get_tensorboard_path", mock_get_tensorboard_path)
+
     with det._local_execution_manager(pathlib.Path(pytorch_onevar_model.__file__).parent):
         experimental.test_one_batch(
             trial_class=pytorch_onevar_model.OneVarTrial,
@@ -24,6 +32,10 @@ def test_test_one_batch() -> None:
                     "dataloader_type": "determined",
                 },
                 "searcher": {"metric": "loss"},
+                "checkpoint_storage": {
+                    "type": "shared_fs",
+                    "host_path": str(tmp_path)
+                }
             },
         )
 


### PR DESCRIPTION
## Description

The default directory for saving tensorboard files is the current user directory. Due to this, tests leave tensorboard artifacts after being run.

This PR passes a tensorboard directory to the PyTorchTrial unit tests so that tensorboard files are created in the pytest temp directory, which is cleaned up after tests are run.


## Test Plan

Run unit tests in `harness/tests/experiment` and confirm that `runs` directory is NOT created.


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-507