### PR TITLE
fix: patch WorkspaceList full-width context menu [WEB-1275]

### DIFF
--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -255,7 +255,7 @@ const WorkspaceList: React.FC = () => {
       onVisibleChange?: (visible: boolean) => void;
       record: Workspace;
     }) => (
-      <WorkspaceActionDropdown workspace={record} onComplete={fetchWorkspaces}>
+      <WorkspaceActionDropdown isContextMenu workspace={record} onComplete={fetchWorkspaces}>
         {children}
       </WorkspaceActionDropdown>
     ),


### PR DESCRIPTION
## Description

Fix an issue on WorkspaceList table view, where a full-width context menu appeared on left-click.

When I tried to open WorkspaceActionDropdown menu from the three-dots menu, it opened up a full-width context menu which covers up the dropdown.  In the screenshot you can see one menu covers up the other

<img width="1167" alt="Screen Shot 2023-05-22 at 10 12 25 AM" src="https://github.com/determined-ai/determined/assets/643918/5f890a77-5dcf-4ddc-af5a-61876f7f1072">

## Test Plan

On `/det/workspaces`, switch to Table view.
- Right-click on blank/inactive spaces of row opens context menu --- this menu is correct width
- Left-click on blank spaces of row **does not** open context menu
- Left-click on three dots menu opens one correct-width dropdown

<img width="345" alt="Screen Shot 2023-05-22 at 10 54 25 AM" src="https://github.com/determined-ai/determined/assets/643918/cad73a95-71b8-4d40-9704-2ed1da292363">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.