### PR TITLE
fix: bump AWS CFN `SecondsUntilAutoPause` to see if it helps with timeouts.

### DIFF
--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -458,7 +458,7 @@ Resources:
         - !GetAtt DatabaseSecurityGroup.GroupId
       ScalingConfiguration:
         AutoPause: true
-        SecondsUntilAutoPause: 3600
+        SecondsUntilAutoPause: 36000
         MinCapacity: 2
         MaxCapacity: 8
 


### PR DESCRIPTION
## Description

Per AWS support:

>Both of the DB Clusters are pausing due to Auto pause being enabled. [1] The Cluster will be resumed if there are any new connections made to the database. 
>Due to this pause the resource is not entering CREATE_COMPLETE status in CFN. The internal team has suggested to not enable Auto pause when creating through CFN, or to increase the autopause idle time to a sufficiently large value (max is 24 hours) or make some connections to the cluster as soon as the DB cluster is created, in order to allow the resource to enter CREATE_COMPLETE properly.

Let's try increasing the AutoPause time.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
