### PR TITLE
docs: Apply consistency to setup guides

### DIFF
--- a/docs/setup-cluster/deploy-cluster/aws/install-on-aws.rst
+++ b/docs/setup-cluster/deploy-cluster/aws/install-on-aws.rst
@@ -4,7 +4,7 @@
  Install Determined
 ####################
 
-This document describes how to deploy a Determined cluster on Amazon Web Services (AWS). The
+This user guide describes how to deploy a Determined cluster on Amazon Web Services (AWS). The
 :ref:`det deploy <determined-deploy>` tool makes it easy to create and install these resources. If
 you would rather create the cluster manually, see the :ref:`aws-manual-deployment` section below.
 

--- a/docs/setup-cluster/deploy-cluster/gcp/install-gcp.rst
+++ b/docs/setup-cluster/deploy-cluster/gcp/install-gcp.rst
@@ -4,9 +4,9 @@
  Install Determined
 ####################
 
-This document describes how to deploy a Determined cluster on Google Cloud Platform (GCP). The ``det
-deploy`` tool makes it easy to create and deploy these resources in GCP. The ``det deploy`` tool
-uses `Terraform <https://learn.hashicorp.com/terraform/getting-started/install.html>`__ to
+This user guide describes how to deploy a Determined cluster on Google Cloud Platform (GCP). The
+``det deploy`` tool makes it easy to create and deploy these resources in GCP. The ``det deploy``
+tool uses `Terraform <https://learn.hashicorp.com/terraform/getting-started/install.html>`__ to
 automatically deploy and configure a Determined cluster in GCP. Alternatively, if you already have a
 process for setting up infrastructure with Terraform, you can use our `Terraform modules
 <https://github.com/determined-ai/determined/tree/master/harness/determined/deploy/gcp/terraform>`__

--- a/docs/setup-cluster/deploy-cluster/k8s/install-on-kubernetes.rst
+++ b/docs/setup-cluster/deploy-cluster/k8s/install-on-kubernetes.rst
@@ -10,8 +10,8 @@
 | :doc:`/reference/deploy/config/helm-config-reference`           |
 +-----------------------------------------------------------------+
 
-This document describes how to install Determined on `Kubernetes <https://kubernetes.io/>`__. using
-the :download:`Determined Helm Chart </helm/determined-latest.tgz>`.
+This user guide describes how to install Determined on `Kubernetes <https://kubernetes.io/>`__.
+using the :download:`Determined Helm Chart </helm/determined-latest.tgz>`.
 
 When the Determined Helm chart is installed, the following entities will be created:
 

--- a/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
@@ -155,18 +155,18 @@ To start an agent container with environment variables instead of a configuratio
    started with ``--network host``. If the ``--network host`` option is used, you must also
    configure workload containers to use ``host`` network mode, as described :ref:`below
    <network-host>`. Alternatively, if the master machine has a static IP address from your router,
-   you can use that. They key is ensuring that the master machine can be reliably addressed from
-   both inside and outside of Docker containers (because the Fluent Bit container will always use
-   host networking).
+   you can use that. The key is ensuring that the master machine can be reliably addressed from both
+   inside and outside of Docker containers (because the Fluent Bit container will always use host
+   networking).
 
 Determined uses `Fluent Bit <https://fluentbit.io>`__ internally. The agent uses the
 ``fluent/fluent-bit:1.9.3`` Docker image at runtime and will attempt to pull this image
 automatically. If the agent machines in the cluster cannot connect to Docker Hub, you'll need to
 manually load this image onto them before Determined can run.
 
-To use a different image for running Fluent Bit--generally to leverage a custom Docker registry, as
-the image doesn't usually require changing otherwise--you can use the agent's
-``--fluent-logging-image`` command-line option or the ``fluent_logging_image`` config file option.
+To use a different image for running Fluent Bit---generally to leverage a custom Docker registry, as
+the image doesn't usually require changing otherwise---you can use the agent's
+``--fluent-logging-image`` command-line option or ``fluent_logging_image`` config file option.
 
 The ``--gpus`` flag should be used to specify which GPUs the agent container will have access to;
 without it, the agent will not have access to any GPUs. For example:
@@ -210,8 +210,8 @@ See `Docker's documentation <https://docs.docker.com/network/host/>`_ for more d
    Even if you run the agents in a named Docker network (e.g. ``--network my-named-network``), the
    workloads launched by the agent will execute in a different Docker network. This difference in
    networks will affect address resolution if you attempt to set the master hostname as the master's
-   container name, because the workload containers will not be in the correct Docker network to
-   reach the master using that name.
+   container name, because the workload containers will not be able to reach the master using that
+   name.
 
 ********************
  Manage the Cluster

--- a/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
@@ -144,20 +144,20 @@ To start an agent container with environment variables instead of a configuratio
        -e DET_MASTER_PORT=8080 \
        determinedai/determined-agent:VERSION
 
-**Agents and Master on Different Machines**
+.. note::
 
-If your agents and master are on different machines, the Determined master hostname or IP address
-should be set to a value that allows your agent machines to connect to the master machine.
+   **Agents and Master on Different Machines**: If your agents and master are on different machines,
+   the Determined master hostname or IP address should be set to a value that allows your agent
+   machines to connect to the master machine.
 
-**Agents and Master on the Same Machine**
-
-If your agents and master are on the same machine, using ``127.0.0.1`` typically will not work
-unless both the master and agent containers were started with ``--network host``. If the ``--network
-host`` option is used, you must also configure workload containers to use ``host`` network mode, as
-described :ref:`below <network-host>`. Alternatively, if the master machine has a static IP address
-from your router, you can use that. They key is ensuring that the master machine can be reliably
-addressed from both inside and outside of Docker containers (because the Fluent Bit container will
-always use host networking).
+   **Agents and Master on the Same Machine**: If your agents and master are on the same machine,
+   using ``127.0.0.1`` typically will not work unless both the master and agent containers were
+   started with ``--network host``. If the ``--network host`` option is used, you must also
+   configure workload containers to use ``host`` network mode, as described :ref:`below
+   <network-host>`. Alternatively, if the master machine has a static IP address from your router,
+   you can use that. They key is ensuring that the master machine can be reliably addressed from
+   both inside and outside of Docker containers (because the Fluent Bit container will always use
+   host networking).
 
 Determined uses `Fluent Bit <https://fluentbit.io>`__ internally. The agent uses the
 ``fluent/fluent-bit:1.9.3`` Docker image at runtime and will attempt to pull this image

--- a/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/docker.rst
@@ -4,6 +4,8 @@
  Install Determined Using Docker
 #################################
 
+This user guide provides step-by-step instructions for installing Determined using Docker.
+
 *******************
  Preliminary Setup
 *******************
@@ -36,10 +38,10 @@
  Configure and Start the Cluster
 *********************************
 
-PostgreSQL
-==========
+Start the PostgreSQL Container
+==============================
 
-The following command starts the PostgreSQL container:
+Run the following command to start the PostgreSQL container:
 
 .. code::
 
@@ -55,8 +57,8 @@ In order to expose the port only on the master machine's loopback network interf
 127.0.0.1:5432:5432`` instead of ``-p 5432:5432``. If you choose to run in host networking mode,
 pass ``--network host`` instead of ``-p 5432:5432``.
 
-Determined Master
-=================
+Start the Determined Master
+===========================
 
 Determined master configuration values can come from a file, environment variables, or command-line
 arguments.
@@ -96,8 +98,8 @@ In order to prevent the master from listening on port 8080 on all network interf
 machine, you may specify the loopback interface in the published port mapping, i.e., ``-p
 127.0.0.1:8080:8080``.
 
-Determined Agents
-=================
+Start the Determined Agents
+===========================
 
 Similar to the master configuration, Determined agent configuration values can come from a file,
 environment variables, or command-line arguments.
@@ -116,8 +118,8 @@ configuration:
        -v "$PWD"/agent.yaml:/etc/determined/agent.yaml \
        determinedai/determined-agent:VERSION
 
-Note that the agent container must bind mount the host's Docker daemon socket. This allows the agent
-container to orchestrate the containers that execute trials and other tasks.
+The agent container must bind mount the host's Docker daemon socket. This allows the agent container
+to orchestrate the containers that execute trials and other tasks.
 
 If you are providing command-line arguments to the container (e.g., using ``--master-port`` as
 opposed to the ``DET_MASTER_PORT`` environment variable), ``run`` must be provided as the first
@@ -142,24 +144,29 @@ To start an agent container with environment variables instead of a configuratio
        -e DET_MASTER_PORT=8080 \
        determinedai/determined-agent:VERSION
 
-When agents are on different machines than the master, the Determined master hostname or IP should
-just be how you expect your agent machines to reach the master machine.
+**Agents and Master on Different Machines**
 
-However, if the agents are on the same machine as the master, ``127.0.0.1`` will typically not work,
-unless both the master and agent containers were started with ``--network host``. Note that even
-that in that case, you will also have to configure workload containers to use ``host`` network mode,
-as described :ref:`below <network-host>`. Otherwise, if the master machine has a static IP address
-from your router, you can use that. What is important is that it is reliably addressable from both
-inside and outside of Docker containers (since the Fluent Bit container will always use host
-networking).
+If your agents and master are on different machines, the Determined master hostname or IP address
+should be set to a value that allows your agent machines to connect to the master machine.
 
-Determined internally makes use of `Fluent Bit <https://fluentbit.io>`__. The agent uses the
-``fluent/fluent-bit:1.9.3`` Docker image at runtime. It will attempt to pull the image
-automatically; if the agent machines in the cluster are not able to connect to Docker Hub, the image
-must be manually placed on them before Determined can run. In order to specify a different image to
-use for running Fluent Bit (generally to make use of a custom Docker registry---the image should not
-normally need to be changed otherwise), use the agent's ``--fluent-logging-image`` command-line
-option or ``fluent_logging_image`` config file option.
+**Agents and Master on the Same Machine**
+
+If your agents and master are on the same machine, using ``127.0.0.1`` typically will not work
+unless both the master and agent containers were started with ``--network host``. If the ``--network
+host`` option is used, you must also configure workload containers to use ``host`` network mode, as
+described :ref:`below <network-host>`. Alternatively, if the master machine has a static IP address
+from your router, you can use that. They key is ensuring that the master machine can be reliably
+addressed from both inside and outside of Docker containers (because the Fluent Bit container will
+always use host networking).
+
+Determined uses `Fluent Bit <https://fluentbit.io>`__ internally. The agent uses the
+``fluent/fluent-bit:1.9.3`` Docker image at runtime and will attempt to pull this image
+automatically. If the agent machines in the cluster cannot connect to Docker Hub, you'll need to
+manually load this image onto them before Determined can run.
+
+To use a different image for running Fluent Bit--generally to leverage a custom Docker registry, as
+the image doesn't usually require changing otherwise--you can use the agent's
+``--fluent-logging-image`` command-line option or the ``fluent_logging_image`` config file option.
 
 The ``--gpus`` flag should be used to specify which GPUs the agent container will have access to;
 without it, the agent will not have access to any GPUs. For example:
@@ -198,11 +205,13 @@ Mac, Docker Desktop for Windows, or Docker EE for Windows Server.
 
 See `Docker's documentation <https://docs.docker.com/network/host/>`_ for more details.
 
-Note that at this time, even if you run the agents in a named Docker network (e.g. ``--network
-my-named-network``), the workloads launched by the agent will execute in a different Docker network.
-This will affect address resolution if you try to set the master hostname as the master's container
-name, as the workload containers will not be in the correct Docker network to reach the master by
-that name.
+.. note::
+
+   Even if you run the agents in a named Docker network (e.g. ``--network my-named-network``), the
+   workloads launched by the agent will execute in a different Docker network. This difference in
+   networks will affect address resolution if you attempt to set the master hostname as the master's
+   container name, because the workload containers will not be in the correct Docker network to
+   reach the master using that name.
 
 ********************
  Manage the Cluster

--- a/docs/setup-cluster/deploy-cluster/on-prem/homebrew.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/homebrew.rst
@@ -4,6 +4,8 @@
  Install Determined Using Homebrew (macOS)
 ###########################################
 
+This user guide provides step-by-step instructions for installing Determined using Homebrew.
+
 Determined publishes a Homebrew tap for installing the Determined master and agent as Homebrew
 services on macOS, for both Apple silicon and Intel hardware.
 

--- a/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
@@ -152,29 +152,27 @@ Install the Determined Master and Agent
  Configure and Start the Cluster
 *********************************
 
-.. important::
-
-   Ensure that an instance of PostgreSQL is running and accessible from the machine where the
+#. Ensure that an instance of PostgreSQL is running and accessible from the machine where the
    Determined master will run.
 
--  Edit the :ref:`YAML configuration files <topic-guides_yaml>` at ``/etc/determined/master.yaml``
+#. Edit the :ref:`YAML configuration files <topic-guides_yaml>` at ``/etc/determined/master.yaml``
    (for the master) and ``/etc/determined/agent.yaml`` (for each agent) as appropriate for your
    setup.
 
-.. important::
+   .. important::
 
-   Ensure that the user, password, and database name correspond to your PostgreSQL configuration.
+      Ensure that the user, password, and database name correspond to your PostgreSQL configuration.
 
-.. code::
+   .. code::
 
-   db:
-     host: <PostgreSQL server IP or hostname, e.g., 127.0.0.1 if running on the master>
-     port: <PostgreSQL port, e.g., 5432 by default>
-     name: <Database name, e.g., determined>
-     user: <PostgreSQL user, e.g., postgres>
-     password: <Database password>
+      db:
+        host: <PostgreSQL server IP or hostname, e.g., 127.0.0.1 if running on the master>
+        port: <PostgreSQL port, e.g., 5432 by default>
+        name: <Database name, e.g., determined>
+        user: <PostgreSQL user, e.g., postgres>
+        password: <Database password>
 
--  Start the master by typing the following command:
+#. Start the master by typing the following command:
 
    .. code::
 
@@ -186,13 +184,13 @@ Install the Determined Master and Agent
       useful when experimenting with Determined such as when you want to quickly test different
       configuration options before writing them to the configuration file.
 
--  Optionally, configure the master to start on boot.
+#. Optionally, configure the master to start on boot.
 
    .. code::
 
       sudo systemctl enable determined-master
 
--  Verify that the master started successfully by viewing the log.
+#. Verify that the master started successfully by viewing the log.
 
    .. code::
 
@@ -204,7 +202,7 @@ Install the Determined Master and Agent
    your web browser (or ``https://<master>:8443`` if TLS is enabled). You should see ``No Agents``
    on the right-hand side of the top navigation bar.
 
--  Start the agent on each agent machine.
+#. Start the agent on each agent machine.
 
    .. code::
 
@@ -212,13 +210,13 @@ Install the Determined Master and Agent
 
    Similarly, the agent can be run with the command ``determined-agent``.
 
--  Optionally, configure the agent to start on boot.
+#. Optionally, configure the agent to start on boot.
 
    .. code::
 
       sudo systemctl enable determined-agent
 
--  Verify that each agent started successfully by viewing the log.
+#. Verify that each agent started successfully by viewing the log.
 
    .. code::
 

--- a/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
@@ -91,11 +91,12 @@ Install PostgreSQL using ``apt`` or ``yum``
    PostgreSQL distribution. To enable the ``determined-master`` to connect to the database, ensure
    that an appropriate authentication method is configured in the ``pg_hba.conf`` file.
 
-   When configuring the database connection in :ref:`configure_the_cluster`, note the following:
+   When configuring the database connection as described in :ref:`configure_the_cluster`, note the
+   following:
 
    -  If you specify the ``db.hostname`` property, you must use a PostgreSQL ``host`` (TCP/IP)
       connection.
-   -  If you omit the ``db.hostname`` property, you must use a PostgreSQL ``local`` (Unix-domain
+   -  If you omit the ``db.hostname`` property, you must use a PostgreSQL ``local`` (Unix domain
       socket) connection.
 
 #. Finally, create a database for Determined's use and configure a system account that Determined
@@ -181,7 +182,7 @@ Install the Determined Master and Agent
    .. note::
 
       You can also run the master directly using the command ``determined-master``. This may be
-      useful when experimenting with Determined such as when you want to quickly test different
+      useful when experimenting with Determined, such as when you want to quickly test different
       configuration options before writing them to the configuration file.
 
 #. Optionally, configure the master to start on boot.

--- a/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/linux-packages.rst
@@ -4,12 +4,16 @@
  Install Determined Using Linux Packages
 #########################################
 
+This user guide provides step-by-step instructions for installing Determined using Linux packages.
+
 Determined releases Debian and RPM packages for installing the Determined master and agent as
 systemd services on machines running Linux.
 
-We support installing the Determined master and agent using Debian packages on Ubuntu 16.04 or
-18.04, or using RPM packages on Red Hat 7-based Linux distributions (e.g., Red Hat Enterprise Linux,
-CentOS, Oracle Linux, and Scientific Linux).
+You have two options for installing the Determined master and agent:
+
+-  Using Debian packages on Ubuntu 16.04 or 18.04, or
+-  Using Red Hat 7-based Linux distributions (e.g., Red Hat Enterprise Linux, CentOS, Oracle Linux,
+   and Scientific Linux).
 
 *******************
  Preliminary Setup
@@ -21,8 +25,10 @@ PostgreSQL
 Determined uses a PostgreSQL database to store experiment and trial metadata. You may either use a
 Docker container or your Linux distribution's package and service.
 
-If you are using an existing PostgreSQL installation, we recommend confirming that
-``max_connections`` is at least 96, which is sufficient for Determined.
+.. note::
+
+   If you are using an existing PostgreSQL installation, we recommend confirming that
+   ``max_connections`` is at least 96, which is sufficient for Determined.
 
 Run PostgreSQL in Docker
 ------------------------
@@ -60,14 +66,19 @@ Install PostgreSQL using ``apt`` or ``yum``
 
 #. Install PostgreSQL 10 or greater.
 
-   On Debian distributions:
+   **Debian Distributions**
+
+   On Debian distributions, use the following command:
 
    .. code::
 
       sudo apt install postgresql-10
 
-   On Red Hat distributions, first configure the PostgreSQL yum repository as described `here
-   <https://www.postgresql.org/download/linux/redhat>`_ in order to then install version 10:
+   **Red Hat Distributions**
+
+   On Red Hat distributions, you'll need to configure the PostgreSQL yum repository as described in
+   the `Red Hat Linux documentation <https://www.postgresql.org/download/linux/redhat>`_. Then,
+   install version 10:
 
    .. code::
 
@@ -77,20 +88,22 @@ Install PostgreSQL using ``apt`` or ``yum``
       sudo systemctl enable postgresql.service
 
 #. The authentication methods enabled by default may vary depending on the provider of your
-   PostgreSQL distribution. Ensure that an appropriate authentication method is configured in
-   ``pg_hba.conf`` to enable the ``determined-master`` to connect to the database.
+   PostgreSQL distribution. To enable the ``determined-master`` to connect to the database, ensure
+   that an appropriate authentication method is configured in the ``pg_hba.conf`` file.
 
-   When configuring the database connection (:ref:`configure_the_cluster`):
+   When configuring the database connection in :ref:`configure_the_cluster`, note the following:
 
-   -  If you specify the ``db.hostname`` property, a PostgreSQL ``host`` (TCP/IP) connection will be
-      required.
-   -  If you omit the ``db.hostname`` property, a PostgreSQL ``local`` (Unix-domain socket)
-      connection will be required.
+   -  If you specify the ``db.hostname`` property, you must use a PostgreSQL ``host`` (TCP/IP)
+      connection.
+   -  If you omit the ``db.hostname`` property, you must use a PostgreSQL ``local`` (Unix-domain
+      socket) connection.
 
 #. Finally, create a database for Determined's use and configure a system account that Determined
-   will use to connect to the database. For example, the following commands will create a database
-   named ``determined``, a user named ``determined`` with the password ``determined-password``, and
-   then will grant the user access to the database:
+   will use to connect to the database.
+
+   For example, executing the following commands will create a database named ``determined``, create
+   a user named ``determined`` with the password ``determined-password``, and grant the user access
+   to the database:
 
    .. code::
 
@@ -99,34 +112,38 @@ Install PostgreSQL using ``apt`` or ``yum``
       postgres=# CREATE USER determined WITH ENCRYPTED PASSWORD 'determined-password';
       postgres=# GRANT ALL PRIVILEGES ON DATABASE determined TO determined;
 
-Master and Agent
-================
+Install the Determined Master and Agent
+=======================================
 
-#. Go to `the webpage for the latest Determined release
+#. Find the latest release of Determined by visiting the `Determined repo
    <https://github.com/determined-ai/determined/releases/latest>`_.
 
 #. Download the appropriate Debian or RPM package file, which will have the name
-   ``determined-master_VERSION_linux_amd64.[deb|rpm]`` (with ``VERSION`` replaced by an actual
-   version, such as |version|). The agent package is similarly named
+   ``determined-master_VERSION_linux_amd64.[deb|rpm]`` (where ``VERSION`` is the actual version,
+   e.g., |version|). Similarly, the agent package is named
    ``determined-agent_VERSION_linux_amd64.[deb|rpm]``.
 
 #. Install the master package on one machine in your cluster, and the agent package on each agent
    machine.
 
-   On Debian distributions:
+   **Debian Distributions**
+
+   On Debian distributions, use the following command:
 
       .. code::
 
          sudo apt install <path to downloaded package>
 
-   On Red Hat distributions:
+   **Red Hat Distributions**
+
+   On Red Hat distributions, use the following command:
 
       .. code::
 
          sudo rpm -i <path to downloaded package>
 
-   Before running the Determined agent, you will have to :ref:`install Docker <install-docker>` on
-   each agent machine and, if the machine has GPUs, ensure that the :ref:`NVIDIA Container Toolkit
+   Before running the Determined agent, :ref:`install Docker <install-docker>` on each agent
+   machine. If the machine has GPUs, ensure that the :ref:`NVIDIA Container Toolkit
    <validate-nvidia-container-toolkit>` is working as expected.
 
 .. _configure_the_cluster:
@@ -135,52 +152,59 @@ Master and Agent
  Configure and Start the Cluster
 *********************************
 
-#. Ensure that an instance of PostgreSQL is running and accessible from the machine where the master
-   will be run.
+.. important::
 
-#. Edit the :ref:`YAML configuration files <topic-guides_yaml>` at ``/etc/determined/master.yaml``
+   Ensure that an instance of PostgreSQL is running and accessible from the machine where the
+   Determined master will run.
+
+-  Edit the :ref:`YAML configuration files <topic-guides_yaml>` at ``/etc/determined/master.yaml``
    (for the master) and ``/etc/determined/agent.yaml`` (for each agent) as appropriate for your
-   setup. Ensure that the user, password, and database name correspond to your PostgreSQL
-   configuration.
+   setup.
 
-   .. code::
+.. important::
 
-      db:
-        host: <PostgreSQL server IP or hostname, e.g., 127.0.0.1 if running on the master>
-        port: <PostgreSQL port, e.g., 5432 by default>
-        name: <Database name, e.g., determined>
-        user: <PostgreSQL user, e.g., postgres>
-        password: <Database password>
+   Ensure that the user, password, and database name correspond to your PostgreSQL configuration.
 
-#. Start the master.
+.. code::
+
+   db:
+     host: <PostgreSQL server IP or hostname, e.g., 127.0.0.1 if running on the master>
+     port: <PostgreSQL port, e.g., 5432 by default>
+     name: <Database name, e.g., determined>
+     user: <PostgreSQL user, e.g., postgres>
+     password: <Database password>
+
+-  Start the master by typing the following command:
 
    .. code::
 
       sudo systemctl start determined-master
 
-   The master can also be run directly with the command ``determined-master``, which may be helpful
-   for experimenting with Determined (e.g., testing different configuration options quickly before
-   writing them to the configuration file).
+   .. note::
 
-#. Optionally, configure the master to start on boot.
+      You can also run the master directly using the command ``determined-master``. This may be
+      useful when experimenting with Determined such as when you want to quickly test different
+      configuration options before writing them to the configuration file.
+
+-  Optionally, configure the master to start on boot.
 
    .. code::
 
       sudo systemctl enable determined-master
 
-#. Verify that the master started successfully by viewing the log.
+-  Verify that the master started successfully by viewing the log.
 
    .. code::
 
       journalctl -u determined-master
 
-   You should see logging indicating that the master can successfully connect to the database, and
-   the last line should indicate ``http server started`` on the configured WebUI port (8080 by
-   default). You can also validate that the WebUI is running by navigating to
-   ``http://<master>:8080`` with your web browser (or ``https://<master>:8443`` if TLS is enabled).
-   You should see ``No Agents`` on the right-hand side of the top navigation bar.
+   You should see logs indicating that the master can successfully connect to the database, and the
+   last line should indicate ``http server started`` on the configured WebUI port (8080 by default).
+   You can also validate that the WebUI is running by navigating to ``http://<master>:8080`` with
+   your web browser (or ``https://<master>:8443`` if TLS is enabled). You should see ``No Agents``
+   on the right-hand side of the top navigation bar.
 
-#. Start the agent on each agent machine.
+-  Start the agent on each agent machine.
 
    .. code::
 
@@ -188,21 +212,21 @@ Master and Agent
 
    Similarly, the agent can be run with the command ``determined-agent``.
 
-#. Optionally, configure the agent to start on boot.
+-  Optionally, configure the agent to start on boot.
 
    .. code::
 
       sudo systemctl enable determined-agent
 
-#. Verify that each agent started successfully by viewing the log.
+-  Verify that each agent started successfully by viewing the log.
 
    .. code::
 
       journalctl -u determined-agent
 
-   You should see logging indicating that the agent started successfully, detected compute devices,
-   and connected to the master. On the Determined WebUI, you should now see slots available, both on
-   the right-hand side of the top navigation bar, and if you select the ``Cluster`` view in the
+   You should see logs indicating that the agent started successfully, detected compute devices, and
+   connected to the master. On the Determined WebUI, you should now see slots available, both on the
+   right-hand side of the top navigation bar, and if you select the ``Cluster`` view in the
    left-hand navigation panel.
 
 .. _socket-activation:

--- a/docs/setup-cluster/deploy-cluster/on-prem/wsl.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/wsl.rst
@@ -165,10 +165,8 @@ Before running the Determined agent, :ref:`install Docker <install-docker>` on e
 Configure and Start the Cluster
 ===============================
 
-.. important::
-
-   Ensure that an instance of PostgreSQL is running and accessible from the machine where the
-   Determined master will run.
+Ensure that an instance of PostgreSQL is running and accessible from the machine where the
+Determined master will run.
 
 To start the Determined master, you'll need to first edit the master and agent configuration files.
 


### PR DESCRIPTION
## Description

The on-prem set-up guides are not consistent with the new WSL set-up guide. The on-prem set-up guides do not clearly describe their purpose. Some of the instructions are unclear, wordy, full of jargon, and difficult to read.

The solution is to edit the on-prem set-up guides to make them more consistent, by reusing the same language and content where possible, and applying consistent formatting and headings where feasible.

