### PR TITLE
fix: add 'check permissions' message to RBAC NotFound errors

### DIFF
--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -627,7 +627,7 @@ def test_log_wait_timeout(tmp_path: Path, secrets: Dict[str, str]) -> None:
 @pytest.mark.e2e_cpu
 def test_log_argument(task_type: str) -> None:
     taskid = "28ad1623-dcf0-47d2-9faa-265aaa05b078"
-    expected = f"task not found: {taskid}"
+    expected = f"task {taskid} not found"
     cmd: List[str] = ["det", "-m", conf.make_master_url(), task_type, "logs", taskid]
     p = subprocess.run(cmd, stderr=subprocess.PIPE, check=False)
     assert p.stderr is not None

--- a/master/internal/api.go
+++ b/master/internal/api.go
@@ -172,10 +172,6 @@ func (a *apiServer) filter(values interface{}, check func(int) bool) {
 	rv.Elem().Set(results)
 }
 
-func errActorNotFound(addr actor.Address) error {
-	return status.Errorf(codes.NotFound, "actor %s could not be found", addr)
-}
-
 // ask asks at addr the req and puts the response into what v points at. When appropriate,
 // errors are converted appropriate for an API response. Error cases are enumerated below:
 //   - If v points to an unsettable value, a 500 is returned.
@@ -195,7 +191,7 @@ func (a *apiServer) ask(addr actor.Address, req interface{}, v interface{}) erro
 	expectingResponse := reflect.ValueOf(v).IsValid() && reflect.ValueOf(v).Elem().CanSet()
 	switch resp := a.m.system.AskAt(addr, req); {
 	case resp.Source() == nil:
-		return errActorNotFound(addr)
+		return api.NotFoundErrs("actor", fmt.Sprint(addr), true)
 	case expectingResponse && resp.Empty(), expectingResponse && resp.Get() == nil:
 		return status.Errorf(
 			codes.NotFound,

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	apiPkg "github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -336,7 +337,7 @@ func TestCheckpointAuthZ(t *testing.T) {
 				require.Equal(t, errCheckpointsNotFound([]string{notFoundUUID}),
 					curCase.IDToReqCall(notFoundUUID))
 			} else {
-				require.Equal(t, errCheckpointNotFound(notFoundUUID),
+				require.Equal(t, apiPkg.NotFoundErrs("checkpoint", notFoundUUID, true),
 					curCase.IDToReqCall(notFoundUUID))
 			}
 
@@ -346,7 +347,7 @@ func TestCheckpointAuthZ(t *testing.T) {
 				require.Equal(t, errCheckpointsNotFound([]string{checkpointID}),
 					curCase.IDToReqCall(checkpointID))
 			} else {
-				require.Equal(t, errCheckpointNotFound(checkpointID),
+				require.Equal(t, apiPkg.NotFoundErrs("checkpoint", checkpointID, true),
 					curCase.IDToReqCall(checkpointID))
 			}
 

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -225,7 +225,7 @@ func (a *apiServer) GetCommands(
 		return nil, err
 	}
 
-	workspaceNotFoundErr := status.Errorf(codes.NotFound, "workspace %d not found", req.WorkspaceId)
+	workspaceNotFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(req.WorkspaceId), true)
 
 	if req.WorkspaceId != 0 {
 		// check if the workspace exists.
@@ -274,7 +274,7 @@ func (a *apiServer) GetCommand(
 	ctx = audit.SupplyEntityID(ctx, req.CommandId)
 	if err := command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Command.WorkspaceId)); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
+		return nil, authz.SubIfUnauthorized(err, api.NotFoundErrs("actor", fmt.Sprint(addr), true))
 	}
 	return resp, nil
 }

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -18,6 +18,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/uptrace/bun"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/prom"
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -131,7 +132,7 @@ func isActiveExperimentState(state experimentv1.State) bool {
 func (a *apiServer) getExperiment(
 	ctx context.Context, curUser model.User, experimentID int,
 ) (*experimentv1.Experiment, error) {
-	expNotFound := status.Errorf(codes.NotFound, "experiment not found: %d", experimentID)
+	expNotFound := api.NotFoundErrs("experiment", fmt.Sprint(experimentID), true)
 	exp := &experimentv1.Experiment{}
 	if err := a.m.db.QueryProto("get_experiment", exp, experimentID); errors.Is(err, db.ErrNotFound) {
 		return nil, expNotFound
@@ -765,7 +766,7 @@ func (a *apiServer) GetExperimentValidationHistory(
 	var resp apiv1.GetExperimentValidationHistoryResponse
 	switch err := a.m.db.QueryProto("proto_experiment_validation_history", &resp, req.ExperimentId); {
 	case err == db.ErrNotFound:
-		return nil, status.Errorf(codes.NotFound, "experiment not found: %d", req.ExperimentId)
+		return nil, api.NotFoundErrs("experiment", fmt.Sprint(req.ExperimentId), true)
 	case err != nil:
 		return nil, errors.Wrapf(err,
 			"error fetching validation history for experiment from database: %d", req.ExperimentId)
@@ -1243,8 +1244,7 @@ func (a *apiServer) GetExperimentCheckpoints(
 	resp.Checkpoints = []*checkpointv1.Checkpoint{}
 	switch err = a.m.db.QueryProto("get_checkpoints_for_experiment", &resp.Checkpoints, req.Id); {
 	case err == db.ErrNotFound:
-		return nil, status.Errorf(
-			codes.NotFound, "no checkpoints found for experiment %d", req.Id)
+		return nil, api.NotFoundErrs("checkpoints for experiment", fmt.Sprint(req.Id), true)
 	case err != nil:
 		return nil,
 			errors.Wrapf(err, "error fetching checkpoints for experiment %d from database", req.Id)
@@ -1337,10 +1337,7 @@ func (a *apiServer) CreateExperiment(
 		req, user,
 	)
 	if err != nil {
-		if _, ok := err.(ErrProjectNotFound); ok {
-			return nil, status.Errorf(codes.NotFound, err.Error())
-		}
-		return nil, status.Errorf(codes.InvalidArgument, "invalid experiment: %s", err)
+		return nil, err
 	}
 	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *user, p); err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, err.Error())

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
@@ -638,8 +639,7 @@ func (a *apiServer) PostModelVersion(
 
 	switch getCheckpointErr := a.m.db.QueryProto("get_checkpoint", c, req.CheckpointUuid); {
 	case getCheckpointErr == db.ErrNotFound:
-		return nil, status.Errorf(
-			codes.NotFound, "checkpoint %s not found", req.CheckpointUuid)
+		return nil, api.NotFoundErrs("checkpoint", req.CheckpointUuid, true)
 	case getCheckpointErr != nil:
 		return nil, getCheckpointErr
 	}

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -102,7 +102,8 @@ func (a *apiServer) GetNotebook(
 	if err := command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Notebook.WorkspaceId),
 	); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
+		return nil, authz.SubIfUnauthorized(err,
+			api.NotFoundErrs("actor", fmt.Sprint(addr), true))
 	}
 	return resp, nil
 }
@@ -184,7 +185,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 	}
 
 	w := &workspacev1.Workspace{}
-	notFoundErr := status.Errorf(codes.NotFound, "workspace (%d) not found", workspaceID)
+	notFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(workspaceID), true)
 	if err := a.m.db.QueryProto(
 		"get_workspace", w, workspaceID, user.ID,
 	); errors.Is(err, db.ErrNotFound) {

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	apiPkg "github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/config"
@@ -149,30 +150,31 @@ func TestCanGetNTSC(t *testing.T) {
 	nbsActor := actor.Addr(command.NotebookActorPath)
 
 	_, err = api.GetNotebook(ctx, &apiv1.GetNotebookRequest{NotebookId: invalidID})
-	require.Equal(t, errActorNotFound(nbsActor.Child(invalidID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(nbsActor.Child(invalidID)), true), err)
 
 	_, err = api.GetNotebook(ctx, &apiv1.GetNotebookRequest{NotebookId: string(nbID)})
-	require.Equal(t, errActorNotFound(nbsActor.Child(nbID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(nbsActor.Child(nbID)), true), err)
 
 	// Commands.
 	cmdID := setupMockCMDActor(t, api.m)
 	cmdsActor := actor.Addr(command.CommandActorPath)
 
 	_, err = api.GetCommand(ctx, &apiv1.GetCommandRequest{CommandId: invalidID})
-	require.Equal(t, errActorNotFound(cmdsActor.Child(invalidID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(cmdsActor.Child(invalidID)), true), err)
 
 	_, err = api.GetCommand(ctx, &apiv1.GetCommandRequest{CommandId: string(cmdID)})
-	require.Equal(t, errActorNotFound(cmdsActor.Child(cmdID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(cmdsActor.Child(cmdID)), true), err)
 
 	// Shells.
 	shellID := setupMockShellActor(t, api.m)
 	shellsActor := actor.Addr(command.ShellActorPath)
 
 	_, err = api.GetShell(ctx, &apiv1.GetShellRequest{ShellId: invalidID})
-	require.Equal(t, errActorNotFound(shellsActor.Child(invalidID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor",
+		fmt.Sprint(shellsActor.Child(invalidID)), true), err)
 
 	_, err = api.GetShell(ctx, &apiv1.GetShellRequest{ShellId: string(shellID)})
-	require.Equal(t, errActorNotFound(shellsActor.Child(shellID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(shellsActor.Child(shellID)), true), err)
 
 	// Tensorboards.
 	// check permission errors are returned with not found status and follow the same pattern.
@@ -183,10 +185,10 @@ func TestCanGetNTSC(t *testing.T) {
 	tbActor := actor.Addr(command.TensorboardActorPath)
 
 	_, err = api.GetTensorboard(ctx, &apiv1.GetTensorboardRequest{TensorboardId: invalidID})
-	require.Equal(t, errActorNotFound(tbActor.Child(invalidID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(tbActor.Child(invalidID)), true), err)
 
 	_, err = api.GetTensorboard(ctx, &apiv1.GetTensorboardRequest{TensorboardId: string(tbID)})
-	require.Equal(t, errActorNotFound(tbActor.Child(tbID)), err)
+	require.Equal(t, apiPkg.NotFoundErrs("actor", fmt.Sprint(tbActor.Child(tbID)), true), err)
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/api/apiutils"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -27,7 +28,7 @@ import (
 func (a *apiServer) GetProjectByID(
 	ctx context.Context, id int32, curUser model.User,
 ) (*projectv1.Project, error) {
-	notFoundErr := status.Errorf(codes.NotFound, "project (%d) not found", id)
+	notFoundErr := api.NotFoundErrs("project", fmt.Sprint(id), true)
 	p := &projectv1.Project{}
 	if err := a.m.db.QueryProto("get_project", p, id); errors.Is(err, db.ErrNotFound) {
 		return nil, notFoundErr

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -58,7 +58,7 @@ func (a *apiServer) GetShells(
 		return nil, err
 	}
 
-	workspaceNotFoundErr := status.Errorf(codes.NotFound, "workspace %d not found", req.WorkspaceId)
+	workspaceNotFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(req.WorkspaceId), true)
 
 	if req.WorkspaceId != 0 {
 		// check if the workspace exists.
@@ -112,7 +112,7 @@ func (a *apiServer) GetShell(
 	ctx = audit.SupplyEntityID(ctx, req.ShellId)
 	if err := command.AuthZProvider.Get().CanGetNSC(
 		ctx, *curUser, model.AccessScopeID(resp.Shell.WorkspaceId)); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
+		return nil, authz.SubIfUnauthorized(err, api.NotFoundErrs("actor", fmt.Sprint(addr), true))
 	}
 	return resp, nil
 }

--- a/master/internal/api_task.go
+++ b/master/internal/api_task.go
@@ -3,11 +3,9 @@ package internal
 import (
 	"context"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -26,8 +24,7 @@ func (a *apiServer) GetTask(
 	t := &taskv1.Task{}
 	switch err := a.m.db.QueryProto("get_task", t, req.TaskId); {
 	case errors.Is(err, db.ErrNotFound):
-		return nil, status.Errorf(
-			codes.NotFound, "task %s not found", req.TaskId)
+		return nil, api.NotFoundErrs("task", req.TaskId, true)
 	default:
 		return &apiv1.GetTaskResponse{Task: t},
 			errors.Wrapf(err, "error fetching task %s from database", req.TaskId)

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -74,7 +74,7 @@ func (a *apiServer) canDoActionsOnTask(
 	ctx context.Context, taskID model.TaskID,
 	actions ...func(context.Context, model.User, *model.Experiment) error,
 ) error {
-	errTaskNotFound := status.Errorf(codes.NotFound, "task not found: %s", taskID)
+	errTaskNotFound := api.NotFoundErrs("task", fmt.Sprint(taskID), true)
 	t, err := a.m.db.TaskByID(taskID)
 	if errors.Is(err, db.ErrNotFound) {
 		return errTaskNotFound
@@ -129,7 +129,7 @@ func (a *apiServer) canEditAllocation(ctx context.Context, allocationID string) 
 	}
 
 	taskID := model.AllocationID(allocationID).ToTaskID()
-	errAllocationNotFound := status.Errorf(codes.NotFound, "allocation not found: %s", allocationID)
+	errAllocationNotFound := api.NotFoundErrs("allocation", allocationID, true)
 	isExp, exp, err := expFromTaskID(ctx, taskID)
 	if err != nil {
 		return err

--- a/master/internal/api_tasks_intg_test.go
+++ b/master/internal/api_tasks_intg_test.go
@@ -12,14 +12,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	apiPkg "github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 )
-
-func errTaskNotFound(id string) error {
-	return status.Errorf(codes.NotFound, "task not found: %s", id)
-}
 
 func TestTaskAuthZ(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
@@ -56,12 +53,12 @@ func TestTaskAuthZ(t *testing.T) {
 	}
 
 	for _, curCase := range cases {
-		require.ErrorIs(t, curCase.IDToReqCall("-999"), errTaskNotFound("-999"))
+		require.ErrorIs(t, curCase.IDToReqCall("-999"), apiPkg.NotFoundErrs("task", "-999", true))
 
 		// Can't view allocation's experiment gives same error.
 		authZExp.On("CanGetExperiment", mock.Anything, curUser, mock.Anything).
 			Return(authz2.PermissionDeniedError{}).Once()
-		require.ErrorIs(t, curCase.IDToReqCall(taskID), errTaskNotFound(taskID))
+		require.ErrorIs(t, curCase.IDToReqCall(taskID), apiPkg.NotFoundErrs("task", taskID, true))
 
 		// Experiment view error is returned unmodified.
 		expectedErr := fmt.Errorf("canGetExperimentError")

--- a/master/internal/api_templates.go
+++ b/master/internal/api_templates.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -9,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -69,7 +71,7 @@ func (a *apiServer) PostTemplate(
 	if req.Template.WorkspaceId != 0 {
 		workspaceID = int(req.Template.WorkspaceId)
 	}
-	notFoundErr := status.Errorf(codes.NotFound, "workspace (%d) not found", workspaceID)
+	notFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(workspaceID), true)
 	var exists bool
 	err = db.Bun().NewSelect().ColumnExpr("1").Table("workspaces").
 		Where("id = ?", workspaceID).

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -127,7 +127,7 @@ func (a *apiServer) GetTensorboard(
 	if err := command.AuthZProvider.Get().CanGetTensorboard(
 		ctx, *curUser, model.AccessScopeID(resp.Tensorboard.WorkspaceId),
 		resp.Tensorboard.ExperimentIds, resp.Tensorboard.TrialIds); err != nil {
-		return nil, authz.SubIfUnauthorized(err, errActorNotFound(addr))
+		return nil, authz.SubIfUnauthorized(err, api.NotFoundErrs("actor", fmt.Sprint(addr), true))
 	}
 	return resp, nil
 }

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -66,7 +66,7 @@ func (a *apiServer) canGetTrialsExperimentAndCheckCanDoAction(ctx context.Contex
 		return err
 	}
 
-	trialNotFound := status.Errorf(codes.NotFound, "trial %d not found", trialID)
+	trialNotFound := api.NotFoundErrs("trial", fmt.Sprint(trialID), true)
 	exp, err := db.ExperimentByTrialID(ctx, trialID)
 	if errors.Is(err, db.ErrNotFound) {
 		return trialNotFound

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -69,7 +70,7 @@ func validateWorkspaceName(name string) error {
 func (a *apiServer) GetWorkspaceByID(
 	ctx context.Context, id int32, curUser model.User, rejectImmutable bool,
 ) (*workspacev1.Workspace, error) {
-	notFoundErr := status.Errorf(codes.NotFound, "workspace (%d) not found", id)
+	notFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(id), true)
 	w := &workspacev1.Workspace{}
 
 	if err := a.m.db.QueryProto("get_workspace", w, id, curUser.ID); errors.Is(err, db.ErrNotFound) {

--- a/master/internal/core_checkpoint.go
+++ b/master/internal/core_checkpoint.go
@@ -96,8 +96,7 @@ func (m *Master) getCheckpointImpl(
 			fmt.Sprintf("unable to retrieve experiment config for checkpoint %s: %s",
 				id.String(), err.Error()))
 	case storageConfig == nil:
-		return echo.NewHTTPError(http.StatusNotFound,
-			fmt.Sprintf("checkpoint not found: %s", id.String()))
+		return api.NotFoundErrs("checkpoint", id.String(), false)
 	}
 
 	// DelayWriter delays the first write until we have successfully downloaded

--- a/master/internal/experiment/bulk_action.go
+++ b/master/internal/experiment/bulk_action.go
@@ -14,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/pkg/actor"
@@ -238,7 +239,7 @@ func ActivateExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -269,7 +270,7 @@ func CancelExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -313,7 +314,7 @@ func KillExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -355,7 +356,7 @@ func PauseExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -430,9 +431,8 @@ func DeleteExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found or no delete permission: %d",
-						originalID),
-					ID: originalID,
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					ID:    originalID,
 				})
 			}
 		}
@@ -523,7 +523,7 @@ func ArchiveExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -614,7 +614,7 @@ func UnarchiveExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}
@@ -700,7 +700,7 @@ func MoveExperiments(ctx context.Context, system *actor.System,
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: status.Errorf(codes.NotFound, "experiment not found: %d", originalID),
+					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
 					ID:    originalID,
 				})
 			}

--- a/master/internal/experiment/postgres_experiments.go
+++ b/master/internal/experiment/postgres_experiments.go
@@ -2,12 +2,14 @@ package experiment
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
@@ -26,8 +28,7 @@ func GetExperimentAndCheckCanDoActions(
 	}
 
 	e, err := db.ExperimentByID(ctx, expID)
-
-	expNotFound := status.Errorf(codes.NotFound, "experiment not found: %d", expID)
+	expNotFound := api.NotFoundErrs("experiment", fmt.Sprint(expID), true)
 	if errors.Is(err, db.ErrNotFound) {
 		return nil, model.User{}, expNotFound
 	} else if err != nil {

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/internal/api"
+
 	"github.com/determined-ai/determined/master/internal/authz"
 	detContext "github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -367,8 +368,8 @@ func (s *Service) patchUser(c echo.Context) (interface{}, error) {
 		return nil, malformedRequestError
 	}
 
-	userNotFoundErr := echo.NewHTTPError(http.StatusBadRequest,
-		fmt.Sprintf("failed to get user '%s'", args.Username))
+	userNotFoundErr := api.NotFoundErrs("user", args.Username, false)
+
 	currUser := c.(*detContext.DetContext).MustGetUser()
 	user, err := UserByUsername(args.Username)
 	switch err {

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/context"
@@ -177,17 +178,14 @@ func TestAuthzPatchUser(t *testing.T) {
 			Return(authz2.PermissionDeniedError{}).Once()
 
 		_, err = svc.patchUser(ctx)
-		require.Equal(t,
-			echo.NewHTTPError(http.StatusBadRequest, "failed to get user 'admin'").Error(),
-			err.Error())
+		require.Equal(t, api.NotFoundErrs("user", "admin", false).Error(), err.Error())
 
 		ctx.SetParamNames("username")
 		ctx.SetParamValues(notFoundUsername)
 		ctx.SetRequest(httptest.NewRequest(http.MethodPatch, "/",
 			strings.NewReader(testCase.body)))
 		_, err = svc.patchUser(ctx)
-		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest,
-			fmt.Sprintf("failed to get user '%s'", notFoundUsername)).Error(), err.Error())
+		require.Equal(t, api.NotFoundErrs("user", notFoundUsername, false).Error(), err.Error())
 	}
 }
 


### PR DESCRIPTION
## Description
For better ux, the cli should check if the cluster has RBAC enabled and include warnings in the error message about potentially missing required permissions if server reports a 404(missing or no perm). This PR adds a "check your permissions" string to the error messages triggered by requests with unauthorized permissions -- which would only occur when RBAC is enabled anyway.

## Test Plan
Manually testing & visually verifying that the following endpoints work & print the desired output with the listed CLI commands & the API (Beta) feature from the WebUI
```

command: // GET /api/v1/NSCs/:nsc_id, // GET /tasks, // GET /api/v1/tensorboards/:tb_id
       Tested on WebUI
       
experiment: // GET /api/v1/experiments/:exp_id, // GET /tasks
        det e logs <exp-id>
        det e list
        det task list
        
model: // GET /api/v1/models, // GET /api/v1/checkpoints/{checkpoint_uuid}, // GET /api/v1/models/{model_name}, // GET /api/v1/models/{model_name}/versions/{model_version_num}, // GET /api/v1/models/{model_name}/versions
        det model ls
        det model describe <model-name>
        Tested on WebUI

project: // GET /api/v1/projects/:project_id
        det project list
        det project describe <workspace-name> <project-name>
        (Now test that it doesn't show up for a different user -- det logout && repeat)

rbac: no listed endpoints
	det rbac list-roles
	det rbac describe-role Editor

trial: // POST /trial-comparison/collections
        Tested on WebUI

`user`: // POST /logout, // POST /login, // GET /users/me, // GET /api/v1/auth/user, // GET /api/v1/users/:user_id	
	det user login admin
	det user logout
	det rbac my-permissions
	det user list
	det user whoami
	det user create alice
	det user change-password alice
	det user rename bob

workspace: // GET /api/v1/workspaces/:workspace_id
        det workspace describe <workspace-name>
	det workspace list-projects <workspace-name>
	Tested on webUI
```



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9035