### PR TITLE
fix: Workspace selection on JupyterLab modal [DET-9503]

### DIFF
--- a/webui/react/src/components/JupyterLabModal.tsx
+++ b/webui/react/src/components/JupyterLabModal.tsx
@@ -69,7 +69,7 @@ interface FullConfigProps {
   form: FormInstance;
   lockedWorkspace: boolean;
   onChange?: (config: string) => void;
-  setWorkspace: (arg0: Workspace) => void;
+  setWorkspace: (arg0: Workspace | undefined) => void;
   workspaces: Workspace[];
 }
 
@@ -94,9 +94,9 @@ const JupyterLabModalComponent: React.FC<Props> = ({ workspace }: Props) => {
 
   const validateFullConfigForm = useCallback(() => {
     const fields = fullConfigForm.getFieldsError();
-    const hasError = fields.some((f) => f.errors.length);
+    const hasError = fields.some((f) => f.errors.length) || !currentWorkspace;
     setFullConfigFormInvalid(hasError);
-  }, [fullConfigForm]);
+  }, [currentWorkspace, fullConfigForm]);
 
   const { settings: defaults, updateSettings: updateDefaults } =
     useSettings<JupyterLabOptions>(settingsConfig);
@@ -260,14 +260,12 @@ const JupyterLabFullConfig: React.FC<FullConfigProps> = ({
   }, [config]);
 
   useEffect(() => {
-    if (currentWorkspace) {
-      form.setFieldValue('workspaceId', currentWorkspace?.id);
-    }
+    form.setFieldValue('workspaceId', currentWorkspace?.id);
   }, [currentWorkspace, form]);
 
-  const onSelectWorkspace = (workspaceId: number) => {
-    const selected = workspaces.find((w) => w.id === workspaceId);
-    if (selected) setWorkspace(selected);
+  const onSelectWorkspace = (workspaceId?: number) => {
+    const selected = workspaces.find((w) => workspaceId && w.id === workspaceId);
+    setWorkspace(selected);
   };
 
   return (
@@ -328,7 +326,7 @@ const JupyterLabForm: React.FC<{
   defaults: JupyterLabOptions;
   form: FormInstance<JupyterLabOptions>;
   lockedWorkspace: boolean;
-  setWorkspace: (arg0: Workspace) => void;
+  setWorkspace: (arg0: Workspace | undefined) => void;
   workspaces: Workspace[];
 }> = ({ form, currentWorkspace, defaults, lockedWorkspace, setWorkspace, workspaces }) => {
   const [templates, setTemplates] = useState<Template[]>([]);
@@ -387,14 +385,12 @@ const JupyterLabForm: React.FC<{
   }, [resourcePools, form]);
 
   useEffect(() => {
-    if (currentWorkspace) {
-      form.setFieldValue('workspaceId', currentWorkspace.id);
-    }
+    form.setFieldValue('workspaceId', currentWorkspace?.id);
   }, [currentWorkspace, form]);
 
-  const onSelectWorkspace = (workspaceId: number) => {
-    const selected = workspaces.find((w) => w.id === workspaceId);
-    if (selected) setWorkspace(selected);
+  const onSelectWorkspace = (workspaceId?: number) => {
+    const selected = workspaces.find((w) => workspaceId && w.id === workspaceId);
+    setWorkspace(selected);
   };
 
   return (


### PR DESCRIPTION
## Description

JupyterLab modal will keep workspace selection when switching between simple-form and full-config modes

## Test Plan

Flexible workspace form and validation
- On `/det/dashboard`, in the top right, click the 'Launch JupyterLab' button
- The "Launch" button in the bottom right of the form is greyed out. Hovering has tooltip "Address validation errors..."
- A dropdown allows you to select a workspace on this form. The form's "Launch" button now turns blue
- Hover over the workspace input and click the small x to clear. The "Launch" button is greyed out again

Retaining workspace between modes
- Select a workspace again
- Click "Show Full Config"
- The same workspace is selected above the config text input. The "Launch" button in the bottom right is blue / enabled
- Clear the workspace. The "Launch" button in the bottom right is grey / disabled
- Click "Show Simple Config". The workspace here is also cleared and "Launch" disabled

Fixed workspace
- As admin, go to `/det/workspaces` and select a workspace
- Under the "Tasks" tab, click the "Launch JupyterLab" button above the right table
- In the simple modal, the workspace name is pre-populated, the dropdown is disabled, and Launch button is blue
- Click "Show Full Config". The workspace name here is also pre-populated and the dropdown is disabled
- Click "Launch". Confirm the notebook launches in the correct workspace.


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.