### PR TITLE
perf: render full experiment list [WEB-1234]

### DIFF
--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -39,7 +39,7 @@ interface Props {
   isContextMenu?: boolean;
   link?: string;
   makeOpen?: boolean;
-  onComplete?: (action?: Action) => Promise<void>;
+  onComplete?: (action?: Action) => void | Promise<void>;
   onLink?: () => void;
   onVisibleChange?: (visible: boolean) => void;
   settings?: ExperimentListSettings;

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -213,6 +213,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const { stopPolling } = usePolling(fetchExperiments, { rerunOnNewFn: true });
 
+  const onContextMenuComplete = useCallback(fetchExperiments, [fetchExperiments]);
+
   // TODO: poll?
   useEffect(() => {
     let mounted = true;
@@ -367,8 +369,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
             clearSelectionTrigger={clearSelectionTrigger}
             colorMap={colorMap}
             data={experiments}
+            dataTotal={Loadable.getOrElse(0, total)}
             excludedExperimentIds={excludedExperimentIds}
-            fetchExperiments={fetchExperiments}
             formStore={formStore}
             handleScroll={handleScroll}
             handleUpdateExperimentList={handleUpdateExperimentList}
@@ -385,6 +387,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
             setSortableColumnIds={setVisibleColumns}
             sortableColumnIds={settings.columns}
             sorts={sorts}
+            onContextMenuComplete={onContextMenuComplete}
             onIsOpenFilterChange={onIsOpenFilterChange}
             onSortChange={onSortChange}
           />

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -71,7 +71,7 @@ export interface GlideTableProps {
   colorMap: MapOfIdsToColors;
   excludedExperimentIds: Set<number>;
   data: Loadable<ExperimentWithTrial>[];
-  fetchExperiments: () => Promise<void>;
+  dataTotal: number;
   handleScroll?: (r: Rectangle) => void;
   height: number;
   scrollPositionSetCount: WritableObservable<number>;
@@ -90,6 +90,7 @@ export interface GlideTableProps {
   onSortChange: (sorts: Sort[]) => void;
   formStore: FilterFormStore;
   onIsOpenFilterChange: (value: boolean) => void;
+  onContextMenuComplete?: () => void;
 }
 
 /**
@@ -111,7 +112,7 @@ const isLinkCell = (cell: GridCell): cell is LinkCell => {
 
 export const GlideTable: React.FC<GlideTableProps> = ({
   data,
-  fetchExperiments,
+  dataTotal = 0,
   excludedExperimentIds,
   clearSelectionTrigger,
   setSelectedExperimentIds,
@@ -132,6 +133,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   projectColumns,
   formStore,
   onIsOpenFilterChange,
+  onContextMenuComplete,
 }) => {
   const gridRef = useRef<DataEditorRef>(null);
 
@@ -154,12 +156,16 @@ export const GlideTable: React.FC<GlideTableProps> = ({
     y: 0,
   });
 
+  const handleContextMenuComplete = useCallback(() => {
+    onContextMenuComplete?.();
+  }, [onContextMenuComplete]);
+
   const [contextMenuOpen] = useState(observable(false));
   const contextMenuIsOpen = useObservable(contextMenuOpen);
 
   const [contextMenuProps, setContextMenuProps] = useState<null | Omit<
     TableContextMenuProps,
-    'open' | 'fetchExperiments' | 'handleUpdateExperimentList'
+    'open' | 'handleUpdateExperimentList'
   >>(null);
 
   const {
@@ -633,7 +639,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           height={height}
           ref={gridRef}
           rowHeight={40}
-          rows={data.length}
+          rows={dataTotal}
           smoothScrollX
           smoothScrollY
           theme={theme}
@@ -652,9 +658,9 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       {contextMenuProps && (
         <TableContextMenu
           {...contextMenuProps}
-          fetchExperiments={fetchExperiments}
           handleUpdateExperimentList={handleUpdateExperimentList}
           open={contextMenuIsOpen}
+          onComplete={handleContextMenuComplete}
         />
       )}
     </div>

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -112,7 +112,7 @@ const isLinkCell = (cell: GridCell): cell is LinkCell => {
 
 export const GlideTable: React.FC<GlideTableProps> = ({
   data,
-  dataTotal = 0,
+  dataTotal,
   excludedExperimentIds,
   clearSelectionTrigger,
   setSelectedExperimentIds,

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -33,7 +33,6 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Eve
 }
 
 export interface TableContextMenuProps extends MenuProps {
-  fetchExperiments: () => Promise<void>;
   handleUpdateExperimentList: (action: BatchAction, successfulIds: number[]) => void;
   open: boolean;
   experiment: ProjectExperiment;
@@ -41,25 +40,26 @@ export interface TableContextMenuProps extends MenuProps {
   link?: string;
   x: number;
   y: number;
+  onComplete?: () => void;
 }
 
 export const TableContextMenu: React.FC<TableContextMenuProps> = ({
   experiment,
-  fetchExperiments,
   handleUpdateExperimentList,
   handleClose,
   open,
   link,
   x,
   y,
+  onComplete,
 }) => {
   const containerRef = useRef(null);
   useOutsideClickHandler(containerRef, handleClose);
 
-  const onComplete = useCallback(async () => {
-    await fetchExperiments();
+  const handleComplete = useCallback(() => {
+    onComplete?.();
     handleClose();
-  }, [fetchExperiments, handleClose]);
+  }, [handleClose, onComplete]);
 
   return (
     <div
@@ -75,7 +75,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
         handleUpdateExperimentList={handleUpdateExperimentList}
         link={link}
         makeOpen={open}
-        onComplete={onComplete}
+        onComplete={handleComplete}
         onLink={handleClose}
         onVisibleChange={() => handleClose()}>
         <div />


### PR DESCRIPTION
## Description

Improve the table experiment loading experience. Currently the new experiment list will render up to the data it has instead of the full total. For example, if the user loads page 3 upfront and each page is roughly 50 entries, then the API will return entries 100 ~ 150. And assuming there are a total of 500 entries, the UI will pad the rows so there are 150 entries and render the data for entries 100 ~ 150 since they are loaded. However for new rows that span beyond 150 ~ 500, it will hit a "wall" on the scroll and wait for new API fetches to occur before the newer entries are returned followed by rendering the next set of entries (150 ~ 200).

Instead, change it so upon knowing that there are 500 entries, create all 500 rows of data and fill in the rows with actual data when they are available and loaded.

BEFORE:
Observe the scroll to the end followed by a slight pause to load more entries before displaying them when fetched.
https://github.com/determined-ai/determined/assets/220971/76162de5-a8a0-4aa6-b7e1-d10e254c1a43

AFTER
In contrast, the scroll continues all the way through and if the row entry being display has not loaded yet, they show as a skeleton, but the scrolling of the table is not impeded in any way.
https://github.com/determined-ai/determined/assets/220971/700839ca-156c-4d45-99fb-1e12d48f5a69



<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- [ ] Navigate to Uncategorized experiment list page (preferably a list that is sizable with multiple pages worth)
- [ ] scroll to the bottom of the table list
- [ ] verify that you can scroll to the end and that no additional rows get added to the end when you reach the end of the scroll (which is the previous behavior).

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1234
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
