### PR TITLE
fix: only select new pages during selectAll mode [WEB-1283]

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -274,13 +274,13 @@ export const GlideTable: React.FC<GlideTableProps> = ({
 
   const previousData = usePrevious(data, undefined);
   useEffect(() => {
-    if (previousData && data.length > previousData.length) {
+    if (selectAll && previousData && data.length > previousData.length) {
       setSelection(({ columns, rows }: GridSelection) => ({
         columns,
         rows: rows.add([previousData.length, data.length]),
       }));
     }
-  }, [data, previousData]);
+  }, [data, previousData, selectAll]);
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, args: HeaderClickedEventArgs) => {


### PR DESCRIPTION
## Description

Fixes bug with scrolling to new pages in the Glide table component. We discussed the issue and selection comes from this code which was intended for `selectAll` mode

## Test Plan

Visit `/det/projects/1/experiments?f_explist_v2=on&page=1` and scroll up and down the table to trigger loading rows for the infinite scroll. The checkbox header should not indicate anything was auto-selected

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.