### PR TITLE
chore: check if a.restored to send task log [DET-9515]

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -1054,9 +1054,15 @@ func (a *Allocation) terminated(ctx *actor.Context, reason string) {
 // markResourcesStarted persists start information.
 func (a *Allocation) markResourcesStarted(ctx *actor.Context) {
 	a.model.StartTime = ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond))
-	a.sendTaskLog(ctx, a.enrichLog(model.TaskLog{
-		Log: fmt.Sprintf("%s was recovered on an agent", a.req.Name),
-	}))
+	if a.restored {
+		a.sendTaskLog(ctx, a.enrichLog(model.TaskLog{
+			Log: fmt.Sprintf("%s was recovered on an agent", a.req.Name),
+		}))
+	} else {
+		a.sendTaskLog(ctx, a.enrichLog(model.TaskLog{
+			Log: fmt.Sprintf("%s was assigned to an agent", a.req.Name),
+		}))
+	}
 	if err := a.db.UpdateAllocationStartTime(a.model); err != nil {
 		ctx.Log().
 			WithError(err).


### PR DESCRIPTION
## Description
Check `a.restored` status and print different task logs accordingly -- this is a cosmetic fix on top of https://github.com/determined-ai/determined/pull/6771

## Test Plan
Attempt restoring an experiment & checking that the error message matches.

## Checklist

- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9515