### PR TITLE
fix: parameterize agent tmp by agent id [DET-9111]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -128,7 +128,7 @@ func (a *Agent) run(ctx context.Context) error {
 	var logShipperDone chan struct{}
 	switch a.opts.ContainerRuntime {
 	case options.PodmanContainerRuntime:
-		acl, sErr := podman.New(a.opts.PodmanOptions)
+		acl, sErr := podman.New(a.opts.PodmanOptions, a.opts.AgentID)
 		if sErr != nil {
 			return fmt.Errorf("failed to build podman client: %w", sErr)
 		}
@@ -139,7 +139,7 @@ func (a *Agent) run(ctx context.Context) error {
 		}()
 		cruntime = acl
 	case options.SingularityContainerRuntime:
-		acl, sErr := singularity.New(a.opts.SingularityOptions)
+		acl, sErr := singularity.New(a.opts.SingularityOptions, a.opts.AgentID)
 		if sErr != nil {
 			return fmt.Errorf("failed to build singularity client: %w", sErr)
 		}

--- a/agent/pkg/cruntimes/crutils.go
+++ b/agent/pkg/cruntimes/crutils.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net/url"
 	"os/exec"
+	"os/user"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -26,6 +27,18 @@ import (
 )
 
 var logLevel = regexp.MustCompile("(?P<level>INFO|WARN|ERROR|FATAL):    (?P<log>.*)")
+
+// BaseTempDirName returns a per-user directory name that is unique
+// for the use and specified id (agentID), but consistently named
+// between agent runs to enable cleanup of earlier tmp files.
+func BaseTempDirName(id string) (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("unable to get username: %w", err)
+	}
+
+	return fmt.Sprintf("/tmp/determined-%s-%s", user.Username, id), nil
+}
 
 // ShipContainerCommandLogs forwards the given output stream to the specified publisher.
 // It is used to reveal the result of container command lines, e.g. podman pull...


### PR DESCRIPTION
## Description

Use a per-user + per agentID /tmp folder to enable multiple users of determined-agent on HPC systems without conflicts.

Drop the pull on singularity since the command is intended to output a file (and it was broken for running local images).


## Test Plan

```
% tools/slurmcluster.sh -A casablanca

%det cmd run --config environment.image=/mnt/lustre/foundation_engineering/images2/determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca  hostname
...
[2023-05-25T15:54:52.992647Z] e7b9f31b || casablanca-login
[2023-05-25T15:54:53.791233Z] e7b9f31b || INFO: resources exited successfully with a zero exit code
[2023-05-25T15:54:53.854017Z]          || INFO: Command (terminally-premium-cockatoo) was terminated: allocation stopped early after resources exited successfully with a zero exit code
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9111
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
