### PR TITLE
fix: no auto in hf cli

### DIFF
--- a/harness/determined/pytorch/dsat/_utils.py
+++ b/harness/determined/pytorch/dsat/_utils.py
@@ -429,14 +429,17 @@ def update_hf_args(args: List[str], ds_config_dict: Dict[str, Any]) -> List[str]
     for idx in range(len(args)):
         if args[idx] in hf_flag_to_ds_key:
             ds_key = hf_flag_to_ds_key[args[idx]]
-            overwrite_value = str(ds_config_dict[ds_key])
-            if args[idx + 1] != overwrite_value:
-                logging.warning(
-                    f"Changing {args[idx]} from {args[idx +1]} to {overwrite_value} to match "
-                    " the deespspeed config values."
-                )
-                args[idx + 1] = overwrite_value
-            del hf_flag_to_ds_key[args[idx]]
+            overwrite_value = ds_config_dict[ds_key]
+            # Check int, protects against using "auto" in CLI arg.
+            if isinstance(overwrite_value, int):
+                overwrite_value_str = str(overwrite_value)
+                if args[idx + 1] != overwrite_value_str:
+                    logging.warning(
+                        f"Changing {args[idx]} from {args[idx +1]} to {overwrite_value_str}"
+                        " to match the deespspeed config values."
+                    )
+                    args[idx + 1] = overwrite_value_str
+                del hf_flag_to_ds_key[args[idx]]
 
     # Any remaining keys in hf_flag_to_ds_key were not provided as args to the HF CLI entrypoint,
     # but they must be added in explicitly, to avoid falling back to HF defaults.

--- a/harness/tests/experiment/pytorch/test_deepspeed_autotuning.py
+++ b/harness/tests/experiment/pytorch/test_deepspeed_autotuning.py
@@ -1534,6 +1534,43 @@ class TestHFConfigOverwriting:
                 for k, v in overwrite_dict.items():
                     assert overwritten_ds_config.get(k) == v
 
+    @pytest.mark.timeout(5)
+    def test_no_auto_in_cli_args(self) -> None:
+        """
+        Verify that if the user has an "overwrite_deepspeed_args" key in their hparam dict, but the
+        ds config json still has "auto" for batch size arguments, these "auto" settings are not
+        propagated as CLI args.  Needed for cases where the user wants to overwrite some json
+        fields via the yaml config, but still wants to configure the batch size through HF CLI
+        entrypoint flags.
+        """
+        optional_arg_possibilities: List[List[str]] = [
+            [],
+            ["--per_device_train_batch_size", "8"],
+            ["--gradient_accumulation_steps", "4"],
+            ["--per_device_train_batch_size", "8", "--gradient_accumulation_steps", "4"],
+        ]
+        for optional_args in optional_arg_possibilities:
+            with tempfile.TemporaryDirectory() as d:
+                ds_config_path = pathlib.Path(d).joinpath("ds_config.json")
+                shutil.copyfile(HF_DS_CONFIG_PATH, ds_config_path)
+                args = (
+                    DEFAULT_HF_ARGS_WITHOUT_DEEPSPEED
+                    + ["--deepspeed", str(ds_config_path)]
+                    + optional_args
+                )
+                hparams = copy.deepcopy(HPARAMS_FIXTURE)
+                # Make the overwrite section non-trivial, but also independent of batch-size args.
+                hparams[_defaults.OVERWRITE_KEY] = {"arbitrary": 0}
+                args = get_hf_args_with_overwrites(args=args, hparams=hparams)
+                hf_flag_to_ds_key = {
+                    "--per_device_train_batch_size": "train_micro_batch_size_per_gpu",
+                    "--gradient_accumulation_steps": "gradient_accumulation_steps",
+                }
+                for idx in range(len(args)):
+                    if args[idx] in hf_flag_to_ds_key:
+                        actual_hf_value = args[idx + 1]
+                        assert actual_hf_value != "auto"
+
 
 class DSATMockMaster(MockMaster):
     """

--- a/harness/tests/experiment/pytorch/test_deepspeed_autotuning.py
+++ b/harness/tests/experiment/pytorch/test_deepspeed_autotuning.py
@@ -1509,7 +1509,7 @@ class TestHFConfigOverwriting:
                         hf_flag = args[idx]
                         ds_key = hf_flag_to_ds_key[hf_flag]
                         expected_hf_value = HPARAMS_FIXTURE[_defaults.OVERWRITE_KEY][ds_key]
-                        actual_hf_value = HPARAMS_FIXTURE[_defaults.OVERWRITE_KEY][ds_key]
+                        actual_hf_value = int(args[idx + 1])
                         assert actual_hf_value == expected_hf_value
 
     @pytest.mark.timeout(5)


### PR DESCRIPTION
## Description

Protects against errors in the case where the user wants to include an `overwrite_deepspeed_args` field in their `hyperparameter` dictionary for a HF integration trial while simultaneously keeping batch-size values in the DS json config as `"auto"` and configuring the batch size through HF CLI args instead.

Without this fix, our `get_hf_args_with_overwrites` function was propagating `"auto"` to the CLI entrypoint and creating flags like `--per_device_train_batch_size "auto"` which is illegal in HF.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
