### PR TITLE
fix: Stabilize return order for experiments

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2055,7 +2055,7 @@ func sortExperiments(sortString *string, experimentQuery *bun.SelectQuery) error
 		"desc": "DESC NULLS LAST",
 	}
 	sortParams := strings.Split(*sortString, ",")
-	hasIdSort := false
+	hasIDSort := false
 	for _, sortParam := range sortParams {
 		paramDetail := strings.Split(sortParam, "=")
 		if len(paramDetail) != 2 {
@@ -2079,12 +2079,12 @@ func sortExperiments(sortString *string, experimentQuery *bun.SelectQuery) error
 			if _, ok := orderColMap[paramDetail[0]]; !ok {
 				return status.Errorf(codes.InvalidArgument, "invalid sort col: %s", paramDetail[0])
 			}
-			hasIdSort = hasIdSort || paramDetail[0] == "id"
+			hasIDSort = hasIDSort || paramDetail[0] == "id"
 			experimentQuery.OrderExpr(
 				fmt.Sprintf("%s %s", orderColMap[paramDetail[0]], sortDirection))
 		}
 	}
-	if !hasIdSort {
+	if !hasIDSort {
 		experimentQuery.OrderExpr("id ASC")
 	}
 	return nil


### PR DESCRIPTION


## Description

This adds a default ascending id sort on the search-experiment api endpoint. On sufficiently large datasets, postgres cannot guarantee the row return order given a certain offset and limit. On Netlify, this issue caused the second page of results to partially overwrite the first page of results.


## Test Plan

* when this code is deployed on netlify, scrolling between pages should not cause the current rows to be overwritten.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1263

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
