### PR TITLE
feat: add defaults to dsat cli help menu

### DIFF
--- a/harness/determined/pytorch/dsat/_utils.py
+++ b/harness/determined/pytorch/dsat/_utils.py
@@ -103,13 +103,23 @@ def get_base_parser() -> argparse.ArgumentParser:
 
 
 def get_full_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="Determined AI DeepSpeed Autotune")
+    parser = argparse.ArgumentParser(
+        prog="Determined AI DeepSpeed Autotune",
+    )
     subparsers = parser.add_subparsers(required=True, dest="search_method")
     base_parser = get_base_parser()
 
-    subparsers.add_parser("_test", parents=[base_parser])
+    subparsers.add_parser(
+        "_test",
+        parents=[base_parser],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-    random_subparser = subparsers.add_parser("random", parents=[base_parser])
+    random_subparser = subparsers.add_parser(
+        "random",
+        parents=[base_parser],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     random_subparser.add_argument(
         "--trials-per-random-config",
         type=int,
@@ -122,7 +132,11 @@ def get_full_parser() -> argparse.ArgumentParser:
         help="Terminates the search if a new best config not found in last `early-stopping` trials",
     )
 
-    binary_subparser = subparsers.add_parser("binary", parents=[base_parser])
+    binary_subparser = subparsers.add_parser(
+        "binary",
+        parents=[base_parser],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     search_range_factor_help = (
         "Expands the initial search range by a factor of `search-range-factor`"
     )
@@ -133,7 +147,11 @@ def get_full_parser() -> argparse.ArgumentParser:
         help=search_range_factor_help,
     )
 
-    asha_subparser = subparsers.add_parser("asha", parents=[base_parser])
+    asha_subparser = subparsers.add_parser(
+        "asha",
+        parents=[base_parser],
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     asha_subparser.add_argument(
         "--max-rungs",
         default=_defaults.AUTOTUNING_ARG_DEFAULTS["max-rungs"],


### PR DESCRIPTION
## Description

Does what it says: now `python3 -m determined.pytorch.dsat asha --help` will display the default values of all args.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
