### PR TITLE
refactor: full trial summary metrics recompute take metric type as param

### DIFF
--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -161,11 +161,11 @@ WHERE id = $1`, id, restartCount); err != nil {
 
 // fullTrialSummaryMetricsRecompute recomputes all summary metrics for a given trial.
 func (db *PgDB) fullTrialSummaryMetricsRecompute(
-	ctx context.Context, tx *sqlx.Tx, trialID int,
-) error {
-	_, err := tx.ExecContext(ctx, `
+	ctx context.Context, tx *sqlx.Tx, trialID int, jsonPath, table string,
+) (model.JSONObj, error) {
+	rows, err := tx.QueryContext(ctx, strings.ReplaceAll(`
 -- Returns pairs of metric names and trial_ids and if they are numeric or not.
-WITH training_trial_metrics as (
+WITH trial_metrics as (
 SELECT
 	name,
 	trial_id,
@@ -183,25 +183,25 @@ FROM (
 	SELECT
 	name,
 	CASE
-		WHEN jsonb_typeof(metrics->'avg_metrics'->name) = 'string' THEN
+		WHEN jsonb_typeof(metrics->$2->name) = 'string' THEN
 			CASE
-				WHEN (metrics->'avg_metrics'->name)::text = '"Infinity"'::text THEN 'number'
-				WHEN (metrics->'avg_metrics'->name)::text = '"-Infinity"'::text THEN 'number'
-				WHEN (metrics->'avg_metrics'->name)::text = '"NaN"'::text THEN 'number'
-				WHEN metrics->'avg_metrics'->>name ~
+				WHEN (metrics->$2->name)::text = '"Infinity"'::text THEN 'number'
+				WHEN (metrics->$2->name)::text = '"-Infinity"'::text THEN 'number'
+				WHEN (metrics->$2->name)::text = '"NaN"'::text THEN 'number'
+				WHEN metrics->$2->>name ~
 					'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$' THEN 'date'
 				ELSE 'string'
 			END
-		ELSE jsonb_typeof(metrics->'avg_metrics'->name)
+		ELSE jsonb_typeof(metrics->$2->name)
 	END as metric_type,
 	trial_id,
 	count(1) as entries
 	FROM (
 		SELECT DISTINCT
-		jsonb_object_keys(s.metrics->'avg_metrics') as name
-		FROM steps s
+		jsonb_object_keys(s.metrics->$2) as name
+		FROM $TABLE s
 		WHERE s.trial_id = $1
-	) names, steps
+	) names, $TABLE
 	JOIN trials ON trial_id = trials.id
 	WHERE trials.id = $1
 	GROUP BY name, metric_type, trial_id
@@ -211,25 +211,25 @@ GROUP BY name, trial_id
 ORDER BY trial_id, name
 ),
 -- Filters to only numeric metrics.
-training_numeric_trial_metrics as (
+numeric_trial_metrics as (
 SELECT name, trial_id
-FROM training_trial_metrics
+FROM trial_metrics
 WHERE metric_type = 'number'
 ),
 -- Calculates count, sum, min, max on each numeric metric name and trial ID pair.
 -- Also adds just the name for non numeric metrics to ensure we record every metric.
-training_trial_metric_aggs as (
+trial_metric_aggs as (
 SELECT
 	name,
 	ntm.trial_id,
 	count(1) as count_agg,
-	sum((steps.metrics->'avg_metrics'->>name)::double precision) as sum_agg,
-	min((steps.metrics->'avg_metrics'->>name)::double precision) as min_agg,
-	max((steps.metrics->'avg_metrics'->>name)::double precision) as max_agg,
+	sum(($TABLE.metrics->$2->>name)::double precision) as sum_agg,
+	min(($TABLE.metrics->$2->>name)::double precision) as min_agg,
+	max(($TABLE.metrics->$2->>name)::double precision) as max_agg,
 	'number' as metric_type
-FROM training_numeric_trial_metrics ntm INNER JOIN steps
-ON steps.trial_id=ntm.trial_id
-WHERE steps.metrics->'avg_metrics'->name IS NOT NULL
+FROM numeric_trial_metrics ntm INNER JOIN $TABLE
+ON $TABLE.trial_id=ntm.trial_id
+WHERE $TABLE.metrics->$2->name IS NOT NULL
 GROUP BY 1, 2
 UNION
 SELECT
@@ -240,7 +240,7 @@ SELECT
 	NULL as min,
 	NULL as max,
 	metric_type as metric_type
-FROM training_trial_metrics
+FROM trial_metrics
 WHERE metric_type != 'number'
 ),
 -- Gets the last reported metric for each trial. Note if we report
@@ -256,14 +256,14 @@ latest_training as (
 		  PARTITION BY s.trial_id
 		  ORDER BY s.end_time DESC
 		) as rank
-	  FROM steps s
+	  FROM $TABLE s
 	  JOIN trials ON s.trial_id = trials.id
 	  WHERE s.trial_id = $1
-	) s, jsonb_each(s.metrics->'avg_metrics') unpacked
+	) s, jsonb_each(s.metrics->$2) unpacked
   WHERE s.rank = 1
 ),
 -- Adds the last reported metric to training the aggregation.
-training_combined_latest_agg as (SELECT
+combined_latest_agg as (SELECT
 	coalesce(lt.trial_id, tma.trial_id) as trial_id,
 	coalesce(lt.name, tma.name) as name,
 	tma.count_agg,
@@ -272,178 +272,38 @@ training_combined_latest_agg as (SELECT
 	tma.max_agg,
 	lt.latest_value,
 	tma.metric_type
-FROM latest_training lt FULL OUTER JOIN training_trial_metric_aggs tma ON
+FROM latest_training lt FULL OUTER JOIN trial_metric_aggs tma ON
 	lt.trial_id = tma.trial_id AND lt.name = tma.name
-),
--- Turns each rows into a JSONB object.
-training_trial_metrics_final as (
-	SELECT
-		trial_id, jsonb_collect(jsonb_build_object(
-			name, jsonb_build_object(
-				'count', count_agg,
-				'sum', sum_agg,
-				'min', CASE WHEN max_agg = 'NaN'::double precision THEN 'NaN'::double precision
-					ELSE min_agg END,
-				'max', max_agg,
-				'last', latest_value,
-				'type', metric_type
-			)
-		)) as training_metrics
-	FROM training_combined_latest_agg
-	GROUP BY trial_id
-),
--- We repeat the same process as above to validation metrics.
-validation_trial_metrics as (
-SELECT
-	name,
-	trial_id,
-	CASE sum(entries)
-		WHEN sum(entries) FILTER (WHERE metric_type = 'number') THEN 'number'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'string') THEN 'string'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'date') THEN 'date'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'object') THEN 'object'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'boolean') THEN 'boolean'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'array') THEN 'array'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'null') THEN 'null'
-		ELSE 'string'
-	END as metric_type
-FROM (
-	SELECT
-	name,
-	CASE
-		WHEN jsonb_typeof(metrics->'validation_metrics'->name) = 'string' THEN
-			CASE
-				WHEN (metrics->'validation_metrics'->name)::text = '"Infinity"'::text THEN 'number'
-				WHEN (metrics->'validation_metrics'->name)::text = '"-Infinity"'::text THEN 'number'
-				WHEN (metrics->'validation_metrics'->name)::text = '"NaN"'::text THEN 'number'
-				WHEN metrics->'validation_metrics'->>name ~
-					'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$' THEN 'date'
-				ELSE 'string'
-			END
-		ELSE jsonb_typeof(metrics->'validation_metrics'->name)
-	END as metric_type,
-	trial_id,
-	count(1) as entries
-	FROM (
-		SELECT DISTINCT
-		jsonb_object_keys(s.metrics->'validation_metrics') as name
-		FROM validations s
-		JOIN trials ON s.trial_id = trials.id
-		WHERE s.trial_id = $1
-	) names, validations
-	JOIN trials ON trial_id = trials.id
-	WHERE trials.id = $1
-	GROUP BY name, metric_type, trial_id
-) typed
-where metric_type is not NULL
-GROUP BY name, trial_id
-ORDER BY trial_id, name
-),
-validation_numeric_trial_metrics as (
-SELECT name, trial_id
-FROM validation_trial_metrics
-WHERE metric_type = 'number'
-),
-validation_trial_metric_aggs as (
-SELECT
-	name,
-	ntm.trial_id,
-	count(1) as count_agg,
-	sum((validations.metrics->'validation_metrics'->>name)::double precision) as sum_agg,
-	min((validations.metrics->'validation_metrics'->>name)::double precision) as min_agg,
-	max((validations.metrics->'validation_metrics'->>name)::double precision) as max_agg,
-	'number' as metric_type
-FROM validation_numeric_trial_metrics ntm INNER JOIN validations
-ON validations.trial_id=ntm.trial_id
-WHERE validations.metrics->'validation_metrics'->name IS NOT NULL
-GROUP BY 1, 2
-UNION
-SELECT
-	name,
-	trial_id,
-	NULL as count_agg,
-	NULL as sum,
-	NULL as min,
-	NULL as max,
-	metric_type as metric_type
-FROM validation_trial_metrics
-WHERE metric_type != 'number'
-),
-latest_validation as (
-	SELECT s.trial_id,
-		unpacked.key as name,
-		unpacked.value as latest_value
-	FROM (
-		SELECT s.*,
-			ROW_NUMBER() OVER(
-				PARTITION BY s.trial_id
-				ORDER BY s.end_time DESC
-			) as rank
-		FROM validations s
-		JOIN trials ON s.trial_id = trials.id
-		WHERE s.trial_id = $1
-	) s, jsonb_each(s.metrics->'validation_metrics') unpacked
-	WHERE s.rank = 1
-),
-validation_combined_latest_agg as (SELECT
-	coalesce(lt.trial_id, tma.trial_id) as trial_id,
-	coalesce(lt.name, tma.name) as name,
-	tma.count_agg,
-	tma.sum_agg,
-	tma.min_agg,
-	tma.max_agg,
-	lt.latest_value,
-	tma.metric_type
-FROM latest_validation lt FULL OUTER JOIN validation_trial_metric_aggs tma ON
-	lt.trial_id = tma.trial_id AND lt.name = tma.name
-),
-validation_trial_metrics_final as (
-	SELECT
-		trial_id, jsonb_collect(jsonb_build_object(
-			name, jsonb_build_object(
-				'count', count_agg,
-				'sum', sum_agg,
-				'min', CASE WHEN max_agg = 'NaN'::double precision THEN 'NaN'::double precision
-					ELSE min_agg END,
-				'max', max_agg,
-				'last', latest_value,
-				'type', metric_type
-			)
-		)) as validation_metrics
-	FROM validation_combined_latest_agg
-	GROUP BY trial_id
-),
--- Combine both training and validation metrics into a single JSON object.
-validation_training_combined_json as (
-	SELECT
-	coalesce(ttm.trial_id, vtm.trial_id) as trial_id,
-	(CASE
-		WHEN ttm.training_metrics IS NOT NULL AND vtm.validation_metrics IS NOT NULL THEN
-			jsonb_build_object(
-				'avg_metrics', ttm.training_metrics,
-				'validation_metrics', vtm.validation_metrics
-			)
-		WHEN ttm.training_metrics IS NOT NULL THEN
-			jsonb_build_object(
-				'avg_metrics', ttm.training_metrics
-			)
-		WHEN vtm.validation_metrics IS NOT NULL THEN jsonb_build_object(
-				'validation_metrics', vtm.validation_metrics
-		   )
-		ELSE '{}'::jsonb END) as summary_metrics
-	FROM training_trial_metrics_final ttm FULL OUTER JOIN validation_trial_metrics_final vtm
-	ON ttm.trial_id = vtm.trial_id
-)
--- Updates trials with this training and validation object.
-UPDATE trials SET
-	summary_metrics = vtcj.summary_metrics, summary_metrics_timestamp = NOW()
-FROM validation_training_combined_json vtcj WHERE vtcj.trial_id = trials.id;
-`, trialID)
+) SELECT name, jsonb_build_object(
+    'count', count_agg,
+    'sum', sum_agg,
+    'min', CASE WHEN max_agg = 'NaN'::double precision
+        THEN 'NaN'::double precision ELSE min_agg END,
+    'max', max_agg,
+    'last', latest_value,
+    'type', metric_type
+) FROM combined_latest_agg;
+`, "$TABLE", table), trialID, jsonPath)
 	if err != nil {
-		return errors.Wrapf(err, "updating trial %d summary metrics", trialID)
+		return nil, errors.Wrapf(err, "getting full compute trial %d summary metrics", trialID)
 	}
 
-	return nil
+	metrics := model.JSONObj{}
+	defer rows.Close()
+	for rows.Next() {
+		var metric model.JSONObj
+		var name string
+		if err = rows.Scan(&name, &metric); err != nil {
+			return nil, fmt.Errorf("scanning summary metric row: %w", err)
+		}
+		metrics[name] = metric
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows err summary metric full compute: %w", err)
+	}
+
+	return metrics, nil
 }
 
 // updateLatestValidationID updates latest validation based on validations table.
@@ -533,9 +393,30 @@ func (db *PgDB) _addTrialMetricsTx(
 				"rollback updating latest validation ID for trial %d: %w", m.TrialId, err)
 		}
 
-		if err := db.fullTrialSummaryMetricsRecompute(ctx, tx, int(m.TrialId)); err != nil {
-			return rollbacks, errors.Wrap(err, "error on rollback compute of summary metrics")
+		trainSummary, err := db.fullTrialSummaryMetricsRecompute(ctx, tx, int(m.TrialId),
+			"avg_metrics", "steps")
+		if err != nil {
+			return rollbacks, fmt.Errorf("rollback computing training summary metrics: %w", err)
 		}
+		valSummary, err := db.fullTrialSummaryMetricsRecompute(ctx, tx, int(m.TrialId),
+			"validation_metrics", "validations")
+		if err != nil {
+			return rollbacks, fmt.Errorf("rollback computing validation summary metrics: %w", err)
+		}
+
+		updatedSummaryMetrics := model.JSONObj{}
+		if len(trainSummary) > 0 {
+			updatedSummaryMetrics["avg_metrics"] = trainSummary
+		}
+		if len(valSummary) > 0 {
+			updatedSummaryMetrics["validation_metrics"] = valSummary
+		}
+
+		if _, err := tx.ExecContext(ctx, `UPDATE trials SET summary_metrics = $1,
+	summary_metrics_timestamp = NOW() WHERE id = $2`, updatedSummaryMetrics, m.TrialId); err != nil {
+			return rollbacks, fmt.Errorf("rollback updating trial summary metrics: %w", err)
+		}
+
 	case pType == GenericMetric:
 		if _, err := tx.ExecContext(ctx, `
 	UPDATE trials SET total_batches = GREATEST(total_batches, $2)

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -276,7 +276,7 @@ WHERE metric_type != 'number'
 -- Gets the last reported metric for each trial. Note if we report
 -- {"a": 1} and {"b": 1} we consider {"b": 1} to be the last reported
 -- metric and "a"'s last will be NULL.
-latest_training as (
+latest_metrics as (
   SELECT s.trial_id,
 	unpacked.key as name,
 	unpacked.value as latest_value
@@ -292,7 +292,7 @@ latest_training as (
 	) s, jsonb_each(s.metrics->$2) unpacked
   WHERE s.rank = 1
 ),
--- Adds the last reported metric to training the aggregation.
+-- Adds the last reported metric to the aggregation.
 combined_latest_agg as (SELECT
 	coalesce(lt.trial_id, tma.trial_id) as trial_id,
 	coalesce(lt.name, tma.name) as name,
@@ -302,7 +302,7 @@ combined_latest_agg as (SELECT
 	tma.max_agg,
 	lt.latest_value,
 	tma.metric_type
-FROM latest_training lt FULL OUTER JOIN trial_metric_aggs tma ON
+FROM latest_metrics lt FULL OUTER JOIN trial_metric_aggs tma ON
 	lt.trial_id = tma.trial_id AND lt.name = tma.name
 ) SELECT name, jsonb_build_object(
     'count', count_agg,

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -233,6 +233,20 @@ func generateSummaryMetricsTestCases(
 		"val_loss": {Min: 1.5, Max: 1.5, Sum: 1.5, Count: 1, Last: "1.5", Type: "number"},
 	}
 
+	onlyTrain := RequireMockTrial(t, db, exp).ID
+	addMetrics(ctx, t, db, onlyTrain, `[{"a": "a"}]`, `[]`, archive)
+	expectedOnlyTrainMetrics := map[string]summaryMetrics{
+		"a": {Last: "a", Type: "string"},
+	}
+	expectedOnlyTrainValMetrics := make(map[string]summaryMetrics)
+
+	onlyVal := RequireMockTrial(t, db, exp).ID
+	addMetrics(ctx, t, db, onlyVal, `[]`, `[{"a": "a"}]`, archive)
+	expectedOnlyValMetrics := make(map[string]summaryMetrics)
+	expectedOnlyValValMetrics := map[string]summaryMetrics{
+		"a": {Last: "a", Type: "string"},
+	}
+
 	nonNumericMetrics := RequireMockTrial(t, db, exp).ID
 	addMetrics(ctx, t, db, nonNumericMetrics,
 		`[{"a":"a", "b":-0.5}, {"a":1.67, "b":0.3, "c":"test"}, {"a":"c", "b":[{"loss":5.0}]}]`,
@@ -332,10 +346,21 @@ func generateSummaryMetricsTestCases(
 		"a": {Last: "1.8", Type: "string"},
 	}
 
-	trialIDs := []int{noMetrics, numericMetrics, nonNumericMetrics, infNaNMetrics, types, mixedTypes}
+	trialIDs := []int{
+		noMetrics,
+		numericMetrics,
+		onlyTrain,
+		onlyVal,
+		nonNumericMetrics,
+		infNaNMetrics,
+		types,
+		mixedTypes,
+	}
 	expectedTrain := []map[string]summaryMetrics{
 		expectedNoMetrics,
 		expectedNumericMetrics,
+		expectedOnlyTrainMetrics,
+		expectedOnlyValMetrics,
 		expectedNonNumericMetrics,
 		expectedInfNaNMetrics,
 		expectedTypesMetrics,
@@ -344,6 +369,8 @@ func generateSummaryMetricsTestCases(
 	expectedVal := []map[string]summaryMetrics{
 		expectedNoValMetrics,
 		expectedNumericValMetrics,
+		expectedOnlyTrainValMetrics,
+		expectedOnlyValValMetrics,
 		expectedNonNumericValMetrics,
 		expectedInfNaNValMetrics,
 		expectedTypesValMetrics,


### PR DESCRIPTION
## Description

Makes summary metrics full recompute take the table as a parameter for help with generic metrics.

## Test Plan


Existing integration tests.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
