### PR TITLE
feat: When modifying glide table filters, keep columns visible [WEB-1232]

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -49,7 +49,11 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const settingsConfig = useMemo(() => settingsConfigForProject(project.id), [project.id]);
 
-  const { settings, updateSettings } = useSettings<F_ExperimentListSettings>(settingsConfig);
+  const {
+    isLoading: isLoadingSettings,
+    settings,
+    updateSettings,
+  } = useSettings<F_ExperimentListSettings>(settingsConfig);
 
   const [page, setPage] = useState(() =>
     isFinite(Number(searchParams.get('page'))) ? Number(searchParams.get('page')) : 0,
@@ -360,7 +364,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         filters={experimentFilters}
         formStore={formStore}
         handleUpdateExperimentList={handleUpdateExperimentList}
-        initialVisibleColumns={settings.columns}
+        initialVisibleColumns={isLoadingSettings ? [] : settings.columns}
         isOpenFilter={isOpenFilter}
         project={project}
         projectColumns={projectColumns}
@@ -392,7 +396,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
             <GlideTable
               clearSelectionTrigger={clearSelectionTrigger}
               colorMap={colorMap}
-              data={isLoading ? [NotLoaded] : experiments}
+              data={isLoading || isLoadingSettings ? [NotLoaded] : experiments}
               dataTotal={Loadable.getOrElse(0, total)}
               excludedExperimentIds={excludedExperimentIds}
               formStore={formStore}
@@ -409,7 +413,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               setSelectAll={setSelectAll}
               setSelectedExperimentIds={setSelectedExperimentIds}
               setSortableColumnIds={setVisibleColumns}
-              sortableColumnIds={settings.columns}
+              sortableColumnIds={isLoadingSettings ? [] : settings.columns}
               sorts={sorts}
               onContextMenuComplete={onContextMenuComplete}
               onIsOpenFilterChange={onIsOpenFilterChange}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -27,7 +27,7 @@ import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import ComparisonView from './ComparisonView';
 import css from './F_ExperimentList.module.scss';
 import { F_ExperimentListSettings, settingsConfigForProject } from './F_ExperimentList.settings';
-import { Error, Loading, NoExperiments } from './glide-table/exceptions';
+import { Error, NoExperiments } from './glide-table/exceptions';
 import GlideTable, { SCROLL_SET_COUNT_NEEDED } from './glide-table/GlideTable';
 import { EMPTY_SORT, Sort, validSort, ValidSort } from './glide-table/MultiSortMenu';
 import TableActionBar, { BatchAction } from './glide-table/TableActionBar';
@@ -127,7 +127,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [canceler] = useState(new AbortController());
 
   const colorMap = useGlasbey(selectedExperimentIds);
-  const { height, width } = useResize(contentRef);
+  const { height } = useResize(contentRef);
   const [scrollPositionSetCount] = useState(observable(0));
 
   const handleScroll = useCallback(
@@ -375,9 +375,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         onSortChange={onSortChange}
       />
       <div className={css.content} ref={contentRef}>
-        {isLoading ? (
-          <Loading width={width} />
-        ) : experiments.length === 0 ? (
+        {!isLoading && experiments.length === 0 ? (
           numFilters === 0 ? (
             <NoExperiments />
           ) : (
@@ -394,7 +392,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
             <GlideTable
               clearSelectionTrigger={clearSelectionTrigger}
               colorMap={colorMap}
-              data={experiments}
+              data={isLoading ? [NotLoaded] : experiments}
               dataTotal={Loadable.getOrElse(0, total)}
               excludedExperimentIds={excludedExperimentIds}
               formStore={formStore}

--- a/webui/react/src/pages/F_ExpList/glide-table/exceptions.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/exceptions.tsx
@@ -1,5 +1,3 @@
-import { Row } from 'antd';
-import SkeletonButton from 'antd/es/skeleton/Button';
 import React, { ReactNode } from 'react';
 
 import Button from 'components/kit/Button';
@@ -89,14 +87,4 @@ export const Error: React.FC<{ fetchExperiments?: () => void }> = ({ fetchExperi
   <ExceptionMessage ImageComponent={ImageAlert} title="Failed to Load Data">
     <Button onClick={fetchExperiments}>Retry</Button>
   </ExceptionMessage>
-);
-
-export const Loading: React.FC<{ width: number }> = ({ width }) => (
-  <>
-    {[...Array(21)].map((x, i) => (
-      <Row key={i} style={{ paddingBottom: '4px' }}>
-        <SkeletonButton style={{ width }} />
-      </Row>
-    ))}
-  </>
 );


### PR DESCRIPTION
## Description

When changing filters, we show a Loading component in place of the GlideTable. Currently this replaces all table headers and rows with grey bars.

OLD VERSION

![image](https://github.com/determined-ai/determined/assets/643918/aeb00f97-705c-4d7c-8642-200dc1278c30)

This PR removes the Loading component, and makes use of the GlideTable's loading-cell for NotLoaded content.

NEW VERSION

<img width="887" alt="Screen Shot 2023-05-31 at 11 46 00 AM" src="https://github.com/determined-ai/determined/assets/643918/2fe38e72-047b-4e14-bc06-714573637687">

## Test Plan

UI test
- go to the Uncategorized project and add `?f_explist_v2=on`
- apply a filter to the table (for example Name Contains ex). the animation quickly appears and goes away, but should keep column headers / names visible
- remove the filter. During animation, headers / column names remain visible
- Add a filter with no results (for example Name Contains rrrrrrrrrr). You see a no results page

If you want to see the loading state for longer time, in `pages/F_ExpList/F_ExperimentList`, comment out `setIsLoading(false)`. This will keep the table perpetually loading.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.