### PR TITLE
fix: In new breadcrumbs, uncategorized links to /projects/1 [WEB-1319]

### DIFF
--- a/webui/react/src/components/ModelMoveModal.tsx
+++ b/webui/react/src/components/ModelMoveModal.tsx
@@ -32,7 +32,10 @@ const ModelMoveModal = ({ model }: Props): JSX.Element => {
     try {
       await moveModel({ destinationWorkspaceId: values.workspaceId, modelName: model.name });
       const workspaceName = workspaces.find((ws) => ws.id === values.workspaceId)?.name;
-      const path = paths.workspaceDetails(values.workspaceId, WorkspaceDetailsTab.ModelRegistry);
+      const path =
+        values.workspaceId === 1
+          ? paths.modelList()
+          : paths.workspaceDetails(values.workspaceId, WorkspaceDetailsTab.ModelRegistry);
       notification.success({
         description: (
           <div>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
@@ -90,13 +90,15 @@ const ExperimentDetails: React.FC = () => {
   const workspaceName = workspaces.find((ws: Workspace) => ws.id === experiment?.workspaceId)?.name;
 
   const pageBreadcrumb: BreadCrumbRoute[] = [
-    {
-      breadcrumbName:
-        workspaceName && experiment?.workspaceId !== 1
-          ? workspaceName
-          : 'Uncategorized Experiments',
-      path: paths.workspaceDetails(experiment?.workspaceId ?? 1),
-    },
+    workspaceName && experiment?.workspaceId !== 1
+      ? {
+          breadcrumbName: workspaceName,
+          path: paths.workspaceDetails(experiment?.workspaceId ?? 1),
+        }
+      : {
+          breadcrumbName: 'Uncategorized Experiments',
+          path: paths.projectDetails(1),
+        },
   ];
 
   if (experiment?.projectName && experiment?.projectId && experiment?.projectId !== 1)

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -405,10 +405,15 @@ const ModelDetails: React.FC = () => {
   const pageBreadcrumb: BreadCrumbRoute[] = [];
   if (workspace) {
     pageBreadcrumb.push(
-      {
-        breadcrumbName: workspace.id !== 1 ? workspace.name : 'Uncategorized Experiments',
-        path: paths.workspaceDetails(workspace.id),
-      },
+      workspace.id === 1
+        ? {
+            breadcrumbName: 'Uncategorized Experiments',
+            path: paths.projectDetails(1),
+          }
+        : {
+            breadcrumbName: workspace.name,
+            path: paths.workspaceDetails(workspace.id),
+          },
       {
         breadcrumbName: 'Model Registry',
         path:

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -425,7 +425,7 @@ const ModelDetails: React.FC = () => {
   }
   pageBreadcrumb.push({
     breadcrumbName: `${model.model.name} (${model.model.id})`,
-    path: paths.modelDetails(model.model.name),
+    path: paths.modelDetails(String(model.model.id)),
   });
 
   return (

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -425,7 +425,7 @@ const ModelDetails: React.FC = () => {
   }
   pageBreadcrumb.push({
     breadcrumbName: `${model.model.name} (${model.model.id})`,
-    path: paths.modelDetails(String(model.model.id)),
+    path: paths.modelDetails(model.model.id.toString()),
   });
 
   return (

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -302,13 +302,21 @@ const ModelVersionDetails: React.FC = () => {
     return <Spinner spinning tip={`Loading model ${modelId} version ${versionNum} details...`} />;
   }
   const pageBreadcrumb: BreadCrumbRoute[] = [
-    {
-      breadcrumbName: workspace.name,
-      path: workspace.id === 1 ? paths.projectDetails(1) : paths.workspaceDetails(workspace.id),
-    },
+    workspace.id === 1
+      ? {
+          breadcrumbName: 'Uncategorized Experiments',
+          path: paths.projectDetails(1),
+        }
+      : {
+          breadcrumbName: workspace.name,
+          path: paths.workspaceDetails(workspace.id),
+        },
     {
       breadcrumbName: 'Model Registry',
-      path: paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry),
+      path:
+        workspace.id === 1
+          ? paths.modelList()
+          : paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry),
     },
     {
       breadcrumbName: `${modelVersion.model.name} (${modelId})`,
@@ -316,7 +324,7 @@ const ModelVersionDetails: React.FC = () => {
     },
     {
       breadcrumbName: `Version ${modelVersion.version}`,
-      path: paths.modelDetails(String(modelVersion.model.id)),
+      path: paths.modelVersionDetails(String(modelVersion.model.id), String(modelVersion.version)),
     },
   ];
 

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -320,11 +320,14 @@ const ModelVersionDetails: React.FC = () => {
     },
     {
       breadcrumbName: `${modelVersion.model.name} (${modelId})`,
-      path: paths.modelDetails(String(modelVersion.model.id)),
+      path: paths.modelDetails(modelVersion.model.id.toString()),
     },
     {
       breadcrumbName: `Version ${modelVersion.version}`,
-      path: paths.modelVersionDetails(String(modelVersion.model.id), String(modelVersion.version)),
+      path: paths.modelVersionDetails(
+        modelVersion.model.id.toString(),
+        modelVersion.version.toString(),
+      ),
     },
   ];
 

--- a/webui/react/src/pages/ModelVersionDetails.tsx
+++ b/webui/react/src/pages/ModelVersionDetails.tsx
@@ -298,11 +298,12 @@ const ModelVersionDetails: React.FC = () => {
     return <Message title={message} type={MessageType.Warning} />;
   } else if (pageError && isNotFound(pageError)) {
     return <PageNotFound />;
-  } else if (!modelVersion || !workspace || rbacLoading) {
+  } else if (!modelVersion || rbacLoading) {
     return <Spinner spinning tip={`Loading model ${modelId} version ${versionNum} details...`} />;
   }
+  const isUncategorized = !workspace?.id || workspace.id === 1;
   const pageBreadcrumb: BreadCrumbRoute[] = [
-    workspace.id === 1
+    isUncategorized
       ? {
           breadcrumbName: 'Uncategorized Experiments',
           path: paths.projectDetails(1),
@@ -313,10 +314,9 @@ const ModelVersionDetails: React.FC = () => {
         },
     {
       breadcrumbName: 'Model Registry',
-      path:
-        workspace.id === 1
-          ? paths.modelList()
-          : paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry),
+      path: isUncategorized
+        ? paths.modelList()
+        : paths.workspaceDetails(workspace.id, WorkspaceDetailsTab.ModelRegistry),
     },
     {
       breadcrumbName: `${modelVersion.model.name} (${modelId})`,

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -174,7 +174,7 @@ const ProjectDetails: React.FC = () => {
       : [
           {
             breadcrumbName: 'Uncategorized Experiments',
-            path: paths.workspaceDetails(project.workspaceId),
+            path: paths.projectDetails(project.id),
           },
         ];
   return (

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -15,7 +15,7 @@ import { paths } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
 import { readStream } from 'services/utils';
-import { CommandType } from 'types';
+import { CommandTask, CommandType } from 'types';
 
 import css from './TaskLogs.module.scss';
 
@@ -148,7 +148,13 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
       bodyNoPadding
       breadcrumb={[
         { breadcrumbName: 'Tasks', path: paths.taskList() },
-        { breadcrumbName: `${taskTypeLabel} ${taskId.substring(0, 8)}`, path: '#' },
+        {
+          breadcrumbName: `${taskTypeLabel} ${taskId.substring(0, 8)}`,
+          path: paths.taskLogs({
+            id: taskId,
+            type: taskType,
+          } as CommandTask),
+        },
       ]}
       headerComponent={headerComponent}
       id="task-logs"

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -228,7 +228,7 @@ const TrialDetailsComp: React.FC = () => {
           path: paths.experimentDetails(experiment.id),
         },
         {
-          breadcrumbName: String(trial.id),
+          breadcrumbName: `Trial ${trial.id}`,
           path: paths.trialDetails(trial.id),
         },
       ]}

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -214,13 +214,15 @@ const TrialDetailsComp: React.FC = () => {
   return (
     <Page
       breadcrumb={[
-        {
-          breadcrumbName:
-            workspaceName && experiment?.workspaceId !== 1
-              ? workspaceName
-              : 'Uncategorized Experiments',
-          path: paths.workspaceDetails(experiment?.workspaceId ?? 1),
-        },
+        workspaceName && experiment?.workspaceId !== 1
+          ? {
+              breadcrumbName: workspaceName,
+              path: paths.workspaceDetails(experiment?.workspaceId ?? 1),
+            }
+          : {
+              breadcrumbName: 'Uncategorized Experiments',
+              path: paths.projectDetails(1),
+            },
         {
           breadcrumbName: experiment?.name ?? '',
           path: paths.experimentDetails(experiment.id),


### PR DESCRIPTION
## Description

The new standardized breadcrumbs in PageHeader are helpful, but are inconsistent in preventing users from reaching `/det/workspaces/1` (the workspace details page for Uncategorized/Uncategorized)

This updates instances of `paths.workspaceDetails(w.id)` for the Uncategorized workspace to instead go to `paths.projectDetails(1)`

## Test Plan

Check breadcrumbs in Uncategorized workspace
- Experiment details page has "Uncategorized Experiments / ExperimentName" linking to `/det/projects/1/experiments`
- In a multi-trial experiment, the trial page (accessible from Trials tab) has "Uncategorized Experiments / ExperimentName / Trial ID" linking to /det/projects/1/experiments`, /det/experiments/ID`, and `/det/trials/trialID`

Find a model in `/det/models` which belongs to the Uncategorized workspace and has 1+ versions. Click to view.
- Model details breadcrumbs has "Uncategorized Experiments / ModelName (id)" linking to `/det/projects/1/experiments`, `/det/models`, and `/det/models/id`
- Model VERSION breadcrumbs has "Uncategorized Experiments / ModelName (id) / Version Num" linking to `/det/projects/1/experiments`, `/det/models`, `/det/models/id`, and `/det/models/id/versions/Num`

Pick another workspace with a multi-trial experiment and a model. You might want to create or move items for this to work.

Check links in one other workspace:
- Experiment details page has "WorkspaceName / ProjectName / ExperimentName"
- In a multi-trial experiment, the trial page has "WorkspaceName / ProjectName / ExperimentName / Trial ID"

Check models from other workspace:
- Model details has "WorkspaceName / Model Registry / ModelName (id)" linking to `/det/workspaces/id`, `/det/workspaces/id/models`, and `/det/models/id`
- Model VERSION has "WorkspaceName / Model Registry / ModelName (id) / Version Num"

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.