### PR TITLE
chore: improve partial checkpoint CLI in progress message

### DIFF
--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -146,10 +146,10 @@ def checkpoints_file_rm(args: Namespace) -> None:
         if len(args.glob) == 0:
             print(
                 "No glob patterns provided, "
-                + f"refreshing resources of checkpoints {args.checkpoints_uuids} is in progress"
+                + f"refreshing resources of checkpoints {args.checkpoints_uuids} is in progress."
             )
         else:
-            print(f"Removal of files from checkpoints {args.checkpoints_uuids} is in progress")
+            print(f"Removal of files from checkpoints {args.checkpoints_uuids} is in progress.")
     else:
         print("Stopping removal of files from checkpoints.")
 


### PR DESCRIPTION
## Description

Avoid misleading message when checkpoint remove files are used to refresh resources.

## Test Plan

On a checkpoint run

```
det checkpoint rm bea90914-f1da-4b50-b406-83ae4dd52fdf
```

and should see

```
No glob patterns provided, refreshing resources of checkpoints bea90914-f1da-4b50-b406-83ae4dd52fdf is in progress
```


and also
```
det checkpoint rm bea90914-f1da-4b50-b406-83ae4dd52fdf --glob="code/"
```

and should see 

```
All files matching specified globs will be deleted in all checkpoints provided
in checkpoint storage. Do you still want to proceed? [y/n]: y
Removal of files from checkpoints bea90914-f1da-4b50-b406-83ae4dd52fdf is in progress
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
