### PR TITLE
chore: make printed bindings more readable

### DIFF
--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -441,7 +441,7 @@ class DetEnum(enum.Enum):
 class Printable:
     # A mixin to provide a __str__ method for classes with attributes.
     def __str__(self) -> str:
-        allowed_types = (str, int, float, bool)
+        allowed_types = (str, int, float, bool, DetEnum)
         attrs = []
         for k, v in self.__dict__.items():
             if v is None: continue

--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -265,7 +265,7 @@ def gen_class(klass: swagger_parser.Class) -> Code:
     required = sorted((k, v) for k, v in klass.params.items() if v.required)
     optional = sorted((k, v) for k, v in klass.params.items() if not v.required)
 
-    out = [f"class {klass.name}:"]
+    out = [f"class {klass.name}(Printable):"]
     for k, v in optional:
         out += [f'    {k}: "typing.Optional[{annotation(v.type, prequoted=True)}]" = None']
     out += [""]
@@ -436,6 +436,21 @@ class DetEnum(enum.Enum):
     def prefix(cls) -> str:
         prefix: str = os.path.commonprefix([e.value for e in cls])
         return prefix if prefix.endswith("_") else ""
+
+
+class Printable:
+    # A mixin to provide a __str__ method for classes with attributes.
+    def __str__(self) -> str:
+        allowed_types = (int, float, str, bool, list, enum.Enum)
+        attrs = []
+        for k, v in self.__dict__.items():
+            if v is None: continue
+            if isinstance(v, allowed_types):
+                attrs.append(f'{k}={v}')
+            else:
+                attrs.append(f'{k}=...')
+        attrs_str = ', '.join(attrs)
+        return f'{self.__class__.__name__}({attrs_str})'
 
 
 """.lstrip()

--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -319,7 +319,6 @@ def gen_class(klass: swagger_parser.Class) -> Code:
         out += [f'        if not omit_unset or "{k}" in vars(self):']
         out += [f'            out["{k}"] = {parsed}']
     out += ["        return out"]
-    out += [""]
 
     return "\n".join(out)
 

--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -319,6 +319,7 @@ def gen_class(klass: swagger_parser.Class) -> Code:
         out += [f'        if not omit_unset or "{k}" in vars(self):']
         out += [f'            out["{k}"] = {parsed}']
     out += ["        return out"]
+    out += [""]
 
     return "\n".join(out)
 
@@ -441,11 +442,14 @@ class DetEnum(enum.Enum):
 class Printable:
     # A mixin to provide a __str__ method for classes with attributes.
     def __str__(self) -> str:
-        allowed_types = (int, float, str, bool, list, enum.Enum)
+        allowed_types = (str, int, float, bool)
         attrs = []
         for k, v in self.__dict__.items():
             if v is None: continue
-            if isinstance(v, allowed_types):
+            if isinstance(v, list):
+                vals = [str(x) if isinstance(x, allowed_types) else "..." for x in v]
+                attrs.append(f'{k}=[{", ".join(vals)}]')
+            elif isinstance(v, allowed_types):
                 attrs.append(f'{k}={v}')
             else:
                 attrs.append(f'{k}=...')

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -681,16 +681,20 @@ def list_experiments(args: Namespace) -> None:
     session = cli.setup_session(args)
 
     def get_with_offset(offset: int) -> bindings.v1GetExperimentsResponse:
-        return bindings.get_GetExperiments(
+        r = bindings.get_GetExperiments(
             session,
             offset=offset,
             archived=None if args.all else False,
             limit=args.limit,
             users=None if args.all else [authentication.must_cli_auth().get_session_user()],
         )
+        print(r)
+        return r
 
     resps = api.read_paginated(get_with_offset, offset=args.offset, pages=args.pages)
     all_experiments = [e for r in resps for e in r.experiments]
+    print(all_experiments[0])
+    exit(1)
 
     def format_experiment(e: bindings.v1Experiment) -> List[Any]:
         result = [

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -681,20 +681,16 @@ def list_experiments(args: Namespace) -> None:
     session = cli.setup_session(args)
 
     def get_with_offset(offset: int) -> bindings.v1GetExperimentsResponse:
-        r = bindings.get_GetExperiments(
+        return bindings.get_GetExperiments(
             session,
             offset=offset,
             archived=None if args.all else False,
             limit=args.limit,
             users=None if args.all else [authentication.must_cli_auth().get_session_user()],
         )
-        print(r)
-        return r
 
     resps = api.read_paginated(get_with_offset, offset=args.offset, pages=args.pages)
     all_experiments = [e for r in resps for e in r.experiments]
-    print(all_experiments[0])
-    exit(1)
 
     def format_experiment(e: bindings.v1Experiment) -> List[Any]:
         result = [

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -66,6 +66,24 @@ class DetEnum(enum.Enum):
         return prefix if prefix.endswith("_") else ""
 
 
+class Printable:
+    # A mixin to provide a __str__ method for classes with attributes.
+    def __str__(self) -> str:
+        allowed_types = (str, int, float, bool)
+        attrs = []
+        for k, v in self.__dict__.items():
+            if v is None: continue
+            if isinstance(v, list):
+                vals = [str(x) if isinstance(x, allowed_types) else "..." for x in v]
+                attrs.append(f'{k}=[{", ".join(vals)}]')
+            elif isinstance(v, allowed_types):
+                attrs.append(f'{k}={v}')
+            else:
+                attrs.append(f'{k}=...')
+        attrs_str = ', '.join(attrs)
+        return f'{self.__class__.__name__}({attrs_str})'
+
+
 
 class GetMasterResponseProduct(DetEnum):
     UNSPECIFIED = "PRODUCT_UNSPECIFIED"
@@ -77,7 +95,7 @@ class GetTrialWorkloadsRequestFilterOption(DetEnum):
     VALIDATION = "FILTER_OPTION_VALIDATION"
     CHECKPOINT_OR_VALIDATION = "FILTER_OPTION_CHECKPOINT_OR_VALIDATION"
 
-class PatchCheckpointOptionalResources:
+class PatchCheckpointOptionalResources(Printable):
     resources: "typing.Optional[typing.Dict[str, str]]" = None
 
     def __init__(
@@ -103,7 +121,8 @@ class PatchCheckpointOptionalResources:
             out["resources"] = self.resources
         return out
 
-class PatchExperimentPatchCheckpointStorage:
+
+class PatchExperimentPatchCheckpointStorage(Printable):
     saveExperimentBest: "typing.Optional[int]" = None
     saveTrialBest: "typing.Optional[int]" = None
     saveTrialLatest: "typing.Optional[int]" = None
@@ -145,7 +164,8 @@ class PatchExperimentPatchCheckpointStorage:
             out["saveTrialLatest"] = self.saveTrialLatest
         return out
 
-class PatchExperimentPatchResources:
+
+class PatchExperimentPatchResources(Printable):
     maxSlots: "typing.Optional[int]" = None
     priority: "typing.Optional[int]" = None
     weight: "typing.Optional[float]" = None
@@ -187,7 +207,8 @@ class PatchExperimentPatchResources:
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-class ResourcesSummaryDevices:
+
+class ResourcesSummaryDevices(Printable):
     devices: "typing.Optional[typing.Sequence[v1Device]]" = None
 
     def __init__(
@@ -213,7 +234,8 @@ class ResourcesSummaryDevices:
             out["devices"] = None if self.devices is None else [x.to_json(omit_unset) for x in self.devices]
         return out
 
-class TrialFiltersRankWithinExp:
+
+class TrialFiltersRankWithinExp(Printable):
     rank: "typing.Optional[int]" = None
     sorter: "typing.Optional[v1TrialSorter]" = None
 
@@ -247,6 +269,7 @@ class TrialFiltersRankWithinExp:
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
 
+
 class TrialProfilerMetricLabelsProfilerMetricType(DetEnum):
     UNSPECIFIED = "PROFILER_METRIC_TYPE_UNSPECIFIED"
     SYSTEM = "PROFILER_METRIC_TYPE_SYSTEM"
@@ -259,7 +282,7 @@ class TrialSorterNamespace(DetEnum):
     TRAINING_METRICS = "NAMESPACE_TRAINING_METRICS"
     VALIDATION_METRICS = "NAMESPACE_VALIDATION_METRICS"
 
-class UpdateTrialTagsRequestIds:
+class UpdateTrialTagsRequestIds(Printable):
     ids: "typing.Optional[typing.Sequence[int]]" = None
 
     def __init__(
@@ -284,6 +307,7 @@ class UpdateTrialTagsRequestIds:
         if not omit_unset or "ids" in vars(self):
             out["ids"] = self.ids
         return out
+
 
 class checkpointv1State(DetEnum):
     UNSPECIFIED = "STATE_UNSPECIFIED"
@@ -341,7 +365,7 @@ class jobv1Type(DetEnum):
     COMMAND = "TYPE_COMMAND"
     CHECKPOINT_GC = "TYPE_CHECKPOINT_GC"
 
-class protobufAny:
+class protobufAny(Printable):
     typeUrl: "typing.Optional[str]" = None
     value: "typing.Optional[str]" = None
 
@@ -375,10 +399,11 @@ class protobufAny:
             out["value"] = self.value
         return out
 
+
 class protobufNullValue(DetEnum):
     NULL_VALUE = "NULL_VALUE"
 
-class runtimeError:
+class runtimeError(Printable):
     code: "typing.Optional[int]" = None
     details: "typing.Optional[typing.Sequence[protobufAny]]" = None
     error: "typing.Optional[str]" = None
@@ -428,7 +453,8 @@ class runtimeError:
             out["message"] = self.message
         return out
 
-class runtimeStreamError:
+
+class runtimeStreamError(Printable):
     details: "typing.Optional[typing.Sequence[protobufAny]]" = None
     grpcCode: "typing.Optional[int]" = None
     httpCode: "typing.Optional[int]" = None
@@ -486,6 +512,7 @@ class runtimeStreamError:
             out["message"] = self.message
         return out
 
+
 class taskv1State(DetEnum):
     UNSPECIFIED = "STATE_UNSPECIFIED"
     PULLING = "STATE_PULLING"
@@ -508,7 +535,7 @@ class trialv1State(DetEnum):
     COMPLETED = "STATE_COMPLETED"
     ERROR = "STATE_ERROR"
 
-class trialv1Trial:
+class trialv1Trial(Printable):
     bestCheckpoint: "typing.Optional[v1CheckpointWorkload]" = None
     bestValidation: "typing.Optional[v1MetricsWorkload]" = None
     checkpointCount: "typing.Optional[int]" = None
@@ -642,7 +669,8 @@ class trialv1Trial:
             out["warmStartCheckpointUuid"] = self.warmStartCheckpointUuid
         return out
 
-class v1AckAllocationPreemptionSignalRequest:
+
+class v1AckAllocationPreemptionSignalRequest(Printable):
 
     def __init__(
         self,
@@ -664,7 +692,8 @@ class v1AckAllocationPreemptionSignalRequest:
         }
         return out
 
-class v1ActivateExperimentsRequest:
+
+class v1ActivateExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -694,7 +723,8 @@ class v1ActivateExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1ActivateExperimentsResponse:
+
+class v1ActivateExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -716,11 +746,12 @@ class v1ActivateExperimentsResponse:
         }
         return out
 
+
 class v1ActivityType(DetEnum):
     UNSPECIFIED = "ACTIVITY_TYPE_UNSPECIFIED"
     GET = "ACTIVITY_TYPE_GET"
 
-class v1AddProjectNoteResponse:
+class v1AddProjectNoteResponse(Printable):
 
     def __init__(
         self,
@@ -742,7 +773,8 @@ class v1AddProjectNoteResponse:
         }
         return out
 
-class v1Address:
+
+class v1Address(Printable):
     containerIp: "typing.Optional[str]" = None
     containerPort: "typing.Optional[int]" = None
     hostIp: "typing.Optional[str]" = None
@@ -792,7 +824,8 @@ class v1Address:
             out["hostPort"] = self.hostPort
         return out
 
-class v1Agent:
+
+class v1Agent(Printable):
     addresses: "typing.Optional[typing.Sequence[str]]" = None
     containers: "typing.Optional[typing.Dict[str, v1Container]]" = None
     draining: "typing.Optional[bool]" = None
@@ -886,7 +919,8 @@ class v1Agent:
             out["version"] = self.version
         return out
 
-class v1AgentUserGroup:
+
+class v1AgentUserGroup(Printable):
     agentGid: "typing.Optional[int]" = None
     agentGroup: "typing.Optional[str]" = None
     agentUid: "typing.Optional[int]" = None
@@ -936,7 +970,8 @@ class v1AgentUserGroup:
             out["agentUser"] = self.agentUser
         return out
 
-class v1AggregateQueueStats:
+
+class v1AggregateQueueStats(Printable):
 
     def __init__(
         self,
@@ -962,7 +997,8 @@ class v1AggregateQueueStats:
         }
         return out
 
-class v1Allocation:
+
+class v1Allocation(Printable):
     endTime: "typing.Optional[str]" = None
     startTime: "typing.Optional[str]" = None
 
@@ -1012,7 +1048,8 @@ class v1Allocation:
             out["startTime"] = self.startTime
         return out
 
-class v1AllocationAllGatherRequest:
+
+class v1AllocationAllGatherRequest(Printable):
     numPeers: "typing.Optional[int]" = None
     requestUuid: "typing.Optional[str]" = None
 
@@ -1054,7 +1091,8 @@ class v1AllocationAllGatherRequest:
             out["requestUuid"] = self.requestUuid
         return out
 
-class v1AllocationAllGatherResponse:
+
+class v1AllocationAllGatherResponse(Printable):
 
     def __init__(
         self,
@@ -1076,7 +1114,8 @@ class v1AllocationAllGatherResponse:
         }
         return out
 
-class v1AllocationPendingPreemptionSignalRequest:
+
+class v1AllocationPendingPreemptionSignalRequest(Printable):
 
     def __init__(
         self,
@@ -1098,7 +1137,8 @@ class v1AllocationPendingPreemptionSignalRequest:
         }
         return out
 
-class v1AllocationPreemptionSignalResponse:
+
+class v1AllocationPreemptionSignalResponse(Printable):
     preempt: "typing.Optional[bool]" = None
 
     def __init__(
@@ -1124,7 +1164,8 @@ class v1AllocationPreemptionSignalResponse:
             out["preempt"] = self.preempt
         return out
 
-class v1AllocationReadyRequest:
+
+class v1AllocationReadyRequest(Printable):
     allocationId: "typing.Optional[str]" = None
 
     def __init__(
@@ -1150,7 +1191,8 @@ class v1AllocationReadyRequest:
             out["allocationId"] = self.allocationId
         return out
 
-class v1AllocationRendezvousInfoResponse:
+
+class v1AllocationRendezvousInfoResponse(Printable):
 
     def __init__(
         self,
@@ -1172,7 +1214,8 @@ class v1AllocationRendezvousInfoResponse:
         }
         return out
 
-class v1AllocationSummary:
+
+class v1AllocationSummary(Printable):
     allocationId: "typing.Optional[str]" = None
     name: "typing.Optional[str]" = None
     priority: "typing.Optional[int]" = None
@@ -1270,7 +1313,8 @@ class v1AllocationSummary:
             out["taskId"] = self.taskId
         return out
 
-class v1AllocationWaitingRequest:
+
+class v1AllocationWaitingRequest(Printable):
     allocationId: "typing.Optional[str]" = None
 
     def __init__(
@@ -1296,7 +1340,8 @@ class v1AllocationWaitingRequest:
             out["allocationId"] = self.allocationId
         return out
 
-class v1ArchiveExperimentsRequest:
+
+class v1ArchiveExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -1326,7 +1371,8 @@ class v1ArchiveExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1ArchiveExperimentsResponse:
+
+class v1ArchiveExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -1348,7 +1394,8 @@ class v1ArchiveExperimentsResponse:
         }
         return out
 
-class v1AssignRolesRequest:
+
+class v1AssignRolesRequest(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
     userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None
 
@@ -1382,7 +1429,8 @@ class v1AssignRolesRequest:
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
 
-class v1AugmentedTrial:
+
+class v1AugmentedTrial(Printable):
     rankWithinExp: "typing.Optional[int]" = None
     searcherMetric: "typing.Optional[str]" = None
     searcherMetricLoss: "typing.Optional[float]" = None
@@ -1500,7 +1548,8 @@ class v1AugmentedTrial:
             out["searcherMetricValue"] = None if self.searcherMetricValue is None else dump_float(self.searcherMetricValue)
         return out
 
-class v1AwsCustomTag:
+
+class v1AwsCustomTag(Printable):
 
     def __init__(
         self,
@@ -1526,7 +1575,8 @@ class v1AwsCustomTag:
         }
         return out
 
-class v1BulkExperimentFilters:
+
+class v1BulkExperimentFilters(Printable):
     archived: "typing.Optional[bool]" = None
     description: "typing.Optional[str]" = None
     excludedExperimentIds: "typing.Optional[typing.Sequence[int]]" = None
@@ -1608,7 +1658,8 @@ class v1BulkExperimentFilters:
             out["userIds"] = self.userIds
         return out
 
-class v1CancelExperimentsRequest:
+
+class v1CancelExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -1638,7 +1689,8 @@ class v1CancelExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1CancelExperimentsResponse:
+
+class v1CancelExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -1660,7 +1712,8 @@ class v1CancelExperimentsResponse:
         }
         return out
 
-class v1Checkpoint:
+
+class v1Checkpoint(Printable):
     allocationId: "typing.Optional[str]" = None
     reportTime: "typing.Optional[str]" = None
     taskId: "typing.Optional[str]" = None
@@ -1722,7 +1775,8 @@ class v1Checkpoint:
             out["taskId"] = self.taskId
         return out
 
-class v1CheckpointTrainingMetadata:
+
+class v1CheckpointTrainingMetadata(Printable):
     experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     experimentId: "typing.Optional[int]" = None
     hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -1796,7 +1850,8 @@ class v1CheckpointTrainingMetadata:
             out["validationMetrics"] = None if self.validationMetrics is None else self.validationMetrics.to_json(omit_unset)
         return out
 
-class v1CheckpointWorkload:
+
+class v1CheckpointWorkload(Printable):
     endTime: "typing.Optional[str]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     resources: "typing.Optional[typing.Dict[str, str]]" = None
@@ -1854,7 +1909,8 @@ class v1CheckpointWorkload:
             out["uuid"] = self.uuid
         return out
 
-class v1CheckpointsRemoveFilesRequest:
+
+class v1CheckpointsRemoveFilesRequest(Printable):
 
     def __init__(
         self,
@@ -1880,7 +1936,8 @@ class v1CheckpointsRemoveFilesRequest:
         }
         return out
 
-class v1CloseTrialOperation:
+
+class v1CloseTrialOperation(Printable):
     requestId: "typing.Optional[str]" = None
 
     def __init__(
@@ -1906,7 +1963,8 @@ class v1CloseTrialOperation:
             out["requestId"] = self.requestId
         return out
 
-class v1ColumnFilter:
+
+class v1ColumnFilter(Printable):
     filter: "typing.Optional[v1DoubleFieldFilter]" = None
     name: "typing.Optional[str]" = None
 
@@ -1940,13 +1998,14 @@ class v1ColumnFilter:
             out["name"] = self.name
         return out
 
+
 class v1ColumnType(DetEnum):
     UNSPECIFIED = "COLUMN_TYPE_UNSPECIFIED"
     TEXT = "COLUMN_TYPE_TEXT"
     NUMBER = "COLUMN_TYPE_NUMBER"
     DATE = "COLUMN_TYPE_DATE"
 
-class v1Command:
+class v1Command(Printable):
     container: "typing.Optional[v1Container]" = None
     displayName: "typing.Optional[str]" = None
     exitStatus: "typing.Optional[str]" = None
@@ -2028,7 +2087,8 @@ class v1Command:
             out["userId"] = self.userId
         return out
 
-class v1ComparableTrial:
+
+class v1ComparableTrial(Printable):
 
     def __init__(
         self,
@@ -2054,7 +2114,8 @@ class v1ComparableTrial:
         }
         return out
 
-class v1CompareTrialsResponse:
+
+class v1CompareTrialsResponse(Printable):
 
     def __init__(
         self,
@@ -2076,7 +2137,8 @@ class v1CompareTrialsResponse:
         }
         return out
 
-class v1CompleteValidateAfterOperation:
+
+class v1CompleteValidateAfterOperation(Printable):
     op: "typing.Optional[v1ValidateAfterOperation]" = None
     searcherMetric: "typing.Optional[typing.Any]" = None
 
@@ -2110,7 +2172,8 @@ class v1CompleteValidateAfterOperation:
             out["searcherMetric"] = self.searcherMetric
         return out
 
-class v1Container:
+
+class v1Container(Printable):
     devices: "typing.Optional[typing.Sequence[v1Device]]" = None
     parent: "typing.Optional[str]" = None
 
@@ -2152,7 +2215,8 @@ class v1Container:
             out["parent"] = self.parent
         return out
 
-class v1CreateExperimentRequest:
+
+class v1CreateExperimentRequest(Printable):
     activate: "typing.Optional[bool]" = None
     config: "typing.Optional[str]" = None
     gitCommit: "typing.Optional[str]" = None
@@ -2266,7 +2330,8 @@ class v1CreateExperimentRequest:
             out["validateOnly"] = self.validateOnly
         return out
 
-class v1CreateExperimentResponse:
+
+class v1CreateExperimentResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
@@ -2300,7 +2365,8 @@ class v1CreateExperimentResponse:
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
-class v1CreateGroupRequest:
+
+class v1CreateGroupRequest(Printable):
     addUsers: "typing.Optional[typing.Sequence[int]]" = None
 
     def __init__(
@@ -2330,7 +2396,8 @@ class v1CreateGroupRequest:
             out["addUsers"] = self.addUsers
         return out
 
-class v1CreateGroupResponse:
+
+class v1CreateGroupResponse(Printable):
 
     def __init__(
         self,
@@ -2352,7 +2419,8 @@ class v1CreateGroupResponse:
         }
         return out
 
-class v1CreateTrialOperation:
+
+class v1CreateTrialOperation(Printable):
     hyperparams: "typing.Optional[str]" = None
     requestId: "typing.Optional[str]" = None
 
@@ -2386,7 +2454,8 @@ class v1CreateTrialOperation:
             out["requestId"] = self.requestId
         return out
 
-class v1CreateTrialRequest:
+
+class v1CreateTrialRequest(Printable):
     experimentId: "typing.Optional[int]" = None
     hparams: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     unmanaged: "typing.Optional[bool]" = None
@@ -2428,7 +2497,8 @@ class v1CreateTrialRequest:
             out["unmanaged"] = self.unmanaged
         return out
 
-class v1CreateTrialResponse:
+
+class v1CreateTrialResponse(Printable):
 
     def __init__(
         self,
@@ -2450,7 +2520,8 @@ class v1CreateTrialResponse:
         }
         return out
 
-class v1CreateTrialsCollectionRequest:
+
+class v1CreateTrialsCollectionRequest(Printable):
 
     def __init__(
         self,
@@ -2484,7 +2555,8 @@ class v1CreateTrialsCollectionRequest:
         }
         return out
 
-class v1CreateTrialsCollectionResponse:
+
+class v1CreateTrialsCollectionResponse(Printable):
     collection: "typing.Optional[v1TrialsCollection]" = None
 
     def __init__(
@@ -2510,7 +2582,8 @@ class v1CreateTrialsCollectionResponse:
             out["collection"] = None if self.collection is None else self.collection.to_json(omit_unset)
         return out
 
-class v1CurrentUserResponse:
+
+class v1CurrentUserResponse(Printable):
 
     def __init__(
         self,
@@ -2532,7 +2605,8 @@ class v1CurrentUserResponse:
         }
         return out
 
-class v1DataPoint:
+
+class v1DataPoint(Printable):
     epoch: "typing.Optional[int]" = None
     values: "typing.Optional[typing.Dict[str, typing.Any]]" = None
 
@@ -2574,7 +2648,8 @@ class v1DataPoint:
             out["values"] = self.values
         return out
 
-class v1DeleteCheckpointsRequest:
+
+class v1DeleteCheckpointsRequest(Printable):
 
     def __init__(
         self,
@@ -2596,7 +2671,8 @@ class v1DeleteCheckpointsRequest:
         }
         return out
 
-class v1DeleteExperimentsRequest:
+
+class v1DeleteExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -2626,7 +2702,8 @@ class v1DeleteExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1DeleteExperimentsResponse:
+
+class v1DeleteExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -2648,7 +2725,8 @@ class v1DeleteExperimentsResponse:
         }
         return out
 
-class v1DeleteProjectResponse:
+
+class v1DeleteProjectResponse(Printable):
 
     def __init__(
         self,
@@ -2670,7 +2748,8 @@ class v1DeleteProjectResponse:
         }
         return out
 
-class v1DeleteWorkspaceResponse:
+
+class v1DeleteWorkspaceResponse(Printable):
 
     def __init__(
         self,
@@ -2692,7 +2771,8 @@ class v1DeleteWorkspaceResponse:
         }
         return out
 
-class v1Device:
+
+class v1Device(Printable):
     brand: "typing.Optional[str]" = None
     id: "typing.Optional[int]" = None
     type: "typing.Optional[devicev1Type]" = None
@@ -2742,7 +2822,8 @@ class v1Device:
             out["uuid"] = self.uuid
         return out
 
-class v1DisableAgentRequest:
+
+class v1DisableAgentRequest(Printable):
     agentId: "typing.Optional[str]" = None
     drain: "typing.Optional[bool]" = None
 
@@ -2776,7 +2857,8 @@ class v1DisableAgentRequest:
             out["drain"] = self.drain
         return out
 
-class v1DisableAgentResponse:
+
+class v1DisableAgentResponse(Printable):
     agent: "typing.Optional[v1Agent]" = None
 
     def __init__(
@@ -2802,7 +2884,8 @@ class v1DisableAgentResponse:
             out["agent"] = None if self.agent is None else self.agent.to_json(omit_unset)
         return out
 
-class v1DisableSlotRequest:
+
+class v1DisableSlotRequest(Printable):
     agentId: "typing.Optional[str]" = None
     drain: "typing.Optional[bool]" = None
     slotId: "typing.Optional[str]" = None
@@ -2844,7 +2927,8 @@ class v1DisableSlotRequest:
             out["slotId"] = self.slotId
         return out
 
-class v1DisableSlotResponse:
+
+class v1DisableSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
     def __init__(
@@ -2870,7 +2954,8 @@ class v1DisableSlotResponse:
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
 
-class v1DoubleFieldFilter:
+
+class v1DoubleFieldFilter(Printable):
     gt: "typing.Optional[float]" = None
     gte: "typing.Optional[float]" = None
     lt: "typing.Optional[float]" = None
@@ -2920,7 +3005,8 @@ class v1DoubleFieldFilter:
             out["lte"] = None if self.lte is None else dump_float(self.lte)
         return out
 
-class v1DownsampledMetrics:
+
+class v1DownsampledMetrics(Printable):
 
     def __init__(
         self,
@@ -2946,7 +3032,8 @@ class v1DownsampledMetrics:
         }
         return out
 
-class v1EnableAgentResponse:
+
+class v1EnableAgentResponse(Printable):
     agent: "typing.Optional[v1Agent]" = None
 
     def __init__(
@@ -2972,7 +3059,8 @@ class v1EnableAgentResponse:
             out["agent"] = None if self.agent is None else self.agent.to_json(omit_unset)
         return out
 
-class v1EnableSlotResponse:
+
+class v1EnableSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
     def __init__(
@@ -2998,11 +3086,12 @@ class v1EnableSlotResponse:
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
 
+
 class v1EntityType(DetEnum):
     UNSPECIFIED = "ENTITY_TYPE_UNSPECIFIED"
     PROJECT = "ENTITY_TYPE_PROJECT"
 
-class v1ExpMetricNamesResponse:
+class v1ExpMetricNamesResponse(Printable):
     searcherMetrics: "typing.Optional[typing.Sequence[str]]" = None
     trainingMetrics: "typing.Optional[typing.Sequence[str]]" = None
     validationMetrics: "typing.Optional[typing.Sequence[str]]" = None
@@ -3044,7 +3133,8 @@ class v1ExpMetricNamesResponse:
             out["validationMetrics"] = self.validationMetrics
         return out
 
-class v1Experiment:
+
+class v1Experiment(Printable):
     bestTrialId: "typing.Optional[int]" = None
     bestTrialSearcherMetric: "typing.Optional[float]" = None
     checkpointCount: "typing.Optional[int]" = None
@@ -3274,7 +3364,8 @@ class v1Experiment:
             out["workspaceName"] = self.workspaceName
         return out
 
-class v1ExperimentActionResult:
+
+class v1ExperimentActionResult(Printable):
 
     def __init__(
         self,
@@ -3300,7 +3391,8 @@ class v1ExperimentActionResult:
         }
         return out
 
-class v1ExperimentInactive:
+
+class v1ExperimentInactive(Printable):
 
     def __init__(
         self,
@@ -3322,7 +3414,8 @@ class v1ExperimentInactive:
         }
         return out
 
-class v1ExperimentSimulation:
+
+class v1ExperimentSimulation(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     seed: "typing.Optional[int]" = None
     trials: "typing.Optional[typing.Sequence[v1TrialSimulation]]" = None
@@ -3364,6 +3457,7 @@ class v1ExperimentSimulation:
             out["trials"] = None if self.trials is None else [x.to_json(omit_unset) for x in self.trials]
         return out
 
+
 class v1FailureType(DetEnum):
     UNSPECIFIED = "FAILURE_TYPE_UNSPECIFIED"
     RESOURCES_FAILED = "FAILURE_TYPE_RESOURCES_FAILED"
@@ -3376,7 +3470,7 @@ class v1FailureType(DetEnum):
     RESTORE_ERROR = "FAILURE_TYPE_RESTORE_ERROR"
     UNKNOWN_ERROR = "FAILURE_TYPE_UNKNOWN_ERROR"
 
-class v1File:
+class v1File(Printable):
 
     def __init__(
         self,
@@ -3422,7 +3516,8 @@ class v1File:
         }
         return out
 
-class v1FileNode:
+
+class v1FileNode(Printable):
     contentLength: "typing.Optional[int]" = None
     contentType: "typing.Optional[str]" = None
     files: "typing.Optional[typing.Sequence[v1FileNode]]" = None
@@ -3496,6 +3591,7 @@ class v1FileNode:
             out["path"] = self.path
         return out
 
+
 class v1FittingPolicy(DetEnum):
     UNSPECIFIED = "FITTING_POLICY_UNSPECIFIED"
     BEST = "FITTING_POLICY_BEST"
@@ -3504,7 +3600,7 @@ class v1FittingPolicy(DetEnum):
     SLURM = "FITTING_POLICY_SLURM"
     PBS = "FITTING_POLICY_PBS"
 
-class v1GetActiveTasksCountResponse:
+class v1GetActiveTasksCountResponse(Printable):
 
     def __init__(
         self,
@@ -3538,7 +3634,8 @@ class v1GetActiveTasksCountResponse:
         }
         return out
 
-class v1GetAgentResponse:
+
+class v1GetAgentResponse(Printable):
 
     def __init__(
         self,
@@ -3560,12 +3657,13 @@ class v1GetAgentResponse:
         }
         return out
 
+
 class v1GetAgentsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
     TIME = "SORT_BY_TIME"
 
-class v1GetAgentsResponse:
+class v1GetAgentsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
 
     def __init__(
@@ -3595,7 +3693,8 @@ class v1GetAgentsResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetBestSearcherValidationMetricResponse:
+
+class v1GetBestSearcherValidationMetricResponse(Printable):
     metric: "typing.Optional[float]" = None
 
     def __init__(
@@ -3621,7 +3720,8 @@ class v1GetBestSearcherValidationMetricResponse:
             out["metric"] = None if self.metric is None else dump_float(self.metric)
         return out
 
-class v1GetCheckpointResponse:
+
+class v1GetCheckpointResponse(Printable):
 
     def __init__(
         self,
@@ -3643,7 +3743,8 @@ class v1GetCheckpointResponse:
         }
         return out
 
-class v1GetCommandResponse:
+
+class v1GetCommandResponse(Printable):
 
     def __init__(
         self,
@@ -3669,6 +3770,7 @@ class v1GetCommandResponse:
         }
         return out
 
+
 class v1GetCommandsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -3676,7 +3778,7 @@ class v1GetCommandsRequestSortBy(DetEnum):
     START_TIME = "SORT_BY_START_TIME"
     WORKSPACE_ID = "SORT_BY_WORKSPACE_ID"
 
-class v1GetCommandsResponse:
+class v1GetCommandsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
 
     def __init__(
@@ -3706,7 +3808,8 @@ class v1GetCommandsResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetCurrentTrialSearcherOperationResponse:
+
+class v1GetCurrentTrialSearcherOperationResponse(Printable):
     completed: "typing.Optional[bool]" = None
     op: "typing.Optional[v1TrialOperation]" = None
 
@@ -3740,6 +3843,7 @@ class v1GetCurrentTrialSearcherOperationResponse:
             out["op"] = None if self.op is None else self.op.to_json(omit_unset)
         return out
 
+
 class v1GetExperimentCheckpointsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     UUID = "SORT_BY_UUID"
@@ -3749,7 +3853,7 @@ class v1GetExperimentCheckpointsRequestSortBy(DetEnum):
     STATE = "SORT_BY_STATE"
     SEARCHER_METRIC = "SORT_BY_SEARCHER_METRIC"
 
-class v1GetExperimentCheckpointsResponse:
+class v1GetExperimentCheckpointsResponse(Printable):
 
     def __init__(
         self,
@@ -3775,7 +3879,8 @@ class v1GetExperimentCheckpointsResponse:
         }
         return out
 
-class v1GetExperimentLabelsResponse:
+
+class v1GetExperimentLabelsResponse(Printable):
     labels: "typing.Optional[typing.Sequence[str]]" = None
 
     def __init__(
@@ -3801,7 +3906,8 @@ class v1GetExperimentLabelsResponse:
             out["labels"] = self.labels
         return out
 
-class v1GetExperimentResponse:
+
+class v1GetExperimentResponse(Printable):
     jobSummary: "typing.Optional[v1JobSummary]" = None
 
     def __init__(
@@ -3831,6 +3937,7 @@ class v1GetExperimentResponse:
             out["jobSummary"] = None if self.jobSummary is None else self.jobSummary.to_json(omit_unset)
         return out
 
+
 class v1GetExperimentTrialsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -3844,7 +3951,7 @@ class v1GetExperimentTrialsRequestSortBy(DetEnum):
     RESTARTS = "SORT_BY_RESTARTS"
     CHECKPOINT_SIZE = "SORT_BY_CHECKPOINT_SIZE"
 
-class v1GetExperimentTrialsResponse:
+class v1GetExperimentTrialsResponse(Printable):
 
     def __init__(
         self,
@@ -3870,7 +3977,8 @@ class v1GetExperimentTrialsResponse:
         }
         return out
 
-class v1GetExperimentValidationHistoryResponse:
+
+class v1GetExperimentValidationHistoryResponse(Printable):
     validationHistory: "typing.Optional[typing.Sequence[v1ValidationHistoryEntry]]" = None
 
     def __init__(
@@ -3896,6 +4004,7 @@ class v1GetExperimentValidationHistoryResponse:
             out["validationHistory"] = None if self.validationHistory is None else [x.to_json(omit_unset) for x in self.validationHistory]
         return out
 
+
 class v1GetExperimentsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -3914,7 +4023,7 @@ class v1GetExperimentsRequestSortBy(DetEnum):
     CHECKPOINT_COUNT = "SORT_BY_CHECKPOINT_COUNT"
     SEARCHER_METRIC_VAL = "SORT_BY_SEARCHER_METRIC_VAL"
 
-class v1GetExperimentsResponse:
+class v1GetExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -3940,7 +4049,8 @@ class v1GetExperimentsResponse:
         }
         return out
 
-class v1GetGroupResponse:
+
+class v1GetGroupResponse(Printable):
 
     def __init__(
         self,
@@ -3962,7 +4072,8 @@ class v1GetGroupResponse:
         }
         return out
 
-class v1GetGroupsAndUsersAssignedToWorkspaceResponse:
+
+class v1GetGroupsAndUsersAssignedToWorkspaceResponse(Printable):
 
     def __init__(
         self,
@@ -3992,7 +4103,8 @@ class v1GetGroupsAndUsersAssignedToWorkspaceResponse:
         }
         return out
 
-class v1GetGroupsRequest:
+
+class v1GetGroupsRequest(Printable):
     name: "typing.Optional[str]" = None
     offset: "typing.Optional[int]" = None
     userId: "typing.Optional[int]" = None
@@ -4038,7 +4150,8 @@ class v1GetGroupsRequest:
             out["userId"] = self.userId
         return out
 
-class v1GetGroupsResponse:
+
+class v1GetGroupsResponse(Printable):
     groups: "typing.Optional[typing.Sequence[v1GroupSearchResult]]" = None
     pagination: "typing.Optional[v1Pagination]" = None
 
@@ -4072,7 +4185,8 @@ class v1GetGroupsResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetJobQueueStatsResponse:
+
+class v1GetJobQueueStatsResponse(Printable):
 
     def __init__(
         self,
@@ -4094,7 +4208,8 @@ class v1GetJobQueueStatsResponse:
         }
         return out
 
-class v1GetJobsResponse:
+
+class v1GetJobsResponse(Printable):
 
     def __init__(
         self,
@@ -4120,7 +4235,8 @@ class v1GetJobsResponse:
         }
         return out
 
-class v1GetJobsV2Response:
+
+class v1GetJobsV2Response(Printable):
 
     def __init__(
         self,
@@ -4146,7 +4262,8 @@ class v1GetJobsV2Response:
         }
         return out
 
-class v1GetMasterConfigResponse:
+
+class v1GetMasterConfigResponse(Printable):
 
     def __init__(
         self,
@@ -4168,7 +4285,8 @@ class v1GetMasterConfigResponse:
         }
         return out
 
-class v1GetMasterResponse:
+
+class v1GetMasterResponse(Printable):
     branding: "typing.Optional[str]" = None
     externalLoginUri: "typing.Optional[str]" = None
     externalLogoutUri: "typing.Optional[str]" = None
@@ -4274,7 +4392,8 @@ class v1GetMasterResponse:
             out["userManagementEnabled"] = self.userManagementEnabled
         return out
 
-class v1GetMeResponse:
+
+class v1GetMeResponse(Printable):
 
     def __init__(
         self,
@@ -4296,7 +4415,8 @@ class v1GetMeResponse:
         }
         return out
 
-class v1GetModelDefFileRequest:
+
+class v1GetModelDefFileRequest(Printable):
     experimentId: "typing.Optional[int]" = None
     path: "typing.Optional[str]" = None
 
@@ -4330,7 +4450,8 @@ class v1GetModelDefFileRequest:
             out["path"] = self.path
         return out
 
-class v1GetModelDefFileResponse:
+
+class v1GetModelDefFileResponse(Printable):
     file: "typing.Optional[str]" = None
 
     def __init__(
@@ -4356,7 +4477,8 @@ class v1GetModelDefFileResponse:
             out["file"] = self.file
         return out
 
-class v1GetModelDefResponse:
+
+class v1GetModelDefResponse(Printable):
 
     def __init__(
         self,
@@ -4378,7 +4500,8 @@ class v1GetModelDefResponse:
         }
         return out
 
-class v1GetModelDefTreeResponse:
+
+class v1GetModelDefTreeResponse(Printable):
     files: "typing.Optional[typing.Sequence[v1FileNode]]" = None
 
     def __init__(
@@ -4404,7 +4527,8 @@ class v1GetModelDefTreeResponse:
             out["files"] = None if self.files is None else [x.to_json(omit_unset) for x in self.files]
         return out
 
-class v1GetModelLabelsResponse:
+
+class v1GetModelLabelsResponse(Printable):
 
     def __init__(
         self,
@@ -4426,7 +4550,8 @@ class v1GetModelLabelsResponse:
         }
         return out
 
-class v1GetModelResponse:
+
+class v1GetModelResponse(Printable):
 
     def __init__(
         self,
@@ -4448,7 +4573,8 @@ class v1GetModelResponse:
         }
         return out
 
-class v1GetModelVersionResponse:
+
+class v1GetModelVersionResponse(Printable):
 
     def __init__(
         self,
@@ -4470,12 +4596,13 @@ class v1GetModelVersionResponse:
         }
         return out
 
+
 class v1GetModelVersionsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     VERSION = "SORT_BY_VERSION"
     CREATION_TIME = "SORT_BY_CREATION_TIME"
 
-class v1GetModelVersionsResponse:
+class v1GetModelVersionsResponse(Printable):
 
     def __init__(
         self,
@@ -4505,6 +4632,7 @@ class v1GetModelVersionsResponse:
         }
         return out
 
+
 class v1GetModelsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     NAME = "SORT_BY_NAME"
@@ -4514,7 +4642,7 @@ class v1GetModelsRequestSortBy(DetEnum):
     NUM_VERSIONS = "SORT_BY_NUM_VERSIONS"
     WORKSPACE = "SORT_BY_WORKSPACE"
 
-class v1GetModelsResponse:
+class v1GetModelsResponse(Printable):
 
     def __init__(
         self,
@@ -4540,7 +4668,8 @@ class v1GetModelsResponse:
         }
         return out
 
-class v1GetNotebookResponse:
+
+class v1GetNotebookResponse(Printable):
 
     def __init__(
         self,
@@ -4566,6 +4695,7 @@ class v1GetNotebookResponse:
         }
         return out
 
+
 class v1GetNotebooksRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -4573,7 +4703,7 @@ class v1GetNotebooksRequestSortBy(DetEnum):
     START_TIME = "SORT_BY_START_TIME"
     WORKSPACE_ID = "SORT_BY_WORKSPACE_ID"
 
-class v1GetNotebooksResponse:
+class v1GetNotebooksResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
 
     def __init__(
@@ -4603,7 +4733,8 @@ class v1GetNotebooksResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetPermissionsSummaryResponse:
+
+class v1GetPermissionsSummaryResponse(Printable):
 
     def __init__(
         self,
@@ -4629,7 +4760,8 @@ class v1GetPermissionsSummaryResponse:
         }
         return out
 
-class v1GetProjectColumnsResponse:
+
+class v1GetProjectColumnsResponse(Printable):
 
     def __init__(
         self,
@@ -4651,7 +4783,8 @@ class v1GetProjectColumnsResponse:
         }
         return out
 
-class v1GetProjectNumericMetricsRangeResponse:
+
+class v1GetProjectNumericMetricsRangeResponse(Printable):
     ranges: "typing.Optional[typing.Sequence[v1MetricsRange]]" = None
 
     def __init__(
@@ -4677,7 +4810,8 @@ class v1GetProjectNumericMetricsRangeResponse:
             out["ranges"] = None if self.ranges is None else [x.to_json(omit_unset) for x in self.ranges]
         return out
 
-class v1GetProjectResponse:
+
+class v1GetProjectResponse(Printable):
 
     def __init__(
         self,
@@ -4699,7 +4833,8 @@ class v1GetProjectResponse:
         }
         return out
 
-class v1GetProjectsByUserActivityResponse:
+
+class v1GetProjectsByUserActivityResponse(Printable):
     projects: "typing.Optional[typing.Sequence[v1Project]]" = None
 
     def __init__(
@@ -4725,7 +4860,8 @@ class v1GetProjectsByUserActivityResponse:
             out["projects"] = None if self.projects is None else [x.to_json(omit_unset) for x in self.projects]
         return out
 
-class v1GetResourcePoolsResponse:
+
+class v1GetResourcePoolsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
     resourcePools: "typing.Optional[typing.Sequence[v1ResourcePool]]" = None
 
@@ -4759,7 +4895,8 @@ class v1GetResourcePoolsResponse:
             out["resourcePools"] = None if self.resourcePools is None else [x.to_json(omit_unset) for x in self.resourcePools]
         return out
 
-class v1GetRolesAssignedToGroupResponse:
+
+class v1GetRolesAssignedToGroupResponse(Printable):
 
     def __init__(
         self,
@@ -4785,7 +4922,8 @@ class v1GetRolesAssignedToGroupResponse:
         }
         return out
 
-class v1GetRolesAssignedToUserResponse:
+
+class v1GetRolesAssignedToUserResponse(Printable):
 
     def __init__(
         self,
@@ -4807,7 +4945,8 @@ class v1GetRolesAssignedToUserResponse:
         }
         return out
 
-class v1GetRolesByIDRequest:
+
+class v1GetRolesByIDRequest(Printable):
     roleIds: "typing.Optional[typing.Sequence[int]]" = None
 
     def __init__(
@@ -4833,7 +4972,8 @@ class v1GetRolesByIDRequest:
             out["roleIds"] = self.roleIds
         return out
 
-class v1GetRolesByIDResponse:
+
+class v1GetRolesByIDResponse(Printable):
     roles: "typing.Optional[typing.Sequence[v1RoleWithAssignments]]" = None
 
     def __init__(
@@ -4859,7 +4999,8 @@ class v1GetRolesByIDResponse:
             out["roles"] = None if self.roles is None else [x.to_json(omit_unset) for x in self.roles]
         return out
 
-class v1GetSearcherEventsResponse:
+
+class v1GetSearcherEventsResponse(Printable):
     searcherEvents: "typing.Optional[typing.Sequence[v1SearcherEvent]]" = None
 
     def __init__(
@@ -4885,7 +5026,8 @@ class v1GetSearcherEventsResponse:
             out["searcherEvents"] = None if self.searcherEvents is None else [x.to_json(omit_unset) for x in self.searcherEvents]
         return out
 
-class v1GetShellResponse:
+
+class v1GetShellResponse(Printable):
 
     def __init__(
         self,
@@ -4911,6 +5053,7 @@ class v1GetShellResponse:
         }
         return out
 
+
 class v1GetShellsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -4918,7 +5061,7 @@ class v1GetShellsRequestSortBy(DetEnum):
     START_TIME = "SORT_BY_START_TIME"
     WORKSPACE_ID = "SORT_BY_WORKSPACE_ID"
 
-class v1GetShellsResponse:
+class v1GetShellsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
 
     def __init__(
@@ -4948,7 +5091,8 @@ class v1GetShellsResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetSlotResponse:
+
+class v1GetSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
     def __init__(
@@ -4974,7 +5118,8 @@ class v1GetSlotResponse:
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
 
-class v1GetSlotsResponse:
+
+class v1GetSlotsResponse(Printable):
     slots: "typing.Optional[typing.Sequence[v1Slot]]" = None
 
     def __init__(
@@ -5000,7 +5145,8 @@ class v1GetSlotsResponse:
             out["slots"] = None if self.slots is None else [x.to_json(omit_unset) for x in self.slots]
         return out
 
-class v1GetTaskResponse:
+
+class v1GetTaskResponse(Printable):
 
     def __init__(
         self,
@@ -5022,7 +5168,8 @@ class v1GetTaskResponse:
         }
         return out
 
-class v1GetTasksResponse:
+
+class v1GetTasksResponse(Printable):
     allocationIdToSummary: "typing.Optional[typing.Dict[str, v1AllocationSummary]]" = None
 
     def __init__(
@@ -5048,7 +5195,8 @@ class v1GetTasksResponse:
             out["allocationIdToSummary"] = None if self.allocationIdToSummary is None else {k: v.to_json(omit_unset) for k, v in self.allocationIdToSummary.items()}
         return out
 
-class v1GetTelemetryResponse:
+
+class v1GetTelemetryResponse(Printable):
     segmentKey: "typing.Optional[str]" = None
 
     def __init__(
@@ -5078,7 +5226,8 @@ class v1GetTelemetryResponse:
             out["segmentKey"] = self.segmentKey
         return out
 
-class v1GetTemplateResponse:
+
+class v1GetTemplateResponse(Printable):
 
     def __init__(
         self,
@@ -5100,11 +5249,12 @@ class v1GetTemplateResponse:
         }
         return out
 
+
 class v1GetTemplatesRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     NAME = "SORT_BY_NAME"
 
-class v1GetTemplatesResponse:
+class v1GetTemplatesResponse(Printable):
 
     def __init__(
         self,
@@ -5130,7 +5280,8 @@ class v1GetTemplatesResponse:
         }
         return out
 
-class v1GetTensorboardResponse:
+
+class v1GetTensorboardResponse(Printable):
 
     def __init__(
         self,
@@ -5156,6 +5307,7 @@ class v1GetTensorboardResponse:
         }
         return out
 
+
 class v1GetTensorboardsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
@@ -5163,7 +5315,7 @@ class v1GetTensorboardsRequestSortBy(DetEnum):
     START_TIME = "SORT_BY_START_TIME"
     WORKSPACE_ID = "SORT_BY_WORKSPACE_ID"
 
-class v1GetTensorboardsResponse:
+class v1GetTensorboardsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
 
     def __init__(
@@ -5193,7 +5345,8 @@ class v1GetTensorboardsResponse:
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-class v1GetTrainingMetricsResponse:
+
+class v1GetTrainingMetricsResponse(Printable):
 
     def __init__(
         self,
@@ -5215,6 +5368,7 @@ class v1GetTrainingMetricsResponse:
         }
         return out
 
+
 class v1GetTrialCheckpointsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     UUID = "SORT_BY_UUID"
@@ -5222,7 +5376,7 @@ class v1GetTrialCheckpointsRequestSortBy(DetEnum):
     END_TIME = "SORT_BY_END_TIME"
     STATE = "SORT_BY_STATE"
 
-class v1GetTrialCheckpointsResponse:
+class v1GetTrialCheckpointsResponse(Printable):
 
     def __init__(
         self,
@@ -5248,7 +5402,8 @@ class v1GetTrialCheckpointsResponse:
         }
         return out
 
-class v1GetTrialProfilerAvailableSeriesResponse:
+
+class v1GetTrialProfilerAvailableSeriesResponse(Printable):
 
     def __init__(
         self,
@@ -5270,7 +5425,8 @@ class v1GetTrialProfilerAvailableSeriesResponse:
         }
         return out
 
-class v1GetTrialProfilerMetricsResponse:
+
+class v1GetTrialProfilerMetricsResponse(Printable):
 
     def __init__(
         self,
@@ -5292,7 +5448,8 @@ class v1GetTrialProfilerMetricsResponse:
         }
         return out
 
-class v1GetTrialResponse:
+
+class v1GetTrialResponse(Printable):
 
     def __init__(
         self,
@@ -5314,7 +5471,8 @@ class v1GetTrialResponse:
         }
         return out
 
-class v1GetTrialWorkloadsResponse:
+
+class v1GetTrialWorkloadsResponse(Printable):
 
     def __init__(
         self,
@@ -5340,7 +5498,8 @@ class v1GetTrialWorkloadsResponse:
         }
         return out
 
-class v1GetTrialsCollectionsResponse:
+
+class v1GetTrialsCollectionsResponse(Printable):
     collections: "typing.Optional[typing.Sequence[v1TrialsCollection]]" = None
 
     def __init__(
@@ -5366,7 +5525,8 @@ class v1GetTrialsCollectionsResponse:
             out["collections"] = None if self.collections is None else [x.to_json(omit_unset) for x in self.collections]
         return out
 
-class v1GetUserByUsernameResponse:
+
+class v1GetUserByUsernameResponse(Printable):
 
     def __init__(
         self,
@@ -5388,7 +5548,8 @@ class v1GetUserByUsernameResponse:
         }
         return out
 
-class v1GetUserResponse:
+
+class v1GetUserResponse(Printable):
 
     def __init__(
         self,
@@ -5410,7 +5571,8 @@ class v1GetUserResponse:
         }
         return out
 
-class v1GetUserSettingResponse:
+
+class v1GetUserSettingResponse(Printable):
 
     def __init__(
         self,
@@ -5432,6 +5594,7 @@ class v1GetUserSettingResponse:
         }
         return out
 
+
 class v1GetUsersRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     DISPLAY_NAME = "SORT_BY_DISPLAY_NAME"
@@ -5441,7 +5604,7 @@ class v1GetUsersRequestSortBy(DetEnum):
     MODIFIED_TIME = "SORT_BY_MODIFIED_TIME"
     NAME = "SORT_BY_NAME"
 
-class v1GetUsersResponse:
+class v1GetUsersResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
     users: "typing.Optional[typing.Sequence[v1User]]" = None
 
@@ -5475,7 +5638,8 @@ class v1GetUsersResponse:
             out["users"] = None if self.users is None else [x.to_json(omit_unset) for x in self.users]
         return out
 
-class v1GetValidationMetricsResponse:
+
+class v1GetValidationMetricsResponse(Printable):
 
     def __init__(
         self,
@@ -5497,7 +5661,8 @@ class v1GetValidationMetricsResponse:
         }
         return out
 
-class v1GetWebhooksResponse:
+
+class v1GetWebhooksResponse(Printable):
 
     def __init__(
         self,
@@ -5519,6 +5684,7 @@ class v1GetWebhooksResponse:
         }
         return out
 
+
 class v1GetWorkspaceProjectsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     CREATION_TIME = "SORT_BY_CREATION_TIME"
@@ -5527,7 +5693,7 @@ class v1GetWorkspaceProjectsRequestSortBy(DetEnum):
     DESCRIPTION = "SORT_BY_DESCRIPTION"
     ID = "SORT_BY_ID"
 
-class v1GetWorkspaceProjectsResponse:
+class v1GetWorkspaceProjectsResponse(Printable):
 
     def __init__(
         self,
@@ -5553,7 +5719,8 @@ class v1GetWorkspaceProjectsResponse:
         }
         return out
 
-class v1GetWorkspaceResponse:
+
+class v1GetWorkspaceResponse(Printable):
 
     def __init__(
         self,
@@ -5575,12 +5742,13 @@ class v1GetWorkspaceResponse:
         }
         return out
 
+
 class v1GetWorkspacesRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     ID = "SORT_BY_ID"
     NAME = "SORT_BY_NAME"
 
-class v1GetWorkspacesResponse:
+class v1GetWorkspacesResponse(Printable):
 
     def __init__(
         self,
@@ -5606,7 +5774,8 @@ class v1GetWorkspacesResponse:
         }
         return out
 
-class v1Group:
+
+class v1Group(Printable):
     groupId: "typing.Optional[int]" = None
     name: "typing.Optional[str]" = None
 
@@ -5640,7 +5809,8 @@ class v1Group:
             out["name"] = self.name
         return out
 
-class v1GroupDetails:
+
+class v1GroupDetails(Printable):
     groupId: "typing.Optional[int]" = None
     name: "typing.Optional[str]" = None
     users: "typing.Optional[typing.Sequence[v1User]]" = None
@@ -5682,7 +5852,8 @@ class v1GroupDetails:
             out["users"] = None if self.users is None else [x.to_json(omit_unset) for x in self.users]
         return out
 
-class v1GroupRoleAssignment:
+
+class v1GroupRoleAssignment(Printable):
 
     def __init__(
         self,
@@ -5708,7 +5879,8 @@ class v1GroupRoleAssignment:
         }
         return out
 
-class v1GroupSearchResult:
+
+class v1GroupSearchResult(Printable):
 
     def __init__(
         self,
@@ -5734,7 +5906,8 @@ class v1GroupSearchResult:
         }
         return out
 
-class v1IdleNotebookRequest:
+
+class v1IdleNotebookRequest(Printable):
     idle: "typing.Optional[bool]" = None
     notebookId: "typing.Optional[str]" = None
 
@@ -5768,7 +5941,8 @@ class v1IdleNotebookRequest:
             out["notebookId"] = self.notebookId
         return out
 
-class v1InitialOperations:
+
+class v1InitialOperations(Printable):
     placeholder: "typing.Optional[int]" = None
 
     def __init__(
@@ -5794,7 +5968,8 @@ class v1InitialOperations:
             out["placeholder"] = self.placeholder
         return out
 
-class v1Int32FieldFilter:
+
+class v1Int32FieldFilter(Printable):
     gt: "typing.Optional[int]" = None
     gte: "typing.Optional[int]" = None
     incl: "typing.Optional[typing.Sequence[int]]" = None
@@ -5860,7 +6035,8 @@ class v1Int32FieldFilter:
             out["notIn"] = self.notIn
         return out
 
-class v1Job:
+
+class v1Job(Printable):
     priority: "typing.Optional[int]" = None
     progress: "typing.Optional[float]" = None
     summary: "typing.Optional[v1JobSummary]" = None
@@ -5962,7 +6138,8 @@ class v1Job:
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-class v1JobSummary:
+
+class v1JobSummary(Printable):
 
     def __init__(
         self,
@@ -5988,7 +6165,8 @@ class v1JobSummary:
         }
         return out
 
-class v1K8PriorityClass:
+
+class v1K8PriorityClass(Printable):
     priorityClass: "typing.Optional[str]" = None
     priorityValue: "typing.Optional[int]" = None
 
@@ -6022,7 +6200,8 @@ class v1K8PriorityClass:
             out["priorityValue"] = self.priorityValue
         return out
 
-class v1KillCommandResponse:
+
+class v1KillCommandResponse(Printable):
     command: "typing.Optional[v1Command]" = None
 
     def __init__(
@@ -6048,7 +6227,8 @@ class v1KillCommandResponse:
             out["command"] = None if self.command is None else self.command.to_json(omit_unset)
         return out
 
-class v1KillExperimentsRequest:
+
+class v1KillExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -6078,7 +6258,8 @@ class v1KillExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1KillExperimentsResponse:
+
+class v1KillExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -6100,7 +6281,8 @@ class v1KillExperimentsResponse:
         }
         return out
 
-class v1KillNotebookResponse:
+
+class v1KillNotebookResponse(Printable):
     notebook: "typing.Optional[v1Notebook]" = None
 
     def __init__(
@@ -6126,7 +6308,8 @@ class v1KillNotebookResponse:
             out["notebook"] = None if self.notebook is None else self.notebook.to_json(omit_unset)
         return out
 
-class v1KillShellResponse:
+
+class v1KillShellResponse(Printable):
     shell: "typing.Optional[v1Shell]" = None
 
     def __init__(
@@ -6152,7 +6335,8 @@ class v1KillShellResponse:
             out["shell"] = None if self.shell is None else self.shell.to_json(omit_unset)
         return out
 
-class v1KillTensorboardResponse:
+
+class v1KillTensorboardResponse(Printable):
     tensorboard: "typing.Optional[v1Tensorboard]" = None
 
     def __init__(
@@ -6178,7 +6362,8 @@ class v1KillTensorboardResponse:
             out["tensorboard"] = None if self.tensorboard is None else self.tensorboard.to_json(omit_unset)
         return out
 
-class v1LaunchCommandRequest:
+
+class v1LaunchCommandRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     data: "typing.Optional[str]" = None
     files: "typing.Optional[typing.Sequence[v1File]]" = None
@@ -6236,7 +6421,8 @@ class v1LaunchCommandRequest:
             out["workspaceId"] = self.workspaceId
         return out
 
-class v1LaunchCommandResponse:
+
+class v1LaunchCommandResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
@@ -6270,7 +6456,8 @@ class v1LaunchCommandResponse:
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
-class v1LaunchNotebookRequest:
+
+class v1LaunchNotebookRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     files: "typing.Optional[typing.Sequence[v1File]]" = None
     preview: "typing.Optional[bool]" = None
@@ -6328,7 +6515,8 @@ class v1LaunchNotebookRequest:
             out["workspaceId"] = self.workspaceId
         return out
 
-class v1LaunchNotebookResponse:
+
+class v1LaunchNotebookResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
@@ -6362,7 +6550,8 @@ class v1LaunchNotebookResponse:
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
-class v1LaunchShellRequest:
+
+class v1LaunchShellRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     data: "typing.Optional[str]" = None
     files: "typing.Optional[typing.Sequence[v1File]]" = None
@@ -6420,7 +6609,8 @@ class v1LaunchShellRequest:
             out["workspaceId"] = self.workspaceId
         return out
 
-class v1LaunchShellResponse:
+
+class v1LaunchShellResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
@@ -6454,7 +6644,8 @@ class v1LaunchShellResponse:
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
-class v1LaunchTensorboardRequest:
+
+class v1LaunchTensorboardRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     experimentIds: "typing.Optional[typing.Sequence[int]]" = None
     files: "typing.Optional[typing.Sequence[v1File]]" = None
@@ -6528,7 +6719,8 @@ class v1LaunchTensorboardRequest:
             out["workspaceId"] = self.workspaceId
         return out
 
-class v1LaunchTensorboardResponse:
+
+class v1LaunchTensorboardResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
     def __init__(
@@ -6562,11 +6754,12 @@ class v1LaunchTensorboardResponse:
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
+
 class v1LaunchWarning(DetEnum):
     UNSPECIFIED = "LAUNCH_WARNING_UNSPECIFIED"
     CURRENT_SLOTS_EXCEEDED = "LAUNCH_WARNING_CURRENT_SLOTS_EXCEEDED"
 
-class v1LimitedJob:
+class v1LimitedJob(Printable):
     priority: "typing.Optional[int]" = None
     progress: "typing.Optional[float]" = None
     summary: "typing.Optional[v1JobSummary]" = None
@@ -6644,7 +6837,8 @@ class v1LimitedJob:
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-class v1ListRolesRequest:
+
+class v1ListRolesRequest(Printable):
     offset: "typing.Optional[int]" = None
 
     def __init__(
@@ -6674,7 +6868,8 @@ class v1ListRolesRequest:
             out["offset"] = self.offset
         return out
 
-class v1ListRolesResponse:
+
+class v1ListRolesResponse(Printable):
 
     def __init__(
         self,
@@ -6700,13 +6895,14 @@ class v1ListRolesResponse:
         }
         return out
 
+
 class v1LocationType(DetEnum):
     UNSPECIFIED = "LOCATION_TYPE_UNSPECIFIED"
     EXPERIMENT = "LOCATION_TYPE_EXPERIMENT"
     HYPERPARAMETERS = "LOCATION_TYPE_HYPERPARAMETERS"
     VALIDATIONS = "LOCATION_TYPE_VALIDATIONS"
 
-class v1LogEntry:
+class v1LogEntry(Printable):
 
     def __init__(
         self,
@@ -6740,6 +6936,7 @@ class v1LogEntry:
         }
         return out
 
+
 class v1LogLevel(DetEnum):
     UNSPECIFIED = "LOG_LEVEL_UNSPECIFIED"
     TRACE = "LOG_LEVEL_TRACE"
@@ -6749,7 +6946,7 @@ class v1LogLevel(DetEnum):
     ERROR = "LOG_LEVEL_ERROR"
     CRITICAL = "LOG_LEVEL_CRITICAL"
 
-class v1LoginRequest:
+class v1LoginRequest(Printable):
     isHashed: "typing.Optional[bool]" = None
 
     def __init__(
@@ -6783,7 +6980,8 @@ class v1LoginRequest:
             out["isHashed"] = self.isHashed
         return out
 
-class v1LoginResponse:
+
+class v1LoginResponse(Printable):
 
     def __init__(
         self,
@@ -6809,7 +7007,8 @@ class v1LoginResponse:
         }
         return out
 
-class v1MarkAllocationResourcesDaemonRequest:
+
+class v1MarkAllocationResourcesDaemonRequest(Printable):
     resourcesId: "typing.Optional[str]" = None
 
     def __init__(
@@ -6839,7 +7038,8 @@ class v1MarkAllocationResourcesDaemonRequest:
             out["resourcesId"] = self.resourcesId
         return out
 
-class v1MasterLogsResponse:
+
+class v1MasterLogsResponse(Printable):
 
     def __init__(
         self,
@@ -6861,7 +7061,8 @@ class v1MasterLogsResponse:
         }
         return out
 
-class v1MetricBatchesResponse:
+
+class v1MetricBatchesResponse(Printable):
     batches: "typing.Optional[typing.Sequence[int]]" = None
 
     def __init__(
@@ -6887,12 +7088,13 @@ class v1MetricBatchesResponse:
             out["batches"] = self.batches
         return out
 
+
 class v1MetricType(DetEnum):
     UNSPECIFIED = "METRIC_TYPE_UNSPECIFIED"
     TRAINING = "METRIC_TYPE_TRAINING"
     VALIDATION = "METRIC_TYPE_VALIDATION"
 
-class v1Metrics:
+class v1Metrics(Printable):
     batchMetrics: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None
 
     def __init__(
@@ -6922,7 +7124,8 @@ class v1Metrics:
             out["batchMetrics"] = self.batchMetrics
         return out
 
-class v1MetricsRange:
+
+class v1MetricsRange(Printable):
 
     def __init__(
         self,
@@ -6952,7 +7155,8 @@ class v1MetricsRange:
         }
         return out
 
-class v1MetricsReport:
+
+class v1MetricsReport(Printable):
 
     def __init__(
         self,
@@ -6998,7 +7202,8 @@ class v1MetricsReport:
         }
         return out
 
-class v1MetricsWorkload:
+
+class v1MetricsWorkload(Printable):
     endTime: "typing.Optional[str]" = None
 
     def __init__(
@@ -7036,7 +7241,8 @@ class v1MetricsWorkload:
             out["endTime"] = self.endTime
         return out
 
-class v1Model:
+
+class v1Model(Printable):
     description: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
     notes: "typing.Optional[str]" = None
@@ -7118,7 +7324,8 @@ class v1Model:
             out["notes"] = self.notes
         return out
 
-class v1ModelVersion:
+
+class v1ModelVersion(Printable):
     comment: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -7216,7 +7423,8 @@ class v1ModelVersion:
             out["username"] = self.username
         return out
 
-class v1MoveExperimentRequest:
+
+class v1MoveExperimentRequest(Printable):
 
     def __init__(
         self,
@@ -7242,7 +7450,8 @@ class v1MoveExperimentRequest:
         }
         return out
 
-class v1MoveExperimentsRequest:
+
+class v1MoveExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -7276,7 +7485,8 @@ class v1MoveExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1MoveExperimentsResponse:
+
+class v1MoveExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -7298,7 +7508,8 @@ class v1MoveExperimentsResponse:
         }
         return out
 
-class v1MoveModelRequest:
+
+class v1MoveModelRequest(Printable):
 
     def __init__(
         self,
@@ -7324,7 +7535,8 @@ class v1MoveModelRequest:
         }
         return out
 
-class v1MoveProjectRequest:
+
+class v1MoveProjectRequest(Printable):
 
     def __init__(
         self,
@@ -7350,7 +7562,8 @@ class v1MoveProjectRequest:
         }
         return out
 
-class v1Note:
+
+class v1Note(Printable):
 
     def __init__(
         self,
@@ -7376,7 +7589,8 @@ class v1Note:
         }
         return out
 
-class v1Notebook:
+
+class v1Notebook(Printable):
     container: "typing.Optional[v1Container]" = None
     displayName: "typing.Optional[str]" = None
     exitStatus: "typing.Optional[str]" = None
@@ -7466,7 +7680,8 @@ class v1Notebook:
             out["userId"] = self.userId
         return out
 
-class v1NotifyContainerRunningRequest:
+
+class v1NotifyContainerRunningRequest(Printable):
     nodeName: "typing.Optional[str]" = None
     numPeers: "typing.Optional[int]" = None
     rank: "typing.Optional[int]" = None
@@ -7524,7 +7739,8 @@ class v1NotifyContainerRunningRequest:
             out["requestUuid"] = self.requestUuid
         return out
 
-class v1NotifyContainerRunningResponse:
+
+class v1NotifyContainerRunningResponse(Printable):
 
     def __init__(
         self,
@@ -7546,12 +7762,13 @@ class v1NotifyContainerRunningResponse:
         }
         return out
 
+
 class v1OrderBy(DetEnum):
     UNSPECIFIED = "ORDER_BY_UNSPECIFIED"
     ASC = "ORDER_BY_ASC"
     DESC = "ORDER_BY_DESC"
 
-class v1Pagination:
+class v1Pagination(Printable):
     endIndex: "typing.Optional[int]" = None
     limit: "typing.Optional[int]" = None
     offset: "typing.Optional[int]" = None
@@ -7609,7 +7826,8 @@ class v1Pagination:
             out["total"] = self.total
         return out
 
-class v1PatchCheckpoint:
+
+class v1PatchCheckpoint(Printable):
     resources: "typing.Optional[PatchCheckpointOptionalResources]" = None
 
     def __init__(
@@ -7639,7 +7857,8 @@ class v1PatchCheckpoint:
             out["resources"] = None if self.resources is None else self.resources.to_json(omit_unset)
         return out
 
-class v1PatchCheckpointsRequest:
+
+class v1PatchCheckpointsRequest(Printable):
 
     def __init__(
         self,
@@ -7661,7 +7880,8 @@ class v1PatchCheckpointsRequest:
         }
         return out
 
-class v1PatchExperiment:
+
+class v1PatchExperiment(Printable):
     checkpointStorage: "typing.Optional[PatchExperimentPatchCheckpointStorage]" = None
     description: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
@@ -7731,7 +7951,8 @@ class v1PatchExperiment:
             out["resources"] = None if self.resources is None else self.resources.to_json(omit_unset)
         return out
 
-class v1PatchExperimentResponse:
+
+class v1PatchExperimentResponse(Printable):
     experiment: "typing.Optional[v1Experiment]" = None
 
     def __init__(
@@ -7757,7 +7978,8 @@ class v1PatchExperimentResponse:
             out["experiment"] = None if self.experiment is None else self.experiment.to_json(omit_unset)
         return out
 
-class v1PatchModel:
+
+class v1PatchModel(Printable):
     description: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -7831,7 +8053,8 @@ class v1PatchModel:
             out["workspaceName"] = self.workspaceName
         return out
 
-class v1PatchModelResponse:
+
+class v1PatchModelResponse(Printable):
 
     def __init__(
         self,
@@ -7853,7 +8076,8 @@ class v1PatchModelResponse:
         }
         return out
 
-class v1PatchModelVersion:
+
+class v1PatchModelVersion(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
     comment: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
@@ -7919,7 +8143,8 @@ class v1PatchModelVersion:
             out["notes"] = self.notes
         return out
 
-class v1PatchModelVersionResponse:
+
+class v1PatchModelVersionResponse(Printable):
 
     def __init__(
         self,
@@ -7941,7 +8166,8 @@ class v1PatchModelVersionResponse:
         }
         return out
 
-class v1PatchProject:
+
+class v1PatchProject(Printable):
     description: "typing.Optional[str]" = None
     name: "typing.Optional[str]" = None
 
@@ -7975,7 +8201,8 @@ class v1PatchProject:
             out["name"] = self.name
         return out
 
-class v1PatchProjectResponse:
+
+class v1PatchProjectResponse(Printable):
 
     def __init__(
         self,
@@ -7997,7 +8224,8 @@ class v1PatchProjectResponse:
         }
         return out
 
-class v1PatchTemplateConfigResponse:
+
+class v1PatchTemplateConfigResponse(Printable):
 
     def __init__(
         self,
@@ -8019,7 +8247,8 @@ class v1PatchTemplateConfigResponse:
         }
         return out
 
-class v1PatchTrialsCollectionRequest:
+
+class v1PatchTrialsCollectionRequest(Printable):
     filters: "typing.Optional[v1TrialFilters]" = None
     name: "typing.Optional[str]" = None
     sorter: "typing.Optional[v1TrialSorter]" = None
@@ -8065,7 +8294,8 @@ class v1PatchTrialsCollectionRequest:
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
 
-class v1PatchTrialsCollectionResponse:
+
+class v1PatchTrialsCollectionResponse(Printable):
     collection: "typing.Optional[v1TrialsCollection]" = None
 
     def __init__(
@@ -8091,7 +8321,8 @@ class v1PatchTrialsCollectionResponse:
             out["collection"] = None if self.collection is None else self.collection.to_json(omit_unset)
         return out
 
-class v1PatchUser:
+
+class v1PatchUser(Printable):
     active: "typing.Optional[bool]" = None
     admin: "typing.Optional[bool]" = None
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
@@ -8173,7 +8404,8 @@ class v1PatchUser:
             out["username"] = self.username
         return out
 
-class v1PatchUserResponse:
+
+class v1PatchUserResponse(Printable):
 
     def __init__(
         self,
@@ -8195,7 +8427,8 @@ class v1PatchUserResponse:
         }
         return out
 
-class v1PatchWorkspace:
+
+class v1PatchWorkspace(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
     checkpointStorageConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     name: "typing.Optional[str]" = None
@@ -8237,7 +8470,8 @@ class v1PatchWorkspace:
             out["name"] = self.name
         return out
 
-class v1PatchWorkspaceResponse:
+
+class v1PatchWorkspaceResponse(Printable):
 
     def __init__(
         self,
@@ -8259,7 +8493,8 @@ class v1PatchWorkspaceResponse:
         }
         return out
 
-class v1PauseExperimentsRequest:
+
+class v1PauseExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -8289,7 +8524,8 @@ class v1PauseExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1PauseExperimentsResponse:
+
+class v1PauseExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -8311,7 +8547,8 @@ class v1PauseExperimentsResponse:
         }
         return out
 
-class v1Permission:
+
+class v1Permission(Printable):
     name: "typing.Optional[str]" = None
     scopeTypeMask: "typing.Optional[v1ScopeTypeMask]" = None
 
@@ -8349,6 +8586,7 @@ class v1Permission:
             out["scopeTypeMask"] = None if self.scopeTypeMask is None else self.scopeTypeMask.to_json(omit_unset)
         return out
 
+
 class v1PermissionType(DetEnum):
     UNSPECIFIED = "PERMISSION_TYPE_UNSPECIFIED"
     ADMINISTRATE_USER = "PERMISSION_TYPE_ADMINISTRATE_USER"
@@ -8383,7 +8621,7 @@ class v1PermissionType(DetEnum):
     UPDATE_ROLES = "PERMISSION_TYPE_UPDATE_ROLES"
     EDIT_WEBHOOKS = "PERMISSION_TYPE_EDIT_WEBHOOKS"
 
-class v1PolymorphicFilter:
+class v1PolymorphicFilter(Printable):
     doubleRange: "typing.Optional[v1DoubleFieldFilter]" = None
     integerRange: "typing.Optional[v1Int32FieldFilter]" = None
     name: "typing.Optional[str]" = None
@@ -8433,7 +8671,8 @@ class v1PolymorphicFilter:
             out["timeRange"] = None if self.timeRange is None else self.timeRange.to_json(omit_unset)
         return out
 
-class v1PostAllocationProxyAddressRequest:
+
+class v1PostAllocationProxyAddressRequest(Printable):
     allocationId: "typing.Optional[str]" = None
     proxyAddress: "typing.Optional[str]" = None
 
@@ -8467,7 +8706,8 @@ class v1PostAllocationProxyAddressRequest:
             out["proxyAddress"] = self.proxyAddress
         return out
 
-class v1PostCheckpointMetadataRequest:
+
+class v1PostCheckpointMetadataRequest(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
 
     def __init__(
@@ -8493,7 +8733,8 @@ class v1PostCheckpointMetadataRequest:
             out["checkpoint"] = None if self.checkpoint is None else self.checkpoint.to_json(omit_unset)
         return out
 
-class v1PostCheckpointMetadataResponse:
+
+class v1PostCheckpointMetadataResponse(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
 
     def __init__(
@@ -8519,7 +8760,8 @@ class v1PostCheckpointMetadataResponse:
             out["checkpoint"] = None if self.checkpoint is None else self.checkpoint.to_json(omit_unset)
         return out
 
-class v1PostModelRequest:
+
+class v1PostModelRequest(Printable):
     description: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -8589,7 +8831,8 @@ class v1PostModelRequest:
             out["workspaceName"] = self.workspaceName
         return out
 
-class v1PostModelResponse:
+
+class v1PostModelResponse(Printable):
 
     def __init__(
         self,
@@ -8611,7 +8854,8 @@ class v1PostModelResponse:
         }
         return out
 
-class v1PostModelVersionRequest:
+
+class v1PostModelVersionRequest(Printable):
     comment: "typing.Optional[str]" = None
     labels: "typing.Optional[typing.Sequence[str]]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -8677,7 +8921,8 @@ class v1PostModelVersionRequest:
             out["notes"] = self.notes
         return out
 
-class v1PostModelVersionResponse:
+
+class v1PostModelVersionResponse(Printable):
 
     def __init__(
         self,
@@ -8699,7 +8944,8 @@ class v1PostModelVersionResponse:
         }
         return out
 
-class v1PostProjectRequest:
+
+class v1PostProjectRequest(Printable):
     description: "typing.Optional[str]" = None
 
     def __init__(
@@ -8733,7 +8979,8 @@ class v1PostProjectRequest:
             out["description"] = self.description
         return out
 
-class v1PostProjectResponse:
+
+class v1PostProjectResponse(Printable):
 
     def __init__(
         self,
@@ -8755,7 +9002,8 @@ class v1PostProjectResponse:
         }
         return out
 
-class v1PostSearcherOperationsRequest:
+
+class v1PostSearcherOperationsRequest(Printable):
     experimentId: "typing.Optional[int]" = None
     searcherOperations: "typing.Optional[typing.Sequence[v1SearcherOperation]]" = None
     triggeredByEvent: "typing.Optional[v1SearcherEvent]" = None
@@ -8797,7 +9045,8 @@ class v1PostSearcherOperationsRequest:
             out["triggeredByEvent"] = None if self.triggeredByEvent is None else self.triggeredByEvent.to_json(omit_unset)
         return out
 
-class v1PostTemplateResponse:
+
+class v1PostTemplateResponse(Printable):
 
     def __init__(
         self,
@@ -8819,7 +9068,8 @@ class v1PostTemplateResponse:
         }
         return out
 
-class v1PostTrialProfilerMetricsBatchRequest:
+
+class v1PostTrialProfilerMetricsBatchRequest(Printable):
     batches: "typing.Optional[typing.Sequence[v1TrialProfilerMetricsBatch]]" = None
 
     def __init__(
@@ -8845,7 +9095,8 @@ class v1PostTrialProfilerMetricsBatchRequest:
             out["batches"] = None if self.batches is None else [x.to_json(omit_unset) for x in self.batches]
         return out
 
-class v1PostUserActivityRequest:
+
+class v1PostUserActivityRequest(Printable):
 
     def __init__(
         self,
@@ -8875,7 +9126,8 @@ class v1PostUserActivityRequest:
         }
         return out
 
-class v1PostUserRequest:
+
+class v1PostUserRequest(Printable):
     isHashed: "typing.Optional[bool]" = None
     password: "typing.Optional[str]" = None
     user: "typing.Optional[v1User]" = None
@@ -8917,7 +9169,8 @@ class v1PostUserRequest:
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
 
-class v1PostUserResponse:
+
+class v1PostUserResponse(Printable):
     user: "typing.Optional[v1User]" = None
 
     def __init__(
@@ -8943,7 +9196,8 @@ class v1PostUserResponse:
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
 
-class v1PostUserSettingRequest:
+
+class v1PostUserSettingRequest(Printable):
 
     def __init__(
         self,
@@ -8969,7 +9223,8 @@ class v1PostUserSettingRequest:
         }
         return out
 
-class v1PostWebhookResponse:
+
+class v1PostWebhookResponse(Printable):
 
     def __init__(
         self,
@@ -8991,7 +9246,8 @@ class v1PostWebhookResponse:
         }
         return out
 
-class v1PostWorkspaceRequest:
+
+class v1PostWorkspaceRequest(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
     checkpointStorageConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None
 
@@ -9029,7 +9285,8 @@ class v1PostWorkspaceRequest:
             out["checkpointStorageConfig"] = self.checkpointStorageConfig
         return out
 
-class v1PostWorkspaceResponse:
+
+class v1PostWorkspaceResponse(Printable):
 
     def __init__(
         self,
@@ -9051,7 +9308,8 @@ class v1PostWorkspaceResponse:
         }
         return out
 
-class v1PreviewHPSearchRequest:
+
+class v1PreviewHPSearchRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     seed: "typing.Optional[int]" = None
 
@@ -9085,7 +9343,8 @@ class v1PreviewHPSearchRequest:
             out["seed"] = self.seed
         return out
 
-class v1PreviewHPSearchResponse:
+
+class v1PreviewHPSearchResponse(Printable):
     simulation: "typing.Optional[v1ExperimentSimulation]" = None
 
     def __init__(
@@ -9111,7 +9370,8 @@ class v1PreviewHPSearchResponse:
             out["simulation"] = None if self.simulation is None else self.simulation.to_json(omit_unset)
         return out
 
-class v1Project:
+
+class v1Project(Printable):
     description: "typing.Optional[str]" = None
     lastExperimentStartedAt: "typing.Optional[str]" = None
     workspaceName: "typing.Optional[str]" = None
@@ -9201,7 +9461,8 @@ class v1Project:
             out["workspaceName"] = self.workspaceName
         return out
 
-class v1ProjectColumn:
+
+class v1ProjectColumn(Printable):
     displayName: "typing.Optional[str]" = None
 
     def __init__(
@@ -9239,7 +9500,8 @@ class v1ProjectColumn:
             out["displayName"] = self.displayName
         return out
 
-class v1ProxyPortConfig:
+
+class v1ProxyPortConfig(Printable):
     port: "typing.Optional[int]" = None
     proxyTcp: "typing.Optional[bool]" = None
     serviceId: "typing.Optional[str]" = None
@@ -9289,7 +9551,8 @@ class v1ProxyPortConfig:
             out["unauthenticated"] = self.unauthenticated
         return out
 
-class v1PutProjectNotesRequest:
+
+class v1PutProjectNotesRequest(Printable):
 
     def __init__(
         self,
@@ -9315,7 +9578,8 @@ class v1PutProjectNotesRequest:
         }
         return out
 
-class v1PutProjectNotesResponse:
+
+class v1PutProjectNotesResponse(Printable):
 
     def __init__(
         self,
@@ -9337,7 +9601,8 @@ class v1PutProjectNotesResponse:
         }
         return out
 
-class v1PutTemplateResponse:
+
+class v1PutTemplateResponse(Printable):
     template: "typing.Optional[v1Template]" = None
 
     def __init__(
@@ -9363,7 +9628,8 @@ class v1PutTemplateResponse:
             out["template"] = None if self.template is None else self.template.to_json(omit_unset)
         return out
 
-class v1QueryTrialsRequest:
+
+class v1QueryTrialsRequest(Printable):
     limit: "typing.Optional[int]" = None
     offset: "typing.Optional[int]" = None
     sorter: "typing.Optional[v1TrialSorter]" = None
@@ -9409,7 +9675,8 @@ class v1QueryTrialsRequest:
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
 
-class v1QueryTrialsResponse:
+
+class v1QueryTrialsResponse(Printable):
 
     def __init__(
         self,
@@ -9431,7 +9698,8 @@ class v1QueryTrialsResponse:
         }
         return out
 
-class v1QueueControl:
+
+class v1QueueControl(Printable):
     aheadOf: "typing.Optional[str]" = None
     behindOf: "typing.Optional[str]" = None
     priority: "typing.Optional[int]" = None
@@ -9493,7 +9761,8 @@ class v1QueueControl:
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-class v1QueueStats:
+
+class v1QueueStats(Printable):
 
     def __init__(
         self,
@@ -9519,7 +9788,8 @@ class v1QueueStats:
         }
         return out
 
-class v1RBACJob:
+
+class v1RBACJob(Printable):
     full: "typing.Optional[v1Job]" = None
     limited: "typing.Optional[v1LimitedJob]" = None
 
@@ -9553,7 +9823,8 @@ class v1RBACJob:
             out["limited"] = None if self.limited is None else self.limited.to_json(omit_unset)
         return out
 
-class v1RPQueueStat:
+
+class v1RPQueueStat(Printable):
     aggregates: "typing.Optional[typing.Sequence[v1AggregateQueueStats]]" = None
 
     def __init__(
@@ -9587,7 +9858,8 @@ class v1RPQueueStat:
             out["aggregates"] = None if self.aggregates is None else [x.to_json(omit_unset) for x in self.aggregates]
         return out
 
-class v1RemoveAssignmentsRequest:
+
+class v1RemoveAssignmentsRequest(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
     userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None
 
@@ -9621,7 +9893,8 @@ class v1RemoveAssignmentsRequest:
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
 
-class v1RendezvousInfo:
+
+class v1RendezvousInfo(Printable):
 
     def __init__(
         self,
@@ -9651,7 +9924,8 @@ class v1RendezvousInfo:
         }
         return out
 
-class v1ReportTrialMetricsRequest:
+
+class v1ReportTrialMetricsRequest(Printable):
 
     def __init__(
         self,
@@ -9677,7 +9951,8 @@ class v1ReportTrialMetricsRequest:
         }
         return out
 
-class v1ResourceAllocationAggregatedEntry:
+
+class v1ResourceAllocationAggregatedEntry(Printable):
 
     def __init__(
         self,
@@ -9723,7 +9998,8 @@ class v1ResourceAllocationAggregatedEntry:
         }
         return out
 
-class v1ResourceAllocationAggregatedResponse:
+
+class v1ResourceAllocationAggregatedResponse(Printable):
 
     def __init__(
         self,
@@ -9745,12 +10021,13 @@ class v1ResourceAllocationAggregatedResponse:
         }
         return out
 
+
 class v1ResourceAllocationAggregationPeriod(DetEnum):
     UNSPECIFIED = "RESOURCE_ALLOCATION_AGGREGATION_PERIOD_UNSPECIFIED"
     DAILY = "RESOURCE_ALLOCATION_AGGREGATION_PERIOD_DAILY"
     MONTHLY = "RESOURCE_ALLOCATION_AGGREGATION_PERIOD_MONTHLY"
 
-class v1ResourceAllocationRawEntry:
+class v1ResourceAllocationRawEntry(Printable):
     endTime: "typing.Optional[str]" = None
     experimentId: "typing.Optional[int]" = None
     kind: "typing.Optional[str]" = None
@@ -9840,7 +10117,8 @@ class v1ResourceAllocationRawEntry:
             out["username"] = self.username
         return out
 
-class v1ResourceAllocationRawResponse:
+
+class v1ResourceAllocationRawResponse(Printable):
     resourceEntries: "typing.Optional[typing.Sequence[v1ResourceAllocationRawEntry]]" = None
 
     def __init__(
@@ -9866,7 +10144,8 @@ class v1ResourceAllocationRawResponse:
             out["resourceEntries"] = None if self.resourceEntries is None else [x.to_json(omit_unset) for x in self.resourceEntries]
         return out
 
-class v1ResourcePool:
+
+class v1ResourcePool(Printable):
     accelerator: "typing.Optional[str]" = None
     slotsPerAgent: "typing.Optional[int]" = None
     stats: "typing.Optional[v1QueueStats]" = None
@@ -10032,7 +10311,8 @@ class v1ResourcePool:
             out["stats"] = None if self.stats is None else self.stats.to_json(omit_unset)
         return out
 
-class v1ResourcePoolAwsDetail:
+
+class v1ResourcePoolAwsDetail(Printable):
     customTags: "typing.Optional[typing.Sequence[v1AwsCustomTag]]" = None
     instanceType: "typing.Optional[str]" = None
     logGroup: "typing.Optional[str]" = None
@@ -10142,7 +10422,8 @@ class v1ResourcePoolAwsDetail:
             out["subnetId"] = self.subnetId
         return out
 
-class v1ResourcePoolDetail:
+
+class v1ResourcePoolDetail(Printable):
     aws: "typing.Optional[v1ResourcePoolAwsDetail]" = None
     gcp: "typing.Optional[v1ResourcePoolGcpDetail]" = None
     priorityScheduler: "typing.Optional[v1ResourcePoolPrioritySchedulerDetail]" = None
@@ -10184,7 +10465,8 @@ class v1ResourcePoolDetail:
             out["priorityScheduler"] = None if self.priorityScheduler is None else self.priorityScheduler.to_json(omit_unset)
         return out
 
-class v1ResourcePoolGcpDetail:
+
+class v1ResourcePoolGcpDetail(Printable):
     networkTags: "typing.Optional[typing.Sequence[str]]" = None
     subnetwork: "typing.Optional[str]" = None
 
@@ -10282,7 +10564,8 @@ class v1ResourcePoolGcpDetail:
             out["subnetwork"] = self.subnetwork
         return out
 
-class v1ResourcePoolPrioritySchedulerDetail:
+
+class v1ResourcePoolPrioritySchedulerDetail(Printable):
     k8Priorities: "typing.Optional[typing.Sequence[v1K8PriorityClass]]" = None
 
     def __init__(
@@ -10316,6 +10599,7 @@ class v1ResourcePoolPrioritySchedulerDetail:
             out["k8Priorities"] = None if self.k8Priorities is None else [x.to_json(omit_unset) for x in self.k8Priorities]
         return out
 
+
 class v1ResourcePoolType(DetEnum):
     UNSPECIFIED = "RESOURCE_POOL_TYPE_UNSPECIFIED"
     AWS = "RESOURCE_POOL_TYPE_AWS"
@@ -10323,7 +10607,7 @@ class v1ResourcePoolType(DetEnum):
     STATIC = "RESOURCE_POOL_TYPE_STATIC"
     K8S = "RESOURCE_POOL_TYPE_K8S"
 
-class v1ResourcesFailure:
+class v1ResourcesFailure(Printable):
     errMsg: "typing.Optional[str]" = None
     exitCode: "typing.Optional[int]" = None
     failureType: "typing.Optional[v1FailureType]" = None
@@ -10365,7 +10649,8 @@ class v1ResourcesFailure:
             out["failureType"] = None if self.failureType is None else self.failureType.value
         return out
 
-class v1ResourcesStarted:
+
+class v1ResourcesStarted(Printable):
     addresses: "typing.Optional[typing.Sequence[v1Address]]" = None
     nativeResourcesId: "typing.Optional[str]" = None
 
@@ -10399,7 +10684,8 @@ class v1ResourcesStarted:
             out["nativeResourcesId"] = self.nativeResourcesId
         return out
 
-class v1ResourcesStopped:
+
+class v1ResourcesStopped(Printable):
     failure: "typing.Optional[v1ResourcesFailure]" = None
 
     def __init__(
@@ -10425,7 +10711,8 @@ class v1ResourcesStopped:
             out["failure"] = None if self.failure is None else self.failure.to_json(omit_unset)
         return out
 
-class v1ResourcesSummary:
+
+class v1ResourcesSummary(Printable):
     agentDevices: "typing.Optional[typing.Dict[str, ResourcesSummaryDevices]]" = None
     allocationId: "typing.Optional[str]" = None
     containerId: "typing.Optional[str]" = None
@@ -10499,7 +10786,8 @@ class v1ResourcesSummary:
             out["started"] = None if self.started is None else self.started.to_json(omit_unset)
         return out
 
-class v1Role:
+
+class v1Role(Printable):
     name: "typing.Optional[str]" = None
     permissions: "typing.Optional[typing.Sequence[v1Permission]]" = None
     scopeTypeMask: "typing.Optional[v1ScopeTypeMask]" = None
@@ -10545,7 +10833,8 @@ class v1Role:
             out["scopeTypeMask"] = None if self.scopeTypeMask is None else self.scopeTypeMask.to_json(omit_unset)
         return out
 
-class v1RoleAssignment:
+
+class v1RoleAssignment(Printable):
     scopeCluster: "typing.Optional[bool]" = None
     scopeWorkspaceId: "typing.Optional[int]" = None
 
@@ -10583,7 +10872,8 @@ class v1RoleAssignment:
             out["scopeWorkspaceId"] = self.scopeWorkspaceId
         return out
 
-class v1RoleAssignmentSummary:
+
+class v1RoleAssignmentSummary(Printable):
     scopeCluster: "typing.Optional[bool]" = None
     scopeWorkspaceIds: "typing.Optional[typing.Sequence[int]]" = None
 
@@ -10621,7 +10911,8 @@ class v1RoleAssignmentSummary:
             out["scopeWorkspaceIds"] = self.scopeWorkspaceIds
         return out
 
-class v1RoleWithAssignments:
+
+class v1RoleWithAssignments(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
     role: "typing.Optional[v1Role]" = None
     userRoleAssignments: "typing.Optional[typing.Sequence[v1UserRoleAssignment]]" = None
@@ -10663,7 +10954,8 @@ class v1RoleWithAssignments:
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
 
-class v1RunnableOperation:
+
+class v1RunnableOperation(Printable):
     length: "typing.Optional[str]" = None
     type: "typing.Optional[v1RunnableType]" = None
 
@@ -10697,12 +10989,13 @@ class v1RunnableOperation:
             out["type"] = None if self.type is None else self.type.value
         return out
 
+
 class v1RunnableType(DetEnum):
     UNSPECIFIED = "RUNNABLE_TYPE_UNSPECIFIED"
     TRAIN = "RUNNABLE_TYPE_TRAIN"
     VALIDATE = "RUNNABLE_TYPE_VALIDATE"
 
-class v1SSOProvider:
+class v1SSOProvider(Printable):
 
     def __init__(
         self,
@@ -10728,6 +11021,7 @@ class v1SSOProvider:
         }
         return out
 
+
 class v1Scale(DetEnum):
     UNSPECIFIED = "SCALE_UNSPECIFIED"
     LINEAR = "SCALE_LINEAR"
@@ -10742,7 +11036,7 @@ class v1SchedulerType(DetEnum):
     SLURM = "SCHEDULER_TYPE_SLURM"
     PBS = "SCHEDULER_TYPE_PBS"
 
-class v1ScopeTypeMask:
+class v1ScopeTypeMask(Printable):
     cluster: "typing.Optional[bool]" = None
     workspace: "typing.Optional[bool]" = None
 
@@ -10776,7 +11070,8 @@ class v1ScopeTypeMask:
             out["workspace"] = self.workspace
         return out
 
-class v1SearchExperimentExperiment:
+
+class v1SearchExperimentExperiment(Printable):
     bestTrial: "typing.Optional[trialv1Trial]" = None
 
     def __init__(
@@ -10806,7 +11101,8 @@ class v1SearchExperimentExperiment:
             out["bestTrial"] = None if self.bestTrial is None else self.bestTrial.to_json(omit_unset)
         return out
 
-class v1SearchExperimentsResponse:
+
+class v1SearchExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -10832,7 +11128,8 @@ class v1SearchExperimentsResponse:
         }
         return out
 
-class v1SearchRolesAssignableToScopeRequest:
+
+class v1SearchRolesAssignableToScopeRequest(Printable):
     offset: "typing.Optional[int]" = None
     workspaceId: "typing.Optional[int]" = None
 
@@ -10870,7 +11167,8 @@ class v1SearchRolesAssignableToScopeRequest:
             out["workspaceId"] = self.workspaceId
         return out
 
-class v1SearchRolesAssignableToScopeResponse:
+
+class v1SearchRolesAssignableToScopeResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
     roles: "typing.Optional[typing.Sequence[v1Role]]" = None
 
@@ -10904,7 +11202,8 @@ class v1SearchRolesAssignableToScopeResponse:
             out["roles"] = None if self.roles is None else [x.to_json(omit_unset) for x in self.roles]
         return out
 
-class v1SearcherEvent:
+
+class v1SearcherEvent(Printable):
     experimentInactive: "typing.Optional[v1ExperimentInactive]" = None
     initialOperations: "typing.Optional[v1InitialOperations]" = None
     trialClosed: "typing.Optional[v1TrialClosed]" = None
@@ -10982,7 +11281,8 @@ class v1SearcherEvent:
             out["validationCompleted"] = None if self.validationCompleted is None else self.validationCompleted.to_json(omit_unset)
         return out
 
-class v1SearcherOperation:
+
+class v1SearcherOperation(Printable):
     closeTrial: "typing.Optional[v1CloseTrialOperation]" = None
     createTrial: "typing.Optional[v1CreateTrialOperation]" = None
     setSearcherProgress: "typing.Optional[v1SetSearcherProgressOperation]" = None
@@ -11040,7 +11340,8 @@ class v1SearcherOperation:
             out["trialOperation"] = None if self.trialOperation is None else self.trialOperation.to_json(omit_unset)
         return out
 
-class v1SetCommandPriorityRequest:
+
+class v1SetCommandPriorityRequest(Printable):
     commandId: "typing.Optional[str]" = None
     priority: "typing.Optional[int]" = None
 
@@ -11074,7 +11375,8 @@ class v1SetCommandPriorityRequest:
             out["priority"] = self.priority
         return out
 
-class v1SetCommandPriorityResponse:
+
+class v1SetCommandPriorityResponse(Printable):
     command: "typing.Optional[v1Command]" = None
 
     def __init__(
@@ -11100,7 +11402,8 @@ class v1SetCommandPriorityResponse:
             out["command"] = None if self.command is None else self.command.to_json(omit_unset)
         return out
 
-class v1SetNotebookPriorityRequest:
+
+class v1SetNotebookPriorityRequest(Printable):
     notebookId: "typing.Optional[str]" = None
     priority: "typing.Optional[int]" = None
 
@@ -11134,7 +11437,8 @@ class v1SetNotebookPriorityRequest:
             out["priority"] = self.priority
         return out
 
-class v1SetNotebookPriorityResponse:
+
+class v1SetNotebookPriorityResponse(Printable):
     notebook: "typing.Optional[v1Notebook]" = None
 
     def __init__(
@@ -11160,7 +11464,8 @@ class v1SetNotebookPriorityResponse:
             out["notebook"] = None if self.notebook is None else self.notebook.to_json(omit_unset)
         return out
 
-class v1SetSearcherProgressOperation:
+
+class v1SetSearcherProgressOperation(Printable):
     progress: "typing.Optional[float]" = None
 
     def __init__(
@@ -11186,7 +11491,8 @@ class v1SetSearcherProgressOperation:
             out["progress"] = None if self.progress is None else dump_float(self.progress)
         return out
 
-class v1SetShellPriorityRequest:
+
+class v1SetShellPriorityRequest(Printable):
     priority: "typing.Optional[int]" = None
     shellId: "typing.Optional[str]" = None
 
@@ -11220,7 +11526,8 @@ class v1SetShellPriorityRequest:
             out["shellId"] = self.shellId
         return out
 
-class v1SetShellPriorityResponse:
+
+class v1SetShellPriorityResponse(Printable):
     shell: "typing.Optional[v1Shell]" = None
 
     def __init__(
@@ -11246,7 +11553,8 @@ class v1SetShellPriorityResponse:
             out["shell"] = None if self.shell is None else self.shell.to_json(omit_unset)
         return out
 
-class v1SetTensorboardPriorityRequest:
+
+class v1SetTensorboardPriorityRequest(Printable):
     priority: "typing.Optional[int]" = None
     tensorboardId: "typing.Optional[str]" = None
 
@@ -11280,7 +11588,8 @@ class v1SetTensorboardPriorityRequest:
             out["tensorboardId"] = self.tensorboardId
         return out
 
-class v1SetTensorboardPriorityResponse:
+
+class v1SetTensorboardPriorityResponse(Printable):
     tensorboard: "typing.Optional[v1Tensorboard]" = None
 
     def __init__(
@@ -11306,7 +11615,8 @@ class v1SetTensorboardPriorityResponse:
             out["tensorboard"] = None if self.tensorboard is None else self.tensorboard.to_json(omit_unset)
         return out
 
-class v1SetUserPasswordResponse:
+
+class v1SetUserPasswordResponse(Printable):
     user: "typing.Optional[v1User]" = None
 
     def __init__(
@@ -11332,7 +11642,8 @@ class v1SetUserPasswordResponse:
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
 
-class v1Shell:
+
+class v1Shell(Printable):
     addresses: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None
     agentUserGroup: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     container: "typing.Optional[v1Container]" = None
@@ -11446,7 +11757,8 @@ class v1Shell:
             out["userId"] = self.userId
         return out
 
-class v1ShutDownOperation:
+
+class v1ShutDownOperation(Printable):
     cancel: "typing.Optional[bool]" = None
     failure: "typing.Optional[bool]" = None
 
@@ -11480,7 +11792,8 @@ class v1ShutDownOperation:
             out["failure"] = self.failure
         return out
 
-class v1Slot:
+
+class v1Slot(Printable):
     container: "typing.Optional[v1Container]" = None
     device: "typing.Optional[v1Device]" = None
     draining: "typing.Optional[bool]" = None
@@ -11538,7 +11851,8 @@ class v1Slot:
             out["id"] = self.id
         return out
 
-class v1SummarizeTrialResponse:
+
+class v1SummarizeTrialResponse(Printable):
 
     def __init__(
         self,
@@ -11564,7 +11878,8 @@ class v1SummarizeTrialResponse:
         }
         return out
 
-class v1Task:
+
+class v1Task(Printable):
     endTime: "typing.Optional[str]" = None
 
     def __init__(
@@ -11606,7 +11921,8 @@ class v1Task:
             out["endTime"] = self.endTime
         return out
 
-class v1TaskLogsFieldsResponse:
+
+class v1TaskLogsFieldsResponse(Printable):
     agentIds: "typing.Optional[typing.Sequence[str]]" = None
     allocationIds: "typing.Optional[typing.Sequence[str]]" = None
     containerIds: "typing.Optional[typing.Sequence[str]]" = None
@@ -11672,7 +11988,8 @@ class v1TaskLogsFieldsResponse:
             out["stdtypes"] = self.stdtypes
         return out
 
-class v1TaskLogsResponse:
+
+class v1TaskLogsResponse(Printable):
     agentId: "typing.Optional[str]" = None
     allocationId: "typing.Optional[str]" = None
     containerId: "typing.Optional[str]" = None
@@ -11762,6 +12079,7 @@ class v1TaskLogsResponse:
             out["stdtype"] = self.stdtype
         return out
 
+
 class v1TaskType(DetEnum):
     UNSPECIFIED = "TASK_TYPE_UNSPECIFIED"
     TRIAL = "TASK_TYPE_TRIAL"
@@ -11771,7 +12089,7 @@ class v1TaskType(DetEnum):
     TENSORBOARD = "TASK_TYPE_TENSORBOARD"
     CHECKPOINT_GC = "TASK_TYPE_CHECKPOINT_GC"
 
-class v1Template:
+class v1Template(Printable):
 
     def __init__(
         self,
@@ -11801,7 +12119,8 @@ class v1Template:
         }
         return out
 
-class v1Tensorboard:
+
+class v1Tensorboard(Printable):
     container: "typing.Optional[v1Container]" = None
     displayName: "typing.Optional[str]" = None
     exitStatus: "typing.Optional[str]" = None
@@ -11907,7 +12226,8 @@ class v1Tensorboard:
             out["userId"] = self.userId
         return out
 
-class v1TestWebhookResponse:
+
+class v1TestWebhookResponse(Printable):
 
     def __init__(
         self,
@@ -11929,7 +12249,8 @@ class v1TestWebhookResponse:
         }
         return out
 
-class v1TimestampFieldFilter:
+
+class v1TimestampFieldFilter(Printable):
     gt: "typing.Optional[str]" = None
     gte: "typing.Optional[str]" = None
     lt: "typing.Optional[str]" = None
@@ -11979,7 +12300,8 @@ class v1TimestampFieldFilter:
             out["lte"] = self.lte
         return out
 
-class v1TrialClosed:
+
+class v1TrialClosed(Printable):
 
     def __init__(
         self,
@@ -12001,7 +12323,8 @@ class v1TrialClosed:
         }
         return out
 
-class v1TrialCreated:
+
+class v1TrialCreated(Printable):
 
     def __init__(
         self,
@@ -12023,7 +12346,8 @@ class v1TrialCreated:
         }
         return out
 
-class v1TrialEarlyExit:
+
+class v1TrialEarlyExit(Printable):
 
     def __init__(
         self,
@@ -12045,12 +12369,13 @@ class v1TrialEarlyExit:
         }
         return out
 
+
 class v1TrialEarlyExitExitedReason(DetEnum):
     UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
     INVALID_HP = "EXITED_REASON_INVALID_HP"
     INIT_INVALID_HP = "EXITED_REASON_INIT_INVALID_HP"
 
-class v1TrialExitedEarly:
+class v1TrialExitedEarly(Printable):
 
     def __init__(
         self,
@@ -12076,13 +12401,14 @@ class v1TrialExitedEarly:
         }
         return out
 
+
 class v1TrialExitedEarlyExitedReason(DetEnum):
     UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
     INVALID_HP = "EXITED_REASON_INVALID_HP"
     USER_REQUESTED_STOP = "EXITED_REASON_USER_REQUESTED_STOP"
     USER_CANCELED = "EXITED_REASON_USER_CANCELED"
 
-class v1TrialFilters:
+class v1TrialFilters(Printable):
     endTime: "typing.Optional[v1TimestampFieldFilter]" = None
     experimentIds: "typing.Optional[typing.Sequence[int]]" = None
     hparams: "typing.Optional[typing.Sequence[v1ColumnFilter]]" = None
@@ -12228,7 +12554,8 @@ class v1TrialFilters:
             out["workspaceIds"] = self.workspaceIds
         return out
 
-class v1TrialLogsFieldsResponse:
+
+class v1TrialLogsFieldsResponse(Printable):
     agentIds: "typing.Optional[typing.Sequence[str]]" = None
     containerIds: "typing.Optional[typing.Sequence[str]]" = None
     rankIds: "typing.Optional[typing.Sequence[int]]" = None
@@ -12286,7 +12613,8 @@ class v1TrialLogsFieldsResponse:
             out["stdtypes"] = self.stdtypes
         return out
 
-class v1TrialLogsResponse:
+
+class v1TrialLogsResponse(Printable):
     agentId: "typing.Optional[str]" = None
     containerId: "typing.Optional[str]" = None
     log: "typing.Optional[str]" = None
@@ -12372,7 +12700,8 @@ class v1TrialLogsResponse:
             out["stdtype"] = self.stdtype
         return out
 
-class v1TrialMetrics:
+
+class v1TrialMetrics(Printable):
 
     def __init__(
         self,
@@ -12406,7 +12735,8 @@ class v1TrialMetrics:
         }
         return out
 
-class v1TrialOperation:
+
+class v1TrialOperation(Printable):
     validateAfter: "typing.Optional[v1ValidateAfterOperation]" = None
 
     def __init__(
@@ -12432,7 +12762,8 @@ class v1TrialOperation:
             out["validateAfter"] = None if self.validateAfter is None else self.validateAfter.to_json(omit_unset)
         return out
 
-class v1TrialPatch:
+
+class v1TrialPatch(Printable):
     addTag: "typing.Optional[typing.Sequence[v1TrialTag]]" = None
     removeTag: "typing.Optional[typing.Sequence[v1TrialTag]]" = None
 
@@ -12466,7 +12797,8 @@ class v1TrialPatch:
             out["removeTag"] = None if self.removeTag is None else [x.to_json(omit_unset) for x in self.removeTag]
         return out
 
-class v1TrialProfilerMetricLabels:
+
+class v1TrialProfilerMetricLabels(Printable):
     agentId: "typing.Optional[str]" = None
     gpuUuid: "typing.Optional[str]" = None
     metricType: "typing.Optional[TrialProfilerMetricLabelsProfilerMetricType]" = None
@@ -12516,7 +12848,8 @@ class v1TrialProfilerMetricLabels:
             out["metricType"] = None if self.metricType is None else self.metricType.value
         return out
 
-class v1TrialProfilerMetricsBatch:
+
+class v1TrialProfilerMetricsBatch(Printable):
 
     def __init__(
         self,
@@ -12550,7 +12883,8 @@ class v1TrialProfilerMetricsBatch:
         }
         return out
 
-class v1TrialProgress:
+
+class v1TrialProgress(Printable):
 
     def __init__(
         self,
@@ -12576,7 +12910,8 @@ class v1TrialProgress:
         }
         return out
 
-class v1TrialRunnerMetadata:
+
+class v1TrialRunnerMetadata(Printable):
 
     def __init__(
         self,
@@ -12598,7 +12933,8 @@ class v1TrialRunnerMetadata:
         }
         return out
 
-class v1TrialSimulation:
+
+class v1TrialSimulation(Printable):
     occurrences: "typing.Optional[int]" = None
     operations: "typing.Optional[typing.Sequence[v1RunnableOperation]]" = None
 
@@ -12632,7 +12968,8 @@ class v1TrialSimulation:
             out["operations"] = None if self.operations is None else [x.to_json(omit_unset) for x in self.operations]
         return out
 
-class v1TrialSorter:
+
+class v1TrialSorter(Printable):
     orderBy: "typing.Optional[v1OrderBy]" = None
 
     def __init__(
@@ -12666,7 +13003,8 @@ class v1TrialSorter:
             out["orderBy"] = None if self.orderBy is None else self.orderBy.value
         return out
 
-class v1TrialTag:
+
+class v1TrialTag(Printable):
 
     def __init__(
         self,
@@ -12688,7 +13026,8 @@ class v1TrialTag:
         }
         return out
 
-class v1TrialsCollection:
+
+class v1TrialsCollection(Printable):
 
     def __init__(
         self,
@@ -12730,7 +13069,8 @@ class v1TrialsCollection:
         }
         return out
 
-class v1TrialsSampleResponse:
+
+class v1TrialsSampleResponse(Printable):
 
     def __init__(
         self,
@@ -12760,7 +13100,8 @@ class v1TrialsSampleResponse:
         }
         return out
 
-class v1TrialsSampleResponseTrial:
+
+class v1TrialsSampleResponseTrial(Printable):
 
     def __init__(
         self,
@@ -12790,7 +13131,8 @@ class v1TrialsSampleResponseTrial:
         }
         return out
 
-class v1TrialsSnapshotResponse:
+
+class v1TrialsSnapshotResponse(Printable):
 
     def __init__(
         self,
@@ -12812,7 +13154,8 @@ class v1TrialsSnapshotResponse:
         }
         return out
 
-class v1TrialsSnapshotResponseTrial:
+
+class v1TrialsSnapshotResponseTrial(Printable):
 
     def __init__(
         self,
@@ -12846,7 +13189,8 @@ class v1TrialsSnapshotResponseTrial:
         }
         return out
 
-class v1Trigger:
+
+class v1Trigger(Printable):
     condition: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     id: "typing.Optional[int]" = None
     triggerType: "typing.Optional[v1TriggerType]" = None
@@ -12896,12 +13240,13 @@ class v1Trigger:
             out["webhookId"] = self.webhookId
         return out
 
+
 class v1TriggerType(DetEnum):
     UNSPECIFIED = "TRIGGER_TYPE_UNSPECIFIED"
     EXPERIMENT_STATE_CHANGE = "TRIGGER_TYPE_EXPERIMENT_STATE_CHANGE"
     METRIC_THRESHOLD_EXCEEDED = "TRIGGER_TYPE_METRIC_THRESHOLD_EXCEEDED"
 
-class v1UnarchiveExperimentsRequest:
+class v1UnarchiveExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
     def __init__(
@@ -12931,7 +13276,8 @@ class v1UnarchiveExperimentsRequest:
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-class v1UnarchiveExperimentsResponse:
+
+class v1UnarchiveExperimentsResponse(Printable):
 
     def __init__(
         self,
@@ -12953,7 +13299,8 @@ class v1UnarchiveExperimentsResponse:
         }
         return out
 
-class v1UpdateGroupRequest:
+
+class v1UpdateGroupRequest(Printable):
     addUsers: "typing.Optional[typing.Sequence[int]]" = None
     name: "typing.Optional[str]" = None
     removeUsers: "typing.Optional[typing.Sequence[int]]" = None
@@ -12999,7 +13346,8 @@ class v1UpdateGroupRequest:
             out["removeUsers"] = self.removeUsers
         return out
 
-class v1UpdateGroupResponse:
+
+class v1UpdateGroupResponse(Printable):
 
     def __init__(
         self,
@@ -13021,7 +13369,8 @@ class v1UpdateGroupResponse:
         }
         return out
 
-class v1UpdateJobQueueRequest:
+
+class v1UpdateJobQueueRequest(Printable):
 
     def __init__(
         self,
@@ -13043,7 +13392,8 @@ class v1UpdateJobQueueRequest:
         }
         return out
 
-class v1UpdateTrialTagsRequest:
+
+class v1UpdateTrialTagsRequest(Printable):
     filters: "typing.Optional[v1TrialFilters]" = None
     trial: "typing.Optional[UpdateTrialTagsRequestIds]" = None
 
@@ -13081,7 +13431,8 @@ class v1UpdateTrialTagsRequest:
             out["trial"] = None if self.trial is None else self.trial.to_json(omit_unset)
         return out
 
-class v1UpdateTrialTagsResponse:
+
+class v1UpdateTrialTagsResponse(Printable):
     rowsAffected: "typing.Optional[int]" = None
 
     def __init__(
@@ -13107,7 +13458,8 @@ class v1UpdateTrialTagsResponse:
             out["rowsAffected"] = self.rowsAffected
         return out
 
-class v1User:
+
+class v1User(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
     displayName: "typing.Optional[str]" = None
     id: "typing.Optional[int]" = None
@@ -13177,7 +13529,8 @@ class v1User:
             out["remote"] = self.remote
         return out
 
-class v1UserRoleAssignment:
+
+class v1UserRoleAssignment(Printable):
 
     def __init__(
         self,
@@ -13203,7 +13556,8 @@ class v1UserRoleAssignment:
         }
         return out
 
-class v1UserWebSetting:
+
+class v1UserWebSetting(Printable):
     storagePath: "typing.Optional[str]" = None
     value: "typing.Optional[str]" = None
 
@@ -13241,7 +13595,8 @@ class v1UserWebSetting:
             out["value"] = self.value
         return out
 
-class v1ValidateAfterOperation:
+
+class v1ValidateAfterOperation(Printable):
     length: "typing.Optional[str]" = None
     requestId: "typing.Optional[str]" = None
 
@@ -13275,7 +13630,8 @@ class v1ValidateAfterOperation:
             out["requestId"] = self.requestId
         return out
 
-class v1ValidationCompleted:
+
+class v1ValidationCompleted(Printable):
 
     def __init__(
         self,
@@ -13305,7 +13661,8 @@ class v1ValidationCompleted:
         }
         return out
 
-class v1ValidationHistoryEntry:
+
+class v1ValidationHistoryEntry(Printable):
 
     def __init__(
         self,
@@ -13335,7 +13692,8 @@ class v1ValidationHistoryEntry:
         }
         return out
 
-class v1Webhook:
+
+class v1Webhook(Printable):
     id: "typing.Optional[int]" = None
     triggers: "typing.Optional[typing.Sequence[v1Trigger]]" = None
 
@@ -13377,12 +13735,13 @@ class v1Webhook:
             out["triggers"] = None if self.triggers is None else [x.to_json(omit_unset) for x in self.triggers]
         return out
 
+
 class v1WebhookType(DetEnum):
     UNSPECIFIED = "WEBHOOK_TYPE_UNSPECIFIED"
     DEFAULT = "WEBHOOK_TYPE_DEFAULT"
     SLACK = "WEBHOOK_TYPE_SLACK"
 
-class v1WorkloadContainer:
+class v1WorkloadContainer(Printable):
     checkpoint: "typing.Optional[v1CheckpointWorkload]" = None
     training: "typing.Optional[v1MetricsWorkload]" = None
     validation: "typing.Optional[v1MetricsWorkload]" = None
@@ -13424,7 +13783,8 @@ class v1WorkloadContainer:
             out["validation"] = None if self.validation is None else self.validation.to_json(omit_unset)
         return out
 
-class v1Workspace:
+
+class v1Workspace(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
     checkpointStorageConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None
     pinnedAt: "typing.Optional[str]" = None
@@ -13509,6 +13869,7 @@ class v1Workspace:
         if not omit_unset or "pinnedAt" in vars(self):
             out["pinnedAt"] = self.pinnedAt
         return out
+
 
 class v1WorkspaceState(DetEnum):
     UNSPECIFIED = "WORKSPACE_STATE_UNSPECIFIED"

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -69,7 +69,7 @@ class DetEnum(enum.Enum):
 class Printable:
     # A mixin to provide a __str__ method for classes with attributes.
     def __str__(self) -> str:
-        allowed_types = (str, int, float, bool)
+        allowed_types = (str, int, float, bool, DetEnum)
         attrs = []
         for k, v in self.__dict__.items():
             if v is None: continue
@@ -121,7 +121,6 @@ class PatchCheckpointOptionalResources(Printable):
             out["resources"] = self.resources
         return out
 
-
 class PatchExperimentPatchCheckpointStorage(Printable):
     saveExperimentBest: "typing.Optional[int]" = None
     saveTrialBest: "typing.Optional[int]" = None
@@ -163,7 +162,6 @@ class PatchExperimentPatchCheckpointStorage(Printable):
         if not omit_unset or "saveTrialLatest" in vars(self):
             out["saveTrialLatest"] = self.saveTrialLatest
         return out
-
 
 class PatchExperimentPatchResources(Printable):
     maxSlots: "typing.Optional[int]" = None
@@ -207,7 +205,6 @@ class PatchExperimentPatchResources(Printable):
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-
 class ResourcesSummaryDevices(Printable):
     devices: "typing.Optional[typing.Sequence[v1Device]]" = None
 
@@ -233,7 +230,6 @@ class ResourcesSummaryDevices(Printable):
         if not omit_unset or "devices" in vars(self):
             out["devices"] = None if self.devices is None else [x.to_json(omit_unset) for x in self.devices]
         return out
-
 
 class TrialFiltersRankWithinExp(Printable):
     rank: "typing.Optional[int]" = None
@@ -268,7 +264,6 @@ class TrialFiltersRankWithinExp(Printable):
         if not omit_unset or "sorter" in vars(self):
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
-
 
 class TrialProfilerMetricLabelsProfilerMetricType(DetEnum):
     UNSPECIFIED = "PROFILER_METRIC_TYPE_UNSPECIFIED"
@@ -307,7 +302,6 @@ class UpdateTrialTagsRequestIds(Printable):
         if not omit_unset or "ids" in vars(self):
             out["ids"] = self.ids
         return out
-
 
 class checkpointv1State(DetEnum):
     UNSPECIFIED = "STATE_UNSPECIFIED"
@@ -399,7 +393,6 @@ class protobufAny(Printable):
             out["value"] = self.value
         return out
 
-
 class protobufNullValue(DetEnum):
     NULL_VALUE = "NULL_VALUE"
 
@@ -452,7 +445,6 @@ class runtimeError(Printable):
         if not omit_unset or "message" in vars(self):
             out["message"] = self.message
         return out
-
 
 class runtimeStreamError(Printable):
     details: "typing.Optional[typing.Sequence[protobufAny]]" = None
@@ -511,7 +503,6 @@ class runtimeStreamError(Printable):
         if not omit_unset or "message" in vars(self):
             out["message"] = self.message
         return out
-
 
 class taskv1State(DetEnum):
     UNSPECIFIED = "STATE_UNSPECIFIED"
@@ -669,7 +660,6 @@ class trialv1Trial(Printable):
             out["warmStartCheckpointUuid"] = self.warmStartCheckpointUuid
         return out
 
-
 class v1AckAllocationPreemptionSignalRequest(Printable):
 
     def __init__(
@@ -691,7 +681,6 @@ class v1AckAllocationPreemptionSignalRequest(Printable):
             "allocationId": self.allocationId,
         }
         return out
-
 
 class v1ActivateExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -723,7 +712,6 @@ class v1ActivateExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1ActivateExperimentsResponse(Printable):
 
     def __init__(
@@ -745,7 +733,6 @@ class v1ActivateExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1ActivityType(DetEnum):
     UNSPECIFIED = "ACTIVITY_TYPE_UNSPECIFIED"
@@ -772,7 +759,6 @@ class v1AddProjectNoteResponse(Printable):
             "notes": [x.to_json(omit_unset) for x in self.notes],
         }
         return out
-
 
 class v1Address(Printable):
     containerIp: "typing.Optional[str]" = None
@@ -823,7 +809,6 @@ class v1Address(Printable):
         if not omit_unset or "hostPort" in vars(self):
             out["hostPort"] = self.hostPort
         return out
-
 
 class v1Agent(Printable):
     addresses: "typing.Optional[typing.Sequence[str]]" = None
@@ -919,7 +904,6 @@ class v1Agent(Printable):
             out["version"] = self.version
         return out
 
-
 class v1AgentUserGroup(Printable):
     agentGid: "typing.Optional[int]" = None
     agentGroup: "typing.Optional[str]" = None
@@ -970,7 +954,6 @@ class v1AgentUserGroup(Printable):
             out["agentUser"] = self.agentUser
         return out
 
-
 class v1AggregateQueueStats(Printable):
 
     def __init__(
@@ -996,7 +979,6 @@ class v1AggregateQueueStats(Printable):
             "seconds": dump_float(self.seconds),
         }
         return out
-
 
 class v1Allocation(Printable):
     endTime: "typing.Optional[str]" = None
@@ -1048,7 +1030,6 @@ class v1Allocation(Printable):
             out["startTime"] = self.startTime
         return out
 
-
 class v1AllocationAllGatherRequest(Printable):
     numPeers: "typing.Optional[int]" = None
     requestUuid: "typing.Optional[str]" = None
@@ -1091,7 +1072,6 @@ class v1AllocationAllGatherRequest(Printable):
             out["requestUuid"] = self.requestUuid
         return out
 
-
 class v1AllocationAllGatherResponse(Printable):
 
     def __init__(
@@ -1114,7 +1094,6 @@ class v1AllocationAllGatherResponse(Printable):
         }
         return out
 
-
 class v1AllocationPendingPreemptionSignalRequest(Printable):
 
     def __init__(
@@ -1136,7 +1115,6 @@ class v1AllocationPendingPreemptionSignalRequest(Printable):
             "allocationId": self.allocationId,
         }
         return out
-
 
 class v1AllocationPreemptionSignalResponse(Printable):
     preempt: "typing.Optional[bool]" = None
@@ -1164,7 +1142,6 @@ class v1AllocationPreemptionSignalResponse(Printable):
             out["preempt"] = self.preempt
         return out
 
-
 class v1AllocationReadyRequest(Printable):
     allocationId: "typing.Optional[str]" = None
 
@@ -1191,7 +1168,6 @@ class v1AllocationReadyRequest(Printable):
             out["allocationId"] = self.allocationId
         return out
 
-
 class v1AllocationRendezvousInfoResponse(Printable):
 
     def __init__(
@@ -1213,7 +1189,6 @@ class v1AllocationRendezvousInfoResponse(Printable):
             "rendezvousInfo": self.rendezvousInfo.to_json(omit_unset),
         }
         return out
-
 
 class v1AllocationSummary(Printable):
     allocationId: "typing.Optional[str]" = None
@@ -1313,7 +1288,6 @@ class v1AllocationSummary(Printable):
             out["taskId"] = self.taskId
         return out
 
-
 class v1AllocationWaitingRequest(Printable):
     allocationId: "typing.Optional[str]" = None
 
@@ -1339,7 +1313,6 @@ class v1AllocationWaitingRequest(Printable):
         if not omit_unset or "allocationId" in vars(self):
             out["allocationId"] = self.allocationId
         return out
-
 
 class v1ArchiveExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -1371,7 +1344,6 @@ class v1ArchiveExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1ArchiveExperimentsResponse(Printable):
 
     def __init__(
@@ -1393,7 +1365,6 @@ class v1ArchiveExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1AssignRolesRequest(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
@@ -1428,7 +1399,6 @@ class v1AssignRolesRequest(Printable):
         if not omit_unset or "userRoleAssignments" in vars(self):
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
-
 
 class v1AugmentedTrial(Printable):
     rankWithinExp: "typing.Optional[int]" = None
@@ -1548,7 +1518,6 @@ class v1AugmentedTrial(Printable):
             out["searcherMetricValue"] = None if self.searcherMetricValue is None else dump_float(self.searcherMetricValue)
         return out
 
-
 class v1AwsCustomTag(Printable):
 
     def __init__(
@@ -1574,7 +1543,6 @@ class v1AwsCustomTag(Printable):
             "value": self.value,
         }
         return out
-
 
 class v1BulkExperimentFilters(Printable):
     archived: "typing.Optional[bool]" = None
@@ -1658,7 +1626,6 @@ class v1BulkExperimentFilters(Printable):
             out["userIds"] = self.userIds
         return out
 
-
 class v1CancelExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
 
@@ -1689,7 +1656,6 @@ class v1CancelExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1CancelExperimentsResponse(Printable):
 
     def __init__(
@@ -1711,7 +1677,6 @@ class v1CancelExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1Checkpoint(Printable):
     allocationId: "typing.Optional[str]" = None
@@ -1774,7 +1739,6 @@ class v1Checkpoint(Printable):
         if not omit_unset or "taskId" in vars(self):
             out["taskId"] = self.taskId
         return out
-
 
 class v1CheckpointTrainingMetadata(Printable):
     experimentConfig: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -1850,7 +1814,6 @@ class v1CheckpointTrainingMetadata(Printable):
             out["validationMetrics"] = None if self.validationMetrics is None else self.validationMetrics.to_json(omit_unset)
         return out
 
-
 class v1CheckpointWorkload(Printable):
     endTime: "typing.Optional[str]" = None
     metadata: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -1909,7 +1872,6 @@ class v1CheckpointWorkload(Printable):
             out["uuid"] = self.uuid
         return out
 
-
 class v1CheckpointsRemoveFilesRequest(Printable):
 
     def __init__(
@@ -1936,7 +1898,6 @@ class v1CheckpointsRemoveFilesRequest(Printable):
         }
         return out
 
-
 class v1CloseTrialOperation(Printable):
     requestId: "typing.Optional[str]" = None
 
@@ -1962,7 +1923,6 @@ class v1CloseTrialOperation(Printable):
         if not omit_unset or "requestId" in vars(self):
             out["requestId"] = self.requestId
         return out
-
 
 class v1ColumnFilter(Printable):
     filter: "typing.Optional[v1DoubleFieldFilter]" = None
@@ -1997,7 +1957,6 @@ class v1ColumnFilter(Printable):
         if not omit_unset or "name" in vars(self):
             out["name"] = self.name
         return out
-
 
 class v1ColumnType(DetEnum):
     UNSPECIFIED = "COLUMN_TYPE_UNSPECIFIED"
@@ -2087,7 +2046,6 @@ class v1Command(Printable):
             out["userId"] = self.userId
         return out
 
-
 class v1ComparableTrial(Printable):
 
     def __init__(
@@ -2114,7 +2072,6 @@ class v1ComparableTrial(Printable):
         }
         return out
 
-
 class v1CompareTrialsResponse(Printable):
 
     def __init__(
@@ -2136,7 +2093,6 @@ class v1CompareTrialsResponse(Printable):
             "trials": [x.to_json(omit_unset) for x in self.trials],
         }
         return out
-
 
 class v1CompleteValidateAfterOperation(Printable):
     op: "typing.Optional[v1ValidateAfterOperation]" = None
@@ -2171,7 +2127,6 @@ class v1CompleteValidateAfterOperation(Printable):
         if not omit_unset or "searcherMetric" in vars(self):
             out["searcherMetric"] = self.searcherMetric
         return out
-
 
 class v1Container(Printable):
     devices: "typing.Optional[typing.Sequence[v1Device]]" = None
@@ -2214,7 +2169,6 @@ class v1Container(Printable):
         if not omit_unset or "parent" in vars(self):
             out["parent"] = self.parent
         return out
-
 
 class v1CreateExperimentRequest(Printable):
     activate: "typing.Optional[bool]" = None
@@ -2330,7 +2284,6 @@ class v1CreateExperimentRequest(Printable):
             out["validateOnly"] = self.validateOnly
         return out
 
-
 class v1CreateExperimentResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
@@ -2365,7 +2318,6 @@ class v1CreateExperimentResponse(Printable):
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
 
-
 class v1CreateGroupRequest(Printable):
     addUsers: "typing.Optional[typing.Sequence[int]]" = None
 
@@ -2396,7 +2348,6 @@ class v1CreateGroupRequest(Printable):
             out["addUsers"] = self.addUsers
         return out
 
-
 class v1CreateGroupResponse(Printable):
 
     def __init__(
@@ -2418,7 +2369,6 @@ class v1CreateGroupResponse(Printable):
             "group": self.group.to_json(omit_unset),
         }
         return out
-
 
 class v1CreateTrialOperation(Printable):
     hyperparams: "typing.Optional[str]" = None
@@ -2453,7 +2403,6 @@ class v1CreateTrialOperation(Printable):
         if not omit_unset or "requestId" in vars(self):
             out["requestId"] = self.requestId
         return out
-
 
 class v1CreateTrialRequest(Printable):
     experimentId: "typing.Optional[int]" = None
@@ -2497,7 +2446,6 @@ class v1CreateTrialRequest(Printable):
             out["unmanaged"] = self.unmanaged
         return out
 
-
 class v1CreateTrialResponse(Printable):
 
     def __init__(
@@ -2519,7 +2467,6 @@ class v1CreateTrialResponse(Printable):
             "trial": self.trial.to_json(omit_unset),
         }
         return out
-
 
 class v1CreateTrialsCollectionRequest(Printable):
 
@@ -2555,7 +2502,6 @@ class v1CreateTrialsCollectionRequest(Printable):
         }
         return out
 
-
 class v1CreateTrialsCollectionResponse(Printable):
     collection: "typing.Optional[v1TrialsCollection]" = None
 
@@ -2582,7 +2528,6 @@ class v1CreateTrialsCollectionResponse(Printable):
             out["collection"] = None if self.collection is None else self.collection.to_json(omit_unset)
         return out
 
-
 class v1CurrentUserResponse(Printable):
 
     def __init__(
@@ -2604,7 +2549,6 @@ class v1CurrentUserResponse(Printable):
             "user": self.user.to_json(omit_unset),
         }
         return out
-
 
 class v1DataPoint(Printable):
     epoch: "typing.Optional[int]" = None
@@ -2648,7 +2592,6 @@ class v1DataPoint(Printable):
             out["values"] = self.values
         return out
 
-
 class v1DeleteCheckpointsRequest(Printable):
 
     def __init__(
@@ -2670,7 +2613,6 @@ class v1DeleteCheckpointsRequest(Printable):
             "checkpointUuids": self.checkpointUuids,
         }
         return out
-
 
 class v1DeleteExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -2702,7 +2644,6 @@ class v1DeleteExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1DeleteExperimentsResponse(Printable):
 
     def __init__(
@@ -2724,7 +2665,6 @@ class v1DeleteExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1DeleteProjectResponse(Printable):
 
@@ -2748,7 +2688,6 @@ class v1DeleteProjectResponse(Printable):
         }
         return out
 
-
 class v1DeleteWorkspaceResponse(Printable):
 
     def __init__(
@@ -2770,7 +2709,6 @@ class v1DeleteWorkspaceResponse(Printable):
             "completed": self.completed,
         }
         return out
-
 
 class v1Device(Printable):
     brand: "typing.Optional[str]" = None
@@ -2822,7 +2760,6 @@ class v1Device(Printable):
             out["uuid"] = self.uuid
         return out
 
-
 class v1DisableAgentRequest(Printable):
     agentId: "typing.Optional[str]" = None
     drain: "typing.Optional[bool]" = None
@@ -2857,7 +2794,6 @@ class v1DisableAgentRequest(Printable):
             out["drain"] = self.drain
         return out
 
-
 class v1DisableAgentResponse(Printable):
     agent: "typing.Optional[v1Agent]" = None
 
@@ -2883,7 +2819,6 @@ class v1DisableAgentResponse(Printable):
         if not omit_unset or "agent" in vars(self):
             out["agent"] = None if self.agent is None else self.agent.to_json(omit_unset)
         return out
-
 
 class v1DisableSlotRequest(Printable):
     agentId: "typing.Optional[str]" = None
@@ -2927,7 +2862,6 @@ class v1DisableSlotRequest(Printable):
             out["slotId"] = self.slotId
         return out
 
-
 class v1DisableSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
@@ -2953,7 +2887,6 @@ class v1DisableSlotResponse(Printable):
         if not omit_unset or "slot" in vars(self):
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
-
 
 class v1DoubleFieldFilter(Printable):
     gt: "typing.Optional[float]" = None
@@ -3005,7 +2938,6 @@ class v1DoubleFieldFilter(Printable):
             out["lte"] = None if self.lte is None else dump_float(self.lte)
         return out
 
-
 class v1DownsampledMetrics(Printable):
 
     def __init__(
@@ -3031,7 +2963,6 @@ class v1DownsampledMetrics(Printable):
             "type": self.type.value,
         }
         return out
-
 
 class v1EnableAgentResponse(Printable):
     agent: "typing.Optional[v1Agent]" = None
@@ -3059,7 +2990,6 @@ class v1EnableAgentResponse(Printable):
             out["agent"] = None if self.agent is None else self.agent.to_json(omit_unset)
         return out
 
-
 class v1EnableSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
@@ -3085,7 +3015,6 @@ class v1EnableSlotResponse(Printable):
         if not omit_unset or "slot" in vars(self):
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
-
 
 class v1EntityType(DetEnum):
     UNSPECIFIED = "ENTITY_TYPE_UNSPECIFIED"
@@ -3132,7 +3061,6 @@ class v1ExpMetricNamesResponse(Printable):
         if not omit_unset or "validationMetrics" in vars(self):
             out["validationMetrics"] = self.validationMetrics
         return out
-
 
 class v1Experiment(Printable):
     bestTrialId: "typing.Optional[int]" = None
@@ -3364,7 +3292,6 @@ class v1Experiment(Printable):
             out["workspaceName"] = self.workspaceName
         return out
 
-
 class v1ExperimentActionResult(Printable):
 
     def __init__(
@@ -3391,7 +3318,6 @@ class v1ExperimentActionResult(Printable):
         }
         return out
 
-
 class v1ExperimentInactive(Printable):
 
     def __init__(
@@ -3413,7 +3339,6 @@ class v1ExperimentInactive(Printable):
             "experimentState": self.experimentState.value,
         }
         return out
-
 
 class v1ExperimentSimulation(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -3456,7 +3381,6 @@ class v1ExperimentSimulation(Printable):
         if not omit_unset or "trials" in vars(self):
             out["trials"] = None if self.trials is None else [x.to_json(omit_unset) for x in self.trials]
         return out
-
 
 class v1FailureType(DetEnum):
     UNSPECIFIED = "FAILURE_TYPE_UNSPECIFIED"
@@ -3515,7 +3439,6 @@ class v1File(Printable):
             "uid": self.uid,
         }
         return out
-
 
 class v1FileNode(Printable):
     contentLength: "typing.Optional[int]" = None
@@ -3591,7 +3514,6 @@ class v1FileNode(Printable):
             out["path"] = self.path
         return out
 
-
 class v1FittingPolicy(DetEnum):
     UNSPECIFIED = "FITTING_POLICY_UNSPECIFIED"
     BEST = "FITTING_POLICY_BEST"
@@ -3634,7 +3556,6 @@ class v1GetActiveTasksCountResponse(Printable):
         }
         return out
 
-
 class v1GetAgentResponse(Printable):
 
     def __init__(
@@ -3656,7 +3577,6 @@ class v1GetAgentResponse(Printable):
             "agent": self.agent.to_json(omit_unset),
         }
         return out
-
 
 class v1GetAgentsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -3693,7 +3613,6 @@ class v1GetAgentsResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetBestSearcherValidationMetricResponse(Printable):
     metric: "typing.Optional[float]" = None
 
@@ -3720,7 +3639,6 @@ class v1GetBestSearcherValidationMetricResponse(Printable):
             out["metric"] = None if self.metric is None else dump_float(self.metric)
         return out
 
-
 class v1GetCheckpointResponse(Printable):
 
     def __init__(
@@ -3742,7 +3660,6 @@ class v1GetCheckpointResponse(Printable):
             "checkpoint": self.checkpoint.to_json(omit_unset),
         }
         return out
-
 
 class v1GetCommandResponse(Printable):
 
@@ -3769,7 +3686,6 @@ class v1GetCommandResponse(Printable):
             "config": self.config,
         }
         return out
-
 
 class v1GetCommandsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -3808,7 +3724,6 @@ class v1GetCommandsResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetCurrentTrialSearcherOperationResponse(Printable):
     completed: "typing.Optional[bool]" = None
     op: "typing.Optional[v1TrialOperation]" = None
@@ -3842,7 +3757,6 @@ class v1GetCurrentTrialSearcherOperationResponse(Printable):
         if not omit_unset or "op" in vars(self):
             out["op"] = None if self.op is None else self.op.to_json(omit_unset)
         return out
-
 
 class v1GetExperimentCheckpointsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -3879,7 +3793,6 @@ class v1GetExperimentCheckpointsResponse(Printable):
         }
         return out
 
-
 class v1GetExperimentLabelsResponse(Printable):
     labels: "typing.Optional[typing.Sequence[str]]" = None
 
@@ -3905,7 +3818,6 @@ class v1GetExperimentLabelsResponse(Printable):
         if not omit_unset or "labels" in vars(self):
             out["labels"] = self.labels
         return out
-
 
 class v1GetExperimentResponse(Printable):
     jobSummary: "typing.Optional[v1JobSummary]" = None
@@ -3936,7 +3848,6 @@ class v1GetExperimentResponse(Printable):
         if not omit_unset or "jobSummary" in vars(self):
             out["jobSummary"] = None if self.jobSummary is None else self.jobSummary.to_json(omit_unset)
         return out
-
 
 class v1GetExperimentTrialsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -3977,7 +3888,6 @@ class v1GetExperimentTrialsResponse(Printable):
         }
         return out
 
-
 class v1GetExperimentValidationHistoryResponse(Printable):
     validationHistory: "typing.Optional[typing.Sequence[v1ValidationHistoryEntry]]" = None
 
@@ -4003,7 +3913,6 @@ class v1GetExperimentValidationHistoryResponse(Printable):
         if not omit_unset or "validationHistory" in vars(self):
             out["validationHistory"] = None if self.validationHistory is None else [x.to_json(omit_unset) for x in self.validationHistory]
         return out
-
 
 class v1GetExperimentsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -4049,7 +3958,6 @@ class v1GetExperimentsResponse(Printable):
         }
         return out
 
-
 class v1GetGroupResponse(Printable):
 
     def __init__(
@@ -4071,7 +3979,6 @@ class v1GetGroupResponse(Printable):
             "group": self.group.to_json(omit_unset),
         }
         return out
-
 
 class v1GetGroupsAndUsersAssignedToWorkspaceResponse(Printable):
 
@@ -4102,7 +4009,6 @@ class v1GetGroupsAndUsersAssignedToWorkspaceResponse(Printable):
             "usersAssignedDirectly": [x.to_json(omit_unset) for x in self.usersAssignedDirectly],
         }
         return out
-
 
 class v1GetGroupsRequest(Printable):
     name: "typing.Optional[str]" = None
@@ -4150,7 +4056,6 @@ class v1GetGroupsRequest(Printable):
             out["userId"] = self.userId
         return out
 
-
 class v1GetGroupsResponse(Printable):
     groups: "typing.Optional[typing.Sequence[v1GroupSearchResult]]" = None
     pagination: "typing.Optional[v1Pagination]" = None
@@ -4185,7 +4090,6 @@ class v1GetGroupsResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetJobQueueStatsResponse(Printable):
 
     def __init__(
@@ -4207,7 +4111,6 @@ class v1GetJobQueueStatsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1GetJobsResponse(Printable):
 
@@ -4235,7 +4138,6 @@ class v1GetJobsResponse(Printable):
         }
         return out
 
-
 class v1GetJobsV2Response(Printable):
 
     def __init__(
@@ -4262,7 +4164,6 @@ class v1GetJobsV2Response(Printable):
         }
         return out
 
-
 class v1GetMasterConfigResponse(Printable):
 
     def __init__(
@@ -4284,7 +4185,6 @@ class v1GetMasterConfigResponse(Printable):
             "config": self.config,
         }
         return out
-
 
 class v1GetMasterResponse(Printable):
     branding: "typing.Optional[str]" = None
@@ -4392,7 +4292,6 @@ class v1GetMasterResponse(Printable):
             out["userManagementEnabled"] = self.userManagementEnabled
         return out
 
-
 class v1GetMeResponse(Printable):
 
     def __init__(
@@ -4414,7 +4313,6 @@ class v1GetMeResponse(Printable):
             "user": self.user.to_json(omit_unset),
         }
         return out
-
 
 class v1GetModelDefFileRequest(Printable):
     experimentId: "typing.Optional[int]" = None
@@ -4450,7 +4348,6 @@ class v1GetModelDefFileRequest(Printable):
             out["path"] = self.path
         return out
 
-
 class v1GetModelDefFileResponse(Printable):
     file: "typing.Optional[str]" = None
 
@@ -4477,7 +4374,6 @@ class v1GetModelDefFileResponse(Printable):
             out["file"] = self.file
         return out
 
-
 class v1GetModelDefResponse(Printable):
 
     def __init__(
@@ -4499,7 +4395,6 @@ class v1GetModelDefResponse(Printable):
             "b64Tgz": self.b64Tgz,
         }
         return out
-
 
 class v1GetModelDefTreeResponse(Printable):
     files: "typing.Optional[typing.Sequence[v1FileNode]]" = None
@@ -4527,7 +4422,6 @@ class v1GetModelDefTreeResponse(Printable):
             out["files"] = None if self.files is None else [x.to_json(omit_unset) for x in self.files]
         return out
 
-
 class v1GetModelLabelsResponse(Printable):
 
     def __init__(
@@ -4549,7 +4443,6 @@ class v1GetModelLabelsResponse(Printable):
             "labels": self.labels,
         }
         return out
-
 
 class v1GetModelResponse(Printable):
 
@@ -4573,7 +4466,6 @@ class v1GetModelResponse(Printable):
         }
         return out
 
-
 class v1GetModelVersionResponse(Printable):
 
     def __init__(
@@ -4595,7 +4487,6 @@ class v1GetModelVersionResponse(Printable):
             "modelVersion": self.modelVersion.to_json(omit_unset),
         }
         return out
-
 
 class v1GetModelVersionsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -4632,7 +4523,6 @@ class v1GetModelVersionsResponse(Printable):
         }
         return out
 
-
 class v1GetModelsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
     NAME = "SORT_BY_NAME"
@@ -4668,7 +4558,6 @@ class v1GetModelsResponse(Printable):
         }
         return out
 
-
 class v1GetNotebookResponse(Printable):
 
     def __init__(
@@ -4694,7 +4583,6 @@ class v1GetNotebookResponse(Printable):
             "notebook": self.notebook.to_json(omit_unset),
         }
         return out
-
 
 class v1GetNotebooksRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -4733,7 +4621,6 @@ class v1GetNotebooksResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetPermissionsSummaryResponse(Printable):
 
     def __init__(
@@ -4760,7 +4647,6 @@ class v1GetPermissionsSummaryResponse(Printable):
         }
         return out
 
-
 class v1GetProjectColumnsResponse(Printable):
 
     def __init__(
@@ -4782,7 +4668,6 @@ class v1GetProjectColumnsResponse(Printable):
             "columns": [x.to_json(omit_unset) for x in self.columns],
         }
         return out
-
 
 class v1GetProjectNumericMetricsRangeResponse(Printable):
     ranges: "typing.Optional[typing.Sequence[v1MetricsRange]]" = None
@@ -4810,7 +4695,6 @@ class v1GetProjectNumericMetricsRangeResponse(Printable):
             out["ranges"] = None if self.ranges is None else [x.to_json(omit_unset) for x in self.ranges]
         return out
 
-
 class v1GetProjectResponse(Printable):
 
     def __init__(
@@ -4832,7 +4716,6 @@ class v1GetProjectResponse(Printable):
             "project": self.project.to_json(omit_unset),
         }
         return out
-
 
 class v1GetProjectsByUserActivityResponse(Printable):
     projects: "typing.Optional[typing.Sequence[v1Project]]" = None
@@ -4859,7 +4742,6 @@ class v1GetProjectsByUserActivityResponse(Printable):
         if not omit_unset or "projects" in vars(self):
             out["projects"] = None if self.projects is None else [x.to_json(omit_unset) for x in self.projects]
         return out
-
 
 class v1GetResourcePoolsResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
@@ -4895,7 +4777,6 @@ class v1GetResourcePoolsResponse(Printable):
             out["resourcePools"] = None if self.resourcePools is None else [x.to_json(omit_unset) for x in self.resourcePools]
         return out
 
-
 class v1GetRolesAssignedToGroupResponse(Printable):
 
     def __init__(
@@ -4922,7 +4803,6 @@ class v1GetRolesAssignedToGroupResponse(Printable):
         }
         return out
 
-
 class v1GetRolesAssignedToUserResponse(Printable):
 
     def __init__(
@@ -4944,7 +4824,6 @@ class v1GetRolesAssignedToUserResponse(Printable):
             "roles": [x.to_json(omit_unset) for x in self.roles],
         }
         return out
-
 
 class v1GetRolesByIDRequest(Printable):
     roleIds: "typing.Optional[typing.Sequence[int]]" = None
@@ -4972,7 +4851,6 @@ class v1GetRolesByIDRequest(Printable):
             out["roleIds"] = self.roleIds
         return out
 
-
 class v1GetRolesByIDResponse(Printable):
     roles: "typing.Optional[typing.Sequence[v1RoleWithAssignments]]" = None
 
@@ -4998,7 +4876,6 @@ class v1GetRolesByIDResponse(Printable):
         if not omit_unset or "roles" in vars(self):
             out["roles"] = None if self.roles is None else [x.to_json(omit_unset) for x in self.roles]
         return out
-
 
 class v1GetSearcherEventsResponse(Printable):
     searcherEvents: "typing.Optional[typing.Sequence[v1SearcherEvent]]" = None
@@ -5026,7 +4903,6 @@ class v1GetSearcherEventsResponse(Printable):
             out["searcherEvents"] = None if self.searcherEvents is None else [x.to_json(omit_unset) for x in self.searcherEvents]
         return out
 
-
 class v1GetShellResponse(Printable):
 
     def __init__(
@@ -5052,7 +4928,6 @@ class v1GetShellResponse(Printable):
             "shell": self.shell.to_json(omit_unset),
         }
         return out
-
 
 class v1GetShellsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5091,7 +4966,6 @@ class v1GetShellsResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetSlotResponse(Printable):
     slot: "typing.Optional[v1Slot]" = None
 
@@ -5117,7 +4991,6 @@ class v1GetSlotResponse(Printable):
         if not omit_unset or "slot" in vars(self):
             out["slot"] = None if self.slot is None else self.slot.to_json(omit_unset)
         return out
-
 
 class v1GetSlotsResponse(Printable):
     slots: "typing.Optional[typing.Sequence[v1Slot]]" = None
@@ -5145,7 +5018,6 @@ class v1GetSlotsResponse(Printable):
             out["slots"] = None if self.slots is None else [x.to_json(omit_unset) for x in self.slots]
         return out
 
-
 class v1GetTaskResponse(Printable):
 
     def __init__(
@@ -5167,7 +5039,6 @@ class v1GetTaskResponse(Printable):
             "task": self.task.to_json(omit_unset),
         }
         return out
-
 
 class v1GetTasksResponse(Printable):
     allocationIdToSummary: "typing.Optional[typing.Dict[str, v1AllocationSummary]]" = None
@@ -5194,7 +5065,6 @@ class v1GetTasksResponse(Printable):
         if not omit_unset or "allocationIdToSummary" in vars(self):
             out["allocationIdToSummary"] = None if self.allocationIdToSummary is None else {k: v.to_json(omit_unset) for k, v in self.allocationIdToSummary.items()}
         return out
-
 
 class v1GetTelemetryResponse(Printable):
     segmentKey: "typing.Optional[str]" = None
@@ -5226,7 +5096,6 @@ class v1GetTelemetryResponse(Printable):
             out["segmentKey"] = self.segmentKey
         return out
 
-
 class v1GetTemplateResponse(Printable):
 
     def __init__(
@@ -5248,7 +5117,6 @@ class v1GetTemplateResponse(Printable):
             "template": self.template.to_json(omit_unset),
         }
         return out
-
 
 class v1GetTemplatesRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5280,7 +5148,6 @@ class v1GetTemplatesResponse(Printable):
         }
         return out
 
-
 class v1GetTensorboardResponse(Printable):
 
     def __init__(
@@ -5306,7 +5173,6 @@ class v1GetTensorboardResponse(Printable):
             "tensorboard": self.tensorboard.to_json(omit_unset),
         }
         return out
-
 
 class v1GetTensorboardsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5345,7 +5211,6 @@ class v1GetTensorboardsResponse(Printable):
             out["pagination"] = None if self.pagination is None else self.pagination.to_json(omit_unset)
         return out
 
-
 class v1GetTrainingMetricsResponse(Printable):
 
     def __init__(
@@ -5367,7 +5232,6 @@ class v1GetTrainingMetricsResponse(Printable):
             "metrics": [x.to_json(omit_unset) for x in self.metrics],
         }
         return out
-
 
 class v1GetTrialCheckpointsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5402,7 +5266,6 @@ class v1GetTrialCheckpointsResponse(Printable):
         }
         return out
 
-
 class v1GetTrialProfilerAvailableSeriesResponse(Printable):
 
     def __init__(
@@ -5424,7 +5287,6 @@ class v1GetTrialProfilerAvailableSeriesResponse(Printable):
             "labels": [x.to_json(omit_unset) for x in self.labels],
         }
         return out
-
 
 class v1GetTrialProfilerMetricsResponse(Printable):
 
@@ -5448,7 +5310,6 @@ class v1GetTrialProfilerMetricsResponse(Printable):
         }
         return out
 
-
 class v1GetTrialResponse(Printable):
 
     def __init__(
@@ -5470,7 +5331,6 @@ class v1GetTrialResponse(Printable):
             "trial": self.trial.to_json(omit_unset),
         }
         return out
-
 
 class v1GetTrialWorkloadsResponse(Printable):
 
@@ -5498,7 +5358,6 @@ class v1GetTrialWorkloadsResponse(Printable):
         }
         return out
 
-
 class v1GetTrialsCollectionsResponse(Printable):
     collections: "typing.Optional[typing.Sequence[v1TrialsCollection]]" = None
 
@@ -5525,7 +5384,6 @@ class v1GetTrialsCollectionsResponse(Printable):
             out["collections"] = None if self.collections is None else [x.to_json(omit_unset) for x in self.collections]
         return out
 
-
 class v1GetUserByUsernameResponse(Printable):
 
     def __init__(
@@ -5547,7 +5405,6 @@ class v1GetUserByUsernameResponse(Printable):
             "user": self.user.to_json(omit_unset),
         }
         return out
-
 
 class v1GetUserResponse(Printable):
 
@@ -5571,7 +5428,6 @@ class v1GetUserResponse(Printable):
         }
         return out
 
-
 class v1GetUserSettingResponse(Printable):
 
     def __init__(
@@ -5593,7 +5449,6 @@ class v1GetUserSettingResponse(Printable):
             "settings": [x.to_json(omit_unset) for x in self.settings],
         }
         return out
-
 
 class v1GetUsersRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5638,7 +5493,6 @@ class v1GetUsersResponse(Printable):
             out["users"] = None if self.users is None else [x.to_json(omit_unset) for x in self.users]
         return out
 
-
 class v1GetValidationMetricsResponse(Printable):
 
     def __init__(
@@ -5661,7 +5515,6 @@ class v1GetValidationMetricsResponse(Printable):
         }
         return out
 
-
 class v1GetWebhooksResponse(Printable):
 
     def __init__(
@@ -5683,7 +5536,6 @@ class v1GetWebhooksResponse(Printable):
             "webhooks": [x.to_json(omit_unset) for x in self.webhooks],
         }
         return out
-
 
 class v1GetWorkspaceProjectsRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5719,7 +5571,6 @@ class v1GetWorkspaceProjectsResponse(Printable):
         }
         return out
 
-
 class v1GetWorkspaceResponse(Printable):
 
     def __init__(
@@ -5741,7 +5592,6 @@ class v1GetWorkspaceResponse(Printable):
             "workspace": self.workspace.to_json(omit_unset),
         }
         return out
-
 
 class v1GetWorkspacesRequestSortBy(DetEnum):
     UNSPECIFIED = "SORT_BY_UNSPECIFIED"
@@ -5773,7 +5623,6 @@ class v1GetWorkspacesResponse(Printable):
             "workspaces": [x.to_json(omit_unset) for x in self.workspaces],
         }
         return out
-
 
 class v1Group(Printable):
     groupId: "typing.Optional[int]" = None
@@ -5808,7 +5657,6 @@ class v1Group(Printable):
         if not omit_unset or "name" in vars(self):
             out["name"] = self.name
         return out
-
 
 class v1GroupDetails(Printable):
     groupId: "typing.Optional[int]" = None
@@ -5852,7 +5700,6 @@ class v1GroupDetails(Printable):
             out["users"] = None if self.users is None else [x.to_json(omit_unset) for x in self.users]
         return out
 
-
 class v1GroupRoleAssignment(Printable):
 
     def __init__(
@@ -5879,7 +5726,6 @@ class v1GroupRoleAssignment(Printable):
         }
         return out
 
-
 class v1GroupSearchResult(Printable):
 
     def __init__(
@@ -5905,7 +5751,6 @@ class v1GroupSearchResult(Printable):
             "numMembers": self.numMembers,
         }
         return out
-
 
 class v1IdleNotebookRequest(Printable):
     idle: "typing.Optional[bool]" = None
@@ -5941,7 +5786,6 @@ class v1IdleNotebookRequest(Printable):
             out["notebookId"] = self.notebookId
         return out
 
-
 class v1InitialOperations(Printable):
     placeholder: "typing.Optional[int]" = None
 
@@ -5967,7 +5811,6 @@ class v1InitialOperations(Printable):
         if not omit_unset or "placeholder" in vars(self):
             out["placeholder"] = self.placeholder
         return out
-
 
 class v1Int32FieldFilter(Printable):
     gt: "typing.Optional[int]" = None
@@ -6034,7 +5877,6 @@ class v1Int32FieldFilter(Printable):
         if not omit_unset or "notIn" in vars(self):
             out["notIn"] = self.notIn
         return out
-
 
 class v1Job(Printable):
     priority: "typing.Optional[int]" = None
@@ -6138,7 +5980,6 @@ class v1Job(Printable):
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-
 class v1JobSummary(Printable):
 
     def __init__(
@@ -6164,7 +6005,6 @@ class v1JobSummary(Printable):
             "state": self.state.value,
         }
         return out
-
 
 class v1K8PriorityClass(Printable):
     priorityClass: "typing.Optional[str]" = None
@@ -6200,7 +6040,6 @@ class v1K8PriorityClass(Printable):
             out["priorityValue"] = self.priorityValue
         return out
 
-
 class v1KillCommandResponse(Printable):
     command: "typing.Optional[v1Command]" = None
 
@@ -6226,7 +6065,6 @@ class v1KillCommandResponse(Printable):
         if not omit_unset or "command" in vars(self):
             out["command"] = None if self.command is None else self.command.to_json(omit_unset)
         return out
-
 
 class v1KillExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -6258,7 +6096,6 @@ class v1KillExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1KillExperimentsResponse(Printable):
 
     def __init__(
@@ -6280,7 +6117,6 @@ class v1KillExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1KillNotebookResponse(Printable):
     notebook: "typing.Optional[v1Notebook]" = None
@@ -6308,7 +6144,6 @@ class v1KillNotebookResponse(Printable):
             out["notebook"] = None if self.notebook is None else self.notebook.to_json(omit_unset)
         return out
 
-
 class v1KillShellResponse(Printable):
     shell: "typing.Optional[v1Shell]" = None
 
@@ -6335,7 +6170,6 @@ class v1KillShellResponse(Printable):
             out["shell"] = None if self.shell is None else self.shell.to_json(omit_unset)
         return out
 
-
 class v1KillTensorboardResponse(Printable):
     tensorboard: "typing.Optional[v1Tensorboard]" = None
 
@@ -6361,7 +6195,6 @@ class v1KillTensorboardResponse(Printable):
         if not omit_unset or "tensorboard" in vars(self):
             out["tensorboard"] = None if self.tensorboard is None else self.tensorboard.to_json(omit_unset)
         return out
-
 
 class v1LaunchCommandRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -6421,7 +6254,6 @@ class v1LaunchCommandRequest(Printable):
             out["workspaceId"] = self.workspaceId
         return out
 
-
 class v1LaunchCommandResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
@@ -6455,7 +6287,6 @@ class v1LaunchCommandResponse(Printable):
         if not omit_unset or "warnings" in vars(self):
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
-
 
 class v1LaunchNotebookRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -6515,7 +6346,6 @@ class v1LaunchNotebookRequest(Printable):
             out["workspaceId"] = self.workspaceId
         return out
 
-
 class v1LaunchNotebookResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
@@ -6549,7 +6379,6 @@ class v1LaunchNotebookResponse(Printable):
         if not omit_unset or "warnings" in vars(self):
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
-
 
 class v1LaunchShellRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -6609,7 +6438,6 @@ class v1LaunchShellRequest(Printable):
             out["workspaceId"] = self.workspaceId
         return out
 
-
 class v1LaunchShellResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
@@ -6643,7 +6471,6 @@ class v1LaunchShellResponse(Printable):
         if not omit_unset or "warnings" in vars(self):
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
-
 
 class v1LaunchTensorboardRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -6719,7 +6546,6 @@ class v1LaunchTensorboardRequest(Printable):
             out["workspaceId"] = self.workspaceId
         return out
 
-
 class v1LaunchTensorboardResponse(Printable):
     warnings: "typing.Optional[typing.Sequence[v1LaunchWarning]]" = None
 
@@ -6753,7 +6579,6 @@ class v1LaunchTensorboardResponse(Printable):
         if not omit_unset or "warnings" in vars(self):
             out["warnings"] = None if self.warnings is None else [x.value for x in self.warnings]
         return out
-
 
 class v1LaunchWarning(DetEnum):
     UNSPECIFIED = "LAUNCH_WARNING_UNSPECIFIED"
@@ -6837,7 +6662,6 @@ class v1LimitedJob(Printable):
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-
 class v1ListRolesRequest(Printable):
     offset: "typing.Optional[int]" = None
 
@@ -6868,7 +6692,6 @@ class v1ListRolesRequest(Printable):
             out["offset"] = self.offset
         return out
 
-
 class v1ListRolesResponse(Printable):
 
     def __init__(
@@ -6894,7 +6717,6 @@ class v1ListRolesResponse(Printable):
             "roles": [x.to_json(omit_unset) for x in self.roles],
         }
         return out
-
 
 class v1LocationType(DetEnum):
     UNSPECIFIED = "LOCATION_TYPE_UNSPECIFIED"
@@ -6935,7 +6757,6 @@ class v1LogEntry(Printable):
             "timestamp": self.timestamp,
         }
         return out
-
 
 class v1LogLevel(DetEnum):
     UNSPECIFIED = "LOG_LEVEL_UNSPECIFIED"
@@ -6980,7 +6801,6 @@ class v1LoginRequest(Printable):
             out["isHashed"] = self.isHashed
         return out
 
-
 class v1LoginResponse(Printable):
 
     def __init__(
@@ -7006,7 +6826,6 @@ class v1LoginResponse(Printable):
             "user": self.user.to_json(omit_unset),
         }
         return out
-
 
 class v1MarkAllocationResourcesDaemonRequest(Printable):
     resourcesId: "typing.Optional[str]" = None
@@ -7038,7 +6857,6 @@ class v1MarkAllocationResourcesDaemonRequest(Printable):
             out["resourcesId"] = self.resourcesId
         return out
 
-
 class v1MasterLogsResponse(Printable):
 
     def __init__(
@@ -7060,7 +6878,6 @@ class v1MasterLogsResponse(Printable):
             "logEntry": self.logEntry.to_json(omit_unset),
         }
         return out
-
 
 class v1MetricBatchesResponse(Printable):
     batches: "typing.Optional[typing.Sequence[int]]" = None
@@ -7087,7 +6904,6 @@ class v1MetricBatchesResponse(Printable):
         if not omit_unset or "batches" in vars(self):
             out["batches"] = self.batches
         return out
-
 
 class v1MetricType(DetEnum):
     UNSPECIFIED = "METRIC_TYPE_UNSPECIFIED"
@@ -7124,7 +6940,6 @@ class v1Metrics(Printable):
             out["batchMetrics"] = self.batchMetrics
         return out
 
-
 class v1MetricsRange(Printable):
 
     def __init__(
@@ -7154,7 +6969,6 @@ class v1MetricsRange(Printable):
             "min": dump_float(self.min),
         }
         return out
-
 
 class v1MetricsReport(Printable):
 
@@ -7202,7 +7016,6 @@ class v1MetricsReport(Printable):
         }
         return out
 
-
 class v1MetricsWorkload(Printable):
     endTime: "typing.Optional[str]" = None
 
@@ -7240,7 +7053,6 @@ class v1MetricsWorkload(Printable):
         if not omit_unset or "endTime" in vars(self):
             out["endTime"] = self.endTime
         return out
-
 
 class v1Model(Printable):
     description: "typing.Optional[str]" = None
@@ -7323,7 +7135,6 @@ class v1Model(Printable):
         if not omit_unset or "notes" in vars(self):
             out["notes"] = self.notes
         return out
-
 
 class v1ModelVersion(Printable):
     comment: "typing.Optional[str]" = None
@@ -7423,7 +7234,6 @@ class v1ModelVersion(Printable):
             out["username"] = self.username
         return out
 
-
 class v1MoveExperimentRequest(Printable):
 
     def __init__(
@@ -7449,7 +7259,6 @@ class v1MoveExperimentRequest(Printable):
             "experimentId": self.experimentId,
         }
         return out
-
 
 class v1MoveExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -7485,7 +7294,6 @@ class v1MoveExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1MoveExperimentsResponse(Printable):
 
     def __init__(
@@ -7507,7 +7315,6 @@ class v1MoveExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1MoveModelRequest(Printable):
 
@@ -7535,7 +7342,6 @@ class v1MoveModelRequest(Printable):
         }
         return out
 
-
 class v1MoveProjectRequest(Printable):
 
     def __init__(
@@ -7562,7 +7368,6 @@ class v1MoveProjectRequest(Printable):
         }
         return out
 
-
 class v1Note(Printable):
 
     def __init__(
@@ -7588,7 +7393,6 @@ class v1Note(Printable):
             "name": self.name,
         }
         return out
-
 
 class v1Notebook(Printable):
     container: "typing.Optional[v1Container]" = None
@@ -7680,7 +7484,6 @@ class v1Notebook(Printable):
             out["userId"] = self.userId
         return out
 
-
 class v1NotifyContainerRunningRequest(Printable):
     nodeName: "typing.Optional[str]" = None
     numPeers: "typing.Optional[int]" = None
@@ -7739,7 +7542,6 @@ class v1NotifyContainerRunningRequest(Printable):
             out["requestUuid"] = self.requestUuid
         return out
 
-
 class v1NotifyContainerRunningResponse(Printable):
 
     def __init__(
@@ -7761,7 +7563,6 @@ class v1NotifyContainerRunningResponse(Printable):
             "data": self.data,
         }
         return out
-
 
 class v1OrderBy(DetEnum):
     UNSPECIFIED = "ORDER_BY_UNSPECIFIED"
@@ -7826,7 +7627,6 @@ class v1Pagination(Printable):
             out["total"] = self.total
         return out
 
-
 class v1PatchCheckpoint(Printable):
     resources: "typing.Optional[PatchCheckpointOptionalResources]" = None
 
@@ -7857,7 +7657,6 @@ class v1PatchCheckpoint(Printable):
             out["resources"] = None if self.resources is None else self.resources.to_json(omit_unset)
         return out
 
-
 class v1PatchCheckpointsRequest(Printable):
 
     def __init__(
@@ -7879,7 +7678,6 @@ class v1PatchCheckpointsRequest(Printable):
             "checkpoints": [x.to_json(omit_unset) for x in self.checkpoints],
         }
         return out
-
 
 class v1PatchExperiment(Printable):
     checkpointStorage: "typing.Optional[PatchExperimentPatchCheckpointStorage]" = None
@@ -7951,7 +7749,6 @@ class v1PatchExperiment(Printable):
             out["resources"] = None if self.resources is None else self.resources.to_json(omit_unset)
         return out
 
-
 class v1PatchExperimentResponse(Printable):
     experiment: "typing.Optional[v1Experiment]" = None
 
@@ -7977,7 +7774,6 @@ class v1PatchExperimentResponse(Printable):
         if not omit_unset or "experiment" in vars(self):
             out["experiment"] = None if self.experiment is None else self.experiment.to_json(omit_unset)
         return out
-
 
 class v1PatchModel(Printable):
     description: "typing.Optional[str]" = None
@@ -8053,7 +7849,6 @@ class v1PatchModel(Printable):
             out["workspaceName"] = self.workspaceName
         return out
 
-
 class v1PatchModelResponse(Printable):
 
     def __init__(
@@ -8075,7 +7870,6 @@ class v1PatchModelResponse(Printable):
             "model": self.model.to_json(omit_unset),
         }
         return out
-
 
 class v1PatchModelVersion(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
@@ -8143,7 +7937,6 @@ class v1PatchModelVersion(Printable):
             out["notes"] = self.notes
         return out
 
-
 class v1PatchModelVersionResponse(Printable):
 
     def __init__(
@@ -8165,7 +7958,6 @@ class v1PatchModelVersionResponse(Printable):
             "modelVersion": self.modelVersion.to_json(omit_unset),
         }
         return out
-
 
 class v1PatchProject(Printable):
     description: "typing.Optional[str]" = None
@@ -8201,7 +7993,6 @@ class v1PatchProject(Printable):
             out["name"] = self.name
         return out
 
-
 class v1PatchProjectResponse(Printable):
 
     def __init__(
@@ -8224,7 +8015,6 @@ class v1PatchProjectResponse(Printable):
         }
         return out
 
-
 class v1PatchTemplateConfigResponse(Printable):
 
     def __init__(
@@ -8246,7 +8036,6 @@ class v1PatchTemplateConfigResponse(Printable):
             "template": self.template.to_json(omit_unset),
         }
         return out
-
 
 class v1PatchTrialsCollectionRequest(Printable):
     filters: "typing.Optional[v1TrialFilters]" = None
@@ -8294,7 +8083,6 @@ class v1PatchTrialsCollectionRequest(Printable):
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
 
-
 class v1PatchTrialsCollectionResponse(Printable):
     collection: "typing.Optional[v1TrialsCollection]" = None
 
@@ -8320,7 +8108,6 @@ class v1PatchTrialsCollectionResponse(Printable):
         if not omit_unset or "collection" in vars(self):
             out["collection"] = None if self.collection is None else self.collection.to_json(omit_unset)
         return out
-
 
 class v1PatchUser(Printable):
     active: "typing.Optional[bool]" = None
@@ -8404,7 +8191,6 @@ class v1PatchUser(Printable):
             out["username"] = self.username
         return out
 
-
 class v1PatchUserResponse(Printable):
 
     def __init__(
@@ -8426,7 +8212,6 @@ class v1PatchUserResponse(Printable):
             "user": self.user.to_json(omit_unset),
         }
         return out
-
 
 class v1PatchWorkspace(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
@@ -8470,7 +8255,6 @@ class v1PatchWorkspace(Printable):
             out["name"] = self.name
         return out
 
-
 class v1PatchWorkspaceResponse(Printable):
 
     def __init__(
@@ -8492,7 +8276,6 @@ class v1PatchWorkspaceResponse(Printable):
             "workspace": self.workspace.to_json(omit_unset),
         }
         return out
-
 
 class v1PauseExperimentsRequest(Printable):
     filters: "typing.Optional[v1BulkExperimentFilters]" = None
@@ -8524,7 +8307,6 @@ class v1PauseExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1PauseExperimentsResponse(Printable):
 
     def __init__(
@@ -8546,7 +8328,6 @@ class v1PauseExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1Permission(Printable):
     name: "typing.Optional[str]" = None
@@ -8585,7 +8366,6 @@ class v1Permission(Printable):
         if not omit_unset or "scopeTypeMask" in vars(self):
             out["scopeTypeMask"] = None if self.scopeTypeMask is None else self.scopeTypeMask.to_json(omit_unset)
         return out
-
 
 class v1PermissionType(DetEnum):
     UNSPECIFIED = "PERMISSION_TYPE_UNSPECIFIED"
@@ -8671,7 +8451,6 @@ class v1PolymorphicFilter(Printable):
             out["timeRange"] = None if self.timeRange is None else self.timeRange.to_json(omit_unset)
         return out
 
-
 class v1PostAllocationProxyAddressRequest(Printable):
     allocationId: "typing.Optional[str]" = None
     proxyAddress: "typing.Optional[str]" = None
@@ -8706,7 +8485,6 @@ class v1PostAllocationProxyAddressRequest(Printable):
             out["proxyAddress"] = self.proxyAddress
         return out
 
-
 class v1PostCheckpointMetadataRequest(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
 
@@ -8733,7 +8511,6 @@ class v1PostCheckpointMetadataRequest(Printable):
             out["checkpoint"] = None if self.checkpoint is None else self.checkpoint.to_json(omit_unset)
         return out
 
-
 class v1PostCheckpointMetadataResponse(Printable):
     checkpoint: "typing.Optional[v1Checkpoint]" = None
 
@@ -8759,7 +8536,6 @@ class v1PostCheckpointMetadataResponse(Printable):
         if not omit_unset or "checkpoint" in vars(self):
             out["checkpoint"] = None if self.checkpoint is None else self.checkpoint.to_json(omit_unset)
         return out
-
 
 class v1PostModelRequest(Printable):
     description: "typing.Optional[str]" = None
@@ -8831,7 +8607,6 @@ class v1PostModelRequest(Printable):
             out["workspaceName"] = self.workspaceName
         return out
 
-
 class v1PostModelResponse(Printable):
 
     def __init__(
@@ -8853,7 +8628,6 @@ class v1PostModelResponse(Printable):
             "model": self.model.to_json(omit_unset),
         }
         return out
-
 
 class v1PostModelVersionRequest(Printable):
     comment: "typing.Optional[str]" = None
@@ -8921,7 +8695,6 @@ class v1PostModelVersionRequest(Printable):
             out["notes"] = self.notes
         return out
 
-
 class v1PostModelVersionResponse(Printable):
 
     def __init__(
@@ -8943,7 +8716,6 @@ class v1PostModelVersionResponse(Printable):
             "modelVersion": self.modelVersion.to_json(omit_unset),
         }
         return out
-
 
 class v1PostProjectRequest(Printable):
     description: "typing.Optional[str]" = None
@@ -8979,7 +8751,6 @@ class v1PostProjectRequest(Printable):
             out["description"] = self.description
         return out
 
-
 class v1PostProjectResponse(Printable):
 
     def __init__(
@@ -9001,7 +8772,6 @@ class v1PostProjectResponse(Printable):
             "project": self.project.to_json(omit_unset),
         }
         return out
-
 
 class v1PostSearcherOperationsRequest(Printable):
     experimentId: "typing.Optional[int]" = None
@@ -9045,7 +8815,6 @@ class v1PostSearcherOperationsRequest(Printable):
             out["triggeredByEvent"] = None if self.triggeredByEvent is None else self.triggeredByEvent.to_json(omit_unset)
         return out
 
-
 class v1PostTemplateResponse(Printable):
 
     def __init__(
@@ -9067,7 +8836,6 @@ class v1PostTemplateResponse(Printable):
             "template": self.template.to_json(omit_unset),
         }
         return out
-
 
 class v1PostTrialProfilerMetricsBatchRequest(Printable):
     batches: "typing.Optional[typing.Sequence[v1TrialProfilerMetricsBatch]]" = None
@@ -9094,7 +8862,6 @@ class v1PostTrialProfilerMetricsBatchRequest(Printable):
         if not omit_unset or "batches" in vars(self):
             out["batches"] = None if self.batches is None else [x.to_json(omit_unset) for x in self.batches]
         return out
-
 
 class v1PostUserActivityRequest(Printable):
 
@@ -9125,7 +8892,6 @@ class v1PostUserActivityRequest(Printable):
             "entityType": self.entityType.value,
         }
         return out
-
 
 class v1PostUserRequest(Printable):
     isHashed: "typing.Optional[bool]" = None
@@ -9169,7 +8935,6 @@ class v1PostUserRequest(Printable):
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
 
-
 class v1PostUserResponse(Printable):
     user: "typing.Optional[v1User]" = None
 
@@ -9195,7 +8960,6 @@ class v1PostUserResponse(Printable):
         if not omit_unset or "user" in vars(self):
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
-
 
 class v1PostUserSettingRequest(Printable):
 
@@ -9223,7 +8987,6 @@ class v1PostUserSettingRequest(Printable):
         }
         return out
 
-
 class v1PostWebhookResponse(Printable):
 
     def __init__(
@@ -9245,7 +9008,6 @@ class v1PostWebhookResponse(Printable):
             "webhook": self.webhook.to_json(omit_unset),
         }
         return out
-
 
 class v1PostWorkspaceRequest(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
@@ -9285,7 +9047,6 @@ class v1PostWorkspaceRequest(Printable):
             out["checkpointStorageConfig"] = self.checkpointStorageConfig
         return out
 
-
 class v1PostWorkspaceResponse(Printable):
 
     def __init__(
@@ -9307,7 +9068,6 @@ class v1PostWorkspaceResponse(Printable):
             "workspace": self.workspace.to_json(omit_unset),
         }
         return out
-
 
 class v1PreviewHPSearchRequest(Printable):
     config: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -9343,7 +9103,6 @@ class v1PreviewHPSearchRequest(Printable):
             out["seed"] = self.seed
         return out
 
-
 class v1PreviewHPSearchResponse(Printable):
     simulation: "typing.Optional[v1ExperimentSimulation]" = None
 
@@ -9369,7 +9128,6 @@ class v1PreviewHPSearchResponse(Printable):
         if not omit_unset or "simulation" in vars(self):
             out["simulation"] = None if self.simulation is None else self.simulation.to_json(omit_unset)
         return out
-
 
 class v1Project(Printable):
     description: "typing.Optional[str]" = None
@@ -9461,7 +9219,6 @@ class v1Project(Printable):
             out["workspaceName"] = self.workspaceName
         return out
 
-
 class v1ProjectColumn(Printable):
     displayName: "typing.Optional[str]" = None
 
@@ -9499,7 +9256,6 @@ class v1ProjectColumn(Printable):
         if not omit_unset or "displayName" in vars(self):
             out["displayName"] = self.displayName
         return out
-
 
 class v1ProxyPortConfig(Printable):
     port: "typing.Optional[int]" = None
@@ -9551,7 +9307,6 @@ class v1ProxyPortConfig(Printable):
             out["unauthenticated"] = self.unauthenticated
         return out
 
-
 class v1PutProjectNotesRequest(Printable):
 
     def __init__(
@@ -9578,7 +9333,6 @@ class v1PutProjectNotesRequest(Printable):
         }
         return out
 
-
 class v1PutProjectNotesResponse(Printable):
 
     def __init__(
@@ -9600,7 +9354,6 @@ class v1PutProjectNotesResponse(Printable):
             "notes": [x.to_json(omit_unset) for x in self.notes],
         }
         return out
-
 
 class v1PutTemplateResponse(Printable):
     template: "typing.Optional[v1Template]" = None
@@ -9627,7 +9380,6 @@ class v1PutTemplateResponse(Printable):
         if not omit_unset or "template" in vars(self):
             out["template"] = None if self.template is None else self.template.to_json(omit_unset)
         return out
-
 
 class v1QueryTrialsRequest(Printable):
     limit: "typing.Optional[int]" = None
@@ -9675,7 +9427,6 @@ class v1QueryTrialsRequest(Printable):
             out["sorter"] = None if self.sorter is None else self.sorter.to_json(omit_unset)
         return out
 
-
 class v1QueryTrialsResponse(Printable):
 
     def __init__(
@@ -9697,7 +9448,6 @@ class v1QueryTrialsResponse(Printable):
             "trials": [x.to_json(omit_unset) for x in self.trials],
         }
         return out
-
 
 class v1QueueControl(Printable):
     aheadOf: "typing.Optional[str]" = None
@@ -9761,7 +9511,6 @@ class v1QueueControl(Printable):
             out["weight"] = None if self.weight is None else dump_float(self.weight)
         return out
 
-
 class v1QueueStats(Printable):
 
     def __init__(
@@ -9787,7 +9536,6 @@ class v1QueueStats(Printable):
             "scheduledCount": self.scheduledCount,
         }
         return out
-
 
 class v1RBACJob(Printable):
     full: "typing.Optional[v1Job]" = None
@@ -9823,7 +9571,6 @@ class v1RBACJob(Printable):
             out["limited"] = None if self.limited is None else self.limited.to_json(omit_unset)
         return out
 
-
 class v1RPQueueStat(Printable):
     aggregates: "typing.Optional[typing.Sequence[v1AggregateQueueStats]]" = None
 
@@ -9857,7 +9604,6 @@ class v1RPQueueStat(Printable):
         if not omit_unset or "aggregates" in vars(self):
             out["aggregates"] = None if self.aggregates is None else [x.to_json(omit_unset) for x in self.aggregates]
         return out
-
 
 class v1RemoveAssignmentsRequest(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
@@ -9893,7 +9639,6 @@ class v1RemoveAssignmentsRequest(Printable):
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
 
-
 class v1RendezvousInfo(Printable):
 
     def __init__(
@@ -9924,7 +9669,6 @@ class v1RendezvousInfo(Printable):
         }
         return out
 
-
 class v1ReportTrialMetricsRequest(Printable):
 
     def __init__(
@@ -9950,7 +9694,6 @@ class v1ReportTrialMetricsRequest(Printable):
             "type": self.type,
         }
         return out
-
 
 class v1ResourceAllocationAggregatedEntry(Printable):
 
@@ -9998,7 +9741,6 @@ class v1ResourceAllocationAggregatedEntry(Printable):
         }
         return out
 
-
 class v1ResourceAllocationAggregatedResponse(Printable):
 
     def __init__(
@@ -10020,7 +9762,6 @@ class v1ResourceAllocationAggregatedResponse(Printable):
             "resourceEntries": [x.to_json(omit_unset) for x in self.resourceEntries],
         }
         return out
-
 
 class v1ResourceAllocationAggregationPeriod(DetEnum):
     UNSPECIFIED = "RESOURCE_ALLOCATION_AGGREGATION_PERIOD_UNSPECIFIED"
@@ -10117,7 +9858,6 @@ class v1ResourceAllocationRawEntry(Printable):
             out["username"] = self.username
         return out
 
-
 class v1ResourceAllocationRawResponse(Printable):
     resourceEntries: "typing.Optional[typing.Sequence[v1ResourceAllocationRawEntry]]" = None
 
@@ -10143,7 +9883,6 @@ class v1ResourceAllocationRawResponse(Printable):
         if not omit_unset or "resourceEntries" in vars(self):
             out["resourceEntries"] = None if self.resourceEntries is None else [x.to_json(omit_unset) for x in self.resourceEntries]
         return out
-
 
 class v1ResourcePool(Printable):
     accelerator: "typing.Optional[str]" = None
@@ -10311,7 +10050,6 @@ class v1ResourcePool(Printable):
             out["stats"] = None if self.stats is None else self.stats.to_json(omit_unset)
         return out
 
-
 class v1ResourcePoolAwsDetail(Printable):
     customTags: "typing.Optional[typing.Sequence[v1AwsCustomTag]]" = None
     instanceType: "typing.Optional[str]" = None
@@ -10422,7 +10160,6 @@ class v1ResourcePoolAwsDetail(Printable):
             out["subnetId"] = self.subnetId
         return out
 
-
 class v1ResourcePoolDetail(Printable):
     aws: "typing.Optional[v1ResourcePoolAwsDetail]" = None
     gcp: "typing.Optional[v1ResourcePoolGcpDetail]" = None
@@ -10464,7 +10201,6 @@ class v1ResourcePoolDetail(Printable):
         if not omit_unset or "priorityScheduler" in vars(self):
             out["priorityScheduler"] = None if self.priorityScheduler is None else self.priorityScheduler.to_json(omit_unset)
         return out
-
 
 class v1ResourcePoolGcpDetail(Printable):
     networkTags: "typing.Optional[typing.Sequence[str]]" = None
@@ -10564,7 +10300,6 @@ class v1ResourcePoolGcpDetail(Printable):
             out["subnetwork"] = self.subnetwork
         return out
 
-
 class v1ResourcePoolPrioritySchedulerDetail(Printable):
     k8Priorities: "typing.Optional[typing.Sequence[v1K8PriorityClass]]" = None
 
@@ -10598,7 +10333,6 @@ class v1ResourcePoolPrioritySchedulerDetail(Printable):
         if not omit_unset or "k8Priorities" in vars(self):
             out["k8Priorities"] = None if self.k8Priorities is None else [x.to_json(omit_unset) for x in self.k8Priorities]
         return out
-
 
 class v1ResourcePoolType(DetEnum):
     UNSPECIFIED = "RESOURCE_POOL_TYPE_UNSPECIFIED"
@@ -10649,7 +10383,6 @@ class v1ResourcesFailure(Printable):
             out["failureType"] = None if self.failureType is None else self.failureType.value
         return out
 
-
 class v1ResourcesStarted(Printable):
     addresses: "typing.Optional[typing.Sequence[v1Address]]" = None
     nativeResourcesId: "typing.Optional[str]" = None
@@ -10684,7 +10417,6 @@ class v1ResourcesStarted(Printable):
             out["nativeResourcesId"] = self.nativeResourcesId
         return out
 
-
 class v1ResourcesStopped(Printable):
     failure: "typing.Optional[v1ResourcesFailure]" = None
 
@@ -10710,7 +10442,6 @@ class v1ResourcesStopped(Printable):
         if not omit_unset or "failure" in vars(self):
             out["failure"] = None if self.failure is None else self.failure.to_json(omit_unset)
         return out
-
 
 class v1ResourcesSummary(Printable):
     agentDevices: "typing.Optional[typing.Dict[str, ResourcesSummaryDevices]]" = None
@@ -10786,7 +10517,6 @@ class v1ResourcesSummary(Printable):
             out["started"] = None if self.started is None else self.started.to_json(omit_unset)
         return out
 
-
 class v1Role(Printable):
     name: "typing.Optional[str]" = None
     permissions: "typing.Optional[typing.Sequence[v1Permission]]" = None
@@ -10833,7 +10563,6 @@ class v1Role(Printable):
             out["scopeTypeMask"] = None if self.scopeTypeMask is None else self.scopeTypeMask.to_json(omit_unset)
         return out
 
-
 class v1RoleAssignment(Printable):
     scopeCluster: "typing.Optional[bool]" = None
     scopeWorkspaceId: "typing.Optional[int]" = None
@@ -10872,7 +10601,6 @@ class v1RoleAssignment(Printable):
             out["scopeWorkspaceId"] = self.scopeWorkspaceId
         return out
 
-
 class v1RoleAssignmentSummary(Printable):
     scopeCluster: "typing.Optional[bool]" = None
     scopeWorkspaceIds: "typing.Optional[typing.Sequence[int]]" = None
@@ -10910,7 +10638,6 @@ class v1RoleAssignmentSummary(Printable):
         if not omit_unset or "scopeWorkspaceIds" in vars(self):
             out["scopeWorkspaceIds"] = self.scopeWorkspaceIds
         return out
-
 
 class v1RoleWithAssignments(Printable):
     groupRoleAssignments: "typing.Optional[typing.Sequence[v1GroupRoleAssignment]]" = None
@@ -10954,7 +10681,6 @@ class v1RoleWithAssignments(Printable):
             out["userRoleAssignments"] = None if self.userRoleAssignments is None else [x.to_json(omit_unset) for x in self.userRoleAssignments]
         return out
 
-
 class v1RunnableOperation(Printable):
     length: "typing.Optional[str]" = None
     type: "typing.Optional[v1RunnableType]" = None
@@ -10989,7 +10715,6 @@ class v1RunnableOperation(Printable):
             out["type"] = None if self.type is None else self.type.value
         return out
 
-
 class v1RunnableType(DetEnum):
     UNSPECIFIED = "RUNNABLE_TYPE_UNSPECIFIED"
     TRAIN = "RUNNABLE_TYPE_TRAIN"
@@ -11020,7 +10745,6 @@ class v1SSOProvider(Printable):
             "ssoUrl": self.ssoUrl,
         }
         return out
-
 
 class v1Scale(DetEnum):
     UNSPECIFIED = "SCALE_UNSPECIFIED"
@@ -11070,7 +10794,6 @@ class v1ScopeTypeMask(Printable):
             out["workspace"] = self.workspace
         return out
 
-
 class v1SearchExperimentExperiment(Printable):
     bestTrial: "typing.Optional[trialv1Trial]" = None
 
@@ -11101,7 +10824,6 @@ class v1SearchExperimentExperiment(Printable):
             out["bestTrial"] = None if self.bestTrial is None else self.bestTrial.to_json(omit_unset)
         return out
 
-
 class v1SearchExperimentsResponse(Printable):
 
     def __init__(
@@ -11127,7 +10849,6 @@ class v1SearchExperimentsResponse(Printable):
             "pagination": self.pagination.to_json(omit_unset),
         }
         return out
-
 
 class v1SearchRolesAssignableToScopeRequest(Printable):
     offset: "typing.Optional[int]" = None
@@ -11167,7 +10888,6 @@ class v1SearchRolesAssignableToScopeRequest(Printable):
             out["workspaceId"] = self.workspaceId
         return out
 
-
 class v1SearchRolesAssignableToScopeResponse(Printable):
     pagination: "typing.Optional[v1Pagination]" = None
     roles: "typing.Optional[typing.Sequence[v1Role]]" = None
@@ -11201,7 +10921,6 @@ class v1SearchRolesAssignableToScopeResponse(Printable):
         if not omit_unset or "roles" in vars(self):
             out["roles"] = None if self.roles is None else [x.to_json(omit_unset) for x in self.roles]
         return out
-
 
 class v1SearcherEvent(Printable):
     experimentInactive: "typing.Optional[v1ExperimentInactive]" = None
@@ -11281,7 +11000,6 @@ class v1SearcherEvent(Printable):
             out["validationCompleted"] = None if self.validationCompleted is None else self.validationCompleted.to_json(omit_unset)
         return out
 
-
 class v1SearcherOperation(Printable):
     closeTrial: "typing.Optional[v1CloseTrialOperation]" = None
     createTrial: "typing.Optional[v1CreateTrialOperation]" = None
@@ -11340,7 +11058,6 @@ class v1SearcherOperation(Printable):
             out["trialOperation"] = None if self.trialOperation is None else self.trialOperation.to_json(omit_unset)
         return out
 
-
 class v1SetCommandPriorityRequest(Printable):
     commandId: "typing.Optional[str]" = None
     priority: "typing.Optional[int]" = None
@@ -11375,7 +11092,6 @@ class v1SetCommandPriorityRequest(Printable):
             out["priority"] = self.priority
         return out
 
-
 class v1SetCommandPriorityResponse(Printable):
     command: "typing.Optional[v1Command]" = None
 
@@ -11401,7 +11117,6 @@ class v1SetCommandPriorityResponse(Printable):
         if not omit_unset or "command" in vars(self):
             out["command"] = None if self.command is None else self.command.to_json(omit_unset)
         return out
-
 
 class v1SetNotebookPriorityRequest(Printable):
     notebookId: "typing.Optional[str]" = None
@@ -11437,7 +11152,6 @@ class v1SetNotebookPriorityRequest(Printable):
             out["priority"] = self.priority
         return out
 
-
 class v1SetNotebookPriorityResponse(Printable):
     notebook: "typing.Optional[v1Notebook]" = None
 
@@ -11464,7 +11178,6 @@ class v1SetNotebookPriorityResponse(Printable):
             out["notebook"] = None if self.notebook is None else self.notebook.to_json(omit_unset)
         return out
 
-
 class v1SetSearcherProgressOperation(Printable):
     progress: "typing.Optional[float]" = None
 
@@ -11490,7 +11203,6 @@ class v1SetSearcherProgressOperation(Printable):
         if not omit_unset or "progress" in vars(self):
             out["progress"] = None if self.progress is None else dump_float(self.progress)
         return out
-
 
 class v1SetShellPriorityRequest(Printable):
     priority: "typing.Optional[int]" = None
@@ -11526,7 +11238,6 @@ class v1SetShellPriorityRequest(Printable):
             out["shellId"] = self.shellId
         return out
 
-
 class v1SetShellPriorityResponse(Printable):
     shell: "typing.Optional[v1Shell]" = None
 
@@ -11552,7 +11263,6 @@ class v1SetShellPriorityResponse(Printable):
         if not omit_unset or "shell" in vars(self):
             out["shell"] = None if self.shell is None else self.shell.to_json(omit_unset)
         return out
-
 
 class v1SetTensorboardPriorityRequest(Printable):
     priority: "typing.Optional[int]" = None
@@ -11588,7 +11298,6 @@ class v1SetTensorboardPriorityRequest(Printable):
             out["tensorboardId"] = self.tensorboardId
         return out
 
-
 class v1SetTensorboardPriorityResponse(Printable):
     tensorboard: "typing.Optional[v1Tensorboard]" = None
 
@@ -11615,7 +11324,6 @@ class v1SetTensorboardPriorityResponse(Printable):
             out["tensorboard"] = None if self.tensorboard is None else self.tensorboard.to_json(omit_unset)
         return out
 
-
 class v1SetUserPasswordResponse(Printable):
     user: "typing.Optional[v1User]" = None
 
@@ -11641,7 +11349,6 @@ class v1SetUserPasswordResponse(Printable):
         if not omit_unset or "user" in vars(self):
             out["user"] = None if self.user is None else self.user.to_json(omit_unset)
         return out
-
 
 class v1Shell(Printable):
     addresses: "typing.Optional[typing.Sequence[typing.Dict[str, typing.Any]]]" = None
@@ -11757,7 +11464,6 @@ class v1Shell(Printable):
             out["userId"] = self.userId
         return out
 
-
 class v1ShutDownOperation(Printable):
     cancel: "typing.Optional[bool]" = None
     failure: "typing.Optional[bool]" = None
@@ -11791,7 +11497,6 @@ class v1ShutDownOperation(Printable):
         if not omit_unset or "failure" in vars(self):
             out["failure"] = self.failure
         return out
-
 
 class v1Slot(Printable):
     container: "typing.Optional[v1Container]" = None
@@ -11851,7 +11556,6 @@ class v1Slot(Printable):
             out["id"] = self.id
         return out
 
-
 class v1SummarizeTrialResponse(Printable):
 
     def __init__(
@@ -11877,7 +11581,6 @@ class v1SummarizeTrialResponse(Printable):
             "trial": self.trial.to_json(omit_unset),
         }
         return out
-
 
 class v1Task(Printable):
     endTime: "typing.Optional[str]" = None
@@ -11920,7 +11623,6 @@ class v1Task(Printable):
         if not omit_unset or "endTime" in vars(self):
             out["endTime"] = self.endTime
         return out
-
 
 class v1TaskLogsFieldsResponse(Printable):
     agentIds: "typing.Optional[typing.Sequence[str]]" = None
@@ -11987,7 +11689,6 @@ class v1TaskLogsFieldsResponse(Printable):
         if not omit_unset or "stdtypes" in vars(self):
             out["stdtypes"] = self.stdtypes
         return out
-
 
 class v1TaskLogsResponse(Printable):
     agentId: "typing.Optional[str]" = None
@@ -12079,7 +11780,6 @@ class v1TaskLogsResponse(Printable):
             out["stdtype"] = self.stdtype
         return out
 
-
 class v1TaskType(DetEnum):
     UNSPECIFIED = "TASK_TYPE_UNSPECIFIED"
     TRIAL = "TASK_TYPE_TRIAL"
@@ -12118,7 +11818,6 @@ class v1Template(Printable):
             "workspaceId": self.workspaceId,
         }
         return out
-
 
 class v1Tensorboard(Printable):
     container: "typing.Optional[v1Container]" = None
@@ -12226,7 +11925,6 @@ class v1Tensorboard(Printable):
             out["userId"] = self.userId
         return out
 
-
 class v1TestWebhookResponse(Printable):
 
     def __init__(
@@ -12248,7 +11946,6 @@ class v1TestWebhookResponse(Printable):
             "completed": self.completed,
         }
         return out
-
 
 class v1TimestampFieldFilter(Printable):
     gt: "typing.Optional[str]" = None
@@ -12300,7 +11997,6 @@ class v1TimestampFieldFilter(Printable):
             out["lte"] = self.lte
         return out
 
-
 class v1TrialClosed(Printable):
 
     def __init__(
@@ -12322,7 +12018,6 @@ class v1TrialClosed(Printable):
             "requestId": self.requestId,
         }
         return out
-
 
 class v1TrialCreated(Printable):
 
@@ -12346,7 +12041,6 @@ class v1TrialCreated(Printable):
         }
         return out
 
-
 class v1TrialEarlyExit(Printable):
 
     def __init__(
@@ -12368,7 +12062,6 @@ class v1TrialEarlyExit(Printable):
             "reason": self.reason.value,
         }
         return out
-
 
 class v1TrialEarlyExitExitedReason(DetEnum):
     UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
@@ -12400,7 +12093,6 @@ class v1TrialExitedEarly(Printable):
             "requestId": self.requestId,
         }
         return out
-
 
 class v1TrialExitedEarlyExitedReason(DetEnum):
     UNSPECIFIED = "EXITED_REASON_UNSPECIFIED"
@@ -12554,7 +12246,6 @@ class v1TrialFilters(Printable):
             out["workspaceIds"] = self.workspaceIds
         return out
 
-
 class v1TrialLogsFieldsResponse(Printable):
     agentIds: "typing.Optional[typing.Sequence[str]]" = None
     containerIds: "typing.Optional[typing.Sequence[str]]" = None
@@ -12612,7 +12303,6 @@ class v1TrialLogsFieldsResponse(Printable):
         if not omit_unset or "stdtypes" in vars(self):
             out["stdtypes"] = self.stdtypes
         return out
-
 
 class v1TrialLogsResponse(Printable):
     agentId: "typing.Optional[str]" = None
@@ -12700,7 +12390,6 @@ class v1TrialLogsResponse(Printable):
             out["stdtype"] = self.stdtype
         return out
 
-
 class v1TrialMetrics(Printable):
 
     def __init__(
@@ -12735,7 +12424,6 @@ class v1TrialMetrics(Printable):
         }
         return out
 
-
 class v1TrialOperation(Printable):
     validateAfter: "typing.Optional[v1ValidateAfterOperation]" = None
 
@@ -12761,7 +12449,6 @@ class v1TrialOperation(Printable):
         if not omit_unset or "validateAfter" in vars(self):
             out["validateAfter"] = None if self.validateAfter is None else self.validateAfter.to_json(omit_unset)
         return out
-
 
 class v1TrialPatch(Printable):
     addTag: "typing.Optional[typing.Sequence[v1TrialTag]]" = None
@@ -12796,7 +12483,6 @@ class v1TrialPatch(Printable):
         if not omit_unset or "removeTag" in vars(self):
             out["removeTag"] = None if self.removeTag is None else [x.to_json(omit_unset) for x in self.removeTag]
         return out
-
 
 class v1TrialProfilerMetricLabels(Printable):
     agentId: "typing.Optional[str]" = None
@@ -12848,7 +12534,6 @@ class v1TrialProfilerMetricLabels(Printable):
             out["metricType"] = None if self.metricType is None else self.metricType.value
         return out
 
-
 class v1TrialProfilerMetricsBatch(Printable):
 
     def __init__(
@@ -12883,7 +12568,6 @@ class v1TrialProfilerMetricsBatch(Printable):
         }
         return out
 
-
 class v1TrialProgress(Printable):
 
     def __init__(
@@ -12910,7 +12594,6 @@ class v1TrialProgress(Printable):
         }
         return out
 
-
 class v1TrialRunnerMetadata(Printable):
 
     def __init__(
@@ -12932,7 +12615,6 @@ class v1TrialRunnerMetadata(Printable):
             "state": self.state,
         }
         return out
-
 
 class v1TrialSimulation(Printable):
     occurrences: "typing.Optional[int]" = None
@@ -12968,7 +12650,6 @@ class v1TrialSimulation(Printable):
             out["operations"] = None if self.operations is None else [x.to_json(omit_unset) for x in self.operations]
         return out
 
-
 class v1TrialSorter(Printable):
     orderBy: "typing.Optional[v1OrderBy]" = None
 
@@ -13003,7 +12684,6 @@ class v1TrialSorter(Printable):
             out["orderBy"] = None if self.orderBy is None else self.orderBy.value
         return out
 
-
 class v1TrialTag(Printable):
 
     def __init__(
@@ -13025,7 +12705,6 @@ class v1TrialTag(Printable):
             "key": self.key,
         }
         return out
-
 
 class v1TrialsCollection(Printable):
 
@@ -13069,7 +12748,6 @@ class v1TrialsCollection(Printable):
         }
         return out
 
-
 class v1TrialsSampleResponse(Printable):
 
     def __init__(
@@ -13099,7 +12777,6 @@ class v1TrialsSampleResponse(Printable):
             "trials": [x.to_json(omit_unset) for x in self.trials],
         }
         return out
-
 
 class v1TrialsSampleResponseTrial(Printable):
 
@@ -13131,7 +12808,6 @@ class v1TrialsSampleResponseTrial(Printable):
         }
         return out
 
-
 class v1TrialsSnapshotResponse(Printable):
 
     def __init__(
@@ -13153,7 +12829,6 @@ class v1TrialsSnapshotResponse(Printable):
             "trials": [x.to_json(omit_unset) for x in self.trials],
         }
         return out
-
 
 class v1TrialsSnapshotResponseTrial(Printable):
 
@@ -13188,7 +12863,6 @@ class v1TrialsSnapshotResponseTrial(Printable):
             "trialId": self.trialId,
         }
         return out
-
 
 class v1Trigger(Printable):
     condition: "typing.Optional[typing.Dict[str, typing.Any]]" = None
@@ -13240,7 +12914,6 @@ class v1Trigger(Printable):
             out["webhookId"] = self.webhookId
         return out
 
-
 class v1TriggerType(DetEnum):
     UNSPECIFIED = "TRIGGER_TYPE_UNSPECIFIED"
     EXPERIMENT_STATE_CHANGE = "TRIGGER_TYPE_EXPERIMENT_STATE_CHANGE"
@@ -13276,7 +12949,6 @@ class v1UnarchiveExperimentsRequest(Printable):
             out["filters"] = None if self.filters is None else self.filters.to_json(omit_unset)
         return out
 
-
 class v1UnarchiveExperimentsResponse(Printable):
 
     def __init__(
@@ -13298,7 +12970,6 @@ class v1UnarchiveExperimentsResponse(Printable):
             "results": [x.to_json(omit_unset) for x in self.results],
         }
         return out
-
 
 class v1UpdateGroupRequest(Printable):
     addUsers: "typing.Optional[typing.Sequence[int]]" = None
@@ -13346,7 +13017,6 @@ class v1UpdateGroupRequest(Printable):
             out["removeUsers"] = self.removeUsers
         return out
 
-
 class v1UpdateGroupResponse(Printable):
 
     def __init__(
@@ -13369,7 +13039,6 @@ class v1UpdateGroupResponse(Printable):
         }
         return out
 
-
 class v1UpdateJobQueueRequest(Printable):
 
     def __init__(
@@ -13391,7 +13060,6 @@ class v1UpdateJobQueueRequest(Printable):
             "updates": [x.to_json(omit_unset) for x in self.updates],
         }
         return out
-
 
 class v1UpdateTrialTagsRequest(Printable):
     filters: "typing.Optional[v1TrialFilters]" = None
@@ -13431,7 +13099,6 @@ class v1UpdateTrialTagsRequest(Printable):
             out["trial"] = None if self.trial is None else self.trial.to_json(omit_unset)
         return out
 
-
 class v1UpdateTrialTagsResponse(Printable):
     rowsAffected: "typing.Optional[int]" = None
 
@@ -13457,7 +13124,6 @@ class v1UpdateTrialTagsResponse(Printable):
         if not omit_unset or "rowsAffected" in vars(self):
             out["rowsAffected"] = self.rowsAffected
         return out
-
 
 class v1User(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
@@ -13529,7 +13195,6 @@ class v1User(Printable):
             out["remote"] = self.remote
         return out
 
-
 class v1UserRoleAssignment(Printable):
 
     def __init__(
@@ -13555,7 +13220,6 @@ class v1UserRoleAssignment(Printable):
             "userId": self.userId,
         }
         return out
-
 
 class v1UserWebSetting(Printable):
     storagePath: "typing.Optional[str]" = None
@@ -13595,7 +13259,6 @@ class v1UserWebSetting(Printable):
             out["value"] = self.value
         return out
 
-
 class v1ValidateAfterOperation(Printable):
     length: "typing.Optional[str]" = None
     requestId: "typing.Optional[str]" = None
@@ -13630,7 +13293,6 @@ class v1ValidateAfterOperation(Printable):
             out["requestId"] = self.requestId
         return out
 
-
 class v1ValidationCompleted(Printable):
 
     def __init__(
@@ -13661,7 +13323,6 @@ class v1ValidationCompleted(Printable):
         }
         return out
 
-
 class v1ValidationHistoryEntry(Printable):
 
     def __init__(
@@ -13691,7 +13352,6 @@ class v1ValidationHistoryEntry(Printable):
             "trialId": self.trialId,
         }
         return out
-
 
 class v1Webhook(Printable):
     id: "typing.Optional[int]" = None
@@ -13734,7 +13394,6 @@ class v1Webhook(Printable):
         if not omit_unset or "triggers" in vars(self):
             out["triggers"] = None if self.triggers is None else [x.to_json(omit_unset) for x in self.triggers]
         return out
-
 
 class v1WebhookType(DetEnum):
     UNSPECIFIED = "WEBHOOK_TYPE_UNSPECIFIED"
@@ -13782,7 +13441,6 @@ class v1WorkloadContainer(Printable):
         if not omit_unset or "validation" in vars(self):
             out["validation"] = None if self.validation is None else self.validation.to_json(omit_unset)
         return out
-
 
 class v1Workspace(Printable):
     agentUserGroup: "typing.Optional[v1AgentUserGroup]" = None
@@ -13869,7 +13527,6 @@ class v1Workspace(Printable):
         if not omit_unset or "pinnedAt" in vars(self):
             out["pinnedAt"] = self.pinnedAt
         return out
-
 
 class v1WorkspaceState(DetEnum):
     UNSPECIFIED = "WORKSPACE_STATE_UNSPECIFIED"


### PR DESCRIPTION
these are used in tests and logs and are more helpful if they're a bit more verbose.
I added some custom logic to skip longers pieces of text that probably contribute less to this goal

```
v1GetExperimentsResponse(experiments=[..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ..., ...], pagination=...)
v1Experiment(archived=False, config=..., id=1, jobId=7288c52e-d61f-488c-996e-e66c00402186, name=Experiment (sincerely-large-pegasus), numTrials=2, originalConfig=, projectId=1, projectOwnerId=1, searcherType=single, startTime=2023-05-17T19:50:47.585372925Z, state=..., username=determined, checkpointCount=0, checkpointSize=0, description=, displayName=determined, duration=302, endTime=2023-05-17T19:55:49.467384100Z, labels=[], notes=, parentArchived=False, progress=0.0, projectName=Uncategorized, resourcePool=pool_prio, trialIds=[], unmanaged=False, userId=2, workspaceId=1, workspaceName=Uncategorized)
```

![Screenshot 2023-05-31 at 13 52 20](https://github.com/determined-ai/determined/assets/12127420/be74d15e-f5ee-4b6d-baa4-0661271d9e07)

## benchmarks

doesn't look like it has a measurable impact. I'm not sure if warmups are fair or not 🤔 
```
hbp ➜ determined git:(main) hyperfine --warmup 10 "python -c 'from determined.common.api import bindings'"
Benchmark 1: python -c 'from determined.common.api import bindings'
  Time (mean ± σ):     195.3 ms ±   3.8 ms    [User: 99.1 ms, System: 31.7 ms]
  Range (min … max):   189.6 ms … 203.8 ms    14 runs

Time: 0h:00m:05s
hbp ➜ determined git:(main) gco -
Switched to branch 'printable-py-bindings'
Your branch is up to date with 'origin/printable-py-bindings'.
hbp ➜ determined git:(printable-py-bindings) hyperfine --warmup 10 "python -c 'from determined.common.api import bindings'"
Benchmark 1: python -c 'from determined.common.api import bindings'
  Time (mean ± σ):     197.1 ms ±   7.5 ms    [User: 99.1 ms, System: 33.6 ms]
  Range (min … max):   189.0 ms … 217.6 ms    14 runs

Time: 0h:00m:06s
hbp ➜ determined git:(printable-py-bindings) hyperfine --warmup 10 "det -h"
Benchmark 1: det -h
  Time (mean ± σ):     502.1 ms ±   5.0 ms    [User: 382.3 ms, System: 56.7 ms]
  Range (min … max):   496.5 ms … 509.3 ms    10 runs

Time: 0h:00m:10s
hbp ➜ determined git:(printable-py-bindings) gco main
Switched to branch 'main'
Your branch is up to date with 'upstream/main'.
hbp ➜ determined git:(main) hyperfine --warmup 10 "det -h"
Benchmark 1: det -h
  Time (mean ± σ):     513.3 ms ±   8.6 ms    [User: 385.4 ms, System: 62.1 ms]
  Range (min … max):   506.5 ms … 536.2 ms    10 runs

Time: 0h:00m:11s
hbp ➜ determined git:(main)
```

### python -X importtime

```
python -X importtime harness/determined/cli/cli.py 2>&1 | ag api.bindings

import time: self [us] | cumulative | imported package

# this branch

import time:     69620 |      69620 |               determined.common.api.bindings
import time:     69800 |      69800 |               determined.common.api.bindings
import time:     70022 |      70022 |               determined.common.api.bindings
import time:     70238 |      70238 |               determined.common.api.bindings
import time:     70262 |      70262 |               determined.common.api.bindings
import time:     70772 |      70772 |               determined.common.api.bindings

(determined) hbp ➜ determined git:(printable-py-bindings) gco $(git merge-base upstream/main HEAD)
HEAD is now at 728078b5d0 chore: bump version: 0.23.0-dev0 -> 0.23.1-dev0

import time:     69537 |      69537 |               determined.common.api.bindings
import time:     69830 |      69830 |               determined.common.api.bindings
import time:     69900 |      69900 |               determined.common.api.bindings
import time:     70040 |      70040 |               determined.common.api.bindings
import time:     70161 |      70161 |               determined.common.api.bindings
import time:     70319 |      70319 |               determined.common.api.bindings
import time:     71477 |      71477 |               determined.common.api.bindings
```