### PR TITLE
fix: det shell start fails on grenoble with 0.21.2 (reading HTTP_PROXY, but ignoring NO_PROXY) [DET-9364]

### DIFF
--- a/harness/determined/cli/proxy.py
+++ b/harness/determined/cli/proxy.py
@@ -199,7 +199,9 @@ def _http_tunnel_listener(
 
     class TunnelHandler(socketserver.BaseRequestHandler):
         def handle(self) -> None:
-            ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url))
+            proxies = {} if urllib.request.proxy_bypass(parsed_master.hostname) else None  # type: ignore
+
+            ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url), proxies=proxies)
             if authorization_token is not None:
                 ws.add_header(b"Authorization", f"Bearer {authorization_token}".encode())
             # We can't send data to the WebSocket before the connection becomes ready,

--- a/harness/determined/cli/proxy.py
+++ b/harness/determined/cli/proxy.py
@@ -199,7 +199,9 @@ def _http_tunnel_listener(
 
     class TunnelHandler(socketserver.BaseRequestHandler):
         def handle(self) -> None:
-            proxies = {} if urllib.request.proxy_bypass(parsed_master.hostname) else None  # type: ignore
+            proxies = (
+                {} if urllib.request.proxy_bypass(parsed_master.hostname) else None  # type: ignore
+            )
 
             ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url), proxies=proxies)
             if authorization_token is not None:

--- a/harness/determined/cli/proxy.py
+++ b/harness/determined/cli/proxy.py
@@ -9,6 +9,7 @@ import ssl
 import sys
 import threading
 import time
+import urllib.request
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Union
 
@@ -145,8 +146,21 @@ def http_connect_tunnel(
 ) -> None:
     parsed_master = request.parse_master_address(master)
     assert parsed_master.hostname is not None, "Failed to parse master address: {}".format(master)
+
+    # The "lomond.WebSocket()" function does not honor the "no_proxy" or
+    # "NO_PROXY" environment variables. To work around that, we check if
+    # the hostname is in the "no_proxy" or "NO_PROXY" environment variables
+    # ourselves using the "proxy_bypass()" function, which checks the "no_proxy"
+    # and "NO_PROXY" environment variables, and returns True if the host does
+    # not require a proxy server. The "lomond.WebSocket()" function will disable
+    # the proxy if the "proxies" parameter is an empty dictionary.  Otherwise,
+    # if the "proxies" parameter is "None", it will honor the "HTTP_PROXY" and
+    # "HTTPS_PROXY" environment variables. When the "proxies" parameter is not
+    # specified, the default value is "None".
+    proxies = {} if urllib.request.proxy_bypass(parsed_master.hostname) else None  # type: ignore
+
     url = request.make_url(master, "proxy/{}/".format(service))
-    ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url))
+    ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url), proxies=proxies)
     if authorization_token is not None:
         ws.add_header(b"Authorization", f"Bearer {authorization_token}".encode())
 


### PR DESCRIPTION
## Description

The Grenoble cluster ("o184i054.gre.smktg.hpecorp.net") is configured to use a proxy server.

```
corujor@o184i054:/cstor/corujor/determined-ee$ env | grep -i proxy
no_proxy=localhost,127.0.0.1,16.16.184.54,172.23.184.54,172.22.184.54,.hpecorp.net
ftp_proxy=http://web-proxy.bbn.hpecorp.net:8088
https_proxy=http://web-proxy.bbn.hpecorp.net:8088
NO_PROXY=localhost,127.0.0.1,16.16.184.54,172.23.184.54,172.22.184.54,.hpecorp.net
FTP_PROXY=http://web-proxy.bbn.hpecorp.net:8088
HTTPS_PROXY=http://web-proxy.bbn.hpecorp.net:8088
HTTP_PROXY=http://web-proxy.bbn.hpecorp.net:8088
http_proxy=http://web-proxy.bbn.hpecorp.net:8088
```

When we run the "det shell start" command on the Grenoble cluster, we get the following error:

```
corujor@o184i054:/cstor/corujor/determined-ee$ det shell start
error connecting to ws://localhost:8080/shells/12f2698a-49c8-4c24-8817-b8caf8b0911d/events; ('proxy fail; {} {}', 503, 'Service Unavailable')
Failed to start a new shell: WebSocket failure: ConnectFail(reason='('proxy fail; {} {}', 503, 'Service Unavailable')')
```

However, the container for the shell does start.

```
corujor@o184i054:/cstor/corujor/determined-ee$ det shell list | grep 12f2698a-49c8-4c24-8817-b8caf8b0911d
 12f2698a-49c8-4c24-8817-b8caf8b0911d | corujor-admin | Shell (severely-busy-redfish)       | RUNNING    |                                          | mlde_cuda_preempt | Uncategorized
```

The "WebSocket failure" error is due to the Determined CLI trying to connect to the container.

We can use the "--show-ssh-command" option to "det shell open" to see the "ssh" command that's being executed, which tells us where the error is originating from.

```
corujor@o184i054:/cstor/corujor/determined-ee$ det shell open 12f2698a-49c8-4c24-8817-b8caf8b0911d --show-ssh-command
ssh -o "ProxyCommand=/usr/bin/python3 -m determined.cli.tunnel localhost:8080 %h" -o StrictHostKeyChecking=no -tt -o IdentitiesOnly=yes -i /home/corujor/.cache/determined/shell/12f2698a-49c8-4c24-8817-b8caf8b0911d/key corujor@12f2698a-49c8-4c24-8817-b8caf8b0911d
error connecting to ws://localhost:8080/proxy/12f2698a-49c8-4c24-8817-b8caf8b0911d/; ('proxy fail; {} {}', 503, 'Service Unavailable')
Exception in thread Thread-2 (copy_from_websocket):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
To reconnect, run: det shell open 12f2698a-49c8-4c24-8817-b8caf8b0911d
```

We can further simplify the command and get "ssh" out of the equation.

```
corujor@o184i054:/cstor/corujor/determined-ee$ /usr/bin/python3 -m determined.cli.tunnel localhost:8080  9129ff8c-cb01-4295-870b-fe2df663c5c
error connecting to ws://localhost:8080/proxy/9129ff8c-cb01-4295-870b-fe2df663c5c/; ('proxy fail; {} {}', 503, 'Service Unavailable')
Exception in thread Thread-2 (copy_from_websocket):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/corujor/.local/lib/python3.10/site-packages/determined/cli/proxy.py", line 103, in copy_from_websocket
    raise Exception("Connection failed: {}".format(event))
Exception: Connection failed: ConnectFail(reason='('proxy fail; {} {}', 503, 'Service Unavailable')')
^CTraceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/corujor/.local/lib/python3.10/site-packages/determined/cli/tunnel.py", line 40, in <module>
    http_connect_tunnel(
  File "/home/corujor/.local/lib/python3.10/site-packages/determined/cli/proxy.py", line 168, in http_connect_tunnel
    c1.join()
  File "/usr/lib/python3.10/threading.py", line 1096, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.10/threading.py", line 1116, in _wait_for_tstate_lock
    if lock.acquire(block, timeout):
KeyboardInterrupt
```

We can see that the error above is originating from the "http_connect_tunnel()" function in "determined/cli/proxy.py".

”http_connect_tunnel()” uses the “lomond” WebSocket.

```
    url = request.make_url(master, "proxy/{}/".format(service))

    ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url))
```

As per the documentation [WebSocket — Dataplicity Lomond 0.3.2 documentation](https://lomond.readthedocs.io/en/latest/websocket.html), the “WebSocket()” function will use the proxies from the environment of “None” is specified, which it is by default.

```
proxies (dict) – A dict containing 'http' or 'https' urls to a proxy server, or None to attempt to auto-detect proxies from environment. Pass an empty dict to disable proxy.
```


As per the source code “./lomond/websocket.py”, the HTTP_PROXY and HTTPS_PROXY environment variables are used, but there is no reference to “NO_PROXY” or “no_proxy” in the documentation or the source code.

```
self.proxies = self._detect_proxies() if proxies is None else proxies
…
def _detect_proxies(cls):
    """Get proxy information form environment."""
    proxies = {
        'http': os.environ.get('HTTP_PROXY'),
        'https': os.environ.get('HTTPS_PROXY')
    }
    return proxies
```

If we run the "det shell open" command using "strace", we can see that the "lomond.WebSocket()" function in "http_connect_tunnel()" is sending "CONNECT localhost:8080 HTTP" to the proxy server.

```
[pid 3945210] socket(PF_INET, SOCK_STREAM|SOCK_CLOEXEC, IPPROTO_TCP) = 3
[pid 3945210] setsockopt(3, SOL_TCP, TCP_NODELAY, [1], 4) = 0
[pid 3945210] ioctl(3, FIONBIO, [1])    = 0
[pid 3945210] connect(3, {sa_family=AF_INET, sin_port=htons(8088), sin_addr=inet_addr("16.46.16.11")}, 16) = -1 EINPROGRESS (Operation now in progress)
[pid 3945210] poll([{fd=3, events=POLLOUT|POLLERR}], 1, 30000) = 1 ([{fd=3, revents=POLLOUT}])
[pid 3945210] getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
[pid 3945210] poll([{fd=3, events=POLLOUT}], 1, 30000) = 1 ([{fd=3, revents=POLLOUT}])
[pid 3945210] sendto(3, "CONNECT localhost:8080 HTTP/1.1\r"..., 106, 0, NULL, 0) = 106
[pid 3945210] poll([{fd=3, events=POLLIN}], 1, 30000) = 1 ([{fd=3, revents=POLLIN}])
[pid 3945210] recvfrom(3, "HTTP/1.1 503 Service Unavailable"..., 1024, 0, NULL, NULL) = 916
[pid 3945210] getpid()                  = 3945207
[pid 3945210] write(2, "error connecting to ws://localho"..., 134error connecting to ws://localhost:8080/proxy/9129ff8c-cb01-4295-870b-fe2df663c5c/; ('proxy fail; {} {}', 503, 'Service Unavailable')
) = 134
[pid 3945210] getsockname(3, {sa_family=AF_INET, sin_port=htons(38048), sin_addr=inet_addr("16.16.184.54")}, [16]) = 0
[pid 3945210] getpeername(3, {sa_family=AF_INET, sin_port=htons(8088), sin_addr=inet_addr("16.46.16.11")}, [16]) = 0
[pid 3945210] close(3)                  = 0
```

Therefore, "lomond.WebSocket()" is honoring "HTTP_PROXY", but it's not honoring the "NO_PROXY" or "no_proxy" environment variables.

Since "lomond.WebSocket()" doesn't honor the "NO_PROXY" or "no_proxy" environment variables, we have to check the "NO_PROXY" and "no_proxy" environment variables ourselves.

Luckily, "urllib.request.proxy_bypass(hostname)" does this for us, and will return "True" if the hostname should not be forwarded to the proxy server based on the value of the "NO_PROXY" and "no_proxy" environment variables.

If "urllib.request.proxy_bypass(hostname)" returns "True", meaning hostname shouldn't be forwarded to the proxy server, we will pass an empty dictionary for the "proxies" argument to "lomond.WebSocket()" which, as per the documentation, disables the proxy.  If "urllib.request.proxy_bypass(hostname)" returns "False", then we will pass "None" for the "proxies" argument to "lomond.WebSocket()" which, as per the documentation, will auto-detect proxies from environment.

This issue is only observed on Grenoble cluster, but is not observed on "casablanca-login", even though both clusters are configured to use a proxy server.  Running strace on the "det shell start" on both systems, we see that on "casablanca-login", the "/etc/nsswitch.conf" and "/etc/hosts" file were being accessed.

```
openat(AT_FDCWD, "/etc/nsswitch.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/host.conf", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3
openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 3
```

However, on the Grenoble cluster, "/etc/nsswitch.conf" and "/etc/hosts" were NOT being accessed.

```
openat(AT_FDCWD, "/etc/host.conf", O_RDONLY|O_CLOEXEC) = 3
```

This may account for the difference in behavior, but I'm not sure.

## Test Plan

On the Grenoble cluster, I made the following modification and set "PYTHONPATH=/cstor/corujor/determined-ee/harness" when I ran the tests to point to the code I modified.

```
corujor@o184i054:/cstor/corujor/determined-ee$ git diff harness/determined/cli/proxy.py
diff --git a/harness/determined/cli/proxy.py b/harness/determined/cli/proxy.py
index ff3ff62662..832fd31901 100644
--- a/harness/determined/cli/proxy.py
+++ b/harness/determined/cli/proxy.py
@@ -9,6 +9,7 @@ import ssl
 import sys
 import threading
 import time
+import urllib.request
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Union
 
@@ -145,8 +146,21 @@ def http_connect_tunnel(
 ) -> None:
     parsed_master = request.parse_master_address(master)
     assert parsed_master.hostname is not None, "Failed to parse master address: {}".format(master)
+
+    # The "lomond.WebSocket()" function does not honor the "no_proxy" or
+    # "NO_PROXY" environment variables. To work around that, we check if
+    # the hostname is in the "no_proxy" or "NO_PROXY" environment variables
+    # ourselves using the "proxy_bypass()" function, which checks the "no_proxy"
+    # and "NO_PROXY" environment variables, and returns True if the host does
+    # not require a proxy server. The "lomond.WebSocket()" function will disable
+    # the proxy if the "proxies" parameter is an empty dictionary.  Otherwise,
+    # if the "proxies" parameter is "None", it will honor the "HTTP_PROXY" and
+    # "HTTPS_PROXY" environment variables. When the "proxies" parameter is not
+    # specified, the default value is "None".
+    proxies = {} if urllib.request.proxy_bypass(parsed_master.hostname) else None  # type: ignore
+
     url = request.make_url(master, "proxy/{}/".format(service))
-    ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url))
+    ws = lomond.WebSocket(request.maybe_upgrade_ws_scheme(url), proxies=proxies)
     if authorization_token is not None:
         ws.add_header(b"Authorization", f"Bearer {authorization_token}".encode())
```

**Test Case #1:**  Run "det shell start" without setting the DET_MASTER environment variable.

We can see that the command runs successfully and we get a shell prompt in the container.

```
corujor@o184i054:/cstor/corujor/determined-ee$ echo $DET_MASTER

corujor@o184i054:/cstor/corujor/determined-ee$ PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start
CLI version 0.22.3-dev0 is less than master version 0.23.0-rc1. Consider upgrading the CLI.
Launched shell (id: 38e6abf4-6ed9-4e76-971e-948e40998a1c).
shell (id: 38e6abf4-6ed9-4e76-971e-948e40998a1c) is ready.                      
Warning: Permanently added '38e6abf4-6ed9-4e76-971e-948e40998a1c' (RSA) to the list of known hosts.
$ 
```

**Test Case #2:**  Run "det shell start" with the DET_MASTER environment variable set to "localhost:8080".

We can see that the command runs successfully and we get a shell prompt in the container.

```
corujor@o184i054:/cstor/corujor/determined-ee$ DET_MASTER=localhost:8080 PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start
CLI version 0.22.3-dev0 is less than master version 0.23.0-rc1. Consider upgrading the CLI.
Launched shell (id: 7e2c6db6-1e59-4885-826c-8336a2e4891f).
shell (id: 7e2c6db6-1e59-4885-826c-8336a2e4891f) is ready.                      
Warning: Permanently added '7e2c6db6-1e59-4885-826c-8336a2e4891f' (RSA) to the list of known hosts.
$ 
```

**Test Case #3:**  Run "det shell start" with the DET_MASTER environment variable set to the fully qualified domain name "o184i054.gre.smktg.hpecorp.net:8080".

We can see that the command runs successfully and we get a shell prompt in the container.

```
corujor@o184i054:/cstor/corujor/determined-ee$ DET_MASTER=o184i054.gre.smktg.hpecorp.net:8080 PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start
CLI version 0.22.3-dev0 is less than master version 0.23.0-rc1. Consider upgrading the CLI.
Launched shell (id: 1370d5ce-4de1-456a-bbe1-6adec67aa4d3).
shell (id: 1370d5ce-4de1-456a-bbe1-6adec67aa4d3) is ready.                      
Warning: Permanently added '1370d5ce-4de1-456a-bbe1-6adec67aa4d3' (RSA) to the list of known hosts.
$ 
```

**Test Case #4:**  Run "det shell start" with the DET_MASTER environment variable set to the short host name "o184i054:8080".

We get a failure due to the short host name "o184i054" not being able to get resolved by the proxy server.

```
corujor@o184i054:/cstor/corujor/determined-ee$ DET_MASTER=o184i054:8080 PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start
Failed to start a new shell: <HTML><HEAD>
<TITLE>Network Error</TITLE>
</HEAD>
<BODY>
<FONT face="Helvetica">
<big><strong></strong></big><BR>
</FONT>
<blockquote>
<TABLE border=0 cellPadding=1 width="80%">
<TR><TD>
<FONT face="Helvetica">
<big>Network Error (dns_unresolved_hostname)</big>
<BR>
<BR>
</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica">
Your requested host "o184i054" could not be resolved by DNS.
</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica">

</FONT>
</TD></TR>
<TR><TD>
<FONT face="Helvetica" SIZE=2>
<BR>
For assistance, contact your network support team.
</FONT>
</TD></TR>
</TABLE>
</blockquote>
</FONT>
</BODY></HTML>
```

We can see by the "strace" command that the failure came from the proxy server.

```
connect(3, {sa_family=AF_INET, sin_port=htons(8088), sin_addr=inet_addr("16.46.16.11")}, 16) = 0
sendto(3, "GET http://o184i054:8080/info HT"..., 168, 0, NULL, 0) = 168
ioctl(3, FIONBIO, [0])                  = 0
recvfrom(3, "HTTP/1.1 404 Not Found\r\nCache-Co"..., 8192, 0, NULL, NULL) = 802
close(3)                                = 0
write(2, "\33[31mFailed to start a new shell"..., 657^[[31mFailed to start a new shell: <HTML><HEAD>
```

```
corujor@o184i054:/cstor/corujor/determined-ee$ echo $HTTP_PROXY
http://web-proxy.bbn.hpecorp.net:8088
corujor@o184i054:/cstor/corujor/determined-ee$ host web-proxy.bbn.hpecorp.net
web-proxy.bbn.hpecorp.net is an alias for proxy-llb-suo05.de.hpecorp.net.
proxy-llb-suo05.de.hpecorp.net has address 16.46.16.11
```

**Test Case #5:**  Test setting up a tunnel to access a custom port that is listening for connections from within the container, as per https://docs.determined.ai/latest/interfaces/proxy-ports.html

Set up the configuration file to use port "8265".

```
corujor@o184i054:~$ cat $HOME/myconfig.yaml
environment:
  proxy_ports:
    - proxy_port: 8265
      proxy_tcp: true
```

Start up a shell and point it to the configuration file.

```
corujor@o184i054:~$ DET_MASTER=http://localhost:8080 HOME=/cstor/corujor PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start --config-file $HOME/myconfig.yaml
CLI version 0.23.0-rc4 is less than master version 0.23.0. Consider upgrading the CLI.
Launched shell (id: 100be411-615d-483b-b435-436cbd61e344).
shell (id: 100be411-615d-483b-b435-436cbd61e344) is ready.                      
Warning: Permanently added '100be411-615d-483b-b435-436cbd61e344' (RSA) to the list of known hosts.
$ 
```

Run the following command to setup a tunnel proxying localhost:8265 to port 8265 in the task container.

```
corujor@o184i054:~$ MASTER=http://localhost:8080 PYTHONPATH=/cstor/corujor/determined-ee/harness python3 -m determined.cli.tunnel --listener 8265 --auth http://localhost:8080 100be411-615d-483b-b435-436cbd61e344:8265
```

In a directory that is accessible by the container running the shell, which, in this example, is "/cstor/corujor" have a server program that will listen on port 8265, such as the one below.  The "/cstor" directory on the Grenoble cluster is mounted by the container, so it will be visible by the shell.

```
corujor@o184i054:/cstor/corujor$ cat python_server.py
import socket

def server_program():
    # get the hostname
    host = socket.gethostname()
    port = 8265  # initiate port no above 1024

    server_socket = socket.socket()  # get instance
    # look closely. The bind() function takes tuple as argument
    server_socket.bind((host, port))  # bind host address and port together

    # configure how many client the server can listen simultaneously
    server_socket.listen(2)
    conn, address = server_socket.accept()  # accept new connection
    print("Connection from: " + str(address))
    while True:
        # receive data stream. it won't accept data packet greater than 1024 bytes
        data = conn.recv(1024).decode()
        if not data:
            # if data is not received break
            break
        print("from connected user: " + str(data))
        data = input(' -> ')
        conn.send(data.encode())  # send data to the client

    conn.close()  # close the connection


if __name__ == '__main__':
    server_program()
```

In any directory on the host where the Determined master is running, have a client program that will connect to port "8265" on the server (i.e., example program above).

```
import socket

def client_program():
    #host = socket.gethostname()  # as both code is running on same pc
    host = "localhost"

    port = 8265  # socket server port number

    client_socket = socket.socket()  # instantiate
    client_socket.connect((host, port))  # connect to the server

    message = input(" -> ")  # take input

    while message.lower().strip() != 'bye':
        client_socket.send(message.encode())  # send message
        data = client_socket.recv(1024).decode()  # receive response

        print('Received from server: ' + data)  # show in terminal

        message = input(" -> ")  # again take input

    client_socket.close()  # close the connection

if __name__ == '__main__':
    client_program()
```

From within the shell you previously started, go to the directory where your server program resides.  In this example, we're using the program "python_server.py" which resides in "/cstor/corujor".  The "/cstor" directory is mounted in the container.  Run your server program.

```
corujor@o184i054:~$ DET_MASTER=http://localhost:8080 HOME=/cstor/corujor PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start --config-file $HOME/myconfig.yaml
CLI version 0.23.0-rc4 is less than master version 0.23.0. Consider upgrading the CLI.
Launched shell (id: 100be411-615d-483b-b435-436cbd61e344).
shell (id: 100be411-615d-483b-b435-436cbd61e344) is ready.                      
Warning: Permanently added '100be411-615d-483b-b435-436cbd61e344' (RSA) to the list of known hosts.
$ cd /cstor/corujor
$ python3 python_server.py 
```

From your host where the Determined master is running, run your client.  In this example, we're typing the message "hello from the client" at the prompt, and when we press the "Enter" key, it will get sent to the server.

```
corujor@o184i054:/cstor/corujor$ python3 python_client.py
 -> hello from the client
```

You can see that the server that's running in your shell received the "hello from the client" message.

```
corujor@o184i054:~$ DET_MASTER=http://localhost:8080 HOME=/cstor/corujor PYTHONPATH=/cstor/corujor/determined-ee/harness det shell start --config-file $HOME/myconfig.yaml
CLI version 0.23.0-rc4 is less than master version 0.23.0. Consider upgrading the CLI.
Launched shell (id: 100be411-615d-483b-b435-436cbd61e344).
shell (id: 100be411-615d-483b-b435-436cbd61e344) is ready.                      
Warning: Permanently added '100be411-615d-483b-b435-436cbd61e344' (RSA) to the list of known hosts.
$ cd /cstor/corujor
$ python3 python_server.py 
Connection from: ('16.16.184.54', 39032)
from connected user: hello from the client
 -> 
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
