### PR TITLE
fix: k8s slots count growing for commands [DET-9550]

### DIFF
--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -601,6 +601,15 @@ func (k *kubernetesResourcePool) resourcesReleased(
 	}
 
 	ctx.Log().Infof("resources are released for %s", msg.AllocationRef.Address())
+
+	if req, ok := k.reqList.TaskByHandler(msg.AllocationRef); ok {
+		group := k.groups[req.Group]
+
+		if group != nil {
+			k.slotsUsedPerGroup[group] -= req.SlotsNeeded
+		}
+	}
+
 	k.reqList.RemoveTaskByHandler(msg.AllocationRef)
 	delete(k.addrToContainerID, msg.AllocationRef)
 	delete(k.allocRefToRunningPods, msg.AllocationRef)
@@ -611,14 +620,6 @@ func (k *kubernetesResourcePool) resourcesReleased(
 			deleteID = id
 			delete(k.containerIDtoAddr, deleteID)
 			break
-		}
-	}
-
-	if req, ok := k.reqList.TaskByHandler(msg.AllocationRef); ok {
-		group := k.groups[msg.AllocationRef]
-
-		if group != nil {
-			k.slotsUsedPerGroup[group] -= req.SlotsNeeded
 		}
 	}
 }


### PR DESCRIPTION
## Description
This was previously fixed for experiments, but tasks followed a different path when releasing slots. This covers the other case.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Run a GKE or local kubernetes cluster and submit a short sleep command. Go to `<cluster address>/api/v1/resource-pools` and look at the `slots available` field. Make sure it increments when the job is submitted and decrements when the job completes.

Also try terminating the command early, making sure the count decrements too.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
