### PR TITLE
chore: Helm file removed static imgs refs, added log config

### DIFF
--- a/helm/charts/determined/Chart.yaml
+++ b/helm/charts/determined/Chart.yaml
@@ -5,8 +5,8 @@ version: "0.23.2-dev0"
 icon: https://github.com/determined-ai/determined/blob/master/determined-logo.png?raw=true
 home: https://github.com/determined-ai/determined.git
 
-# appVersion controls the version Determined that is deployed. If using a
-# a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
+# appVersion controls the version HPE MLDE / Determined OSS that is deployed. 
+# If using a non-release version (e.g., X.Y.Z.dev0) you will have to specify an
 # existing official release version (e.g., X.Y.Z) or specify a commit has
 # that has been publicly published (all commits from master).
 appVersion: "0.23.2-dev0"

--- a/helm/charts/determined/scripts/k8s-password-change.py
+++ b/helm/charts/determined/scripts/k8s-password-change.py
@@ -51,6 +51,7 @@ def getMasterAddress(
     service_port: str,
     token: str,
 ) -> str:
+
     target_service = f"determined-master-service-{service_name}"
 
     if node_port != "true":

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -20,10 +20,10 @@ spec:
     spec:
       serviceAccount: determined-master-{{ .Release.Name }}
       restartPolicy: OnFailure
-      {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809")._1}}
+
       containers:
       - name: change-password
-        image: {{ .Values.imageRegistry }}/{{ $cpuImage }}
+        image: {{ .Values.defaultImages.cpuImage | quote }}
         imagePullPolicy: "Always"
         command: ["/bin/bash"]
         args:

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       priorityClassName: determined-system-priority
       containers:
       - name: determined-db-{{ .Release.Name }}
-        image: postgres:10.14
+        image: {{ .Values.defaultImages.postgreSQL | quote }}
         imagePullPolicy: "Always"
         resources:
           requests:

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -81,7 +81,7 @@ data:
     {{- if .Values.enterpriseEdition }}
     {{- if .Values.oidc }}
     oidc:
-      enabled: {{ .Values.oidc.enabled | default true }}
+      enabled: {{ .Values.oidc.enabled | default false }}
       provider: {{ required "A valid provider entry is required!" .Values.oidc.provider}}
       idp_recipient_url: {{ required "A valid recipient url is required!" .Values.oidc.idpRecipientUrl }}
       idp_sso_url: {{ required "A valid sso url is required!" .Values.oidc.idpSsoUrl }}
@@ -96,7 +96,7 @@ data:
 
     {{- if .Values.scim }}
     scim:
-      enabled: {{ .Values.scim.enabled | default true }}
+      enabled: {{ .Values.scim.enabled | default false }}
       auth:
         type: {{ required "A valid authentication type is required!" .Values.scim.auth.type }}
         {{- if eq .Values.scim.auth.type "basic" }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -8,6 +8,10 @@ metadata:
      release: {{ .Release.Name }}
 data:
   master.yaml: |
+    log:
+      level: {{ .Values.logLevel  | quote | default "info" }}
+      color: {{ .Values.logColor | default true }}
+
     checkpoint_storage:
       type: {{ required "A valid Values.checkpointStorage.type entry is required!" .Values.checkpointStorage.type | quote}}
       {{- if eq .Values.checkpointStorage.type "shared_fs" }}
@@ -131,8 +135,6 @@ data:
       {{- toYaml .Values.resourcePools | nindent 6}}
     {{- end }}
 
-    {{$cpuImage := (split "/" "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-6eceaca")._1}}
-    {{- $gpuImage := (split "/" "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca")._1 -}}
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
       {{- if .Values.taskContainerDefaults.networkMode }}
@@ -151,10 +153,10 @@ data:
       image:
          cpu: {{ .Values.taskContainerDefaults.cpuImage | quote }}
          gpu: {{ .Values.taskContainerDefaults.gpuImage | quote }}
-      {{- else if .Values.imageRegistry }}
+      {{- else }}
       image:
-         cpu: {{ .Values.imageRegistry }}/{{ $cpuImage }}
-         gpu: {{ .Values.imageRegistry }}/{{ $gpuImage }}
+         cpu: {{ .Values.defaultImages.cpuImage | quote }}
+         gpu: {{ .Values.defaultImages.gpuImage | quote }}
       {{- if or .Values.taskContainerDefaults.cpuImage .Values.taskContainerDefaults.gpuImage }}
         {{ required "A valid .Values.taskContainerDefaults.cpuImage entry is required if setting .Values.taskContainerDefaults.gpuImage!" .Values.taskContainerDefaults.cpuImage }}
         {{ required "A valid .Values.taskContainerDefaults.gpuImage entry is required if setting .Values.taskContainerDefaults.cpuImage!" .Values.taskContainerDefaults.gpuImage }}
@@ -163,11 +165,11 @@ data:
       {{- if .Values.taskContainerDefaults.forcePullImage }}
       force_pull_image: {{ .Values.taskContainerDefaults.forcePullImage }}
       {{- end }}
-    {{ else if .Values.imageRegistry }}
+    {{ else }}
     task_container_defaults:
       image:
-         cpu: {{ .Values.imageRegistry }}/{{ $cpuImage }}
-         gpu: {{ .Values.imageRegistry }}/{{ $gpuImage }}
+         cpu: {{ .Values.defaultImages.cpuImage | quote }}
+         gpu: {{ .Values.defaultImages.gpuImage | quote }}
     {{ end }}
 
     {{- if .Values.telemetry }}

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -32,9 +32,9 @@ spec:
         - --config=/etc/config/config.yaml
         name: {{ $schedulerType }}
         {{- if eq $schedulerType "preemption"}}
-        image: determinedai/kube-scheduler:0.17.0
+        image: "{{ .Values.defaultImages.kubeSchedulerPreemption }}"
         {{- else }}
-        image: k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9
+        image: "{{ .Values.defaultImages.kubeScheduler }}"
         {{- end}}
         imagePullPolicy: "Always"
         livenessProbe:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -1,5 +1,38 @@
-# The image registry to use. Defaults to the determinedai repository in DockerHub.
+# The image registry to be used to pull the Master image.
+# Determined OSS edition uses the determinedai repository in DockerHub.
 imageRegistry: determinedai
+# HPE Machine Learning Development Environment (MLDE), Determined Enterprise Edition, uses the HPE MSC as the image registry
+#imageRegistry: hub.myenterpriselicense.hpe.com/hpe-mlde/<SKU>
+# ATTENTION
+# Please also set: 
+#   - communicated product SKU, 
+#   - enterpriseEdition flag to true, 
+# and configure the imagePullSecretName to the HPE MSC credentials K8s Secret (e.g. mlde-hpe-registry)
+#
+# To get the HPE MSC credentials go to the myenterpriselicense.hpe.com website, and along with the information provided with your order
+# create the HPE MSC credentials K8s Secret (e.g. mlde-hpe-registry) using the following command: 
+# kubectl create secret docker-registry mlde-hpe-registry  \
+# --docker-server=hub.myenterpriselicense.hpe.com/hpe-mlde/<SKU> \
+# --docker-username=<HPE MSC user name>  \
+# --docker-password=<HPE MSC MLDE license key> \
+# --docker-email=<HPE MSC user email> \
+# -n <MLDE deployment K8s namespace, if any>
+
+# Default images used during the deployment 
+defaultImages:
+  # PostgreSQL image
+  postgreSQL: "postgres:10.14" 
+
+  # default Kube Scheduler image
+  kubeScheduler: "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9"
+
+  # Kube Scheduler used when the K8s default scheduler is set to preemption
+  # when, defaultScheduler: preemption
+  kubeSchedulerPreemption: "determinedai/kube-scheduler:0.17.0"
+
+  # default images for CPU and GPU environments
+  cpuImage: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809"
+  gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca"
 
 # Install Determined enterprise edition.
 enterpriseEdition: false
@@ -7,6 +40,11 @@ enterpriseEdition: false
 # Should be configured if using the master image in the Determined enterprise edition
 # or private registry.
 imagePullSecretName:
+
+# Logger Level in master.yaml - Four severity levels: debug, info, warn, error
+logLevel: info 
+# Sets in master.yaml the output of Logger in color mode - Values: true (default), false
+logColor: true 
 
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080


### PR DESCRIPTION
This change is related to helm charts only.

The change results from the experience made during the installation of MLDE in the ISP's K8s environment. The HPE MSC (HPE My Software Center) images registry for licensed image download was used.

Removed: the static image references that were left inside the templates and created for each image a "default" var in values.yaml, added logger level and color (t/f) variables in master.yaml config.

## This branch replaces "chore: helm files rm images static refs added in values.yaml" #6245

Git branch: helm-static-imgs-ref