### PR TITLE
chore: Pass in the allocation ID to releasedResources()

### DIFF
--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -70,6 +70,7 @@ type (
 
 	// ResourcesReleased notifies resource providers to return resources from a task.
 	ResourcesReleased struct {
+		AllocationID  model.AllocationID
 		AllocationRef *actor.Ref
 		ResourcesID   *ResourcesID
 	}

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -423,7 +423,10 @@ func (a *Allocation) Cleanup(ctx *actor.Context) {
 		a.sendTaskLog(&model.TaskLog{
 			Log: fmt.Sprintf("%s was terminated: %s", a.req.Name, "allocation did not exit correctly"),
 		})
-		a.rm.Release(ctx, sproto.ResourcesReleased{AllocationRef: ctx.Self()})
+		a.rm.Release(ctx, sproto.ResourcesReleased{
+			AllocationID:  a.req.AllocationID,
+			AllocationRef: ctx.Self(),
+		})
 	}
 }
 
@@ -658,6 +661,7 @@ func (a *Allocation) ResourcesStateChanged(
 		a.resources[msg.ResourcesID].Exited = msg.ResourcesStopped
 
 		a.rm.Release(ctx, sproto.ResourcesReleased{
+			AllocationID:  a.req.AllocationID,
 			AllocationRef: ctx.Self(),
 			ResourcesID:   &msg.ResourcesID,
 		})
@@ -959,7 +963,10 @@ func (a *Allocation) terminated(ctx *actor.Context, reason string) {
 	a.exited = true
 	exitReason := fmt.Sprintf("allocation terminated after %s", reason)
 	defer ctx.Tell(ctx.Self().Parent(), exit)
-	defer a.rm.Release(ctx, sproto.ResourcesReleased{AllocationRef: ctx.Self()})
+	defer a.rm.Release(ctx, sproto.ResourcesReleased{
+		AllocationID:  a.req.AllocationID,
+		AllocationRef: ctx.Self(),
+	})
 	defer a.unregisterProxies(ctx)
 	defer ctx.Self().Stop()
 


### PR DESCRIPTION
## Description

DET-9466 - https://hpe-aiatscale.atlassian.net/browse/DET-9466

In https://github.com/determined-ai/determined-ee/pull/822  Bradley requested that we pass in the allocationID to the “releasedResources()” function in “dispatcher_resource_manager.go”, rather than get it inside the function from “m.reqList.Allocation()”.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
