### PR TITLE
chore: added release note for DET-9035

### DIFF
--- a/docs/release-notes/rbac-not-found-errs.rst
+++ b/docs/release-notes/rbac-not-found-errs.rst
@@ -2,7 +2,7 @@
 
 **Improvements**
 
--  Errors: Errors that return 404 or 'Not Found' codes are now standardized in their 
-   messageas "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, 
-   the errors adds a suffix to remind users to check their permissions, since, with RBAC, permission 
-   denied errors & not found errors would both return as 'Not Found'. 
+-  Errors: Errors that return 404 or 'Not Found' codes are now standardized in their messageas
+   "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, the errors adds
+   a suffix to remind users to check their permissions, since, with RBAC, permission denied errors &
+   not found errors would both return as 'Not Found'.

--- a/docs/release-notes/rbac-not-found-errs.rst
+++ b/docs/release-notes/rbac-not-found-errs.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+**Improvements**
+
+-  Errors: Errors that return 404 or 'Not Found' codes are now standardized in their 
+   messageas "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, 
+   the errors adds a suffix to remind users to check their permissions, since, with RBAC, permission 
+   denied errors & not found errors would both return as 'Not Found'. 

--- a/docs/release-notes/rbac-not-found-errs.rst
+++ b/docs/release-notes/rbac-not-found-errs.rst
@@ -3,6 +3,6 @@
 **Improvements**
 
 -  Errors: Errors that return 404 or 'Not Found' codes are now standardized in their messageas
-   "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, the errors adds
+   "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, the errors add
    a suffix to remind users to check their permissions, since, with RBAC, permission denied errors &
    not found errors would both return as 'Not Found'.


### PR DESCRIPTION
## Description

Release note for https://github.com/determined-ai/determined/pull/6937


## Test Plan


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9035