### PR TITLE
fix: Button with icon styling

### DIFF
--- a/webui/react/src/components/kit/Button.module.scss
+++ b/webui/react/src/components/kit/Button.module.scss
@@ -49,8 +49,9 @@
   }
 }
 .withIcon {
-  display: flex;
   align-items: center;
+  display: flex;
+
   &.withChildren {
     [class^='icon-']::before,
     [class*=' icon-']::before {

--- a/webui/react/src/components/kit/Button.module.scss
+++ b/webui/react/src/components/kit/Button.module.scss
@@ -48,3 +48,13 @@
     margin-inline-start: 0;
   }
 }
+.withIcon {
+  display: flex;
+  align-items: center;
+  &.withChildren {
+    [class^='icon-']::before,
+    [class*=' icon-']::before {
+      margin-inline-end: 0.25em;
+    }
+  }
+}

--- a/webui/react/src/components/kit/Button.tsx
+++ b/webui/react/src/components/kit/Button.tsx
@@ -29,6 +29,8 @@ const Button: React.FC<ButtonProps> = forwardRef(
     const classes = [css.base];
     if (props.selected) classes.push(css.selected);
     if (props.column) classes.push(css.column);
+    if (props.icon) classes.push(css.withIcon);
+    if (props.children) classes.push(css.withChildren);
     return (
       <ConditionalWrapper
         condition={tooltip.length > 0}

--- a/webui/react/src/components/kit/Dropdown.tsx
+++ b/webui/react/src/components/kit/Dropdown.tsx
@@ -65,6 +65,15 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
     };
   }, [menu, onClick]);
 
+  const renderedChildren = useMemo(() => {
+    return (
+      <div>
+        {/* wrap in div to prevent antd from overwriting classes for child button element */}
+        {children}
+      </div>
+    );
+  }, [children]);
+
   /**
    * Using `dropdownRender` for Dropdown causes some issues with triggering the dropdown.
    * Instead, Popover is used when rendering content (as opposed to menu).
@@ -77,7 +86,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       placement={placement}
       showArrow={false}
       trigger="click">
-      {children}
+      {renderedChildren}
     </AntdPopover>
   ) : (
     <AntDropdown
@@ -87,7 +96,7 @@ const Dropdown: React.FC<PropsWithChildren<Props>> = ({
       open={open}
       placement={placement}
       trigger={[isContextMenu ? 'contextMenu' : 'click']}>
-      {children}
+      {renderedChildren}
     </AntDropdown>
   );
 };

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -254,8 +254,12 @@ const ButtonsSection: React.FC = () => {
         With Font Icon
         <Space>
           <Button icon={<Icon name="play" size="large" title="Play" />} />
-          <Button icon={<Icon name="play" size="large" title="Play" />}>ButtonWithLargeFontIcon</Button>
-          <Button icon={<Icon name="play" size="tiny" title="Play" />}>ButtonWithTinyFontIcon</Button>
+          <Button icon={<Icon name="play" size="large" title="Play" />}>
+            ButtonWithLargeFontIcon
+          </Button>
+          <Button icon={<Icon name="play" size="tiny" title="Play" />}>
+            ButtonWithTinyFontIcon
+          </Button>
         </Space>
         <hr />
         <strong>Button with icon and text displayed in a column</strong>

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -246,7 +246,7 @@ const ButtonsSection: React.FC = () => {
         </Space>
         <hr />
         <strong>Default Button with icon</strong>
-        With Antd Icon
+        With SVG Icon
         <Space>
           <Button icon={<PoweroffOutlined />} />
           <Button icon={<PoweroffOutlined />}>ButtonText</Button>

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -246,8 +246,16 @@ const ButtonsSection: React.FC = () => {
         </Space>
         <hr />
         <strong>Default Button with icon</strong>
+        With Antd Icon
         <Space>
-          <Button icon={<PoweroffOutlined />}>ButtonWithIcon</Button>
+          <Button icon={<PoweroffOutlined />} />
+          <Button icon={<PoweroffOutlined />}>ButtonText</Button>
+        </Space>
+        With Font Icon
+        <Space>
+          <Button icon={<Icon name="play" size="large" title="Play" />} />
+          <Button icon={<Icon name="play" size="large" title="Play" />}>ButtonWithLargeFontIcon</Button>
+          <Button icon={<Icon name="play" size="tiny" title="Play" />}>ButtonWithTinyFontIcon</Button>
         </Space>
         <hr />
         <strong>Button with icon and text displayed in a column</strong>


### PR DESCRIPTION
## Description

Styling for buttons was dependent on usage of Antd icons. Adding classes to support using both Antd icons and our `Icon` component in the `Button`'s `icon` prop.

## Test Plan

No release testing required. Regression testing on Buttons. Design Kit page should show examples with Antd icons and font icons

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
WEB-1226