### PR TITLE
fix: Bottom of code editor, find tool both visible [WEB-1318]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.module.scss
@@ -1,5 +1,5 @@
 .codeContainer {
-  height: calc(100vh - 220px);
+  height: calc(100vh - 236px);
 
   &.multitrialContainer {
     height: calc(100vh - 270px);


### PR DESCRIPTION
## Description

On the experiment code view, needed to shorten the code editor component by a few pixels for:
- bottom of code editor to be above last log banner
- find tool (Ctrl F) visible above last log banner

<img width="1199" alt="Screen Shot 2023-06-05 at 9 56 57 AM" src="https://github.com/determined-ai/determined/assets/643918/bc7adcc1-d873-4574-bb40-86854fbceec5">


## Test Plan

On an experiment, where the last log banner is visible on the bottom of the page, click the Code tab.
Select a code file (most Python files) longer than the window can fit
Confirm the bottom of the code window is just above the last log banner
Select the code editor and type: Ctrl F. The find appears inside the code editor component

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.