### PR TITLE
chore: bind mount options for singularity

### DIFF
--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -262,16 +262,6 @@ func (s *SingularityClient) RunContainer(
 	}
 
 	for _, m := range req.HostConfig.Mounts {
-		// TODO(DET-9079): Investigate handling these options.
-		if m.ReadOnly {
-			if err = p.Publish(ctx, docker.NewLogEvent(model.LogLevelWarning, fmt.Sprintf(
-				"mount %s:%s was requested as readonly but singularity does not support this; "+
-					"will bind mount anyway, without it being readonly",
-				m.Source, m.Target,
-			))); err != nil {
-				return nil, err
-			}
-		}
 		if m.BindOptions != nil && m.BindOptions.Propagation != "rprivate" { // rprivate is default.
 			if err = p.Publish(ctx, docker.NewLogEvent(model.LogLevelWarning, fmt.Sprintf(
 				"mount %s:%s had propagation settings but singularity does not support this; "+
@@ -281,7 +271,11 @@ func (s *SingularityClient) RunContainer(
 				return nil, err
 			}
 		}
-		args = append(args, "--bind", fmt.Sprintf("%s:%s", m.Source, m.Target))
+		bindMountTemplate := "%s:%s"
+		if m.ReadOnly {
+			bindMountTemplate += ":ro"
+		}
+		args = append(args, "--bind", fmt.Sprintf(bindMountTemplate, m.Source, m.Target))
 	}
 
 	if shmsize := req.HostConfig.ShmSize; shmsize != 4294967296 { // 4294967296 is the default.


### PR DESCRIPTION
## Description
Cater for read-only bind mounts.

To the experiment definition add:

```
bind_mounts:
  - host_path: /home/users/gaisford/determined-agent_0.22.1-dev0_linux_amd64
    container_path: /whatever
  - host_path: /home/users/gaisford/determined-agent_0.21.3-dev0_linux_amd64
    container_path: /whatever2
    read_only: true
```

In the experiment log, observe the following:
```
[2023-06-05 18:15:50]
[13ac25ed] singularity run \ 	--writable-tmpfs \
	--pwd /run/determined/workdir \ 	--env-file /tmp/determined-gaisford-node002/1151093388-13ac25ed-52a6-4a57-ac91-809a1ddbe18a/envfile \
	--bind /tmp/determined-gaisford-node002/1151093388-13ac25ed-52a6-4a57-ac91-809a1ddbe18a/archives/etc/ssh/ssh_config:/etc/ssh/ssh_config \
 	--bind /tmp/determined-gaisford-node002/1151093388-13ac25ed-52a6-4a57-ac91-809a1ddbe18a/archives/opt/determined:/opt/determined \
	--bind /tmp/determined-gaisford-node002/1151093388-13ac25ed-52a6-4a57-ac91-809a1ddbe18a/archives/run/determined:/run/determined \
	--bind /home/users/gaisford/determined-agent_0.22.1-dev0_linux_amd64:/whatever \
	--bind /home/users/gaisford/determined-agent_0.21.3-dev0_linux_amd64:/whatever2:ro /
	--bind /tmp/determined-cp:/determined_shared_fs docker://determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-6eceaca /run/determined/singularity-entrypoint-wrapper.sh /run/determined/train/entrypoint.sh
```

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
