### PR TITLE
feat: New default glide table columns [WEB-1197]

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -141,6 +141,18 @@ func (a *apiServer) getProjectColumnsByID(
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 		},
+		{
+			Column:			 "searcherMetric",
+			DisplayName: "Searcher Metric",
+			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
+			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+		},
+		{
+			Column:			 "searcherMetricValue",
+			DisplayName: "Searcher Metric Value",
+			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
+			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+		},
 	}
 
 	hyperparameters := []struct {

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -142,13 +142,13 @@ func (a *apiServer) getProjectColumnsByID(
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 		},
 		{
-			Column:			 "searcherMetric",
+			Column:      "searcherMetric",
 			DisplayName: "Searcher Metric",
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 		},
 		{
-			Column:			 "searcherMetricValue",
+			Column:      "searcherMetricValue",
 			DisplayName: "Searcher Metric Value",
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -148,7 +148,7 @@ func (a *apiServer) getProjectColumnsByID(
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 		},
 		{
-			Column:      "searcherMetricValue",
+			Column:      "searcherMetricsVal",
 			DisplayName: "Searcher Metric Value",
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -13,7 +13,7 @@ import Pagination from 'components/kit/Pagination';
 import useResize from 'hooks/useResize';
 import { useSettings } from 'hooks/useSettings';
 import { getProjectColumns, searchExperiments } from 'services/api';
-import { V1BulkExperimentFilters } from 'services/api-ts-sdk';
+import { V1BulkExperimentFilters, V1LocationType } from 'services/api-ts-sdk';
 import usePolling from 'shared/hooks/usePolling';
 import { getCssVar } from 'shared/themes';
 import {
@@ -36,6 +36,7 @@ import {
   settingsConfigForProject,
   settingsConfigGlobal,
 } from './F_ExperimentList.settings';
+import { ExperimentColumn, experimentColumns } from './glide-table/columns';
 import { Error, NoExperiments } from './glide-table/exceptions';
 import GlideTable, { SCROLL_SET_COUNT_NEEDED } from './glide-table/GlideTable';
 import { EMPTY_SORT, Sort, validSort, ValidSort } from './glide-table/MultiSortMenu';
@@ -256,6 +257,12 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     (async () => {
       try {
         const columns = await getProjectColumns({ id: project.id });
+        columns.sort((a, b) =>
+          a.location === V1LocationType.EXPERIMENT && b.location === V1LocationType.EXPERIMENT
+            ? experimentColumns.indexOf(a.column as ExperimentColumn) -
+              experimentColumns.indexOf(b.column as ExperimentColumn)
+            : 0,
+        );
 
         if (mounted) {
           setProjectColumns(Loaded(columns));

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -389,7 +389,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       return Loadable.match(data[row], {
         Loaded: (rowData) => {
           const columnId = columnIds[col];
-          return columnDefs[columnId].renderer(rowData, row);
+          return columnDefs[columnId]?.renderer?.(rowData, row) || loadingCell;
         },
         NotLoaded: () => loadingCell,
       });
@@ -561,6 +561,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         if (columnName in columnDefs) return columnDefs[columnName];
         if (!Loadable.isLoaded(projectColumnsMap)) return;
         const currentColumn = projectColumnsMap.data[columnName];
+        if (!currentColumn) return;
         let dataPath: string | undefined = undefined;
         switch (currentColumn.location) {
           case V1LocationType.EXPERIMENT:

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -313,6 +313,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         return;
       }
 
+      const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal']);
       const filterMenuItemsForColumn = () => {
         const isSpecialColumn = (SpecialColumnNames as ReadonlyArray<string>).includes(
           column.column,
@@ -334,10 +335,10 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       };
 
       const { bounds } = args;
-      const items: MenuProps['items'] = [
-        ...sortMenuItemsForColumn(column, sorts, onSortChange),
-        { type: 'divider' },
-        {
+      const items: MenuProps['items'] = [...sortMenuItemsForColumn(column, sorts, onSortChange)];
+      if (!BANNED_FILTER_COLUMNS.has(column.column)) {
+        items.push({ type: 'divider' });
+        items.push({
           icon: <FilterOutlined />,
           key: 'filter',
           label: 'Filter by this column',
@@ -346,8 +347,8 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               filterMenuItemsForColumn();
             }, 5);
           },
-        },
-      ];
+        });
+      }
       const x = bounds.x;
       const y = bounds.y + bounds.height;
       setMenuProps((prev) => ({ ...prev, items, title: `${columnId} menu`, x, y }));

--- a/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
@@ -12,7 +12,7 @@ import { Loadable } from 'utils/loadable';
 import css from './MultiSortMenu.module.scss';
 
 // in the list of columns from the api but not supported by the sort functionality
-const BANNED_COLUMNS = new Set(['tags']);
+const BANNED_COLUMNS = new Set(['tags', 'searcherMetric', 'searcherMetricValue']);
 
 const directionType = io.keyof({ asc: null, desc: null });
 export type DirectionType = io.TypeOf<typeof directionType>;
@@ -105,8 +105,11 @@ export const sortMenuItemsForColumn = (
   column: ProjectColumn,
   sorts: Sort[],
   onSortChange: (sorts: Sort[]) => void,
-): ItemType[] =>
-  optionsByColumnType[column.type].map((option) => {
+): ItemType[] => {
+  if (BANNED_COLUMNS.has(column.column)) {
+    return [];
+  }
+  return optionsByColumnType[column.type].map((option) => {
     const curSort = sorts.find((s) => s.column === column.column);
     const isSortMatch = curSort && curSort.direction === option.value;
     return {
@@ -133,6 +136,7 @@ export const sortMenuItemsForColumn = (
       },
     };
   });
+};
 
 const DirectionOptions: React.FC<DirectionOptionsProps> = ({ onChange, type, value }) => (
   <Select

--- a/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
@@ -12,7 +12,7 @@ import { Loadable } from 'utils/loadable';
 import css from './MultiSortMenu.module.scss';
 
 // in the list of columns from the api but not supported by the sort functionality
-const BANNED_COLUMNS = new Set(['tags', 'searcherMetric', 'searcherMetricValue']);
+const BANNED_COLUMNS = new Set(['tags', 'searcherMetric']);
 
 const directionType = io.keyof({ asc: null, desc: null });
 export type DirectionType = io.TypeOf<typeof directionType>;

--- a/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
@@ -12,7 +12,7 @@ import { Loadable } from 'utils/loadable';
 import css from './MultiSortMenu.module.scss';
 
 // in the list of columns from the api but not supported by the sort functionality
-const BANNED_COLUMNS = new Set(['tags', 'searcherMetric']);
+const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetric']);
 
 const directionType = io.keyof({ asc: null, desc: null });
 export type DirectionType = io.TypeOf<typeof directionType>;
@@ -106,7 +106,7 @@ export const sortMenuItemsForColumn = (
   sorts: Sort[],
   onSortChange: (sorts: Sort[]) => void,
 ): ItemType[] => {
-  if (BANNED_COLUMNS.has(column.column)) {
+  if (BANNED_SORT_COLUMNS.has(column.column)) {
     return [];
   }
   return optionsByColumnType[column.type].map((option) => {
@@ -153,7 +153,7 @@ const ColumnOptions: React.FC<ColumnOptionsProps> = ({ onChange, columns, value 
     autoFocus
     loading={Loadable.isLoading(columns)}
     options={Loadable.getOrElse([], columns)
-      .filter((c) => !BANNED_COLUMNS.has(c.column))
+      .filter((c) => !BANNED_SORT_COLUMNS.has(c.column))
       .map((c) => ({
         label: c.displayName || c.column,
         value: c.column,

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -20,43 +20,39 @@ import { getDisplayName } from 'utils/user';
 
 import { getDurationInEnglish, getTimeInEnglish } from './utils';
 
-const experimentColumns = [
+// order used in ColumnPickerMenu
+export const experimentColumns = [
+  'selected',
   'archived',
-  'checkpointCount',
-  'checkpointSize',
-  'description',
-  'duration',
-  'forkedFrom',
-  'id',
   'name',
-  'progress',
+  'id',
+  'forkedFrom',
+  'startTime',
+  'user',
+  'description',
+  'tags',
+  'state',
+  'duration',
   'resourcePool',
   'searcherType',
-  'selected',
-  'startTime',
-  'state',
-  'tags',
+  'progress',
   'numTrials',
-  'user',
+  'checkpointCount',
+  'checkpointSize',
+  'searcherMetric',
+  'searcherMetricValue',
 ] as const;
 
 export type ExperimentColumn = (typeof experimentColumns)[number];
 
 export const defaultExperimentColumns: ExperimentColumn[] = [
-  'id',
+  'startTime',
+  'user',
   'description',
   'tags',
-  'forkedFrom',
-  'progress',
-  'startTime',
   'state',
-  'searcherType',
-  'user',
   'duration',
-  'numTrials',
-  'resourcePool',
-  'checkpointSize',
-  'checkpointCount',
+  'searcherType',
 ];
 
 export type ColumnDef = SizedGridColumn & {
@@ -266,18 +262,38 @@ export const getColumnDefs = ({
     tooltip: () => undefined,
     width: columnWidths.resourcePool,
   },
+  searcherMetric: {
+    id: 'searcherMetric',
+    isNumerical: false,
+    renderer: (record: ExperimentWithTrial) => {
+      const sMetric = record.experiment.config.searcher.metric;
+      return {
+        allowOverlay: false,
+        data: sMetric,
+        displayData: sMetric,
+        kind: GridCellKind.Text,
+      };
+    },
+    title: 'Searcher Metric',
+    tooltip: () => undefined,
+    width: columnWidths.searcherMetric,
+  },
   searcherMetricValue: {
     id: 'searcherMetricValue',
     isNumerical: true,
-    renderer: (record: ExperimentWithTrial) => ({
-      allowOverlay: false,
-      data:
-        record.experiment.searcherMetricValue !== undefined
-          ? humanReadableNumber(record.experiment.searcherMetricValue)
+    renderer: (record: ExperimentWithTrial) => {
+      const sMetricValue = record.bestTrial?.bestValidationMetric?.metrics?.avgMetrics;
+      return {
+        allowOverlay: false,
+        data: sMetricValue?.toString() || '',
+        displayData: sMetricValue
+          ? typeof sMetricValue === 'number'
+            ? humanReadableNumber(sMetricValue)
+            : sMetricValue
           : '',
-      displayData: String(record.experiment.searcherMetricValue ?? ''),
-      kind: GridCellKind.Text,
-    }),
+        kind: GridCellKind.Text,
+      };
+    },
     title: 'Searcher Metric Values',
     tooltip: () => undefined,
     width: columnWidths.searcherMetricValue,
@@ -468,6 +484,8 @@ export const defaultColumnWidths: Record<ExperimentColumn, number> = {
   numTrials: 50,
   progress: 65,
   resourcePool: 140,
+  searcherMetric: 120,
+  searcherMetricValue: 120,
   searcherType: 120,
   selected: 40,
   startTime: 118,

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -40,7 +40,7 @@ export const experimentColumns = [
   'checkpointCount',
   'checkpointSize',
   'searcherMetric',
-  'searcherMetricValue',
+  'searcherMetricsVal',
 ] as const;
 
 export type ExperimentColumn = (typeof experimentColumns)[number];
@@ -278,8 +278,8 @@ export const getColumnDefs = ({
     tooltip: () => undefined,
     width: columnWidths.searcherMetric,
   },
-  searcherMetricValue: {
-    id: 'searcherMetricValue',
+  searcherMetricsVal: {
+    id: 'searcherMetricsVal',
     isNumerical: true,
     renderer: (record: ExperimentWithTrial) => {
       const sMetric = record.experiment.config.searcher.metric;
@@ -297,7 +297,7 @@ export const getColumnDefs = ({
     },
     title: 'Searcher Metric Values',
     tooltip: () => undefined,
-    width: columnWidths.searcherMetricValue,
+    width: columnWidths.searcherMetricsVal,
   },
   searcherType: {
     id: 'searcherType',
@@ -486,7 +486,7 @@ export const defaultColumnWidths: Record<ExperimentColumn, number> = {
   progress: 65,
   resourcePool: 140,
   searcherMetric: 120,
-  searcherMetricValue: 120,
+  searcherMetricsVal: 120,
   searcherType: 120,
   selected: 40,
   startTime: 118,

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -282,7 +282,8 @@ export const getColumnDefs = ({
     id: 'searcherMetricValue',
     isNumerical: true,
     renderer: (record: ExperimentWithTrial) => {
-      const sMetricValue = record.bestTrial?.bestValidationMetric?.metrics?.avgMetrics;
+      const sMetric = record.experiment.config.searcher.metric;
+      const sMetricValue = record.bestTrial?.bestValidationMetric?.metrics?.[sMetric];
       return {
         allowOverlay: false,
         data: sMetricValue?.toString() || '',


### PR DESCRIPTION
## Description

Changes the default columns on the new experiment table
Includes a server-side change to add searcherMetric and searcherMetricValue to possible columns.

## Test Plan

Visit `/det/projects/1/experiments?f_explist_v2=on` or another project with Glide Table visible.
Click the Columns button, and on the bottom right of the menu click "Reset" to see the new default settings.

- active columns should be: name, start time, user, description, tags, state, duration, searcher type
- click the header for Tags. There is a "Filter by this column" menu option, but no "Sort" option

Open the columns menu again
- Columns menu has **searcher metric and searcher metric value at the end**
- Column order in the menu is id, forked, start time, user, description, tags, state, duration, resource pool, searcher type, progress, trial count, checkpoint count, checkpoint size, searcher metric, searcher metric value
- Check "searcher metric" and "searcher metric value" to show these columns
- Searcher Metric and Searcher Metric Value columns have values in some rows
- Searcher Metric and Searcher Metric Value are currently unsortable, like tags column

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.