### PR TITLE
chore: capabilities options for singularity

### DIFF
--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -312,16 +312,7 @@ func (s *SingularityClient) RunContainer(
 		args = append(args, "--nv")
 	}
 
-	// TODO(DET-9079): It is unlikely we can handle this, but we should do better at documenting.
-	if len(req.HostConfig.CapAdd) != 0 || len(req.HostConfig.CapDrop) != 0 {
-		if err = p.Publish(ctx, docker.NewLogEvent(model.LogLevelWarning, fmt.Sprintf(
-			"cap add or drop was requested but singularity does not support this; "+
-				"will be ignored (cap_add: %+v, cap_drop: %+v)", req.HostConfig.CapAdd,
-			req.HostConfig.CapDrop,
-		))); err != nil {
-			return nil, err
-		}
-	}
+	args = capabilitiesToSingularityArgs(req, args)
 
 	image := cruntimes.CanonicalizeImage(req.ContainerConfig.Image)
 	args = append(args, image)
@@ -393,6 +384,16 @@ func (s *SingularityClient) RunContainer(
 		},
 		ContainerWaiter: s.waitOnContainer(cproto.ID(id), cont, p),
 	}, nil
+}
+
+func capabilitiesToSingularityArgs(req cproto.RunSpec, args []string) []string {
+	if len(req.HostConfig.CapAdd) > 0 {
+		args = append(args, "--add-caps", strings.Join(req.HostConfig.CapAdd, ","))
+	}
+	if len(req.HostConfig.CapDrop) > 0 {
+		args = append(args, "--drop-caps", strings.Join(req.HostConfig.CapDrop, ","))
+	}
+	return args
 }
 
 func addEnvironmentValueIfSet(variables []string, cmd *exec.Cmd) {


### PR DESCRIPTION
## Description

Forward any capabilities configuration from the experiment to the singularity command line.


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
To the experiment configuration, add this:

```
environment:
  add_capabilities:
    - add_one
    - add_two
  drop_capabilities:
    - drop_one
    - drop_two

```
In the experiment log, observe:
```
2023-06-06 17:22:11]
[659bd6a1] singularity run \ 	--writable-tmpfs \
	--pwd /run/determined/workdir \
 	--env-file /tmp/determined-gaisford-node002/1346786491-659bd6a1-2232-4568-809c-d545ffe26372/envfile \
	--bind /tmp/determined-gaisford-node002/1346786491-659bd6a1-2232-4568-809c-d545ffe26372/archives/etc/ssh/ssh_config:/etc/ssh/ssh_config \
 	--bind /tmp/determined-gaisford-node002/1346786491-659bd6a1-2232-4568-809c-d545ffe26372/archives/opt/determined:/opt/determined \
	--bind /tmp/determined-gaisford-node002/1346786491-659bd6a1-2232-4568-809c-d545ffe26372/archives/run/determined:/run/determined \
 	--bind /tmp/determined-cp:/determined_shared_fs \
	--add-caps add_one,add_two \
 	--drop-caps drop_one,drop_two docker://determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-6eceaca /run/determined/singularity-entrypoint-wrapper.sh /run/determined/train/entrypoint.sh
<info> [2023-06-06 17:22:11] [659bd6a1] Resources for Trial 1923 (Experiment 226) have started
<info> [2023-06-06 17:22:14] [659bd6a1] Using cached SIF image
<info> [2023-06-06 17:22:14] [659bd6a1] WARNING: DEPRECATED USAGE: Environment variable SINGULARITYENV_CUDA_VISIBLE_DEVICES will not be supported in the future, use APPTAINERENV_CUDA_VISIBLE_DEVICES instead
<info> [2023-06-06 17:22:14] [659bd6a1] WARNING: Overriding HOME environment variable with APPTAINERENV_HOME is not permitted
<info> [2023-06-06 17:22:14] [659bd6a1] WARNING: won't add unknown capability: CAP_ADD_ONE,CAP_ADD_TWO
<info> [2023-06-06 17:22:14] [659bd6a1] WARNING: won't drop unknown capability: CAP_DROP_ONE,CAP_DROP_TWO

```
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
