### PR TITLE
fix: Prevent re-renders on glide table

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -404,6 +404,16 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     );
   }, [experiments, selectedExperimentIds]);
 
+  const columnsIfLoaded = useMemo(
+    () => (isLoadingSettings ? [] : settings.columns),
+    [isLoadingSettings, settings.columns],
+  );
+
+  const experimentsIfLoaded = useMemo(
+    () => (isLoading ? [NotLoaded] : experiments),
+    [isLoading, experiments],
+  );
+
   return (
     <>
       <TableActionBar
@@ -413,7 +423,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         filters={experimentFilters}
         formStore={formStore}
         handleUpdateExperimentList={handleUpdateExperimentList}
-        initialVisibleColumns={isLoadingSettings ? [] : settings.columns}
+        initialVisibleColumns={columnsIfLoaded}
         isOpenFilter={isOpenFilter}
         project={project}
         projectColumns={projectColumns}
@@ -447,7 +457,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               <GlideTable
                 clearSelectionTrigger={clearSelectionTrigger}
                 colorMap={colorMap}
-                data={isLoading || isLoadingSettings ? [NotLoaded] : experiments}
+                data={experimentsIfLoaded}
                 dataTotal={
                   globalSettings.expListView === 'scroll'
                     ? Loadable.getOrElse(0, total)
@@ -472,7 +482,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
                 setSelectAll={setSelectAll}
                 setSelectedExperimentIds={setSelectedExperimentIds}
                 setSortableColumnIds={setVisibleColumns}
-                sortableColumnIds={isLoadingSettings ? [] : settings.columns}
+                sortableColumnIds={columnsIfLoaded}
                 sorts={sorts}
                 onContextMenuComplete={onContextMenuComplete}
                 onIsOpenFilterChange={onIsOpenFilterChange}


### PR DESCRIPTION
## Description

Memo-ize loading state introduced in #7010 and with new behavior in #7026 

Prevents multiple re-renders by creating `[]` or `[NotLoaded]` only once

Comment: we typically use a name like `loadableExperiments` to represent `Loadable<Experiment[]>` type, with `Loadable` as the outer wrapper, so it would not fit a `Loadable<Experiment>[]` type.  I went with `experimentsIfLoaded` for the name of memo-ized variable.

## Test Plan

Visit `/projects/107/experiments?f_explist_v2=on` or similar glide table page to see rows and column names load successfully.

Use console.log or React DevTools - Profiler to check for excessive re-renders

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.