### PR TITLE
fix: Chart regression in detecting single point cluster chart

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -44,6 +44,20 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
 
     return data;
   }, [hoursByLabel, hoursTotal, time]);
+
+  const hasData = useMemo(() => {
+    return Object.keys(hoursByLabel).reduce(
+      (agg, label) => agg || hoursByLabel[label].length > 0,
+      false,
+    );
+  }, [hoursByLabel]);
+
+  const singlePoint = useMemo(
+    // one series, and that one series has one point
+    () => Object.keys(hoursByLabel).length === 1 && Object.values(hoursByLabel)[0].length === 1,
+    [hoursByLabel],
+  );
+
   const chartOptions: Options = useMemo(() => {
     let dateFormat = 'MM-DD';
     let timeSeries: Series = { label: 'Day', value: '{YYYY}-{MM}-{DD}' };
@@ -68,10 +82,6 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
         width: 2,
       });
     });
-
-    const singlePoint =
-      Object.keys(hoursByLabel).length + (hoursTotal?.length || 0) <= 1 &&
-      !((hoursByLabel.total?.length || 0) > 1);
 
     return {
       axes: [
@@ -108,13 +118,7 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
       series,
       tzDate: (ts) => uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'),
     };
-  }, [groupBy, height, hoursByLabel, hoursTotal, label, chartKey]);
-  const hasData = useMemo(() => {
-    return Object.keys(hoursByLabel).reduce(
-      (agg, label) => agg || hoursByLabel[label].length > 0,
-      false,
-    );
-  }, [hoursByLabel]);
+  }, [groupBy, height, hoursByLabel, hoursTotal, label, chartKey, singlePoint]);
 
   if (!hasData) {
     return <Message title="No data to plot." type={MessageType.Empty} />;

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -68,7 +68,10 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
         width: 2,
       });
     });
-    const singlePoint = Object.keys(hoursByLabel).length + (hoursTotal?.length || 0) <= 1;
+
+    const singlePoint =
+      Object.keys(hoursByLabel).length + (hoursTotal?.length || 0) <= 1 &&
+      !((hoursByLabel.total?.length || 0) > 1);
 
     return {
       axes: [


### PR DESCRIPTION
## Description

Fixes an issue introduced in #6737 which was displaying the historical usage compute chart in single-point form (x axis forming calendar year)

New version accurately displays single and multi-day on this chart

## Test Plan

- View `/det/clusters/historical-usage`; chart x-axis should match a few days of data

<img width="1156" alt="Screen Shot 2023-06-07 at 10 12 56 AM" src="https://github.com/determined-ai/determined/assets/643918/217c5ac0-1211-4c57-896d-edb642737355">

- Single-point mode selected when there is only one point in total. To demo this, I replaced the section in `src/pages/Cluster/ClusterHistoricalUsage` with

```
<Section bodyBorder loading={!chartSeries} title="Compute Hours Allocated">
  {chartSeries && (
    <ClusterHistoricalUsageChart
      groupBy={chartSeries.groupedBy}
      hoursByLabel={{total: [chartSeries.hoursTotal.total[0]] }}
      time={[chartSeries.time[0]]}
    />
  )}
</Section>
``` 

<img width="625" alt="Screen Shot 2023-06-07 at 10 15 42 AM" src="https://github.com/determined-ai/determined/assets/643918/83994668-7c9c-4a74-ab52-73c6d17b7e91">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.