### PR TITLE
chore: account for paths passed in for DET_MASTER

### DIFF
--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -29,7 +29,10 @@ def parse_master_address(master_address: str) -> parse.ParseResult:
 
 def make_url(master_address: str, suffix: str) -> str:
     parsed = parse_master_address(master_address)
-    return parse.urljoin(parsed.geturl(), suffix)
+    master_url = parsed.geturl().rstrip("/")
+    suffix = suffix.lstrip("/")
+    separator = "/" if suffix or master_address.endswith("/") else ""
+    return "{}{}{}".format(master_url, separator, suffix)
 
 
 def maybe_upgrade_ws_scheme(master_address: str) -> str:

--- a/harness/tests/common/test_api.py
+++ b/harness/tests/common/test_api.py
@@ -1,15 +1,16 @@
-from typing import NamedTuple
+from typing import List, NamedTuple
 
 import pytest
 
 from determined.common.api import request
 
+Case = NamedTuple("Case", [("base", str), ("path", str), ("expected", str)])
 
-def gen_make_url_cases():
-    Case = NamedTuple("Case", [("base", str), ("path", str), ("expected", str)])
+
+def gen_make_url_cases() -> List[Case]:
     host = "http://localhost:8080"
     path = "api/v1/experiments"
-    cases = [
+    cases: List[Case] = [
         Case("http://localhost:8080/", "", f"{host}/"),
         Case("http://localhost:8080", "", f"{host}"),
         Case("http://localhost:8080", "/api/v1/experiments", f"{host}/{path}"),
@@ -27,5 +28,5 @@ def gen_make_url_cases():
 
 
 @pytest.mark.parametrize("base, path, expected", gen_make_url_cases())
-def test_make_url(base: str, path: str, expected: str):
+def test_make_url(base: str, path: str, expected: str) -> None:
     assert request.make_url(base, path) == expected, f"base: {base}, path: {path}"

--- a/harness/tests/common/test_api.py
+++ b/harness/tests/common/test_api.py
@@ -1,0 +1,26 @@
+from typing import NamedTuple
+
+from determined.common.api import request
+
+
+def test_make_url():
+    Case = NamedTuple("Case", [("base", str), ("path", str), ("expected", str)])
+    host = "http://localhost:8080"
+    path = "api/v1/experiments"
+    cases = [
+        Case("http://localhost:8080/", "", f"{host}/"),
+        Case("http://localhost:8080", "", f"{host}"),
+        Case("http://localhost:8080", "/api/v1/experiments", f"{host}/{path}"),
+        Case("http://localhost:8080", "api/v1/experiments/", f"{host}/{path}/"),
+        Case("http://localhost:8080/", "/api/v1/experiments", f"{host}/{path}"),
+        Case("http://localhost:8080/", "api/v1/experiments/", f"{host}/{path}/"),
+        # Case("http://localhost:8080/proxied", "/api/v1/experiments", f"{host}/proxied/{path}"),
+        # Case("http://localhost:8080/proxied/", "/api/v1/experiments", f"{host}/proxied/{path}"),
+        # Case("http://localhost:8080/proxied/", "/api/v1/experiments/", f"{host}/proxied/{path}/"),
+        # Case("http://localhost:8080/proxied", "", f"{host}/proxied"),
+        # Case("http://localhost:8080/proxied/", "", f"{host}/proxied"),
+    ]
+
+    for idx, case in enumerate(cases):
+        base, path, expected = case
+        assert request.make_url(base, path) == expected, f"{idx}  {case}"

--- a/harness/tests/common/test_api.py
+++ b/harness/tests/common/test_api.py
@@ -14,11 +14,12 @@ def test_make_url():
         Case("http://localhost:8080", "api/v1/experiments/", f"{host}/{path}/"),
         Case("http://localhost:8080/", "/api/v1/experiments", f"{host}/{path}"),
         Case("http://localhost:8080/", "api/v1/experiments/", f"{host}/{path}/"),
-        # Case("http://localhost:8080/proxied", "/api/v1/experiments", f"{host}/proxied/{path}"),
-        # Case("http://localhost:8080/proxied/", "/api/v1/experiments", f"{host}/proxied/{path}"),
-        # Case("http://localhost:8080/proxied/", "/api/v1/experiments/", f"{host}/proxied/{path}/"),
-        # Case("http://localhost:8080/proxied", "", f"{host}/proxied"),
-        # Case("http://localhost:8080/proxied/", "", f"{host}/proxied"),
+        Case("http://localhost:8080/proxied/", "", f"{host}/proxied/"),
+        Case("http://localhost:8080/proxied", "", f"{host}/proxied"),
+        Case("http://localhost:8080/proxied", "/api/v1/experiments", f"{host}/proxied/{path}"),
+        Case("http://localhost:8080/proxied", "api/v1/experiments/", f"{host}/proxied/{path}/"),
+        Case("http://localhost:8080/proxied/", "/api/v1/experiments", f"{host}/proxied/{path}"),
+        Case("http://localhost:8080/proxied/", "api/v1/experiments/", f"{host}/proxied/{path}/"),
     ]
 
     for idx, case in enumerate(cases):

--- a/harness/tests/common/test_api.py
+++ b/harness/tests/common/test_api.py
@@ -1,9 +1,11 @@
 from typing import NamedTuple
 
+import pytest
+
 from determined.common.api import request
 
 
-def test_make_url():
+def gen_make_url_cases():
     Case = NamedTuple("Case", [("base", str), ("path", str), ("expected", str)])
     host = "http://localhost:8080"
     path = "api/v1/experiments"
@@ -21,7 +23,9 @@ def test_make_url():
         Case("http://localhost:8080/proxied/", "/api/v1/experiments", f"{host}/proxied/{path}"),
         Case("http://localhost:8080/proxied/", "api/v1/experiments/", f"{host}/proxied/{path}/"),
     ]
+    return cases
 
-    for idx, case in enumerate(cases):
-        base, path, expected = case
-        assert request.make_url(base, path) == expected, f"{idx}  {case}"
+
+@pytest.mark.parametrize("base, path, expected", gen_make_url_cases())
+def test_make_url(base: str, path: str, expected: str):
+    assert request.make_url(base, path) == expected, f"base: {base}, path: {path}"


### PR DESCRIPTION
## Description

fix an issue with make_url that ignored paths given in through master_addres
allow for paths passed in as part of master url to `make_url` util

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
