### PR TITLE
docs: Fix a typo in a release note

### DIFF
--- a/docs/release-notes/rbac-not-found-errs.rst
+++ b/docs/release-notes/rbac-not-found-errs.rst
@@ -2,7 +2,7 @@
 
 **Improvements**
 
--  Errors: Errors that return 404 or 'Not Found' codes are now standardized in their messageas
-   "<task/trial/workspace etc.> <ID> not found". Additionally, when RBAC is enabled, the errors add
-   a suffix to remind users to check their permissions, since, with RBAC, permission denied errors &
-   not found errors would both return as 'Not Found'.
+-  Errors: Errors that return 404 or 'Not Found' codes now have standardized messaging using the
+   format "<task/trial/workspace etc.> <ID> not found". In addition, if RBAC is enabled, the error
+   message includes a suffix to remind users to check their permissions. This is because with RBAC
+   enabled, permission denied errors & not found errors would both return a 'Not Found' response.


### PR DESCRIPTION
Rewriting the release note and fixing a spelling error.
