### PR TITLE
docs: Provide user docs for manage-enroot-cache

### DIFF
--- a/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
@@ -11,8 +11,10 @@ and then reference them using file system paths instead of Docker registry refer
 There are two mechanisms you can use to reference cached container images depending upon the
 container runtime in use.
 
-   -  :ref:`referencing-local-image-paths`
-   -  :ref:`singularity-image-cache`
+-  :ref:`referencing-local-image-paths`
+-  :ref:`singularity-image-cache`
+-  :ref:`manage-singularity-cache`
+-  :ref:`manage-enroot-cache`
 
 ***********************
  Default Docker Images
@@ -48,32 +50,32 @@ directory needs to be accessible on all compute nodes.
 When using Podman, you could save images in OCI archive format to files in a local directory
 ``/shared/containers``
 
-   .. code:: bash
+.. code:: bash
 
-      podman save determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730 \
-        --format=oci-archive \
-        -o /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu
+   podman save determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730 \
+      --format=oci-archive \
+      -o /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu
 
 and then reference the image in your experiment configuration using the syntax below.
 
-   .. code:: yaml
+.. code:: yaml
 
-      environment:
-         image: oci-archive:/shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu
+   environment:
+      image: oci-archive:/shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu
 
 When using Singularity, you could save SIF files in a local directory ``/shared/containers``
 
-   .. code:: bash
+.. code:: bash
 
-      singularity pull /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu \
-         determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730
+   singularity pull /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu \
+      determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730
 
 and then reference in your experiment configuration using a full path using the syntax below.
 
-   .. code:: yaml
+.. code:: yaml
 
-      environment:
-         image: /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu.sif
+   environment:
+      image: /shared/containers/cuda-11.3-pytorch-1.10-tf-2.8-gpu.sif
 
 Set these ``image`` file references above as the default for all jobs by specifying them in the
 :ref:`task_container_defaults <master-task-container-defaults>` section of the
@@ -144,41 +146,85 @@ and permissions of content added to the cache. Adding container images to the Si
 cache avoids the overhead of downloading the images and allows for sharing of images between
 multiple users. It provides the following features:
 
-   -  Download the Determined default cuda, cpu, or rocm environment images
-   -  Download an arbitrary Docker image reference
-   -  Copy a local Singularity image file into the cache
-   -  List the currently available images in the cache
+-  Download the Determined default cuda, cpu, or rocm environment images
+-  Download an arbitrary Docker image reference
+-  Copy a local Singularity image file into the cache
+-  List the currently available images in the cache
 
 If your system has internet access, you can download images directly into the cache. Use the
 ``--cuda``, ``--cpu``, or ``--rocm`` options to download the current default CUDA, CPU, or ROCM
 environment container image into the cache. For example, to download the default CUDA container
 image, use the following command:
 
-   .. code:: bash
+.. code:: bash
 
-      manage-singularity-cache --cuda
+   manage-singularity-cache --cuda
 
 If your system has internet access, you can download any desired Docker container image (e.g.
 ``determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730``) into the cache using the
 command:
 
-   .. code:: bash
+.. code:: bash
 
-      manage-singularity-cache determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
+   manage-singularity-cache determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
 
 Otherwise, from an internet-connected system, download the desired image using the Singularity
 ``pull`` command, then copy it to a system with access to the ``singularity_image_root`` folder. You
 can then add the image to the cache by specifying the local file name using ``-i`` and the Docker
 image reference which determines the name to be added to the cache.
 
-   .. code:: bash
+.. code:: bash
 
-      manage-singularity-cache -i localfile.sif determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
+   manage-singularity-cache -i localfile.sif determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
 
 You can view the current set of Docker image names in the cache with the ``-l`` option.
 
-   .. code:: bash
+.. code:: bash
 
-      manage-singularity-cache -l
-      determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
-      determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730
+   manage-singularity-cache -l
+   determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-096d730
+   determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-096d730
+
+.. _manage-enroot-cache:
+
+**********************************************************************
+ Managing the Enroot Image Cache using the manage-enroot-cache script
+**********************************************************************
+
+This script, ``/usr/bin/manage-enroot-cache``, simplifies the management of a set of shared Enroot
+.sqsh file downloads and then creates an Enroot container for use by the current user. It provides
+the following features:
+
+-  Download the Determined default cuda, cpu, or rocm environment images
+-  Download an arbitrary Docker image reference
+-  Share a directory of re-usable imported .sqsh files
+-  Create a per-user container from a shared .sqsh file
+-  List the currently available images in the shared .sqsh file cache
+
+When using ``manage-enroot-cache`` you must provide a temporary directory via the ``-s`` option
+which is used to download (enroot import) the associated enroot .sqsh file. The .sqsh file is read
+by the ``enroot create`` command to generate the container. The directory need only be accessible on
+the local host. If the directory you specify is shared with other users, the script will re-use any
+downloaded .sqsh files and directly ``enroot create`` an enroot container without needing a separate
+download.
+
+Download the shared cache .sqsh file for the current default Determined CUDA and CPU images (enroot
+import), and then create the associated containers from them for the current user (``enroot
+create``) use the following command:
+
+.. code:: bash
+
+   manage-enroot-cache -s /shared/enroot --cuda --cpu
+
+Download the shared cache .sqsh file for an arbitrary docker image (enroot import), and then create
+a container from it for the current user (``enroot create``) use the following command:
+
+.. code:: bash
+
+   manage-enroot-cache -s /shared/enroot determinedai/environments:cuda-10.2-base-gpu-mpi-0.19.4
+
+You can view the current set of Docker image names in the cache with the ``-l`` option.
+
+.. code:: bash
+
+   manage-enroot-cache -s /shared/enroot -l

--- a/docs/setup-cluster/deploy-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/deploy-cluster/slurm/slurm-requirements.rst
@@ -394,3 +394,6 @@ platform. There may be additional per-user configuration that is required.
 
 #. The Enroot container storage directory for the user ``${ENROOT_CACHE_PATH}`` (which defaults to
    ``$HOME/.local/share/enroot``) must be accessible on all compute nodes.
+
+#. A convenience script, ``/usr/bin/manage-enroot-cache``, is provided by the HPC launcher
+   installation to simplify the :ref:`management of enroot images <manage-enroot-cache>`.


### PR DESCRIPTION
## Description

Add user docs for manage-enroot-cache

![image](https://github.com/determined-ai/determined/assets/107056780/6364a7c0-1ee4-4fe1-95f5-d4b42718be6d)



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
