### PR TITLE
fix: allow creating a user with original username of a renamed user

### DIFF
--- a/docs/release-notes/username-cant-make-same-user.rst
+++ b/docs/release-notes/username-cant-make-same-user.rst
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Users: Fix a bug where if a user is renamed an error was returned trying to create a user with the original username of the renamed user.
+-  Users: Fix a bug where if a user is renamed an error was returned trying to create a user with
+   the original username of the renamed user.

--- a/docs/release-notes/username-cant-make-same-user.rst
+++ b/docs/release-notes/username-cant-make-same-user.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Users: Fix a bug where if a user is renamed an error was returned trying to create a user with the original username of the renamed user.

--- a/master/internal/db/postgres_users.go
+++ b/master/internal/db/postgres_users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jackc/pgconn"
@@ -90,16 +91,16 @@ const PersonalGroupPostfix = "DeterminedPersonalGroup"
 
 func addUserPersonalGroup(tx *sqlx.Tx, userID model.UserID) error {
 	query := `
-INSERT INTO groups(group_name, user_id) 
-SELECT username || $2 AS group_name, id AS user_id FROM users 
-WHERE id = $1`
-	if _, err := tx.Exec(query, userID, PersonalGroupPostfix); err != nil {
+INSERT INTO groups(group_name, user_id)
+SELECT $1 || $3 AS group_name, id AS user_id FROM users
+WHERE id = $2`
+	if _, err := tx.Exec(query, strconv.Itoa(int(userID)), userID, PersonalGroupPostfix); err != nil {
 		return errors.WithStack(err)
 	}
 
 	query = `
 INSERT INTO user_group_membership(user_id, group_id)
-SELECT user_id AS user_id, id AS group_id FROM groups 
+SELECT user_id AS user_id, id AS group_id FROM groups
 WHERE user_id = $1`
 	if _, err := tx.Exec(query, userID); err != nil {
 		return errors.WithStack(err)

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	"github.com/o1egl/paseto"
@@ -83,7 +84,7 @@ func AddUserExec(user *model.User) error {
 		Name    string       `bun:"group_name,notnull"  json:"name"`
 		OwnerID model.UserID `bun:"user_id,nullzero"    json:"userId,omitempty"`
 	}{
-		Name:    user.Username + db.PersonalGroupPostfix,
+		Name:    fmt.Sprintf("%d%s", user.ID, db.PersonalGroupPostfix),
 		OwnerID: user.ID,
 	}
 	if _, err = tx.NewInsert().Model(&personalGroup).Exec(ctx); err != nil {

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -73,7 +73,7 @@ func TestAddUserExec(t *testing.T) {
 		Name          string `bun:"group_name,notnull"  json:"name"`
 	}{}
 	require.NoError(t, db.Bun().NewSelect().Model(actualGroup).Where("user_id = ?", u.ID).Scan(ctx))
-	require.Equal(t, fmt.Sprintf("%d%s", u.Id, db.PersonalGroupPostfix), actualGroup.Name)
+	require.Equal(t, fmt.Sprintf("%d%s", u.ID, db.PersonalGroupPostfix), actualGroup.Name)
 
 	groupMember := &struct {
 		bun.BaseModel `bun:"table:user_group_membership"`

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -73,7 +73,7 @@ func TestAddUserExec(t *testing.T) {
 		Name          string `bun:"group_name,notnull"  json:"name"`
 	}{}
 	require.NoError(t, db.Bun().NewSelect().Model(actualGroup).Where("user_id = ?", u.ID).Scan(ctx))
-	require.Equal(t, u.Username+db.PersonalGroupPostfix, actualGroup.Name)
+	require.Equal(t, fmt.Sprintf("%d%s", u.Id, db.PersonalGroupPostfix), actualGroup.Name)
 
 	groupMember := &struct {
 		bun.BaseModel `bun:"table:user_group_membership"`

--- a/master/static/migrations/20230612120719_rename-new-username-fix.tx.down.sql
+++ b/master/static/migrations/20230612120719_rename-new-username-fix.tx.down.sql
@@ -1,0 +1,5 @@
+UPDATE public.groups
+  SET group_name = users.username || 'DeterminedPersonalGroup'
+  FROM public.users
+  WHERE public.groups.user_id = public.users.id
+  AND public.groups.user_id IS NOT NULL;

--- a/master/static/migrations/20230612120719_rename-new-username-fix.tx.up.sql
+++ b/master/static/migrations/20230612120719_rename-new-username-fix.tx.up.sql
@@ -1,0 +1,3 @@
+UPDATE public.groups
+  SET group_name = user_id || 'DeterminedPersonalGroup'
+  WHERE user_id IS NOT NULL;


### PR DESCRIPTION
## Description

Bug where we couldn't create a user with the same name as a previously renamed user.


## Test Plan

```
det -u admin user create testoriginal
det -u admin user rename testoriginal testnew
det -u admin user create testoriginal # should not fail
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
