### PR TITLE
fix: Glide Table comparison view no data error; loading saved filters issue

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterForm.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterForm.tsx
@@ -27,12 +27,12 @@ const FilterForm = ({ formStore, columns, onHidePopOver }: Props): JSX.Element =
   });
 
   const onAddItem = (formKind: FormKind) => {
-    const data = Loadable.getOrElse(null, loadableData);
-    if (!data) return;
-    formStore.addChild(data.filterGroup.id, formKind);
-    setTimeout(() => {
-      scrollBottomRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-    }, 100);
+    Loadable.forEach(loadableData, (data) => {
+      formStore.addChild(data.filterGroup.id, formKind);
+      setTimeout(() => {
+        scrollBottomRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      }, 100);
+    });
   };
 
   return (

--- a/webui/react/src/components/FilterForm/components/FilterForm.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterForm.tsx
@@ -7,6 +7,7 @@ import { FormKind } from 'components/FilterForm/components/type';
 import Button from 'components/kit/Button';
 import Toggle from 'components/kit/Toggle';
 import { V1ProjectColumn } from 'services/api-ts-sdk';
+import { Loadable } from 'utils/loadable';
 
 import css from './FilterForm.module.scss';
 
@@ -18,15 +19,19 @@ interface Props {
 
 const FilterForm = ({ formStore, columns, onHidePopOver }: Props): JSX.Element => {
   const scrollBottomRef = useRef<HTMLDivElement>(null);
-  const data = useObservable(formStore.formset);
-  const isButtonDisabled = data.filterGroup.children.length > ITEM_LIMIT;
+  const loadableData = useObservable(formStore.formset);
+  const data = Loadable.getOrElse(null, loadableData);
+  const isButtonDisabled = (data?.filterGroup?.children?.length ?? -1) > ITEM_LIMIT;
 
   const onAddItem = (formKind: FormKind) => {
+    if (!data) return;
     formStore.addChild(data.filterGroup.id, formKind);
     setTimeout(() => {
       scrollBottomRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }, 100);
   };
+
+  if (!data) return <div className={css.base} />;
 
   return (
     <div className={css.base}>

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
@@ -120,7 +120,7 @@ describe('FilterFormStore', () => {
       filterFormStore.init();
       const loadableFormset = filterFormStore.formset.get();
 
-      const jsonWithId = Loadable.getOrElse({}, loadableFormset);
+      const jsonWithId = Loadable.getOrElse(null, loadableFormset);
       expect(jsonWithId).toStrictEqual({
         filterGroup: {
           children: [],
@@ -194,7 +194,6 @@ describe('FilterFormStore', () => {
 
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
@@ -243,7 +242,6 @@ describe('FilterFormStore', () => {
 
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
@@ -263,7 +261,6 @@ describe('FilterFormStore', () => {
         if (group?.kind === FormKind.Group) {
           filterFormStore.addChild(group.id, FormKind.Group);
 
-          loadableFormset = filterFormStore.formset.get();
           formset = Loadable.getOrElse(null, loadableFormset);
           expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
             filterGroup: {
@@ -319,7 +316,6 @@ describe('FilterFormStore', () => {
           filterFormStore.addChild(group.id, FormKind.Field);
           filterFormStore.addChild(group.id, FormKind.Group);
 
-          loadableFormset = filterFormStore.formset.get();
           formset = Loadable.getOrElse(null, loadableFormset);
           expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
             filterGroup: {
@@ -388,7 +384,6 @@ describe('FilterFormStore', () => {
           filterFormStore.removeChild(groupId);
         }
 
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual(EMPTY_DATA);
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
@@ -486,11 +481,9 @@ describe('FilterFormStore', () => {
         expect(fields[2].id).toBe(ID);
         // move index2 to index0
         filterFormStore.removeChild(fields[2].id);
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(formset?.filterGroup?.children).toHaveLength(2);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 0, item: item });
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(formset?.filterGroup?.children).toHaveLength(3);
         expect(formset?.filterGroup?.children?.[0]?.id).toBe(ID);
@@ -514,16 +507,13 @@ describe('FilterFormStore', () => {
 
         // move index2 to index0
         filterFormStore.removeChild(ID);
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         expect(formset?.filterGroup?.children).toHaveLength(1);
 
         filterFormStore.addChild(fields?.[0]?.id ?? '', FormKind.Field, { index: 0, item: item });
-        loadableFormset = filterFormStore.formset.get();
         formset = Loadable.getOrElse(null, loadableFormset);
         const group = formset?.filterGroup?.children?.[0];
         if (group && group.kind === FormKind.Group) {
-          loadableFormset = filterFormStore.formset.get();
           formset = Loadable.getOrElse(null, loadableFormset);
           expect(formset?.filterGroup?.children).toHaveLength(1);
           expect(group.children).toHaveLength(1);

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
@@ -171,7 +171,7 @@ describe('FilterFormStore', () => {
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
 
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
@@ -229,7 +229,7 @@ describe('FilterFormStore', () => {
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
@@ -286,7 +286,7 @@ describe('FilterFormStore', () => {
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
         expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
@@ -377,7 +377,7 @@ describe('FilterFormStore', () => {
         const filterFormStore = new FilterFormStore();
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
         const groupId = formset?.filterGroup?.children?.[0]?.id;
         if (groupId) {
@@ -474,7 +474,7 @@ describe('FilterFormStore', () => {
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 2, item: item });
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
         const fields = formset?.filterGroup?.children ?? [];
         expect(fields).toHaveLength(3);
@@ -499,7 +499,7 @@ describe('FilterFormStore', () => {
 
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 2, item: item });
-        let loadableFormset = filterFormStore.formset.get();
+        const loadableFormset = filterFormStore.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
         const fields = formset?.filterGroup?.children;
         expect(fields).toHaveLength(2);

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
@@ -4,11 +4,11 @@ import {
   FilterFormSet,
   FilterFormSetWithoutId,
   FormField,
-  FormGroup,
   FormKind,
   Operator,
 } from 'components/FilterForm/components/type';
 import { V1ColumnType, V1LocationType, V1ProjectColumn } from 'services/api-ts-sdk';
+import { Loadable, NotLoaded } from 'utils/loadable';
 
 // Remove `id` property from object
 const jsonReplacer = (key: string, value: unknown): unknown => {
@@ -110,11 +110,17 @@ const initData: Readonly<FilterFormSet> = {
 
 describe('FilterFormStore', () => {
   describe('Init', () => {
-    it('should initialize store without init data', () => {
+    it('should initialize store as NotLoaded', () => {
       const filterFormStore = new FilterFormStore();
-      const jsonWithId = filterFormStore.formset.get();
-      const asJsonString = filterFormStore.asJsonString.get();
+      expect(filterFormStore.formset.get()).toEqual(NotLoaded);
+    });
 
+    it('should have an empty init() fill with default values', () => {
+      const filterFormStore = new FilterFormStore();
+      filterFormStore.init();
+      const loadableFormset = filterFormStore.formset.get();
+
+      const jsonWithId = Loadable.getOrElse({}, loadableFormset);
       expect(jsonWithId).toStrictEqual({
         filterGroup: {
           children: [],
@@ -124,6 +130,8 @@ describe('FilterFormStore', () => {
         },
         showArchived: false,
       });
+
+      const asJsonString = filterFormStore.asJsonString.get();
       expect(asJsonString).toStrictEqual(JSON.stringify(EMPTY_DATA));
 
       expect(filterFormStore.fieldCount.get()).toBe(0);
@@ -133,7 +141,9 @@ describe('FilterFormStore', () => {
       const filterFormStore = new FilterFormStore();
       filterFormStore.init(initData);
 
-      expect(filterFormStore.formset.get()).toStrictEqual(initData);
+      const loadableFormset = filterFormStore.formset.get();
+      const formset = Loadable.getOrElse(null, loadableFormset);
+      expect(formset).toStrictEqual(initData);
       expect(filterFormStore.fieldCount.get()).toBe(6);
     });
 
@@ -158,11 +168,13 @@ describe('FilterFormStore', () => {
 
       it('should add new fields', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual({
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
             children: [
               {
@@ -182,9 +194,9 @@ describe('FilterFormStore', () => {
 
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual({
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
             children: [
               {
@@ -215,11 +227,12 @@ describe('FilterFormStore', () => {
 
       it('should add new groups', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual({
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
             children: [{ children: [], conjunction: Conjunction.And, kind: FormKind.Group }],
             conjunction: Conjunction.And,
@@ -230,9 +243,9 @@ describe('FilterFormStore', () => {
 
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual({
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
             children: [
               { children: [], conjunction: Conjunction.And, kind: FormKind.Group },
@@ -244,14 +257,15 @@ describe('FilterFormStore', () => {
           showArchived: false,
         });
 
-        const jsonWithId = filterFormStore.formset.get();
-        const group = jsonWithId.filterGroup.children[1];
-        if (group.kind === FormKind.Group) {
+        const loadableJsonWithId = filterFormStore.formset.get();
+        const jsonWithId = Loadable.getOrElse(null, loadableJsonWithId);
+        const group = jsonWithId?.filterGroup?.children?.[1];
+        if (group?.kind === FormKind.Group) {
           filterFormStore.addChild(group.id, FormKind.Group);
 
-          expect(
-            JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-          ).toStrictEqual({
+          loadableFormset = filterFormStore.formset.get();
+          formset = Loadable.getOrElse(null, loadableFormset);
+          expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
             filterGroup: {
               children: [
                 { children: [], conjunction: Conjunction.And, kind: FormKind.Group },
@@ -271,12 +285,13 @@ describe('FilterFormStore', () => {
 
       it('should add new fields/group comprehensively', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual({
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
           filterGroup: {
             children: [
               { children: [], conjunction: Conjunction.And, kind: FormKind.Group },
@@ -297,15 +312,16 @@ describe('FilterFormStore', () => {
 
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
 
-        const jsonWithId = filterFormStore.formset.get();
-        const group = jsonWithId.filterGroup.children[1];
-        if (group.kind === FormKind.Group) {
+        const loadableJsonWithId = filterFormStore.formset.get();
+        const jsonWithId = Loadable.getOrElse(null, loadableJsonWithId);
+        const group = jsonWithId?.filterGroup?.children?.[1];
+        if (group?.kind === FormKind.Group) {
           filterFormStore.addChild(group.id, FormKind.Field);
           filterFormStore.addChild(group.id, FormKind.Group);
 
-          expect(
-            JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-          ).toStrictEqual({
+          loadableFormset = filterFormStore.formset.get();
+          formset = Loadable.getOrElse(null, loadableFormset);
+          expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual({
             filterGroup: {
               children: [
                 {
@@ -344,33 +360,48 @@ describe('FilterFormStore', () => {
 
       it('should remove field', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
-        const json = filterFormStore.formset.get();
-        expect(json.filterGroup.children.length).toBe(4);
-        const thirdFieldId = json.filterGroup.children[2].id;
-        filterFormStore.removeChild(thirdFieldId);
-        expect(filterFormStore.formset.get().filterGroup.children).not.toContain(thirdFieldId);
+        const loadableJson = filterFormStore.formset.get();
+        const json = Loadable.getOrElse(null, loadableJson);
+        expect(json?.filterGroup?.children?.length).toBe(4);
+        const thirdFieldId = json?.filterGroup?.children?.[2]?.id;
+        if (thirdFieldId) {
+          filterFormStore.removeChild(thirdFieldId);
+        }
+        const loadableFormset = filterFormStore.formset.get();
+        const formSet = Loadable.getOrElse(null, loadableFormset);
+        expect(formSet?.filterGroup?.children).not.toContain(thirdFieldId);
       });
 
       it('should remove empty group', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
-        const groupId = filterFormStore.formset.get().filterGroup.children[0].id;
-        filterFormStore.removeChild(groupId);
-        expect(
-          JSON.parse(JSON.stringify(filterFormStore.formset.get(), jsonReplacer)),
-        ).toStrictEqual(EMPTY_DATA);
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        const groupId = formset?.filterGroup?.children?.[0]?.id;
+        if (groupId) {
+          filterFormStore.removeChild(groupId);
+        }
+
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(JSON.parse(JSON.stringify(formset, jsonReplacer))).toStrictEqual(EMPTY_DATA);
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
       });
 
       it('should remove non-empty group', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
-        const group = filterFormStore.formset.get().filterGroup.children[0];
-        if (group.kind === FormKind.Group) {
+        const loadableFormset = filterFormStore.formset.get();
+        const formSet = Loadable.getOrElse(null, loadableFormset);
+        const group = formSet?.filterGroup?.children?.[0];
+        if (group?.kind === FormKind.Group) {
           filterFormStore.addChild(group.id, FormKind.Field);
           filterFormStore.removeChild(group.id);
           expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
@@ -379,6 +410,7 @@ describe('FilterFormStore', () => {
 
       it('should clear all (remove ROOT_ID)', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.removeChild(ROOT_ID);
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
@@ -396,22 +428,35 @@ describe('FilterFormStore', () => {
 
       it('should change `show archived` value', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.setArchivedValue(true);
-        expect(filterFormStore.formset.get().showArchived).toBeTruthy();
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeTruthy();
         filterFormStore.setArchivedValue(false);
-        expect(filterFormStore.formset.get().showArchived).toBeFalsy();
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeFalsy();
         filterFormStore.setArchivedValue(false);
-        expect(filterFormStore.formset.get().showArchived).toBeFalsy();
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeFalsy();
       });
 
       it('should `show archived` value remain the same after clear all', () => {
         const filterFormStoreWithInit = new FilterFormStore();
         filterFormStoreWithInit.init(initData);
-        expect(filterFormStoreWithInit.formset.get().showArchived).toBeFalsy();
+        let loadableFormset = filterFormStoreWithInit.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeFalsy();
         filterFormStoreWithInit.setArchivedValue(true);
-        expect(filterFormStoreWithInit.formset.get().showArchived).toBeTruthy();
+        loadableFormset = filterFormStoreWithInit.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeTruthy();
         filterFormStoreWithInit.removeChild(ROOT_ID);
-        expect(filterFormStoreWithInit.formset.get().showArchived).toBeTruthy();
+        loadableFormset = filterFormStoreWithInit.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.showArchived).toBeTruthy();
       });
     });
 
@@ -429,19 +474,26 @@ describe('FilterFormStore', () => {
 
       it('should change the field order', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
 
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 2, item: item });
-        const fields = filterFormStore.formset.get().filterGroup.children;
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        const fields = formset?.filterGroup?.children ?? [];
         expect(fields).toHaveLength(3);
         expect(fields[2].id).toBe(ID);
         // move index2 to index0
         filterFormStore.removeChild(fields[2].id);
-        expect(filterFormStore.formset.get().filterGroup.children).toHaveLength(2);
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.filterGroup?.children).toHaveLength(2);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 0, item: item });
-        expect(filterFormStore.formset.get().filterGroup.children).toHaveLength(3);
-        expect(filterFormStore.formset.get().filterGroup.children[0].id).toBe(ID);
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.filterGroup?.children).toHaveLength(3);
+        expect(formset?.filterGroup?.children?.[0]?.id).toBe(ID);
 
         // to make sure the original object is not referenced (should not be shallow copy)
         filterFormStore.setFieldValue(ID, 'value');
@@ -450,19 +502,30 @@ describe('FilterFormStore', () => {
 
       it('should move field into different group', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
 
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         filterFormStore.addChild(ROOT_ID, FormKind.Field, { index: 2, item: item });
-        const fields = filterFormStore.formset.get().filterGroup.children;
+        let loadableFormset = filterFormStore.formset.get();
+        let formset = Loadable.getOrElse(null, loadableFormset);
+        const fields = formset?.filterGroup?.children;
         expect(fields).toHaveLength(2);
-        expect(fields[1].id).toBe(ID);
+        expect(fields?.[1]?.id).toBe(ID);
+
         // move index2 to index0
         filterFormStore.removeChild(ID);
-        expect(filterFormStore.formset.get().filterGroup.children).toHaveLength(1);
-        filterFormStore.addChild(fields[0].id, FormKind.Field, { index: 0, item: item });
-        const group = filterFormStore.formset.get().filterGroup.children[0];
-        if (group.kind === FormKind.Group) {
-          expect(filterFormStore.formset.get().filterGroup.children).toHaveLength(1);
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        expect(formset?.filterGroup?.children).toHaveLength(1);
+
+        filterFormStore.addChild(fields?.[0]?.id ?? '', FormKind.Field, { index: 0, item: item });
+        loadableFormset = filterFormStore.formset.get();
+        formset = Loadable.getOrElse(null, loadableFormset);
+        const group = formset?.filterGroup?.children?.[0];
+        if (group && group.kind === FormKind.Group) {
+          loadableFormset = filterFormStore.formset.get();
+          formset = Loadable.getOrElse(null, loadableFormset);
+          expect(formset?.filterGroup?.children).toHaveLength(1);
           expect(group.children).toHaveLength(1);
           expect(group.children[0].id).toBe(ID);
 
@@ -476,11 +539,14 @@ describe('FilterFormStore', () => {
     describe('Field Value Interaction', () => {
       it('should change column name', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        const field: Readonly<FormGroup | FormField> =
-          filterFormStore.formset.get().filterGroup.children[0];
-        if (field.kind === FormKind.Field) {
+        const loadableFormset = filterFormStore.formset.get();
+        const formset = Loadable.getOrElse(null, loadableFormset);
+
+        const field = formset?.filterGroup?.children?.[0];
+        if (field && field.kind === FormKind.Field) {
           expect(field.columnName).toBe('name');
         }
         const col: V1ProjectColumn = {
@@ -489,19 +555,22 @@ describe('FilterFormStore', () => {
           location: V1LocationType.EXPERIMENT,
           type: 'COLUMN_TYPE_NUMBER',
         };
-        filterFormStore.setFieldColumnName(field.id, col);
-        if (field.kind === FormKind.Field) {
+        filterFormStore.setFieldColumnName(field?.id ?? '', col);
+        if (field && field.kind === FormKind.Field) {
           expect(field.columnName).toBe('id');
         }
       });
 
       it('should change operator', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        const field: Readonly<FormGroup | FormField> =
-          filterFormStore.formset.get().filterGroup.children[0];
-        if (field.kind === FormKind.Field) {
+        const loadableFormset = filterFormStore.formset.get();
+        const formset = Loadable.getOrElse(null, loadableFormset);
+
+        const field = formset?.filterGroup?.children?.[0];
+        if (field && field.kind === FormKind.Field) {
           expect(field.operator).toBe(Operator.Contains);
           filterFormStore.setFieldOperator(field.id, Operator.GreaterEq);
           expect(field.operator).toBe(Operator.GreaterEq);
@@ -510,11 +579,14 @@ describe('FilterFormStore', () => {
 
       it('should change value', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
-        const field: Readonly<FormGroup | FormField> =
-          filterFormStore.formset.get().filterGroup.children[0];
-        if (field.kind === FormKind.Field) {
+        const loadableFormset = filterFormStore.formset.get();
+        const formset = Loadable.getOrElse(null, loadableFormset);
+
+        const field = formset?.filterGroup?.children?.[0];
+        if (field && field.kind === FormKind.Field) {
           const value = 'test';
           expect(field.value).toBeNull();
           filterFormStore.setFieldValue(field.id, value);
@@ -526,11 +598,14 @@ describe('FilterFormStore', () => {
     describe('Group Value Interaction', () => {
       it('should change conjugation', () => {
         const filterFormStore = new FilterFormStore();
+        filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
-        const field: Readonly<FormGroup | FormField> =
-          filterFormStore.formset.get().filterGroup.children[0];
-        if (field.kind === FormKind.Group) {
+        const loadableFormset = filterFormStore.formset.get();
+        const formset = Loadable.getOrElse(null, loadableFormset);
+
+        const field = formset?.filterGroup?.children[0];
+        if (field?.kind === FormKind.Group) {
           expect(field.conjunction).toBe(Conjunction.And);
           filterFormStore.setFieldConjunction(field.id, Conjunction.Or);
           expect(field.conjunction).toBe(Conjunction.Or);

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -156,67 +156,51 @@ export class FilterFormStore {
     col: Pick<V1ProjectColumn, 'location' | 'type' | 'column'>,
   ): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
-        const ans = this.#getFormById(filterGroup, id);
-        if (ans && ans.kind === FormKind.Field) {
-          ans.columnName = col.column;
-          ans.location = col.location;
-          ans.type = col.type;
-          this.#formset.update((prev) => ({ ...prev, filterGroup }));
-        }
-      },
-      NotLoaded: () => null,
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
+      const ans = this.#getFormById(filterGroup, id);
+      if (ans && ans.kind === FormKind.Field) {
+        ans.columnName = col.column;
+        ans.location = col.location;
+        ans.type = col.type;
+        this.#formset.update((prev) => ({ ...prev, filterGroup }));
+      }
     });
   }
 
   public setFieldOperator(id: string, operator: Operator): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
-        const ans = this.#getFormById(filterGroup, id);
-        if (ans && ans.kind === FormKind.Field && Object.values(Operator).includes(operator)) {
-          ans.operator = operator;
-          this.#formset.update((prev) => ({ ...prev, filterGroup }));
-        }
-      },
-      NotLoaded: () => null,
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
+      const ans = this.#getFormById(filterGroup, id);
+      if (ans && ans.kind === FormKind.Field && Object.values(Operator).includes(operator)) {
+        ans.operator = operator;
+        this.#formset.update((prev) => ({ ...prev, filterGroup }));
+      }
     });
   }
 
   public setFieldConjunction(id: string, conjunction: Conjunction): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
-        const ans = this.#getFormById(filterGroup, id);
-        if (
-          ans &&
-          ans.kind === FormKind.Group &&
-          Object.values(Conjunction).includes(conjunction)
-        ) {
-          ans.conjunction = conjunction;
-          this.#formset.update((prev) => ({ ...prev, filterGroup }));
-        }
-      },
-      NotLoaded: () => null,
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
+      const ans = this.#getFormById(filterGroup, id);
+      if (ans && ans.kind === FormKind.Group && Object.values(Conjunction).includes(conjunction)) {
+        ans.conjunction = conjunction;
+        this.#formset.update((prev) => ({ ...prev, filterGroup }));
+      }
     });
   }
 
   public setFieldValue(id: string, value: FormFieldValue): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
-        const ans = this.#getFormById(filterGroup, id);
-        if (ans && ans.kind === FormKind.Field) {
-          ans.value = value;
-          this.#formset.update((prev) => ({ ...prev, filterGroup }));
-        }
-      },
-      NotLoaded: () => null,
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
+      const ans = this.#getFormById(filterGroup, id);
+      if (ans && ans.kind === FormKind.Field) {
+        ans.value = value;
+        this.#formset.update((prev) => ({ ...prev, filterGroup }));
+      }
     });
   }
 
@@ -226,75 +210,68 @@ export class FilterFormStore {
     obj?: { index: number; item: Readonly<FormGroup | FormField> },
   ): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
-        const traverse = (form: FormGroup | FormField): void => {
-          if (form.id === id && form.kind === FormKind.Group) {
-            if (obj) {
-              form.children.splice(obj.index, 0, structuredClone(obj.item));
-            } else {
-              form.children.push(addType === FormKind.Group ? getInitGroup() : getInitField());
-            }
-            return;
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
+      const traverse = (form: FormGroup | FormField): void => {
+        if (form.id === id && form.kind === FormKind.Group) {
+          if (obj) {
+            form.children.splice(obj.index, 0, structuredClone(obj.item));
+          } else {
+            form.children.push(addType === FormKind.Group ? getInitGroup() : getInitField());
           }
+          return;
+        }
 
-          if (form.kind === FormKind.Group) {
-            for (const child of form.children) {
-              traverse(child);
-            }
+        if (form.kind === FormKind.Group) {
+          for (const child of form.children) {
+            traverse(child);
           }
-        };
+        }
+      };
 
-        traverse(filterGroup);
-        this.#formset.update((prev) => ({ ...prev, filterGroup }));
-      },
-      NotLoaded: () => null,
+      traverse(filterGroup);
+      this.#formset.update((prev) => ({ ...prev, filterGroup }));
     });
   }
 
   public removeChild(id: string): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (filterSet) => {
-        const filterGroup = filterSet.filterGroup;
+    Loadable.forEach(loadableFilterSet, (filterSet) => {
+      const filterGroup = filterSet.filterGroup;
 
-        if (filterGroup.id === id) {
-          // if remove top group
-          this.#formset.set(
-            Loaded({ ...structuredClone(INIT_FORMSET), showArchived: filterSet.showArchived }),
-          );
-          return;
-        }
+      if (filterGroup.id === id) {
+        // if remove top group
+        this.#formset.set(
+          Loaded({ ...structuredClone(INIT_FORMSET), showArchived: filterSet.showArchived }),
+        );
+        return;
+      }
 
-        const traverse = (form: FormGroup | FormField): void => {
-          if (form.kind === FormKind.Group) {
-            const prevLength = form.children.length;
-            form.children = form.children.filter((c) => c.id !== id);
-            if (prevLength === form.children.length) {
-              for (const child of form.children) {
-                traverse(child);
-              }
+      const traverse = (form: FormGroup | FormField): void => {
+        if (form.kind === FormKind.Group) {
+          const prevLength = form.children.length;
+          form.children = form.children.filter((c) => c.id !== id);
+          if (prevLength === form.children.length) {
+            for (const child of form.children) {
+              traverse(child);
             }
           }
-        };
-        traverse(filterGroup);
-        this.#formset.update((loadablePrev) =>
-          Loadable.match(loadablePrev, {
-            Loaded: (prev) => Loaded({ ...prev, filterGroup }),
-            NotLoaded: () => NotLoaded,
-          }),
-        );
-      },
-      NotLoaded: () => null,
+        }
+      };
+      traverse(filterGroup);
+      this.#formset.update((loadablePrev) =>
+        Loadable.match(loadablePrev, {
+          Loaded: (prev) => Loaded({ ...prev, filterGroup }),
+          NotLoaded: () => NotLoaded,
+        }),
+      );
     });
   }
 
   public setArchivedValue(val: boolean): void {
     const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
-    Loadable.match(loadableFilterSet, {
-      Loaded: (fs) => this.#formset.set(Loaded({ ...fs, showArchived: val })),
-      NotLoaded: () => null,
-    });
+    Loadable.forEach(loadableFilterSet, (fs) =>
+      this.#formset.set(Loaded({ ...fs, showArchived: val })),
+    );
   }
 }

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -13,6 +13,7 @@ import {
   Operator,
 } from 'components/FilterForm/components/type';
 import { V1ColumnType, V1LocationType, V1ProjectColumn } from 'services/api-ts-sdk';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
 export const ITEM_LIMIT = 50;
 
@@ -41,15 +42,13 @@ const getInitField = (): FormField => ({
 });
 
 export class FilterFormStore {
-  #formset: WritableObservable<FilterFormSet> = observable(structuredClone(INIT_FORMSET));
-  #loaded: WritableObservable<boolean> = observable(false);
+  #formset: WritableObservable<Loadable<FilterFormSet>> = observable(NotLoaded);
 
   public init(data?: Readonly<FilterFormSet>): void {
-    this.#formset.update(() => structuredClone(data ? data : INIT_FORMSET));
-    this.#loaded.update(() => true);
+    this.#formset.update(() => structuredClone(Loaded(data ? data : INIT_FORMSET)));
   }
 
-  public get formset(): Observable<Readonly<FilterFormSet>> {
+  public get formset(): Observable<Loadable<FilterFormSet>> {
     return this.#formset.readOnly();
   }
 
@@ -57,13 +56,18 @@ export class FilterFormStore {
     const replacer = (key: string, value: unknown): unknown => {
       return key === 'id' ? undefined : value;
     };
-    return this.#formset.select((formset) => {
-      const sweepedForm = this.#sweepInvalid(structuredClone(formset.filterGroup));
-      const newFormSet: FilterFormSetWithoutId = JSON.parse(
-        JSON.stringify({ ...formset, filterGroup: sweepedForm }, replacer),
-      );
-      return JSON.stringify(newFormSet);
-    });
+    return this.#formset.select((loadableFormset) =>
+      Loadable.match(loadableFormset, {
+        Loaded: (formset) => {
+          const sweepedForm = this.#sweepInvalid(structuredClone(formset.filterGroup));
+          const newFormSet: FilterFormSetWithoutId = JSON.parse(
+            JSON.stringify({ ...formset, filterGroup: sweepedForm }, replacer),
+          );
+          return JSON.stringify(newFormSet);
+        },
+        NotLoaded: () => '',
+      }),
+    );
   }
 
   public get fieldCount(): Observable<number> {
@@ -74,11 +78,12 @@ export class FilterFormStore {
       }
       return count;
     };
-    return this.#formset.select((formset) => countFields(formset.filterGroup));
-  }
-
-  public get isLoaded(): Observable<Readonly<boolean>> {
-    return this.#loaded.readOnly();
+    return this.#formset.select((loadableFormset) =>
+      Loadable.match(loadableFormset, {
+        Loaded: (formset) => countFields(formset.filterGroup),
+        NotLoaded: () => 0,
+      }),
+    );
   }
 
   #isValid(form: Readonly<FormGroup | FormField>): boolean {
@@ -112,10 +117,15 @@ export class FilterFormStore {
 
   // remove invalid groups and conditions and then store sweeped data in #formset
   public sweep(): void {
-    this.#formset.update((prev) => {
-      const filterGroup = this.#sweepInvalid(prev.filterGroup);
-      return { ...prev, filterGroup };
-    });
+    this.#formset.update((loadablePrev) =>
+      Loadable.match(loadablePrev, {
+        Loaded: (prev) => {
+          const filterGroup = this.#sweepInvalid(prev.filterGroup);
+          return Loaded({ ...prev, filterGroup });
+        },
+        NotLoaded: () => NotLoaded,
+      }),
+    );
   }
 
   #getFormById(filterGroup: FormGroup, id: string): FormField | FormGroup | undefined {
@@ -145,45 +155,69 @@ export class FilterFormStore {
     id: string,
     col: Pick<V1ProjectColumn, 'location' | 'type' | 'column'>,
   ): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
-    const ans = this.#getFormById(filterGroup, id);
-    if (ans && ans.kind === FormKind.Field) {
-      ans.columnName = col.column;
-      ans.location = col.location;
-      ans.type = col.type;
-      this.#formset.update((prev) => ({ ...prev, filterGroup }));
-    }
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
+        const ans = this.#getFormById(filterGroup, id);
+        if (ans && ans.kind === FormKind.Field) {
+          ans.columnName = col.column;
+          ans.location = col.location;
+          ans.type = col.type;
+          this.#formset.update((prev) => ({ ...prev, filterGroup }));
+        }
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public setFieldOperator(id: string, operator: Operator): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
-    const ans = this.#getFormById(filterGroup, id);
-    if (ans && ans.kind === FormKind.Field && Object.values(Operator).includes(operator)) {
-      ans.operator = operator;
-      this.#formset.update((prev) => ({ ...prev, filterGroup }));
-    }
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
+        const ans = this.#getFormById(filterGroup, id);
+        if (ans && ans.kind === FormKind.Field && Object.values(Operator).includes(operator)) {
+          ans.operator = operator;
+          this.#formset.update((prev) => ({ ...prev, filterGroup }));
+        }
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public setFieldConjunction(id: string, conjunction: Conjunction): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
-    const ans = this.#getFormById(filterGroup, id);
-    if (ans && ans.kind === FormKind.Group && Object.values(Conjunction).includes(conjunction)) {
-      ans.conjunction = conjunction;
-      this.#formset.update((prev) => ({ ...prev, filterGroup }));
-    }
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
+        const ans = this.#getFormById(filterGroup, id);
+        if (
+          ans &&
+          ans.kind === FormKind.Group &&
+          Object.values(Conjunction).includes(conjunction)
+        ) {
+          ans.conjunction = conjunction;
+          this.#formset.update((prev) => ({ ...prev, filterGroup }));
+        }
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public setFieldValue(id: string, value: FormFieldValue): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
-    const ans = this.#getFormById(filterGroup, id);
-    if (ans && ans.kind === FormKind.Field) {
-      ans.value = value;
-      this.#formset.update((prev) => ({ ...prev, filterGroup }));
-    }
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
+        const ans = this.#getFormById(filterGroup, id);
+        if (ans && ans.kind === FormKind.Field) {
+          ans.value = value;
+          this.#formset.update((prev) => ({ ...prev, filterGroup }));
+        }
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public addChild(
@@ -191,56 +225,76 @@ export class FilterFormStore {
     addType: FormKind,
     obj?: { index: number; item: Readonly<FormGroup | FormField> },
   ): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
-    const traverse = (form: FormGroup | FormField): void => {
-      if (form.id === id && form.kind === FormKind.Group) {
-        if (obj) {
-          form.children.splice(obj.index, 0, structuredClone(obj.item));
-        } else {
-          form.children.push(addType === FormKind.Group ? getInitGroup() : getInitField());
-        }
-        return;
-      }
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
+        const traverse = (form: FormGroup | FormField): void => {
+          if (form.id === id && form.kind === FormKind.Group) {
+            if (obj) {
+              form.children.splice(obj.index, 0, structuredClone(obj.item));
+            } else {
+              form.children.push(addType === FormKind.Group ? getInitGroup() : getInitField());
+            }
+            return;
+          }
 
-      if (form.kind === FormKind.Group) {
-        for (const child of form.children) {
-          traverse(child);
-        }
-      }
-    };
+          if (form.kind === FormKind.Group) {
+            for (const child of form.children) {
+              traverse(child);
+            }
+          }
+        };
 
-    traverse(filterGroup);
-    this.#formset.update((prev) => ({ ...prev, filterGroup }));
+        traverse(filterGroup);
+        this.#formset.update((prev) => ({ ...prev, filterGroup }));
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public removeChild(id: string): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    const filterGroup = filterSet.filterGroup;
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (filterSet) => {
+        const filterGroup = filterSet.filterGroup;
 
-    if (filterGroup.id === id) {
-      // if remove top group
-      this.#formset.set({ ...structuredClone(INIT_FORMSET), showArchived: filterSet.showArchived });
-      return;
-    }
-
-    const traverse = (form: FormGroup | FormField): void => {
-      if (form.kind === FormKind.Group) {
-        const prevLength = form.children.length;
-        form.children = form.children.filter((c) => c.id !== id);
-        if (prevLength === form.children.length) {
-          for (const child of form.children) {
-            traverse(child);
-          }
+        if (filterGroup.id === id) {
+          // if remove top group
+          this.#formset.set(
+            Loaded({ ...structuredClone(INIT_FORMSET), showArchived: filterSet.showArchived }),
+          );
+          return;
         }
-      }
-    };
-    traverse(filterGroup);
-    this.#formset.update((prev) => ({ ...prev, filterGroup }));
+
+        const traverse = (form: FormGroup | FormField): void => {
+          if (form.kind === FormKind.Group) {
+            const prevLength = form.children.length;
+            form.children = form.children.filter((c) => c.id !== id);
+            if (prevLength === form.children.length) {
+              for (const child of form.children) {
+                traverse(child);
+              }
+            }
+          }
+        };
+        traverse(filterGroup);
+        this.#formset.update((loadablePrev) =>
+          Loadable.match(loadablePrev, {
+            Loaded: (prev) => Loaded({ ...prev, filterGroup }),
+            NotLoaded: () => NotLoaded,
+          }),
+        );
+      },
+      NotLoaded: () => null,
+    });
   }
 
   public setArchivedValue(val: boolean): void {
-    const filterSet: Readonly<FilterFormSet> = this.#formset.get();
-    this.#formset.set({ ...filterSet, showArchived: val });
+    const loadableFilterSet: Loadable<FilterFormSet> = this.#formset.get();
+    Loadable.match(loadableFilterSet, {
+      Loaded: (fs) => this.#formset.set(Loaded({ ...fs, showArchived: val })),
+      NotLoaded: () => null,
+    });
   }
 }

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -42,9 +42,11 @@ const getInitField = (): FormField => ({
 
 export class FilterFormStore {
   #formset: WritableObservable<FilterFormSet> = observable(structuredClone(INIT_FORMSET));
+  #loaded: WritableObservable<boolean> = observable(false);
 
   public init(data?: Readonly<FilterFormSet>): void {
     this.#formset.update(() => structuredClone(data ? data : INIT_FORMSET));
+    this.#loaded.update(() => true);
   }
 
   public get formset(): Observable<Readonly<FilterFormSet>> {
@@ -73,6 +75,10 @@ export class FilterFormStore {
       return count;
     };
     return this.#formset.select((formset) => countFields(formset.filterGroup));
+  }
+
+  public get isLoaded(): Observable<Readonly<boolean>> {
+    return this.#loaded.readOnly();
   }
 
   #isValid(form: Readonly<FormGroup | FormField>): boolean {

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -118,12 +118,9 @@ export class FilterFormStore {
   // remove invalid groups and conditions and then store sweeped data in #formset
   public sweep(): void {
     this.#formset.update((loadablePrev) =>
-      Loadable.match(loadablePrev, {
-        Loaded: (prev) => {
-          const filterGroup = this.#sweepInvalid(prev.filterGroup);
-          return Loaded({ ...prev, filterGroup });
-        },
-        NotLoaded: () => NotLoaded,
+      Loadable.map(loadablePrev, (prev) => {
+        const filterGroup = this.#sweepInvalid(prev.filterGroup);
+        return { ...prev, filterGroup };
       }),
     );
   }
@@ -260,10 +257,7 @@ export class FilterFormStore {
       };
       traverse(filterGroup);
       this.#formset.update((loadablePrev) =>
-        Loadable.match(loadablePrev, {
-          Loaded: (prev) => Loaded({ ...prev, filterGroup }),
-          NotLoaded: () => NotLoaded,
-        }),
+        Loadable.map(loadablePrev, (prev) => ({ ...prev, filterGroup })),
       );
     });
   }

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -333,7 +333,7 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
       chartsProps.forEach((chart) => {
         chart.series.forEach((serie) => {
           Object.entries(serie.data).forEach(([xAxisOption, dataPoints]) => {
-            if ((dataPoints?.length ?? 0) > 0) {
+            if (dataPoints.length > 0) {
               xOpts.add(xAxisOption);
             }
           });

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -333,7 +333,7 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
       chartsProps.forEach((chart) => {
         chart.series.forEach((serie) => {
           Object.entries(serie.data).forEach(([xAxisOption, dataPoints]) => {
-            if (dataPoints.length > 0) {
+            if ((dataPoints?.length ?? 0) > 0) {
               xOpts.add(xAxisOption);
             }
           });

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -302,10 +302,9 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     return formStore.asJsonString.subscribe(() => {
       resetPagination();
       const loadableFormset = formStore.formset.get();
-      Loadable.match(loadableFormset, {
-        Loaded: (formSet) => updateSettings({ filterset: JSON.stringify(formSet) }),
-        NotLoaded: () => null,
-      });
+      Loadable.forEach(loadableFormset, (formSet) =>
+        updateSettings({ filterset: JSON.stringify(formSet) }),
+      );
     });
   }, [resetPagination, updateSettings]);
 

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -99,6 +99,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [isOpenFilter, setIsOpenFilter] = useState<boolean>(false);
   const filtersString = useObservable(formStore.asJsonString);
   const rootFilterChildren = useObservable(formStore.formset).filterGroup.children;
+  const filtersLoaded = useObservable(formStore.isLoaded);
 
   const onIsOpenFilterChange = useCallback((newOpen: boolean) => {
     setIsOpenFilter(newOpen);
@@ -127,6 +128,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   useEffect(() => {
     // useSettings load the default value first, and then load the data from DB
     // use this useEffect to re-init the correct useSettings value when settings.filterset is changed
+    if (isLoadingSettings) return;
     const formSetValidation = IOFilterFormSet.decode(JSON.parse(settings.filterset));
     if (isLeft(formSetValidation)) {
       handleError(formSetValidation.left, {
@@ -136,7 +138,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
       const formset = formSetValidation.right;
       formStore.init(formset);
     }
-  }, [settings.filterset]);
+  }, [settings.filterset, isLoadingSettings]);
 
   const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>([]);
   const [excludedExperimentIds, setExcludedExperimentIds] = useState<Set<number>>(
@@ -196,7 +198,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   const fetchExperiments = useCallback(async (): Promise<void> => {
-    if (isLoadingSettings) return;
+    if (!filtersLoaded) return;
     try {
       const tableOffset = Math.max((page - 0.5) * PAGE_SIZE, 0);
       const response = await searchExperiments(
@@ -244,7 +246,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   }, [
     page,
     experimentFilters,
-    isLoadingSettings,
+    filtersLoaded,
     isPagedView,
     canceler.signal,
     filtersString,

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -446,82 +446,79 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       setStandAloneSelect(undefined);
 
       const [col, row] = cell;
-      Loadable.match(data[row], {
-        Loaded: (rowData) => {
-          const columnId = columnIds[col];
-          const cell = columnDefs[columnId].renderer(rowData, row);
+      Loadable.forEach(data[row], (rowData) => {
+        const columnId = columnIds[col];
+        const cell = columnDefs[columnId].renderer(rowData, row);
 
-          if (isLinkCell(cell)) {
-            handlePath(event as unknown as AnyMouseEvent, { path: cell.data.link.href });
-            // cell.data.link.onClick(event);
-          } else {
-            if (event.shiftKey) {
-              setSelection(({ rows }: GridSelection) => {
-                if (standAloneSelect && standAloneSelect > row) {
-                  return {
-                    columns: CompactSelection.empty(),
-                    rows: event.metaKey
-                      ? rows.add([row, standAloneSelect + 1])
-                      : CompactSelection.fromSingleSelection([row, standAloneSelect + 1]),
-                  };
-                }
-                const rowsArray = rows.toArray();
-                const smallestClosest = rowsArray.filter((r) => r < row).last();
-                const largestClosest = rowsArray.filter((r) => r > row).first();
-                const smallestLinked = findConsecutiveBefore(rowsArray, smallestClosest);
-                const greatestLinked = findConsecutiveAfter(rowsArray, largestClosest);
+        if (isLinkCell(cell)) {
+          handlePath(event as unknown as AnyMouseEvent, { path: cell.data.link.href });
+          // cell.data.link.onClick(event);
+        } else {
+          if (event.shiftKey) {
+            setSelection(({ rows }: GridSelection) => {
+              if (standAloneSelect && standAloneSelect > row) {
                 return {
                   columns: CompactSelection.empty(),
-                  rows:
-                    smallestClosest >= 0
-                      ? event.metaKey
-                        ? rows.add([smallestClosest, row + 1])
-                        : CompactSelection.fromSingleSelection([smallestLinked, row + 1])
-                      : largestClosest
-                      ? event.metaKey
-                        ? rows.add([row, largestClosest + 1])
-                        : CompactSelection.fromSingleSelection([row, greatestLinked + 1])
-                      : CompactSelection.fromSingleSelection(row),
+                  rows: event.metaKey
+                    ? rows.add([row, standAloneSelect + 1])
+                    : CompactSelection.fromSingleSelection([row, standAloneSelect + 1]),
                 };
-              });
-            } else {
-              isStandAlone(selection.rows, row) &&
-                !selection.rows.hasIndex(row) &&
-                setStandAloneSelect(row);
+              }
+              const rowsArray = rows.toArray();
+              const smallestClosest = rowsArray.filter((r) => r < row).last();
+              const largestClosest = rowsArray.filter((r) => r > row).first();
+              const smallestLinked = findConsecutiveBefore(rowsArray, smallestClosest);
+              const greatestLinked = findConsecutiveAfter(rowsArray, largestClosest);
+              return {
+                columns: CompactSelection.empty(),
+                rows:
+                  smallestClosest >= 0
+                    ? event.metaKey
+                      ? rows.add([smallestClosest, row + 1])
+                      : CompactSelection.fromSingleSelection([smallestLinked, row + 1])
+                    : largestClosest
+                    ? event.metaKey
+                      ? rows.add([row, largestClosest + 1])
+                      : CompactSelection.fromSingleSelection([row, greatestLinked + 1])
+                    : CompactSelection.fromSingleSelection(row),
+              };
+            });
+          } else {
+            isStandAlone(selection.rows, row) &&
+              !selection.rows.hasIndex(row) &&
+              setStandAloneSelect(row);
 
-              if (selection.rows.hasIndex(row)) {
-                setSelection(({ columns, rows }: GridSelection) => ({
-                  columns,
-                  rows: rows.remove(row),
-                }));
-                if (selectAll) {
-                  const experiment = data[row];
-                  if (Loadable.isLoaded(experiment)) {
-                    setExcludedExperimentIds((prev) => {
-                      if (experiment.data.experiment) {
-                        return new Set([...prev, experiment.data.experiment?.id]);
-                      } else {
-                        return prev;
-                      }
-                    });
-                  }
-                }
-              } else {
-                setSelection(({ columns, rows }: GridSelection) => ({
-                  columns,
-                  rows: rows.add(row),
-                }));
+            if (selection.rows.hasIndex(row)) {
+              setSelection(({ columns, rows }: GridSelection) => ({
+                columns,
+                rows: rows.remove(row),
+              }));
+              if (selectAll) {
                 const experiment = data[row];
                 if (Loadable.isLoaded(experiment)) {
                   setExcludedExperimentIds((prev) => {
-                    return new Set([...prev].filter((id) => id !== experiment.data.experiment?.id));
+                    if (experiment.data.experiment) {
+                      return new Set([...prev, experiment.data.experiment?.id]);
+                    } else {
+                      return prev;
+                    }
                   });
                 }
               }
+            } else {
+              setSelection(({ columns, rows }: GridSelection) => ({
+                columns,
+                rows: rows.add(row),
+              }));
+              const experiment = data[row];
+              if (Loadable.isLoaded(experiment)) {
+                setExcludedExperimentIds((prev) => {
+                  return new Set([...prev].filter((id) => id !== experiment.data.experiment?.id));
+                });
+              }
             }
           }
-        },
-        NotLoaded: () => null,
+        }
       });
     },
     [data, columnIds, columnDefs, selection, selectAll, setExcludedExperimentIds, standAloneSelect],
@@ -533,33 +530,30 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       contextMenuOpen.set(false);
 
       const [col, row] = cell;
-      Loadable.match(data[row], {
-        Loaded: (rowData) => {
-          // Prevent the browser native context menu from showing up.
-          event.preventDefault();
+      Loadable.forEach(data[row], (rowData) => {
+        // Prevent the browser native context menu from showing up.
+        event.preventDefault();
 
-          // Delay needed due to the call to close previously existing context menu.
-          setTimeout(() => {
-            const columnId = columnIds[col];
-            const cell = columnDefs[columnId].renderer(rowData, row);
+        // Delay needed due to the call to close previously existing context menu.
+        setTimeout(() => {
+          const columnId = columnIds[col];
+          const cell = columnDefs[columnId].renderer(rowData, row);
 
-            // Update the context menu based on the cell context.
-            setContextMenuProps({
-              experiment: getProjectExperimentForExperimentItem(rowData.experiment, project),
-              handleClose: (e?: Event) => {
-                // Prevent the context menu closing click from triggering something else.
-                if (contextMenuOpen.get()) e?.stopPropagation();
-                contextMenuOpen.set(false);
-              },
-              link: isLinkCell(cell) ? cell.data.link.href : undefined,
-              x: Math.max(0, event.bounds.x + event.localEventX - 4),
-              y: Math.max(0, event.bounds.y + event.localEventY - 4),
-            });
+          // Update the context menu based on the cell context.
+          setContextMenuProps({
+            experiment: getProjectExperimentForExperimentItem(rowData.experiment, project),
+            handleClose: (e?: Event) => {
+              // Prevent the context menu closing click from triggering something else.
+              if (contextMenuOpen.get()) e?.stopPropagation();
+              contextMenuOpen.set(false);
+            },
+            link: isLinkCell(cell) ? cell.data.link.href : undefined,
+            x: Math.max(0, event.bounds.x + event.localEventX - 4),
+            y: Math.max(0, event.bounds.y + event.localEventY - 4),
+          });
 
-            contextMenuOpen.set(true);
-          }, 50);
-        },
-        NotLoaded: () => null,
+          contextMenuOpen.set(true);
+        }, 50);
       });
     },
     [columnDefs, columnIds, data, project, setContextMenuProps, contextMenuOpen],

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -333,12 +333,16 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       }
 
       const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal']);
+      const loadableFormset = formStore.formset.get();
       const filterMenuItemsForColumn = () => {
         const isSpecialColumn = (SpecialColumnNames as ReadonlyArray<string>).includes(
           column.column,
         );
         formStore.addChild(ROOT_ID, FormKind.Field, {
-          index: formStore.formset.get().filterGroup.children.length,
+          index: Loadable.match(loadableFormset, {
+            Loaded: (formset) => formset.filterGroup.children.length,
+            NotLoaded: () => 0,
+          }),
           item: {
             columnName: column.column,
             id: uuidv4(),

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -49,11 +49,11 @@ const summarizedMetricToSeries = (
   });
   const trialData: Record<string, Serie> = {};
   selectedMetrics.forEach((metric) => {
-    const data: Partial<Record<XAxisDomain, [number, number][]>> = {
-      [XAxisDomain.Batches]: rawBatchValuesMap[metric.name],
-      [XAxisDomain.Time]: rawBatchTimesMap[metric.name],
-      [XAxisDomain.Epochs]: rawBatchEpochMap[metric.name],
-    };
+    const data: Partial<Record<XAxisDomain, [number, number][]>> = {};
+    if (rawBatchValuesMap[metric.name]) data[XAxisDomain.Batches] = rawBatchValuesMap[metric.name];
+    if (rawBatchTimesMap[metric.name]) data[XAxisDomain.Time] = rawBatchTimesMap[metric.name];
+    if (rawBatchEpochMap[metric.name]) data[XAxisDomain.Epochs] = rawBatchEpochMap[metric.name];
+
     const series: Serie = {
       color:
         metric.type === MetricType.Validation ? VALIDATION_SERIES_COLOR : TRAINING_SERIES_COLOR,


### PR DESCRIPTION
## Description

When loading an experiment which ended or errored early (`dataPoints` is undefined), the LineChart xAxis code should work around it

When we load a filter from settings, the page fires `fetchExperiments` when `isLoadingSettings` changes, and shortly after for `filtersString` change. The unfiltered request can take longer and overwrite the filtered request.
We want to wait for `formStore.init()` so we can access the `filtersString` observable. I'm proposing to fix this with an `isLoaded` observable inside `formStore`.

## Test Plan

Doing `make live` for latest-main experiments to replicate locally

**Bug 1**
- On `/det/projects/1/experiments?f_explist_v2=on`, filter experiment name contains "lightning".  You should see 7 experiments, some are complete and some are errored.
- Open the Compare view
- Slowly check the 7 experiments from top to bottom, until a chart appears. Then uncheck the experiments from bottom to top. This should trigger an Application Error on `latest-main` and not with this fix.

**Bug 2**
Replicating the bug: stay on `/det/projects/1/experiments?f_explist_v2=on` with the "lightning" name filter on.  When I refresh (Ctrl Shift R) I see a flash of the 7 filtered exps, then the 300 experiment list for a few seconds, then the filtered ones on next poll.

- After this fix, make sure that Ctrl Shift R only loads filtered experiments (can check network tab or console.log inside fetchExperiments)
- Remove all filters. Ctrl Shift R to load all experiments (this is to make sure fetchExperiments happens even if there is no new filters-changed event)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.