### PR TITLE
feat: add glide table filter field add shortcut

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -159,8 +159,7 @@ const FilterField = ({
 
   const captureEnterKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        e.stopPropagation();
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
         formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
       }
     },
@@ -231,12 +230,7 @@ const FilterField = ({
                   const val = e.target.value || null; // when empty string, val is null
                   updateFieldValue(field.id, val, true);
                 }}
-                onPressEnter={() =>
-                  formStore.addChild(parentId, FormKind.Field, {
-                    index: index + 1,
-                    item: getInitField(),
-                  })
-                }
+                onPressEnter={captureEnterKeyDown}
               />
             )}
             {currentColumn?.type === V1ColumnType.NUMBER && (
@@ -247,12 +241,7 @@ const FilterField = ({
                   const value = val != null ? Number(val) : null;
                   updateFieldValue(field.id, value, true);
                 }}
-                onPressEnter={() =>
-                  formStore.addChild(parentId, FormKind.Field, {
-                    index: index + 1,
-                    item: getInitField(),
-                  })
-                }
+                onPressEnter={captureEnterKeyDown}
               />
             )}
             {currentColumn?.type === V1ColumnType.DATE && (

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -159,7 +159,8 @@ const FilterField = ({
 
   const captureEnterKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      // would use isComposing alone but safari has a bug: https://bugs.webkit.org/show_bug.cgi?id=165004
+      if (e.key === 'Enter' && (!e.nativeEvent.isComposing || e.keyCode === 229)) {
         formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
       }
     },

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -160,7 +160,7 @@ const FilterField = ({
   const captureEnterKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // would use isComposing alone but safari has a bug: https://bugs.webkit.org/show_bug.cgi?id=165004
-      if (e.key === 'Enter' && (!e.nativeEvent.isComposing || e.keyCode === 229)) {
+      if (e.key === 'Enter' && !e.nativeEvent.isComposing && e.keyCode !== 229) {
         formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
       }
     },

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -65,6 +65,7 @@ const FilterField = ({
   const currentColumn = columns.find((c) => c.column === field.columnName);
   const isSpecialColumn = (SpecialColumnNames as ReadonlyArray<string>).includes(field.columnName);
 
+  const [inputOpen, setInputOpen] = useState(false);
   const [fieldValue, setFieldValue] = useState<FormFieldValue>(field.value);
 
   // use this function to update field value
@@ -160,11 +161,15 @@ const FilterField = ({
   const captureEnterKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // would use isComposing alone but safari has a bug: https://bugs.webkit.org/show_bug.cgi?id=165004
-      if (e.key === 'Enter' && !e.nativeEvent.isComposing && e.keyCode !== 229) {
+      if (e.key === 'Enter' && !inputOpen && !e.nativeEvent.isComposing && e.keyCode !== 229) {
         formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
+        // stop panel flashing for selects and dates
+        if (field.type === 'COLUMN_TYPE_DATE' || isSpecialColumn) {
+          e.stopPropagation();
+        }
       }
     },
-    [formStore, index, parentId],
+    [field.type, formStore, index, inputOpen, isSpecialColumn, parentId],
   );
 
   return (
@@ -216,6 +221,7 @@ const FilterField = ({
                 const val = value?.toString() ?? null;
                 updateFieldValue(field.id, val);
               }}
+              onDropdownVisibleChange={setInputOpen}
             />
           </div>
         ) : (
@@ -257,6 +263,7 @@ const FilterField = ({
                     const dateString = dayjs(value).utc().startOf('date').format();
                     updateFieldValue(field.id, dateString);
                   }}
+                  onOpenChange={setInputOpen}
                 />
               </div>
             )}

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -161,7 +161,7 @@ const FilterField = ({
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter') {
         e.stopPropagation();
-        formStore.addChild(parentId, FormKind.Field, { index, item: getInitField() });
+        formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
       }
     },
     [formStore, index, parentId],
@@ -232,7 +232,10 @@ const FilterField = ({
                   updateFieldValue(field.id, val, true);
                 }}
                 onPressEnter={() =>
-                  formStore.addChild(parentId, FormKind.Field, { index, item: getInitField() })
+                  formStore.addChild(parentId, FormKind.Field, {
+                    index: index + 1,
+                    item: getInitField(),
+                  })
                 }
               />
             )}
@@ -245,7 +248,10 @@ const FilterField = ({
                   updateFieldValue(field.id, value, true);
                 }}
                 onPressEnter={() =>
-                  formStore.addChild(parentId, FormKind.Field, { index, item: getInitField() })
+                  formStore.addChild(parentId, FormKind.Field, {
+                    index: index + 1,
+                    item: getInitField(),
+                  })
                 }
               />
             )}

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -31,7 +31,7 @@ const getInitGroup = (): FormGroup => ({
   kind: FormKind.Group,
 });
 
-const getInitField = (): FormField => ({
+export const getInitField = (): FormField => ({
   columnName: 'name',
   id: uuidv4(),
   kind: FormKind.Field,

--- a/webui/react/src/components/kit/InputNumber.tsx
+++ b/webui/react/src/components/kit/InputNumber.tsx
@@ -12,6 +12,7 @@ interface InputNumberProps {
   precision?: number;
   step?: number;
   value?: number;
+  onPressEnter?: () => void;
 }
 
 const InputNumber: React.FC<InputNumberProps> = (props: InputNumberProps) => {

--- a/webui/react/src/components/kit/InputNumber.tsx
+++ b/webui/react/src/components/kit/InputNumber.tsx
@@ -12,7 +12,7 @@ interface InputNumberProps {
   precision?: number;
   step?: number;
   value?: number;
-  onPressEnter?: () => void;
+  onPressEnter?: (e: React.KeyboardEvent) => void;
 }
 
 const InputNumber: React.FC<InputNumberProps> = (props: InputNumberProps) => {

--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -36,6 +36,7 @@ export interface SelectProps<T extends SelectValue = SelectValue> {
   searchable?: boolean;
   value?: T;
   width?: React.CSSProperties['width'];
+  onDropdownVisibleChange?: (open: boolean) => void;
 }
 
 const countOptions = (children: React.ReactNode, options?: Options): number => {


### PR DESCRIPTION

## Description

This adds a shortcut to the filter field where the user can press the enter key while the value field is focused in order to add a new field below it.



## Test Plan

in the glide table's filter menu, pressing the enter button with any value column focused should insert a new form field below the currently focused field.



## Commentary (optional)

Default enter behavior on select and datepicker is overridden by intercepting the keyDown event.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1255


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
