### PR TITLE
fix: persist Experiment List sorts

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -5,6 +5,7 @@ import { SettingsConfig } from 'hooks/useSettings';
 import { valueof } from 'ioTypes';
 
 import { defaultColumnWidths, defaultExperimentColumns } from './glide-table/columns';
+import { EMPTY_SORT } from './glide-table/MultiSortMenu';
 
 export type ExpListView = 'scroll' | 'paged';
 export const RowHeight = {
@@ -21,6 +22,7 @@ export interface F_ExperimentListSettings {
   columnWidths: Record<string, number>;
   compare: boolean;
   filterset: string; // save FilterFormSet as string
+  sorts: string;
   pageLimit: number;
   rowHeight: RowHeight;
 }
@@ -60,6 +62,12 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       skipUrlEncoding: true,
       storageKey: 'rowHeight',
       type: ioRowHeight,
+    },
+    sorts: {
+      defaultValue: JSON.stringify([EMPTY_SORT]),
+      skipUrlEncoding: true,
+      storageKey: 'sorts',
+      type: string,
     },
   },
   storagePath: `f_project-details-${id}`,

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -5,7 +5,6 @@ import { SettingsConfig } from 'hooks/useSettings';
 import { valueof } from 'ioTypes';
 
 import { defaultColumnWidths, defaultExperimentColumns } from './glide-table/columns';
-import { EMPTY_SORT } from './glide-table/MultiSortMenu';
 
 export type ExpListView = 'scroll' | 'paged';
 export const RowHeight = {
@@ -22,7 +21,7 @@ export interface F_ExperimentListSettings {
   columnWidths: Record<string, number>;
   compare: boolean;
   filterset: string; // save FilterFormSet as string
-  sorts: string;
+  sortString: string;
   pageLimit: number;
   rowHeight: RowHeight;
 }
@@ -63,10 +62,10 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       storageKey: 'rowHeight',
       type: ioRowHeight,
     },
-    sorts: {
-      defaultValue: JSON.stringify([EMPTY_SORT]),
+    sortString: {
+      defaultValue: '',
       skipUrlEncoding: true,
-      storageKey: 'sorts',
+      storageKey: 'sortString',
       type: string,
     },
   },

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -76,20 +76,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [page, setPage] = useState(() =>
     isFinite(Number(searchParams.get('page'))) ? Math.max(Number(searchParams.get('page')), 0) : 0,
   );
-  const [sorts, setSorts] = useState<Sort[]>(() => {
-    const sortString = searchParams.get('sort') || '';
-    if (!sortString) {
-      return [EMPTY_SORT];
-    }
-    const components = sortString.split(',');
-    return components.map((c) => {
-      const [column, direction] = c.split('=', 2);
-      return {
-        column,
-        direction: direction === 'asc' || direction === 'desc' ? direction : undefined,
-      };
-    });
-  });
+  const [sorts, setSorts] = useState<Sort[]>([EMPTY_SORT]);
   const [sortString, setSortString] = useState<string>('');
   const [experiments, setExperiments] = useState<Loadable<ExperimentWithTrial>[]>(
     INITIAL_LOADING_EXPERIMENTS,
@@ -113,11 +100,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         params.set('page', page.toString());
       } else {
         params.delete('page');
-      }
-      if (sortString) {
-        params.set('sort', sortString);
-      } else {
-        params.delete('sort');
       }
       return params;
     });
@@ -276,7 +258,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         columns.sort((a, b) =>
           a.location === V1LocationType.EXPERIMENT && b.location === V1LocationType.EXPERIMENT
             ? experimentColumns.indexOf(a.column as ExperimentColumn) -
-            experimentColumns.indexOf(b.column as ExperimentColumn)
+              experimentColumns.indexOf(b.column as ExperimentColumn)
             : 0,
         );
 

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -269,7 +269,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         columns.sort((a, b) =>
           a.location === V1LocationType.EXPERIMENT && b.location === V1LocationType.EXPERIMENT
             ? experimentColumns.indexOf(a.column as ExperimentColumn) -
-            experimentColumns.indexOf(b.column as ExperimentColumn)
+              experimentColumns.indexOf(b.column as ExperimentColumn)
             : 0,
         );
 

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -186,14 +186,25 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const onSortChange = useCallback(
     (sorts: Sort[]) => {
       setSorts(sorts);
+      updateSettings({
+        // save sorts to settings:
+        sorts: JSON.stringify(sorts),
+      });
       const newSortString = makeSortString(sorts.filter(validSort.is));
       if (newSortString !== sortString) {
         resetPagination();
       }
       setSortString(newSortString);
     },
-    [resetPagination, sortString],
+    [resetPagination, sortString, updateSettings],
   );
+
+  useEffect(() => {
+    if (settings.sorts) {
+      // apply saved sorts on load:
+      onSortChange(JSON.parse(settings.sorts));
+    }
+  }, [settings, onSortChange]);
 
   const fetchExperiments = useCallback(async (): Promise<void> => {
     if (isLoadingSettings) return;
@@ -265,7 +276,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         columns.sort((a, b) =>
           a.location === V1LocationType.EXPERIMENT && b.location === V1LocationType.EXPERIMENT
             ? experimentColumns.indexOf(a.column as ExperimentColumn) -
-              experimentColumns.indexOf(b.column as ExperimentColumn)
+            experimentColumns.indexOf(b.column as ExperimentColumn)
             : 0,
         );
 


### PR DESCRIPTION
## Description

Add `sorts` to user settings, to save sorts on new Experiment List.



## Test Plan

On new experiment list (`f_explist_v2=on`)
- [ ] Set sorting on multiple columns
- [ ] Refresh page and make sure sorts that were set persist

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
