### PR TITLE
feat: Drawer component added to UI Kit [WEB-1349]

### DIFF
--- a/webui/react/src/components/kit/Drawer.module.scss
+++ b/webui/react/src/components/kit/Drawer.module.scss
@@ -1,0 +1,22 @@
+.body {
+  max-height: calc(100vh - 56px);
+  overflow-y: scroll;
+  padding: 16px;
+}
+.header {
+  align-items: center;
+  background-color: var(--theme-background);
+  border-bottom: 1px solid var(--color-background-border);
+  display: flex;
+  height: 56px;
+  justify-content: space-between;
+  padding: 0 17px;
+
+  .headerTitle {
+    font-size: 16px;
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/webui/react/src/components/kit/Drawer.module.scss
+++ b/webui/react/src/components/kit/Drawer.module.scss
@@ -23,3 +23,9 @@
     font-weight: bold;
   }
 }
+
+@media only screen and (max-width: 700px) {
+  .mobileWidth > div {
+    width: 100% !important;
+  }
+}

--- a/webui/react/src/components/kit/Drawer.module.scss
+++ b/webui/react/src/components/kit/Drawer.module.scss
@@ -1,5 +1,5 @@
 .body {
-  max-height: calc(100vh - 56px);
+  height: calc(100vh - 56px);
   overflow-y: scroll;
   padding: 16px;
 }
@@ -18,5 +18,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+  button > span::before {
+    font-weight: bold;
   }
 }

--- a/webui/react/src/components/kit/Drawer.tsx
+++ b/webui/react/src/components/kit/Drawer.tsx
@@ -21,13 +21,18 @@ const DrawerComponent: React.FC<DrawerProps> = ({ children, open, placement, tit
     <Drawer
       bodyStyle={{ padding: 0 }}
       closable={false}
+      maskClosable={false}
       open={open}
       placement={placement}
-      width="40%"
+      width="700px"
       onClose={onClose}>
       <div className={css.header}>
         <div className={css.headerTitle}>{title}</div>
-        <Button icon={<Icon name="close" size="small" title="Close drawer" />} onClick={onClose} />
+        <Button
+          icon={<Icon name="close" size="small" title="Close drawer" />}
+          type="text"
+          onClick={onClose}
+        />
       </div>
       <div className={css.body}>{children}</div>
     </Drawer>

--- a/webui/react/src/components/kit/Drawer.tsx
+++ b/webui/react/src/components/kit/Drawer.tsx
@@ -24,6 +24,7 @@ const DrawerComponent: React.FC<DrawerProps> = ({ children, open, placement, tit
       maskClosable={false}
       open={open}
       placement={placement}
+      rootClassName={css.mobileWidth}
       width="700px"
       onClose={onClose}>
       <div className={css.header}>

--- a/webui/react/src/components/kit/Drawer.tsx
+++ b/webui/react/src/components/kit/Drawer.tsx
@@ -1,0 +1,37 @@
+import { Drawer } from 'antd';
+import React from 'react';
+
+import Button from 'components/kit/Button';
+import Icon from 'components/kit/Icon';
+
+import css from './Drawer.module.scss';
+
+type DrawerPlacement = 'left' | 'right';
+
+interface DrawerProps {
+  children: React.ReactNode;
+  open: boolean;
+  placement: DrawerPlacement;
+  title: string;
+  onClose: () => void;
+}
+
+const DrawerComponent: React.FC<DrawerProps> = ({ children, open, placement, title, onClose }) => {
+  return (
+    <Drawer
+      bodyStyle={{ padding: 0 }}
+      closable={false}
+      open={open}
+      placement={placement}
+      width="40%"
+      onClose={onClose}>
+      <div className={css.header}>
+        <div className={css.headerTitle}>{title}</div>
+        <Button icon={<Icon name="close" size="small" title="Close drawer" />} onClick={onClose} />
+      </div>
+      <div className={css.body}>{children}</div>
+    </Drawer>
+  );
+};
+
+export default DrawerComponent;

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -13,6 +13,7 @@ import Checkbox from 'components/kit/Checkbox';
 import ClipboardButton from 'components/kit/ClipboardButton';
 import CodeEditor from 'components/kit/CodeEditor';
 import { Column, Columns } from 'components/kit/Columns';
+import Drawer from 'components/kit/Drawer';
 import Dropdown, { MenuItem } from 'components/kit/Dropdown';
 import Empty from 'components/kit/Empty';
 import Facepile from 'components/kit/Facepile';
@@ -84,6 +85,7 @@ const ComponentTitles = {
   CodeEditor: 'CodeEditor',
   Color: 'Color',
   Columns: 'Columns',
+  Drawer: 'Drawer',
   Dropdown: 'Dropdown',
   Empty: 'Empty',
   Facepile: 'Facepile',
@@ -2678,6 +2680,58 @@ const AccordionSection: React.FC = () => {
   );
 };
 
+const DrawerSection: React.FC = () => {
+  const [openLeft, setOpenLeft] = useState(false);
+  const [openRight, setOpenRight] = useState(false);
+  const scrollLines = [];
+  for (let i = 0; i < 100; i++) {
+    scrollLines.push(i);
+  }
+
+  return (
+    <ComponentSection id="Drawer" title="Drawer">
+      <AntDCard>
+        <p>
+          An <code>{'<Drawer>'}</code> is a full-height overlaid sidebar which moves into the
+          viewport from the left or right side.
+        </p>
+      </AntDCard>
+      <AntDCard title="Left side">
+        <p>
+          Drawer appears from the left side in an animation. Similar to a Modal, it can be closed
+          with a Close button (at top right) or by clicking outside of the Drawer.
+        </p>
+        <p>If the drawer body has extra content, it is scrollable without hiding the header.</p>
+        <Space>
+          <Button onClick={() => setOpenLeft(true)}>Open Drawer</Button>
+        </Space>
+        <Drawer
+          open={openLeft}
+          placement="left"
+          title="Left Drawer"
+          onClose={() => setOpenLeft(!openLeft)}>
+          {scrollLines.map((i) => (
+            <p key={i}>Sample scrollable content</p>
+          ))}
+        </Drawer>
+      </AntDCard>
+      <AntDCard title="Right side">
+        <p>Drawer appears from the right side.</p>
+        <Space>
+          <Button onClick={() => setOpenRight(true)}>Open Drawer</Button>
+        </Space>
+        <Drawer
+          open={openRight}
+          placement="right"
+          title="Right Drawer"
+          onClose={() => setOpenRight(!openRight)}>
+          <p>Sample content</p>
+        </Drawer>
+      </AntDCard>
+    </ComponentSection>
+  );
+};
+
 const Components = {
   Accordion: <AccordionSection />,
   Breadcrumbs: <BreadcrumbsSection />,
@@ -2689,6 +2743,7 @@ const Components = {
   CodeEditor: <CodeEditorSection />,
   Color: <ColorSection />,
   Columns: <ColumnsSection />,
+  Drawer: <DrawerSection />,
   Dropdown: <DropdownSection />,
   Empty: <EmptySection />,
   Facepile: <FacepileSection />,

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -2699,7 +2699,7 @@ const DrawerSection: React.FC = () => {
       <AntDCard title="Left side">
         <p>
           Drawer appears from the left side in an animation. Similar to a Modal, it can be closed
-          with a Close button (at top right) or by clicking outside of the Drawer.
+          only by clicking a Close button (at top right) or Escape key.
         </p>
         <p>If the drawer body has extra content, it is scrollable without hiding the header.</p>
         <Space>
@@ -2717,6 +2717,9 @@ const DrawerSection: React.FC = () => {
       </AntDCard>
       <AntDCard title="Right side">
         <p>Drawer appears from the right side.</p>
+        <p>
+          When a drawer has stateful content, that state is persisted when closed and re-opened.
+        </p>
         <Space>
           <Button onClick={() => setOpenRight(true)}>Open Drawer</Button>
         </Space>
@@ -2726,6 +2729,13 @@ const DrawerSection: React.FC = () => {
           title="Right Drawer"
           onClose={() => setOpenRight(!openRight)}>
           <p>Sample content</p>
+          <Checkbox>A</Checkbox>
+          <Checkbox>B</Checkbox>
+          <Checkbox>C</Checkbox>
+          <Checkbox>D</Checkbox>
+          <Form.Item label="Sample Persistent Input" name="sample_drawer">
+            <Input.TextArea />
+          </Form.Item>
         </Drawer>
       </AntDCard>
     </ComponentSection>


### PR DESCRIPTION
## Description

Adds a customized Antd.Drawer, a full-height sidebar / overlay which scrolls into the window from the left or right.

This is a new component, so it does not replace existing components on the site.

## Test Plan

- On `/det/design`, open the left and right Drawer components
- Confirm Drawer can close by clicking 'x' button
- Left Drawer scrollable content scrolls the body content, not the header
- Right Drawer content has checkboxes and text area; this content is preserved if you close and re-open the Drawer
- Confirm Drawer **does not close** if clicking on or outside the Drawer
- Antd animation is 0.3 seconds and does not need customization

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.