### PR TITLE
fix: Display chart if filters.batch is a number

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -195,7 +195,8 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
      * In the case of Custom Searchers, all the tabs besides
      * "Learning Curve" aren't helpful or relevant, so we are hiding them
      */
-    if (!(filters.maxTrial && filters.batchMargin && filters.batch)) return [];
+    if (!(filters.maxTrial && filters.batchMargin && (filters.batch || filters.batch === 0)))
+      return [];
 
     const tabs: TabsProps['items'] = [
       {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -195,8 +195,13 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
      * In the case of Custom Searchers, all the tabs besides
      * "Learning Curve" aren't helpful or relevant, so we are hiding them
      */
-    if (!(filters.maxTrial && filters.batchMargin && (filters.batch || filters.batch === 0)))
+    if (
+      filters.maxTrial === undefined ||
+      filters.batchMargin === undefined ||
+      filters.batch === undefined
+    ) {
       return [];
+    }
 
     const tabs: TabsProps['items'] = [
       {


### PR DESCRIPTION
## Description

We discussed an issue where http://latest-main.determined.ai:8080/det/experiments/2072/visualization/learning-curve is not displaying a LearningCurve chart.

Though we believed this was related to no validation metrics, the fix is related to displaying multi-trial tabs when `filters.batch === 0` - the original statement is intended to delay rendering while `filters.batch === undefined` , but was triggering on any false-y values.

## Test Plan

While connected to the latest-main DB, test experiment 2072.  Or use another experiment with no validation metrics.

Training loss should appear on a LearningCurve chart.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.