### PR TITLE
fix: set protocol scheme in kubernetes resource manager

### DIFF
--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -94,8 +94,12 @@ func (p *pod) configureEnvVars(
 		slotIds = append(slotIds, strconv.Itoa(i))
 	}
 
+	masterScheme := "http"
+	if p.masterTLSConfig.Enabled {
+		masterScheme = "https"
+	}
 	envVarsMap["DET_CLUSTER_ID"] = p.clusterID
-	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s:%d", p.masterIP, p.masterPort)
+	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s://%s:%d", masterScheme, p.masterIP, p.masterPort)
 	envVarsMap["DET_MASTER_HOST"] = p.masterIP
 	envVarsMap["DET_MASTER_ADDR"] = p.masterIP
 	envVarsMap["DET_MASTER_PORT"] = fmt.Sprintf("%d", p.masterPort)


### PR DESCRIPTION
## Description

We currently are not checking if tls is enabled when setting `DET_MASTER` in a Kubernetes agent. This results in protocol errors running experiments if tls is enabled. This change sets the `DET_MASTER` protocol to https if tls is enabled and http otherwise. 


## Test Plan

- Create a Kubernetes cluster with TLS enabled
- Validate that you can run experiments 
- Create a Kubernetes cluster with TLS disabled
- Validate that you can run experiments

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
