### PR TITLE
fix: correct scale positional argument in compareTrials API call [WEB-1386]

### DIFF
--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -990,6 +990,7 @@ export const timeSeries: DetApi<
       params.startBatches,
       params.endBatches,
       params.metricType ? Type.metricTypeParamMap[params.metricType] : 'METRIC_TYPE_UNSPECIFIED',
+      undefined,
       params.scale === Type.Scale.Log ? 'SCALE_LOG' : 'SCALE_LINEAR',
     ),
 };


### PR DESCRIPTION
## Description
Due to incorrect argument positioning in the call to `compareTrials` we are currently sending a `customType` argument as `SCALE_LINEAR` this bug causes the backend to not return any metrics since the customType is bogus.

This PR fixed the positional arguments. 

Current Behavior:
**Trial Overview**
![Screen Shot 2023-06-16 at 12 55 00 PM](https://github.com/determined-ai/determined/assets/103522725/5174c075-6ca4-40a7-bbf5-39dafb92f9ea)

**Compare Metrics tab**
![Screen Shot 2023-06-16 at 12 56 43 PM](https://github.com/determined-ai/determined/assets/103522725/cb6325fb-0d60-4c8f-a21b-681e81c4eac2)

Fixed Behavior:
**Trial Overview**
![Screen Shot 2023-06-16 at 12 56 12 PM](https://github.com/determined-ai/determined/assets/103522725/12c0872a-0870-4efa-ac14-fe908702c624)

**Compare Metrics tab**
![Screen Shot 2023-06-16 at 12 57 09 PM](https://github.com/determined-ai/determined/assets/103522725/4bf9a071-10b1-4327-a4bb-174b8bc184a9)

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
1. In the new experiment list `compare` view `metric` tab ensure that any experiment that has metrics has viewable chart data. At least a single chart should not show "No data to plot."
2. Ensure that the `Trial Overview` chart for trials that have metrics, show the metric values and not just "No Data to plot."
 
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1386
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
