### PR TITLE
fix: Race condition loading parsed query settings into all settings [WEB-1376]

### DIFF
--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -313,7 +313,7 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
 
   useLayoutEffect(() => {
     if (initialLoading) return;
-    setTimeout(clearQuerySettings, 200);
+    clearQuerySettings();
     return derivedOb.subscribe(async (cur, prev) => {
       if (!cur || !currentUser || isEqual(cur, prev)) return;
 

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -320,7 +320,7 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
 
   useLayoutEffect(() => {
     if (initialLoading) return;
-    clearQuerySettings();
+    setTimeout(clearQuerySettings, 200);
     return derivedOb.subscribe(async (cur, prev) => {
       if (!cur || !currentUser || isEqual(cur, prev)) return;
 

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -177,21 +177,6 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
   const navigate = useNavigate();
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
 
-  // parse navigation url to state
-  useEffect(() => {
-    if (!querySettings) return;
-
-    const parsedSettings = queryToSettings<T>(config, querySettings);
-    stateOb.update((s) => {
-      const oldSettings = s.get(config.storagePath) ?? {};
-      const newSettings = { ...s.get(config.storagePath), ...parsedSettings };
-      return s.set(
-        config.storagePath,
-        isEqual(oldSettings, newSettings) ? oldSettings : newSettings,
-      );
-    });
-  }, [config, querySettings, stateOb]);
-
   const settings: SettingsRecord<T> = useMemo(
     () =>
       ({
@@ -317,6 +302,14 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
     },
     [config, stateOb],
   );
+
+  // parse navigation url to state
+  useEffect(() => {
+    if (!querySettings) return;
+
+    const parsedSettings = queryToSettings<T>(config, querySettings);
+    updateSettings(parsedSettings);
+  }, [config, querySettings, updateSettings]);
 
   useLayoutEffect(() => {
     if (initialLoading) return;

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -1,6 +1,6 @@
 import { Map } from 'immutable';
 import { observable, useObservable, WritableObservable } from 'micro-observables';
-import React, { createContext, useCallback, useEffect, useRef, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 
 import Spinner from 'components/Spinner';
 import { getUserSetting } from 'services/api';
@@ -21,16 +21,12 @@ type UserSettingsState = Map<string, Settings>;
 export type Settings = { [key: string]: any }; //TODO: find a way to use a better type here
 
 type UserSettingsContext = {
-  clearQuerySettings: () => void;
   isLoading: WritableObservable<boolean>;
-  querySettings: string;
   state: WritableObservable<UserSettingsState>;
 };
 
 export const UserSettings = createContext<UserSettingsContext>({
-  clearQuerySettings: () => undefined,
   isLoading: observable(false),
-  querySettings: '',
   state: observable(Map<string, Settings>()),
 });
 
@@ -39,7 +35,6 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   const isAuthChecked = useObservable(authStore.isChecked);
   const [canceler] = useState(new AbortController());
   const [isLoading] = useState(() => observable(true));
-  const querySettings = useRef('');
   const [settingsState] = useState(() => observable(Map<string, Settings>()));
 
   useEffect(() => {
@@ -80,25 +75,13 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
     return () => canceler.abort();
   }, [canceler, isAuthChecked, isLoading, settingsState]);
 
-  useEffect(() => {
-    const url = window.location.search.substring(/^\?/.test(location.search) ? 1 : 0);
-
-    querySettings.current = url;
-  }, []);
-
-  const clearQuerySettings = useCallback(() => {
-    querySettings.current = '';
-  }, []);
-
   return (
     <Spinner
       spinning={useObservable(isLoading) && !(isAuthChecked && !currentUser)}
       tip="Loading Page">
       <UserSettings.Provider
         value={{
-          clearQuerySettings,
           isLoading: isLoading,
-          querySettings: querySettings.current,
           state: settingsState,
         }}>
         {children}

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -1,6 +1,6 @@
 import { Map } from 'immutable';
 import { observable, useObservable, WritableObservable } from 'micro-observables';
-import React, { createContext, useCallback, useEffect, useRef, useState } from 'react';
+import React, { createContext, useEffect, useRef, useState } from 'react';
 
 import Spinner from 'components/Spinner';
 import { getUserSetting } from 'services/api';
@@ -21,16 +21,14 @@ type UserSettingsState = Map<string, Settings>;
 export type Settings = { [key: string]: any }; //TODO: find a way to use a better type here
 
 type UserSettingsContext = {
-  clearQuerySettings: () => void;
   isLoading: WritableObservable<boolean>;
-  querySettings: string;
+  querySettings: URLSearchParams;
   state: WritableObservable<UserSettingsState>;
 };
 
 export const UserSettings = createContext<UserSettingsContext>({
-  clearQuerySettings: () => undefined,
   isLoading: observable(false),
-  querySettings: '',
+  querySettings: new URLSearchParams(''),
   state: observable(Map<string, Settings>()),
 });
 
@@ -39,7 +37,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   const isAuthChecked = useObservable(authStore.isChecked);
   const [canceler] = useState(new AbortController());
   const [isLoading] = useState(() => observable(true));
-  const querySettings = useRef('');
+  const querySettings = useRef(new URLSearchParams(''));
   const [settingsState] = useState(() => observable(Map<string, Settings>()));
 
   useEffect(() => {
@@ -83,11 +81,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   useEffect(() => {
     const url = window.location.search.substring(/^\?/.test(location.search) ? 1 : 0);
 
-    querySettings.current = url;
-  }, []);
-
-  const clearQuerySettings = useCallback(() => {
-    querySettings.current = '';
+    querySettings.current = new URLSearchParams(url);
   }, []);
 
   return (
@@ -96,7 +90,6 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
       tip="Loading Page">
       <UserSettings.Provider
         value={{
-          clearQuerySettings,
           isLoading: isLoading,
           querySettings: querySettings.current,
           state: settingsState,

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -79,9 +79,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   }, [canceler, isAuthChecked, isLoading, settingsState]);
 
   useEffect(() => {
-    const url = window.location.search.substring(/^\?/.test(location.search) ? 1 : 0);
-
-    querySettings.current = new URLSearchParams(url);
+    querySettings.current = new URLSearchParams(window.location.search);
   }, []);
 
   return (

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -1,6 +1,6 @@
 import { Map } from 'immutable';
 import { observable, useObservable, WritableObservable } from 'micro-observables';
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useCallback, useEffect, useRef, useState } from 'react';
 
 import Spinner from 'components/Spinner';
 import { getUserSetting } from 'services/api';
@@ -86,9 +86,9 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
     querySettings.current = url;
   }, []);
 
-  const clearQuerySettings = () => {
+  const clearQuerySettings = useCallback(() => {
     querySettings.current = '';
-  };
+  }, []);
 
   return (
     <Spinner


### PR DESCRIPTION
## Description

**The observed bug**: gcloud server, or localhost with gcloud backend, consistently do not read from querySettings. Latest-main and running locally cannot replicate.

**Our explanation**: on servers where querySettings code runs first, the query and stored settings merge successfully.
When querySettings happens later, the code to apply changes `stateOb.update((s) => s.set(config.storagePath, stateSettings))` is not triggering the update to settings expected by `settings = useMemo(() => ... [state])`  (due to s, state, and stateSettings being Immutable.Map objects)

**The fix**: `stateOb.update((s) => { ... }` should be based on `useSettings` code

**Clearing settings**:
- The `useEffect` for querySettings is run multiple times, so if navigation is checked before page-specific settings, `clearQuerySettings` clears all settings.
- `clearQuerySettings` should run after all instances of `useSettings` on the page have parsed their query params.
- The PR currently places `clearQuerySettings` inside the `useLayoutEffect` callback, after `initialLoading` is finished

## Test Plan

During release party: check gcloud

During pre-release review:
Run `make live` and `dev serverAddress set ` + gcloud
Visit `/det/projects/1/experiments` and try `?search=pytorch` in the browser, setting a search in the table filter, overwriting the table filter with your `?search=abc`
Also affects state=COMPLETED, state=ACTIVE, etc.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.