### PR TITLE
fix: Don't draw rows after end of data; compare panel width [WEB-1339] [WEB-1365]

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -164,7 +164,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [canceler] = useState(new AbortController());
 
   const colorMap = useGlasbey(selectedExperimentIds);
-  const { height: containerHeight } = useResize(contentRef);
+  const { height: containerHeight, width: containerWidth } = useResize(contentRef);
   const height =
     containerHeight - 2 * parseInt(getCssVar('--theme-stroke-width')) - (isPagedView ? 40 : 0);
   const [scrollPositionSetCount] = useState(observable(0));
@@ -441,11 +441,14 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   }, [settings.columns, settings.pinnedColumnsCount]);
 
   const comparisonViewWidth = useMemo(() => {
-    return pinnedColumns.reduce(
-      (totalWidth, curCol) => totalWidth + settings.columnWidths[curCol] ?? 0,
-      17, // Constant of 17px accounts for scrollbar width
+    return Math.min(
+      containerWidth - 30,
+      pinnedColumns.reduce(
+        (totalWidth, curCol) => totalWidth + settings.columnWidths[curCol] ?? 0,
+        17, // Constant of 17px accounts for scrollbar width
+      ),
     );
-  }, [pinnedColumns, settings.columnWidths]);
+  }, [containerWidth, pinnedColumns, settings.columnWidths]);
 
   const handleCompareWidthChange = useCallback(
     (width: number) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -267,7 +267,11 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       // to put a border on the bottom row (actually the top of the row below it)
       if (row === data.length) return;
       // avoid showing 'empty rows' below data
-      if (!data[row]) return;
+      if (!data[row]) {
+        return {
+          borderColor: getCssVar(Surface.Surface),
+        };
+      }
 
       const hoverStyle = row === hoveredRow ? { bgCell: getCssVar(Surface.SurfaceWeak) } : {};
 


### PR DESCRIPTION
## Description

**updated to fix two small issues with Glide Table**

1. When compare view is on, we check window width to keep some part of the compare panel visible

2. If the experiment glide table does not fill with rows, avoid showing row lines below:

Comment: the name column line is still there because `getRowThemeOverride` does not pass a column value, and `verticalBorder` does not pass a row value.

<img width="757" alt="Screen Shot 2023-06-21 at 7 24 44 AM" src="https://github.com/determined-ai/determined/assets/643918/d0925326-dbd6-4791-9c10-b69f78d3eb83">

## Test Plan

Use the `f_explist_v2=on` flag to view a project with just a few experiments: example `/det/projects/49/experiments?f_explist_v2=on`

**Table rows**
- Confirm the last data row has a bottom border
- Confirm rows below the last row do not have distinct markings

**Compare view**
- Click the "Compare" button to see table and compare panel side by side.
- Move the divider left and right; the divider cannot be moved 100% to the right
- Resize the browser window to be narrower. At first you will cover up some of the Compare panel, but then it will override settings and keep a small part of Compare visible.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.