### PR TITLE
fix: potential overflow in summary metrics migration and rollback

### DIFF
--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -362,6 +362,40 @@ func generateSummaryMetricsTestCases(
 		"a": {Last: "1.8", Type: "string"},
 	}
 
+	doubleOverflow := RequireMockTrial(t, db, exp).ID
+	addMetrics(ctx, t, db, doubleOverflow,
+		`[{"a":1.79769e308}, {"a":1.79769e308}]`,
+		`[{"a":1.79769e308}, {"a":1.79769e308}]`, archive)
+	doubleOverflowMetrics := map[string]summaryMetrics{
+		"a": {
+			Count: 2, Sum: math.Inf(1), Min: 1.79769e308, Max: 1.79769e308,
+			Last: "179769" + strings.Repeat("0", 303), Type: "number",
+		},
+	}
+	doubleOverflowValMetrics := map[string]summaryMetrics{
+		"a": {
+			Count: 2, Sum: math.Inf(1), Min: 1.79769e308, Max: 1.79769e308,
+			Last: "179769" + strings.Repeat("0", 303), Type: "number",
+		},
+	}
+
+	doubleOverflowNeg := RequireMockTrial(t, db, exp).ID
+	addMetrics(ctx, t, db, doubleOverflowNeg,
+		`[{"a":-1.79769e308}, {"a":-1.79769e308}]`,
+		`[{"a":-1.79769e308}, {"a":-1.79769e308}]`, archive)
+	doubleOverflowNegMetrics := map[string]summaryMetrics{
+		"a": {
+			Count: 2, Sum: math.Inf(-1), Min: -1.79769e308, Max: -1.79769e308,
+			Last: "-179769" + strings.Repeat("0", 303), Type: "number",
+		},
+	}
+	doubleOverflowNegValMetrics := map[string]summaryMetrics{
+		"a": {
+			Count: 2, Sum: math.Inf(-1), Min: -1.79769e308, Max: -1.79769e308,
+			Last: "-179769" + strings.Repeat("0", 303), Type: "number",
+		},
+	}
+
 	trialIDs := []int{
 		noMetrics,
 		numericMetrics,
@@ -371,6 +405,8 @@ func generateSummaryMetricsTestCases(
 		infNaNMetrics,
 		types,
 		mixedTypes,
+		doubleOverflow,
+		doubleOverflowNeg,
 	}
 	expectedTrain := []map[string]summaryMetrics{
 		expectedNoMetrics,
@@ -381,6 +417,8 @@ func generateSummaryMetricsTestCases(
 		expectedInfNaNMetrics,
 		expectedTypesMetrics,
 		expectedMixedTypesMetrics,
+		doubleOverflowMetrics,
+		doubleOverflowNegMetrics,
 	}
 	expectedVal := []map[string]summaryMetrics{
 		expectedNoValMetrics,
@@ -391,6 +429,8 @@ func generateSummaryMetricsTestCases(
 		expectedInfNaNValMetrics,
 		expectedTypesValMetrics,
 		expectedMixedTypesValMetrics,
+		doubleOverflowValMetrics,
+		doubleOverflowNegValMetrics,
 	}
 
 	return trialIDs, expectedTrain, expectedVal

--- a/master/static/migrations/20230503144448_add-summary-metrics.tx.down.sql
+++ b/master/static/migrations/20230503144448_add-summary-metrics.tx.down.sql
@@ -1,3 +1,5 @@
 ALTER TABLE trials
     DROP COLUMN summary_metrics,
     DROP COLUMN summary_metrics_timestamp;
+
+DROP AGGREGATE IF EXISTS safe_sum(numeric);

--- a/master/static/migrations/20230621150207_add-safe-sum-aggregate.tx.down.sql
+++ b/master/static/migrations/20230621150207_add-safe-sum-aggregate.tx.down.sql
@@ -1,0 +1,3 @@
+DROP AGGREGATE IF EXISTS safe_sum(float8);
+
+DROP FUNCTION IF EXISTS safe_sum_accumulate(float8, float8, OUT float8);

--- a/master/static/migrations/20230621150207_add-safe-sum-aggregate.tx.up.sql
+++ b/master/static/migrations/20230621150207_add-safe-sum-aggregate.tx.up.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION safe_sum_accumulate(float8, float8, OUT float8)
+  RETURNS float8 AS $$
+  BEGIN
+    -- Check for potential overflow
+    BEGIN
+      IF $1 IS NULL THEN
+        $3 := $2;
+      ELSIF $2 IS NULL THEN
+        $3 := $1;
+      ELSE
+        $3 := $1 + $2;
+      END IF;
+    EXCEPTION
+      WHEN numeric_value_out_of_range THEN
+        IF $1 < 0 THEN
+          $3 := '-Infinity';
+        ELSE
+          $3 := 'Infinity';
+        END IF;
+    END;
+  END;
+$$ LANGUAGE plpgsql;
+
+DROP AGGREGATE IF EXISTS safe_sum(float8);
+
+CREATE AGGREGATE safe_sum(float8) (
+  SFUNC = safe_sum_accumulate,
+  STYPE = float8
+);

--- a/master/static/srv/calculate-full-trial-summary-metrics.sql
+++ b/master/static/srv/calculate-full-trial-summary-metrics.sql
@@ -3,14 +3,14 @@ WITH trial_metrics as (
 SELECT
 	name,
 	trial_id,
-	CASE sum(entries)
-		WHEN sum(entries) FILTER (WHERE metric_type = 'number') THEN 'number'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'string') THEN 'string'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'date') THEN 'date'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'object') THEN 'object'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'boolean') THEN 'boolean'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'array') THEN 'array'
-		WHEN sum(entries) FILTER (WHERE metric_type = 'null') THEN 'null'
+	CASE safe_sum(entries)
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'number') THEN 'number'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'string') THEN 'string'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'date') THEN 'date'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'object') THEN 'object'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'boolean') THEN 'boolean'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'array') THEN 'array'
+		WHEN safe_sum(entries) FILTER (WHERE metric_type = 'null') THEN 'null'
 		ELSE 'string'
 	END as metric_type
 FROM (
@@ -58,7 +58,7 @@ SELECT
 	name,
 	ntm.trial_id,
 	count(1) as count_agg,
-	sum((metrics.metrics->$2->>name)::double precision) as sum_agg,
+	safe_sum((metrics.metrics->$2->>name)::double precision) as sum_agg,
 	min((metrics.metrics->$2->>name)::double precision) as min_agg,
 	max((metrics.metrics->$2->>name)::double precision) as max_agg,
 	'number' as metric_type


### PR DESCRIPTION
## Description

Fix a potential issue with summary metrics migration and rollback for values that could overflow postgres's floats.

## Test Plan

Automated tests.


## Commentary (optional)

TODO bench results

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
