### PR TITLE
fix: pinned column resizing in compare view [WEB-1395]

### DIFF
--- a/webui/react/src/components/SplitPane.tsx
+++ b/webui/react/src/components/SplitPane.tsx
@@ -32,6 +32,7 @@ const SplitPane: React.FC<Props> = ({
 
   useEffect(() => {
     const c = (e: MouseEvent) => {
+      if (e.button !== 0) return;
       e.preventDefault();
       setIsDragging(true);
     };
@@ -72,7 +73,8 @@ const SplitPane: React.FC<Props> = ({
 
   useEffect(() => {
     if (!isDragging) return;
-    const c = () => {
+    const c = (e: MouseEvent) => {
+      if (e.button !== 0) return;
       // Turn off dragging flag when user mouse is up
       setIsDragging(false);
       onChange?.(width);

--- a/webui/react/src/components/SplitPane.tsx
+++ b/webui/react/src/components/SplitPane.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { throttle } from 'throttle-debounce';
 
 import useResize from 'hooks/useResize';
 
@@ -24,6 +25,8 @@ const SplitPane: React.FC<Props> = ({
   const container = useRef<HTMLDivElement>(null);
   const handle = useRef<HTMLDivElement>(null);
   const containerDimensions = useResize(container);
+
+  const throttledOnChange = useMemo(() => onChange && throttle(10, onChange), [onChange]);
 
   useEffect(() => setWidth(initialWidth), [initialWidth]);
 
@@ -54,11 +57,18 @@ const SplitPane: React.FC<Props> = ({
 
       // Resize box A
       setWidth(newWidth);
+      throttledOnChange?.(newWidth);
     };
     document.addEventListener('mousemove', c);
 
     return () => document.removeEventListener('mousemove', c);
-  }, [containerDimensions.width, containerDimensions.x, isDragging, minimumWidths]);
+  }, [
+    containerDimensions.width,
+    containerDimensions.x,
+    throttledOnChange,
+    isDragging,
+    minimumWidths,
+  ]);
 
   useEffect(() => {
     if (!isDragging) return;

--- a/webui/react/src/components/SplitPane.tsx
+++ b/webui/react/src/components/SplitPane.tsx
@@ -26,43 +26,48 @@ const SplitPane: React.FC<Props> = ({
   const handle = useRef<HTMLDivElement>(null);
   const containerDimensions = useResize(container);
 
-  const throttledOnChange = useMemo(() => onChange && throttle(8, onChange), [onChange]);
+  const throttledOnChange = useMemo(
+    () => onChange && throttle(8, onChange, { noTrailing: true }),
+    [onChange],
+  );
 
   useEffect(() => setWidth(initialWidth), [initialWidth]);
 
   useEffect(() => {
-    const c = (e: MouseEvent) => {
+    const handleDragStart = (e: MouseEvent) => {
       if (e.button !== 0) return;
       e.preventDefault();
       setIsDragging(true);
     };
     const handleRef = handle.current;
-    handleRef?.addEventListener('mousedown', c);
+    handleRef?.addEventListener('mousedown', handleDragStart);
 
-    return () => handleRef?.removeEventListener('mousedown', c);
+    return () => handleRef?.removeEventListener('mousedown', handleDragStart);
   }, []);
 
   useEffect(() => {
     if (!isDragging) return;
-    const c = (e: MouseEvent) => {
+    const handleDrag = (e: MouseEvent) => {
       e.preventDefault();
 
       // Get x-coordinate of pointer relative to container
       const pointerRelativeXpos = e.clientX - containerDimensions.x;
 
       // * 8px is the left/right spacing between .handle and its inner pseudo-element
-      const newWidth = Math.min(
-        Math.max(minimumWidths[0], pointerRelativeXpos - 8),
-        containerDimensions.width - minimumWidths[1],
+      const newWidth = Math.round(
+        Math.min(
+          Math.max(minimumWidths[0], pointerRelativeXpos - 8),
+          containerDimensions.width - minimumWidths[1],
+        ),
       );
 
       // Resize box A
       setWidth(newWidth);
       throttledOnChange?.(newWidth);
     };
-    document.addEventListener('mousemove', c);
+    document.addEventListener('mousemove', handleDrag);
 
-    return () => document.removeEventListener('mousemove', c);
+    return () => document.removeEventListener('mousemove', handleDrag);
   }, [
     containerDimensions.width,
     containerDimensions.x,
@@ -73,17 +78,17 @@ const SplitPane: React.FC<Props> = ({
 
   useEffect(() => {
     if (!isDragging) return;
-    const c = (e: MouseEvent) => {
+    const handleDragStop = (e: MouseEvent) => {
       if (e.button !== 0) return;
       // Turn off dragging flag when user mouse is up
       setIsDragging(false);
+      throttledOnChange?.cancel();
       onChange?.(width);
     };
+    document.addEventListener('mouseup', handleDragStop);
 
-    document.addEventListener('mouseup', c);
-
-    return () => document.removeEventListener('mouseup', c);
-  }, [width, isDragging, onChange]);
+    return () => document.removeEventListener('mouseup', handleDragStop);
+  }, [width, isDragging, onChange, throttledOnChange]);
 
   const classnames = [css.base];
   if (open) classnames.push(css.open);

--- a/webui/react/src/components/SplitPane.tsx
+++ b/webui/react/src/components/SplitPane.tsx
@@ -26,7 +26,7 @@ const SplitPane: React.FC<Props> = ({
   const handle = useRef<HTMLDivElement>(null);
   const containerDimensions = useResize(container);
 
-  const throttledOnChange = useMemo(() => onChange && throttle(10, onChange), [onChange]);
+  const throttledOnChange = useMemo(() => onChange && throttle(8, onChange), [onChange]);
 
   useEffect(() => setWidth(initialWidth), [initialWidth]);
 

--- a/webui/react/src/hooks/useScrollbarWidth.ts
+++ b/webui/react/src/hooks/useScrollbarWidth.ts
@@ -1,0 +1,30 @@
+/*
+ * Hook to measure the width of a vertical scrollbar in px. May return 0 on mobile devices.
+ * Based on this answer from StackOverflow: https://stackoverflow.com/a/55278118
+ */
+import { useEffect, useState } from 'react';
+
+const useScrollbarWidth = (): number => {
+  const [scrollbarWidth, setScrollbarWidth] = useState<number>(0);
+
+  useEffect(() => {
+    // Add temporary box to wrapper
+    const scrollbox = document.createElement('div');
+
+    // Make box scrollable
+    scrollbox.style.overflow = 'scroll';
+
+    // Append box to document
+    document.body.appendChild(scrollbox);
+
+    // Measure inner width of box
+    setScrollbarWidth(scrollbox.offsetWidth - scrollbox.clientWidth);
+
+    // Remove box
+    document.body.removeChild(scrollbox);
+  }, []);
+
+  return scrollbarWidth;
+};
+
+export default useScrollbarWidth;

--- a/webui/react/src/pages/F_ExpList/ComparisonView.tsx
+++ b/webui/react/src/pages/F_ExpList/ComparisonView.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from 'react';
 
 import Pivot, { TabItem } from 'components/kit/Pivot';
 import SplitPane from 'components/SplitPane';
+import useScrollbarWidth from 'hooks/useScrollbarWidth';
 import { TrialsComparisonTable } from 'pages/ExperimentDetails/TrialsComparisonModal';
 import { ExperimentWithTrial, TrialItem } from 'types';
 
 import CompareMetrics from './CompareMetrics';
 import CompareParallelCoordinates from './CompareParallelCoordinates';
-import { minColumnWidth } from './glide-table/columns';
+import { MIN_COLUMN_WIDTH } from './glide-table/columns';
 
 interface Props {
   children: React.ReactElement;
@@ -27,9 +28,11 @@ const ComparisonView: React.FC<Props> = ({
   projectId,
   selectedExperiments,
 }) => {
+  const scrollbarWidth = useScrollbarWidth();
+
   const minWidths: [number, number] = useMemo(() => {
-    return [fixedColumnsCount * minColumnWidth + 17, 100]; // Constant of 17px accounts for scrollbar width
-  }, [fixedColumnsCount]);
+    return [fixedColumnsCount * MIN_COLUMN_WIDTH + scrollbarWidth, 100];
+  }, [fixedColumnsCount, scrollbarWidth]);
 
   const trials = useMemo(
     () =>

--- a/webui/react/src/pages/F_ExpList/ComparisonView.tsx
+++ b/webui/react/src/pages/F_ExpList/ComparisonView.tsx
@@ -7,12 +7,14 @@ import { ExperimentWithTrial, TrialItem } from 'types';
 
 import CompareMetrics from './CompareMetrics';
 import CompareParallelCoordinates from './CompareParallelCoordinates';
+import { minColumnWidth } from './glide-table/columns';
 
 interface Props {
   children: React.ReactElement;
   open: boolean;
   initialWidth: number;
   onWidthChange: (width: number) => void;
+  fixedColumnsCount: number;
   projectId: number;
   selectedExperiments: ExperimentWithTrial[];
 }
@@ -21,9 +23,14 @@ const ComparisonView: React.FC<Props> = ({
   open,
   initialWidth,
   onWidthChange,
+  fixedColumnsCount,
   projectId,
   selectedExperiments,
 }) => {
+  const minWidths: [number, number] = useMemo(() => {
+    return [fixedColumnsCount * minColumnWidth + 17, 50]; // Constant of 17px accounts for scrollbar width
+  }, [fixedColumnsCount]);
+
   const trials = useMemo(
     () =>
       selectedExperiments.filter((exp) => !!exp.bestTrial).map((exp) => exp.bestTrial as TrialItem),
@@ -62,7 +69,11 @@ const ComparisonView: React.FC<Props> = ({
   }, [selectedExperiments, projectId, experiments, trials]);
 
   return (
-    <SplitPane initialWidth={initialWidth} open={open} onChange={onWidthChange}>
+    <SplitPane
+      initialWidth={initialWidth}
+      minimumWidths={minWidths}
+      open={open}
+      onChange={onWidthChange}>
       {children}
       <Pivot destroyInactiveTabPane items={tabs} />
     </SplitPane>

--- a/webui/react/src/pages/F_ExpList/ComparisonView.tsx
+++ b/webui/react/src/pages/F_ExpList/ComparisonView.tsx
@@ -28,7 +28,7 @@ const ComparisonView: React.FC<Props> = ({
   selectedExperiments,
 }) => {
   const minWidths: [number, number] = useMemo(() => {
-    return [fixedColumnsCount * minColumnWidth + 17, 50]; // Constant of 17px accounts for scrollbar width
+    return [fixedColumnsCount * minColumnWidth + 17, 100]; // Constant of 17px accounts for scrollbar width
   }, [fixedColumnsCount]);
 
   const trials = useMemo(

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.module.scss
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.module.scss
@@ -1,4 +1,8 @@
 .base {
   border: var(--theme-stroke-width) solid var(--theme-ix-border);
   border-radius: var(--theme-border-radius);
+
+  .compareTable {
+    overflow-x: hidden !important;
+  }
 }

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -59,6 +59,7 @@ import {
   defaultTextColumn,
   getColumnDefs,
   getHeaderIcons,
+  minColumnWidth,
 } from './columns';
 import { TableContextMenu, TableContextMenuProps } from './contextMenu';
 import { customRenderers } from './custom-renderers';
@@ -766,13 +767,13 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           drawHeader={drawHeader}
           freezeColumns={staticColumns.length + pinnedColumnsCount}
           getCellContent={getCellContent}
-          // `getCellsForSelection` is required for double click column resize to content.
-          getCellsForSelection
+          getCellsForSelection // `getCellsForSelection` is required for double click column resize to content.
           getRowThemeOverride={getRowThemeOverride}
           gridSelection={selection}
           headerHeight={36}
           headerIcons={headerIcons}
           height={height}
+          minColumnWidth={minColumnWidth}
           ref={gridRef}
           rowHeight={rowHeightMap[rowHeight]}
           rows={dataTotal}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -762,6 +762,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
       {tooltip}
       <div className={css.base}>
         <DataEditor
+          className={comparisonViewOpen ? css.compareTable : undefined}
           columns={columns}
           customRenderers={customRenderers}
           drawHeader={drawHeader}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -59,7 +59,8 @@ import {
   defaultTextColumn,
   getColumnDefs,
   getHeaderIcons,
-  minColumnWidth,
+  MIN_COLUMN_WIDTH,
+  MULTISELECT,
 } from './columns';
 import { TableContextMenu, TableContextMenuProps } from './contextMenu';
 import { customRenderers } from './custom-renderers';
@@ -289,7 +290,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   const onColumnResize: DataEditorProps['onColumnResize'] = useCallback(
     (column: GridColumn, width: number) => {
       const columnId = column.id;
-      if (columnId === undefined || columnId === 'selected') return;
+      if (columnId === undefined || columnId === MULTISELECT) return;
       setColumnWidths({ ...columnWidths, [columnId]: width });
     },
     [columnWidths, setColumnWidths],
@@ -323,7 +324,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
     (col: number, { bounds }: HeaderClickedEventArgs) => {
       const columnId = columnIds[col];
 
-      if (columnId === 'selected') {
+      if (columnId === MULTISELECT) {
         const items: MenuItem[] = [
           selection.rows.length > 0
             ? {
@@ -689,14 +690,14 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           case V1ColumnType.NUMBER:
             columnDefs[currentColumn.column] = defaultNumberColumn(
               currentColumn,
-              columnWidths,
+              columnWidths[currentColumn.column],
               dataPath,
             );
             break;
           case V1ColumnType.DATE:
             columnDefs[currentColumn.column] = defaultDateColumn(
               currentColumn,
-              columnWidths,
+              columnWidths[currentColumn.column],
               dataPath,
             );
             break;
@@ -705,7 +706,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           default:
             columnDefs[currentColumn.column] = defaultTextColumn(
               currentColumn,
-              columnWidths,
+              columnWidths[currentColumn.column],
               dataPath,
             );
         }
@@ -729,7 +730,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
 
   const drawHeader: DrawHeaderCallback = useCallback(
     ({ ctx, column, rect, theme }) => {
-      if (!column.id || column.id === 'selected') return false;
+      if (!column.id || column.id === MULTISELECT) return false;
 
       const sortDirection = column.id && sortMap[column.id];
       if (sortDirection) {
@@ -774,7 +775,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           headerHeight={36}
           headerIcons={headerIcons}
           height={height}
-          minColumnWidth={minColumnWidth}
+          minColumnWidth={MIN_COLUMN_WIDTH}
           ref={gridRef}
           rowHeight={rowHeightMap[rowHeight]}
           rows={dataTotal}

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -20,6 +20,8 @@ import { getDisplayName } from 'utils/user';
 
 import { getDurationInEnglish, getTimeInEnglish } from './utils';
 
+export const minColumnWidth = 40;
+
 // order used in ColumnPickerMenu
 export const experimentColumns = [
   'selected',

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -20,11 +20,13 @@ import { getDisplayName } from 'utils/user';
 
 import { getDurationInEnglish, getTimeInEnglish } from './utils';
 
-export const minColumnWidth = 40;
+export const MIN_COLUMN_WIDTH = 40;
+
+export const MULTISELECT = 'selected';
 
 // order used in ColumnPickerMenu
 export const experimentColumns = [
-  'selected',
+  MULTISELECT,
   'archived',
   'name',
   'id',
@@ -315,7 +317,7 @@ export const getColumnDefs = ({
   },
   selected: {
     icon: selectAll ? 'allSelected' : rowSelection.length ? 'someSelected' : 'noneSelected',
-    id: 'selected',
+    id: MULTISELECT,
     renderer: (_: ExperimentWithTrial, idx) => ({
       allowOverlay: false,
       contentAlign: 'left',
@@ -411,7 +413,7 @@ export const getColumnDefs = ({
 
 export const defaultTextColumn = (
   column: ProjectColumn,
-  columnWidths?: Record<string, number>,
+  columnWidth?: number,
   dataPath?: string,
 ): ColumnDef => {
   return {
@@ -427,13 +429,13 @@ export const defaultTextColumn = (
     },
     title: column.displayName || column.column,
     tooltip: () => undefined,
-    width: columnWidths?.[column.column] ?? 140,
+    width: columnWidth ?? 140,
   };
 };
 
 export const defaultNumberColumn = (
   column: ProjectColumn,
-  columnWidths?: Record<string, number>,
+  columnWidth?: number,
   dataPath?: string,
 ): ColumnDef => {
   return {
@@ -449,13 +451,13 @@ export const defaultNumberColumn = (
     },
     title: column.displayName || column.column,
     tooltip: () => undefined,
-    width: columnWidths?.[column.column] ?? 140,
+    width: columnWidth ?? 140,
   };
 };
 
 export const defaultDateColumn = (
   column: ProjectColumn,
-  columnWidths?: Record<string, number>,
+  columnWidth?: number,
   dataPath?: string,
 ): ColumnDef => {
   return {
@@ -471,7 +473,7 @@ export const defaultDateColumn = (
     },
     title: column.displayName || column.column,
     tooltip: () => undefined,
-    width: columnWidths?.[column.column] ?? 140,
+    width: columnWidth ?? 140,
   };
 };
 


### PR DESCRIPTION
## Description
This is a tricky situation, I'm open to suggestions both on the behavior I chose and how I implemented it. The issue was that on the new experiment list if:

- you had extra columns pinned (beyond just checkboxes and name)
- you opened the comparison pane
- you resized the comparison pane so that it covered the pinned experiments
- and you closed the comparison pane

Then the columns would overlap on the table.

The behavior I implemented to fix this is that when you resize the comparison pane, the difference between the old width and the new width is taken. If the table pane grew, then that difference is added onto the last pinned column. (This is the same behavior as previously) If the table pane shrunk, the last pinned column shrinks until it has exhausted that difference or it reaches a minimum width (set to 40px). If there's any difference left over, it cascades down to the second to last pinned column, and so on. The minimum width for the table pane as a whole is numPinnedCols*40px (+17px to account for scrollbars).

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Follow the steps laid out in the description on Netlify and latest-main and note the differences. Report any oddities in behavior.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
