### PR TITLE
chore: add NewProxyHandler test to proxy_intg_test [DET-9555]

### DIFF
--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -129,7 +128,6 @@ func TestNewProxyHandler(t *testing.T) {
 			t.Logf("failed to start server: %s", err)
 		}
 	}()
-	defer e.Shutdown(context.TODO())
 
 	// Ensure server is up, before testing it.
 	i := 0

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -59,7 +59,7 @@ func waitForCondition(timeout time.Duration, condition func() bool) bool {
 func conditionServerUp() bool {
 	resp, err := http.Get("http://" + u.Path + "/proxy")
 	if err == nil {
-		resp.Body.Close()
+		resp.Body.Close() //nolint:errcheck
 	}
 	return err == nil
 }

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -61,7 +61,7 @@ func conditionServerUp() bool {
 	if err == nil {
 		resp.Body.Close()
 	}
-	return err != nil
+	return err == nil
 }
 
 func TestProxyLifecycle(t *testing.T) {
@@ -153,7 +153,6 @@ func TestNewProxyHandler(t *testing.T) {
 	if !ok {
 		t.FailNow()
 	}
-
 	// Case 1: handler returns OK because service name is registered/found
 	register(t, true, true)
 	c.SetPath("/:service")

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -45,7 +45,7 @@ func unregister(t *testing.T) {
 	}
 }
 
-// TODO carolina/bradley: add to utils
+// TODO carolina/bradley: add to utils.
 func waitForCondition(timeout time.Duration, condition func() bool) bool {
 	for i := 0; i < int(timeout/tickInterval); i++ {
 		if condition() {
@@ -57,7 +57,10 @@ func waitForCondition(timeout time.Duration, condition func() bool) bool {
 }
 
 func conditionServerUp() bool {
-	_, err := http.Get("http://" + u.Path + "/proxy")
+	resp, err := http.Get("http://" + u.Path + "/proxy")
+	if err == nil {
+		resp.Body.Close()
+	}
 	return err != nil
 }
 
@@ -146,12 +149,8 @@ func TestNewProxyHandler(t *testing.T) {
 		}
 	}()
 
-	waitForCondition(5*time.Second, conditionServerUp)
-
-	resp, err := http.Get("http://" + u.Path + "/proxy")
-	if err == nil {
-		resp.Body.Close()
-	} else {
+	ok := waitForCondition(5*time.Second, conditionServerUp)
+	if !ok {
 		t.FailNow()
 	}
 

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -17,7 +17,7 @@ var (
 		return true, nil
 	}
 	serviceIDs = []string{"a", "b", "c"}
-	u          = url.URL{Path: "localhost:8081"}
+	u          = url.URL{Path: "localhost:8082"}
 )
 
 func register(t *testing.T, prTCP bool, unauth bool) {

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -109,18 +108,6 @@ func TestProxyLifecycle(t *testing.T) {
 		t.Errorf("failed to clear all proxy services.")
 	}
 	require.Equal(t, 0, len(DefaultProxy.Summaries()))
-}
-
-type logStore struct {
-	inner []*logrus.Entry
-}
-
-func (l *logStore) Fire(e *logrus.Entry) error {
-	l.inner = append(l.inner, e)
-	return nil
-}
-func (l *logStore) Levels() []logrus.Level {
-	return logrus.AllLevels
 }
 
 func TestNewProxyHandler(t *testing.T) {


### PR DESCRIPTION
## Description
To flesh out the testing suite for proxy, add a test for the function `NewProxyHandler` which returns the echo handler function used for proxying HTTP-like traffic to services running in the cluster.

## Test Plan
The intg test `TestNewProxyHandler` in `proxy_intg_test.go` should pass.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9555