### PR TITLE
fix: Modify the Determined master dialer to honor the proxy environment variables [FE-69]

### DIFF
--- a/master/internal/proxy/tcp.go
+++ b/master/internal/proxy/tcp.go
@@ -3,13 +3,13 @@ package proxy
 import (
 	"bytes"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"golang.org/x/net/proxy"
 )
 
 // websocketReadWriter exposes an io.ReadWriter interface to a WebSocket connection that is only
@@ -47,8 +47,10 @@ func (w *websocketReadWriter) Write(buf []byte) (int, error) {
 
 func newSingleHostReverseTCPOverWebSocketProxy(c echo.Context, t *url.URL) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dialer := proxy.FromEnvironment()
+
 		// Make sure we can open the connection to the remote host.
-		out, err := net.Dial("tcp", t.Host)
+		out, err := dialer.Dial("tcp", t.Host)
 		if err != nil {
 			c.Error(echo.NewHTTPError(http.StatusBadGateway,
 				errors.Errorf("error dialing to %v: %v", t, err)))


### PR DESCRIPTION
## Description

Associated pull request in the ```determined-ee``` repo is https://github.com/determined-ai/determined-ee/pull/904.  Together, they address [FE-52](https://hpe-aiatscale.atlassian.net/browse/FE-52).

These code changes are relevant only when running ```tools/slurmcluster.sh``` or ```make slurmcluster``` (found in the ```determined-ee``` repo), which starts the Determined master locally on your laptop or test machine.   The Determined master that runs locally on your laptop or test machine runs experiments/shells/notebooks/etc on the HPC cluster (i.e., ```Slurm```) via the ```launcher```.

The issue being addressed here is that the ```det shell start``` command doesn't work when run locally from your laptop or test machine and ```DET_MASTER=localhost:8081```.

This is because the master tries to communicate with the shell container that's running on a compute node, which has a private address (e.g., ```172.23.0.3```), and is not reachable from a machine that is outside the cluster, such as your laptop or test machine.

The first step in allowing this to work is to, on your laptop or test machine, create a SOCKS5 proxy SSH tunnel to the admin node in the cluster.

The SOCKS5 proxy SSH tunnel is created on the MAC laptop or test machine using the following command.  In this example, ```casablanca-login.us.cray.com``` is the ```admin node``` of the cluster.  Port ```60002``` is totally arbitrary and any other unused port above 1024 would work just as well.

```
ssh -D 60002 -nNT casablanca-login.us.cray.com
```

The reason the master cannot connect to the shell container is because it is using ```net.Dial("tcp", t.Host)```, which does not honor the ```ALL_PROXY``` environment variable or, apparently, any other environment variables and, therefore, it is not using the SOCKS5 proxy that we configured to allow access to the compute nodes.

Instead of using ```net.Dial()```, we can use ```dialer.Dial()```, where the ```dialer``` is created using "proxy.FromEnvironment()", which allows the ALL_PROXY environment variable to be honored.

Now, if we start the master with the ```ALL_PROXY=socks5://localhost:60002``` environment variable set, the master is able to honor the ```ALL_PROXY``` variable and have a direct connection to the compute nodes.

**Note:** On a production cluster, the Determined master is started as a service, which does not inherit any of the environment variables that a login shell would.  Therefore, there is no danger that even of ALL_PROXY is set in, for example, "/etc/environment", it will be used by the Determined master.  The change made in this pull request only affects the development environment (i.e., ```tools/slurmcluster.sh```) that runs on your laptop for testing.

## Test Plan

Refer to the test plan in pull request https://github.com/determined-ai/determined-ee/pull/904


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[FE-52]: https://hpe-aiatscale.atlassian.net/browse/FE-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ