### PR TITLE
fix: sort of  `GetWorkspaceProjects` API

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -156,12 +156,13 @@ func (a *apiServer) GetWorkspaceProjects(
 	// Construct the ordering expression.
 	startTime := apiv1.GetWorkspaceProjectsRequest_SORT_BY_LAST_EXPERIMENT_START_TIME
 	sortColMap := map[apiv1.GetWorkspaceProjectsRequest_SortBy]string{
-		apiv1.GetWorkspaceProjectsRequest_SORT_BY_UNSPECIFIED:   "id",
-		apiv1.GetWorkspaceProjectsRequest_SORT_BY_CREATION_TIME: "created_at",
+		// `p` is an alias of `project` which is defined in master/static/srv/get_workspace_projects.sql
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_UNSPECIFIED:   "p.id",
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_CREATION_TIME: "p.created_at",
 		startTime: "last_experiment_started_at",
-		apiv1.GetWorkspaceProjectsRequest_SORT_BY_ID:          "id",
-		apiv1.GetWorkspaceProjectsRequest_SORT_BY_NAME:        "name",
-		apiv1.GetWorkspaceProjectsRequest_SORT_BY_DESCRIPTION: "description",
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_ID:          "p.id",
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_NAME:        "p.name",
+		apiv1.GetWorkspaceProjectsRequest_SORT_BY_DESCRIPTION: "p.description",
 	}
 	orderByMap := map[apiv1.OrderBy]string{
 		apiv1.OrderBy_ORDER_BY_UNSPECIFIED: "ASC",


### PR DESCRIPTION
## Description

`GetWorkspaceProjects` API's sorting doesnt work due to ambiguous reference
 
[WEB-1378]

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Check if all sorts work in a project page and API
- Check if sorting is applied as soon as it's selected
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1378]: https://hpe-aiatscale.atlassian.net/browse/WEB-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ