### PR TITLE
fix: Windows file permissions

### DIFF
--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -84,16 +84,13 @@ def show_ssh_command(args: Namespace) -> None:
 
 
 def _prepare_key(retention_dir: Union[Path, None]) -> Tuple[ContextManager[IO], str]:
-    """
-    Open a keyfile path, and make sure it has the necessary mode via chmod.
-    On Windows, chmod only affects the read-only flag on the file. To emulate the
-    actual functionality of chmod, an external library is used for Windows systems.
-    """
     if retention_dir:
         key_path = retention_dir / "key"
         keyfile = key_path.open("w")
 
         if platform.system() == "Windows":
+            # On Windows, chmod only affects the read-only flag on the file. To emulate the
+            # actual functionality of chmod, an external library is used for Windows systems.
             import oschmod
 
             oschmod.set_mode(str(key_path), "600")

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -96,7 +96,7 @@ def _prepare_key(retention_dir: Union[Path, None]) -> Tuple[ContextManager[IO], 
         if platform.system() == "Windows":
             import oschmod
 
-            oschmod.set_mode(key_path, "600")
+            oschmod.set_mode(str(key_path), "600")
         else:
             key_path.chmod(0o600)
 

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -34,6 +34,7 @@ setuptools.setup(
         "azure-storage-blob",
         "termcolor>=1.1.0",
         "boto3",
+        "oschmod;platform_system=='Windows'",
         # CLI:
         "argcomplete>=1.9.4",
         "gitpython>=3.1.3",


### PR DESCRIPTION
## Description

`os.chmod` does not work as intended on Windows. This PR replaces the `os.chmod` operation if a Windows System is detected.


## Test Plan

Run `det shell start` on a windows machine, making sure that the key file is created in a Public tempdir, such as `C://Users/Public` 
It's probably easiest to hardcode the `retention_dir` inside of `determined.cli.shell._prepare_key()` , run `setup.py`, and then try to create a shell via `python -m determined.cli shell start`


## Commentary (optional)

Windows inherits permissions from the current directory. If that directory is public, the file becomes public, causing this issue. `os.chmod` does not fix that. We are adding a new dependency for Windows systems.

See: https://github.com/determined-ai/determined/issues/6433


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-405
