### PR TITLE
fix: Save experiment glide table selection rows in settings [WEB-1366]

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -21,6 +21,7 @@ export interface F_ExperimentListSettings {
   columnWidths: Record<string, number>;
   compare: boolean;
   filterset: string; // save FilterFormSet as string
+  selectedExperimentIds: number[];
   sortString: string;
   pageLimit: number;
   rowHeight: RowHeight;
@@ -68,6 +69,12 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       skipUrlEncoding: true,
       storageKey: 'rowHeight',
       type: ioRowHeight,
+    },
+    selectedExperimentIds: {
+      defaultValue: [],
+      skipUrlEncoding: true,
+      storageKey: 'selectedExperimentIds',
+      type: array(number),
     },
     sortString: {
       defaultValue: '',

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -20,7 +20,9 @@ export interface F_ExperimentListSettings {
   columns: string[];
   columnWidths: Record<string, number>;
   compare: boolean;
+  excludedExperimentIds: number[];
   filterset: string; // save FilterFormSet as string
+  selectAll: boolean;
   selectedExperimentIds: number[];
   sortString: string;
   pageLimit: number;
@@ -46,6 +48,12 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       storageKey: 'compare',
       type: boolean,
     },
+    excludedExperimentIds: {
+      defaultValue: [],
+      skipUrlEncoding: true,
+      storageKey: 'excludedExperimentIds',
+      type: array(number),
+    },
     filterset: {
       defaultValue: JSON.stringify(INIT_FORMSET),
       skipUrlEncoding: true,
@@ -69,6 +77,12 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       skipUrlEncoding: true,
       storageKey: 'rowHeight',
       type: ioRowHeight,
+    },
+    selectAll: {
+      defaultValue: false,
+      skipUrlEncoding: true,
+      storageKey: 'selectAll',
+      type: boolean,
     },
     selectedExperimentIds: {
       defaultValue: [],

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -172,7 +172,9 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const [isLoading, setIsLoading] = useState(true);
 
-  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>([]);
+  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>(
+    settings.selectedExperimentIds,
+  );
   useEffect(() => {
     if (!isLoadingSettings) {
       // loading experiment data first

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -159,8 +159,9 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     }
   }, [settings.filterset, isLoadingSettings]);
 
-  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>(settings.selectedExperimentIds);
-  console.log(selectedExperimentIds);
+  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>(
+    settings.selectedExperimentIds,
+  );
   const [excludedExperimentIds, setExcludedExperimentIds] = useState<Set<number>>(
     new Set<number>(),
   );
@@ -498,7 +499,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     return Loadable.filterNotLoaded(experiments, (experiment) =>
       selectedIdSet.has(experiment.experiment.id),
     );
-  }, [experiments, selectedExperimentIds]);
+  }, [updateSettings, experiments, selectedExperimentIds]);
 
   const columnsIfLoaded = useMemo(
     () => (isLoadingSettings ? [] : settings.columns),

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -159,12 +159,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     }
   }, [settings.filterset, isLoadingSettings]);
 
-  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>(
-    settings.selectedExperimentIds,
-  );
-  const [excludedExperimentIds, setExcludedExperimentIds] = useState<Set<number>>(
-    new Set<number>(),
-  );
+  const [selectedExperimentIds, setSelectedExperimentIds] = useState<Loadable<number[]>>(NotLoaded);
+  const [excludedExperimentIds, setExcludedExperimentIds] = useState<Loadable<Set<number>>>(NotLoaded);
   const [selectAll, setSelectAll] = useState(false);
   const [clearSelectionTrigger, setClearSelectionTrigger] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -491,6 +487,13 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     },
     [updateSettings],
   );
+
+  useMemo(() => {
+    console.log([isLoading, selectedExperimentIds]);
+    if (!isLoading) {
+      updateSettings({ selectedExperimentIds });
+    }
+  }, [isLoading, updateSettings, selectedExperimentIds]);
 
   const selectedExperiments: ExperimentWithTrial[] = useMemo(() => {
     updateSettings({ selectedExperimentIds });

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -159,7 +159,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     }
   }, [settings.filterset, isLoadingSettings]);
 
-  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>([]);
+  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>(settings.selectedExperimentIds);
+  console.log(selectedExperimentIds);
   const [excludedExperimentIds, setExcludedExperimentIds] = useState<Set<number>>(
     new Set<number>(),
   );
@@ -491,6 +492,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   const selectedExperiments: ExperimentWithTrial[] = useMemo(() => {
+    updateSettings({ selectedExperimentIds });
     if (selectedExperimentIds.length === 0) return [];
     const selectedIdSet = new Set(selectedExperimentIds);
     return Loadable.filterNotLoaded(experiments, (experiment) =>

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -159,8 +159,16 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     }
   }, [settings.filterset, isLoadingSettings]);
 
-  const [selectedExperimentIds, setSelectedExperimentIds] = useState<Loadable<number[]>>(NotLoaded);
-  const [excludedExperimentIds, setExcludedExperimentIds] = useState<Loadable<Set<number>>>(NotLoaded);
+  const [loadableSelectedExperimentIds, setSelectedExperimentIds] =
+    useState<Loadable<number[]>>(NotLoaded);
+  const selectedExperimentIds = Loadable.getOrElse([], loadableSelectedExperimentIds);
+  const [loadableExcludedExperimentIds, setExcludedExperimentIds] =
+    useState<Loadable<Set<number>>>(NotLoaded);
+  const excludedExperimentIds = Loadable.getOrElse(
+    new Set<number>(),
+    loadableExcludedExperimentIds,
+  );
+
   const [selectAll, setSelectAll] = useState(false);
   const [clearSelectionTrigger, setClearSelectionTrigger] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -489,11 +497,21 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   useMemo(() => {
-    console.log([isLoading, selectedExperimentIds]);
-    if (!isLoading) {
-      updateSettings({ selectedExperimentIds });
+    if (!isLoadingSettings) {
+      if (!Loadable.isLoaded(loadableSelectedExperimentIds)) {
+        setSelectedExperimentIds(Loaded(settings.selectedExperimentIds));
+      } else {
+        updateSettings({
+          selectedExperimentIds: Loadable.getOrElse([], loadableSelectedExperimentIds),
+        });
+      }
     }
-  }, [isLoading, updateSettings, selectedExperimentIds]);
+  }, [
+    isLoadingSettings,
+    updateSettings,
+    loadableSelectedExperimentIds,
+    settings.selectedExperimentIds,
+  ]);
 
   const selectedExperiments: ExperimentWithTrial[] = useMemo(() => {
     updateSettings({ selectedExperimentIds });

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -159,7 +159,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     }
   }, [settings.filterset, isLoadingSettings]);
 
-  const selectAllIfLoaded = useMemo(
+  const selectAll = useMemo(
     () => !isLoadingSettings && settings.selectAll,
     [isLoadingSettings, settings.selectAll],
   );
@@ -170,7 +170,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     [updateSettings],
   );
 
-  const selectedExperimentsIfLoaded = useMemo(
+  const selectedExperimentIds = useMemo(
     () => (isLoadingSettings ? [] : settings.selectedExperimentIds),
     [isLoadingSettings, settings.selectedExperimentIds],
   );
@@ -183,17 +183,17 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     [updateSettings],
   );
 
-  const excludedExperimentsIfLoaded = useMemo(
+  const excludedExperimentIds = useMemo(
     () => new Set<number>(isLoadingSettings ? [] : settings.excludedExperimentIds),
     [isLoadingSettings, settings.excludedExperimentIds],
   );
   const handleExperimentExclusion = useCallback(
     (callback: (arg0: Set<number>) => Set<number>) => {
       updateSettings({
-        excludedExperimentIds: Array.from(callback(excludedExperimentsIfLoaded)),
+        excludedExperimentIds: Array.from(callback(excludedExperimentIds)),
       });
     },
-    [updateSettings, excludedExperimentsIfLoaded],
+    [updateSettings, excludedExperimentIds],
   );
 
   const [clearSelectionTrigger, setClearSelectionTrigger] = useState(0);
@@ -201,7 +201,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [error] = useState(false);
   const [canceler] = useState(new AbortController());
 
-  const colorMap = useGlasbey(selectedExperimentsIfLoaded);
+  const colorMap = useGlasbey(selectedExperimentIds);
   const { height: containerHeight, width: containerWidth } = useResize(contentRef);
   const height =
     containerHeight - 2 * parseInt(getCssVar('--theme-stroke-width')) - (isPagedView ? 40 : 0);
@@ -523,12 +523,12 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   const selectedExperiments: ExperimentWithTrial[] = useMemo(() => {
-    if (selectedExperimentsIfLoaded.length === 0) return [];
-    const selectedIdSet = new Set(selectedExperimentsIfLoaded);
+    if (selectedExperimentIds.length === 0) return [];
+    const selectedIdSet = new Set(selectedExperimentIds);
     return Loadable.filterNotLoaded(experiments, (experiment) =>
       selectedIdSet.has(experiment.experiment.id),
     );
-  }, [experiments, selectedExperimentsIfLoaded]);
+  }, [experiments, selectedExperimentIds]);
 
   const columnsIfLoaded = useMemo(
     () => (isLoadingSettings ? [] : settings.columns),
@@ -543,7 +543,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   return (
     <>
       <TableActionBar
-        excludedExperimentIds={excludedExperimentsIfLoaded}
+        excludedExperimentIds={excludedExperimentIds}
         experiments={experiments}
         expListView={globalSettings.expListView}
         filters={experimentFilters}
@@ -554,8 +554,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         project={project}
         projectColumns={projectColumns}
         rowHeight={settings.rowHeight}
-        selectAll={selectAllIfLoaded}
-        selectedExperimentIds={selectedExperimentsIfLoaded}
+        selectAll={selectAll}
+        selectedExperimentIds={selectedExperimentIds}
         setExpListView={updateExpListView}
         setIsOpenFilter={onIsOpenFilterChange}
         setVisibleColumns={setVisibleColumns}
@@ -591,7 +591,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
                 comparisonViewOpen={settings.compare}
                 data={experimentsIfLoaded}
                 dataTotal={isPagedView ? experiments.length : Loadable.getOrElse(0, total)}
-                excludedExperimentIds={excludedExperimentsIfLoaded}
+                excludedExperimentIds={excludedExperimentIds}
                 formStore={formStore}
                 handleScroll={isPagedView ? undefined : handleScroll}
                 handleUpdateExperimentList={handleUpdateExperimentList}
@@ -602,8 +602,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
                 projectColumns={projectColumns}
                 rowHeight={settings.rowHeight}
                 scrollPositionSetCount={scrollPositionSetCount}
-                selectAll={selectAllIfLoaded}
-                selectedExperimentIds={selectedExperimentsIfLoaded}
+                selectAll={selectAll}
+                selectedExperimentIds={selectedExperimentIds}
                 setColumnWidths={handleColumnWidthChange}
                 setExcludedExperimentIds={handleExperimentExclusion}
                 setPinnedColumnsCount={setPinnedColumnsCount}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -174,20 +174,20 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>([]);
   useEffect(() => {
-    if (!isLoading) { // loading experiment data first
+    if (!isLoadingSettings) {
+      // loading experiment data first
       setSelectedExperimentIds(settings.selectedExperimentIds);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading]);
+  }, [isLoadingSettings]);
   const handleExperimentSelection = useCallback(
-    (setIds: number[]) => {
-      if (setIds === selectedExperimentIds) return;
-      setSelectedExperimentIds(setIds);
+    (selectedExperimentIds: number[]) => {
+      setSelectedExperimentIds(selectedExperimentIds);
       updateSettings({
-        selectedExperimentIds: setIds,
+        selectedExperimentIds,
       });
     },
-    [updateSettings],
+    [updateSettings, setSelectedExperimentIds],
   );
 
   const excludedExperimentIds = useMemo(

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -170,14 +170,21 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     [updateSettings],
   );
 
-  const selectedExperimentIds = useMemo(
-    () => (isLoadingSettings ? [] : settings.selectedExperimentIds),
-    [isLoadingSettings, settings.selectedExperimentIds],
-  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [selectedExperimentIds, setSelectedExperimentIds] = useState<number[]>([]);
+  useEffect(() => {
+    if (!isLoading) { // loading experiment data first
+      setSelectedExperimentIds(settings.selectedExperimentIds);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading]);
   const handleExperimentSelection = useCallback(
-    (selectedExperimentIds: number[]) => {
+    (setIds: number[]) => {
+      if (setIds === selectedExperimentIds) return;
+      setSelectedExperimentIds(setIds);
       updateSettings({
-        selectedExperimentIds,
+        selectedExperimentIds: setIds,
       });
     },
     [updateSettings],
@@ -197,7 +204,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   );
 
   const [clearSelectionTrigger, setClearSelectionTrigger] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [error] = useState(false);
   const [canceler] = useState(new AbortController());
 

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -219,10 +219,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   }, [clearSelectionTrigger]);
 
   useEffect(() => {
-    const loadedRows = data.filter(Loadable.isLoaded);
-    if (loadedRows.length !== data.length) return;
-
-    if (!selection.rows.length && selectedExperimentIds.length) {
+    if (selection.rows.length !== selectedExperimentIds.length) {
       setSelection(({ columns, rows }: GridSelection) => {
         data.forEach((loadableRow, idx) => {
           Loadable.map(loadableRow, (row) => {
@@ -234,7 +231,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         return { columns, rows };
       });
     }
-  }, [selection.rows, selectedExperimentIds, setSelectedExperimentIds, data]);
+  }, [selection.rows, selectedExperimentIds, data]);
 
   const columnDefs = useMemo<Record<string, ColumnDef>>(
     () =>
@@ -297,8 +294,9 @@ export const GlideTable: React.FC<GlideTableProps> = ({
 
   const deselectAllRows = useCallback(() => {
     setSelectAll(false);
+    setSelectedExperimentIds([]);
     setSelection((prev) => ({ ...prev, rows: CompactSelection.empty() }));
-  }, [setSelectAll, setSelection]);
+  }, [setSelectAll, setSelection, setSelectedExperimentIds]);
 
   const selectAllRows = useCallback(() => {
     setExcludedExperimentIds(() => new Set());

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -134,6 +134,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   rowHeight,
   selectAll,
   setSelectAll,
+  excludedExperimentIds,
   setExcludedExperimentIds,
   handleScroll,
   scrollPositionSetCount,
@@ -323,7 +324,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         return { columns, rows };
       });
     }
-  }, [data, previousData, selectAll]);
+  }, [data, excludedExperimentIds, previousData, selectAll]);
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, { bounds }: HeaderClickedEventArgs) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -219,19 +219,14 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   }, [clearSelectionTrigger]);
 
   useEffect(() => {
-    if (selection.rows.length !== selectedExperimentIds.length) {
-      setSelection(({ columns, rows }: GridSelection) => {
-        data.forEach((loadableRow, idx) => {
-          Loadable.map(loadableRow, (row) => {
-            if (selectedExperimentIds.includes(row.experiment.id)) {
-              rows = rows.add([idx, idx + 1]);
-            }
-          });
-        });
-        return { columns, rows };
-      });
-    }
-  }, [selection.rows, selectedExperimentIds, data]);
+    const selectedRowIndices = selection.rows.toArray();
+    const selectedIds = selectedRowIndices
+      .map((idx) => data?.[idx])
+      .filter((row) => row !== undefined)
+      .filter(Loadable.isLoaded)
+      .map((record) => record.data.experiment.id);
+    setSelectedExperimentIds(selectedIds);
+  }, [selection.rows, setSelectedExperimentIds, data]);
 
   const columnDefs = useMemo<Record<string, ColumnDef>>(
     () =>

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -304,20 +304,25 @@ export const GlideTable: React.FC<GlideTableProps> = ({
 
   const previousData = usePrevious(data, undefined);
   useEffect(() => {
-    if (selectAll && previousData && data.length > previousData.length) {
+    if (previousData && data.length > previousData.length) {
       setSelection(({ columns, rows }: GridSelection) => {
-        rows = rows.add([previousData.length - 1, data.length]);
+        if (selectAll) {
+          rows = rows.add([previousData.length - 1, data.length]);
+        }
         data.forEach((loadableRow, idx) => {
           Loadable.map(loadableRow, (row) => {
-            if (excludedExperimentIds.has(row.experiment.id)) {
+            if (selectAll && excludedExperimentIds.has(row.experiment.id)) {
               rows = rows.remove([idx, idx + 1]);
+            }
+            if (!selectAll && selectedExperimentIds.includes(row.experiment.id)) {
+              rows = rows.add([idx, idx + 1]);
             }
           });
         });
         return { columns, rows };
       });
     }
-  }, [data, excludedExperimentIds, previousData, selectAll]);
+  }, [data, selectedExperimentIds, excludedExperimentIds, previousData, selectAll]);
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, { bounds }: HeaderClickedEventArgs) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -15,7 +15,6 @@ import DataEditor, {
   Theme,
 } from '@glideapps/glide-data-grid';
 import { DrawHeaderCallback } from '@glideapps/glide-data-grid/dist/ts/data-grid/data-grid-types';
-import { MenuProps } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -324,7 +323,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
         return { columns, rows };
       });
     }
-  }, [data, previousData, selectAll, excludedExperimentIds]);
+  }, [data, previousData, selectAll]);
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
     (col: number, { bounds }: HeaderClickedEventArgs) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -78,7 +78,7 @@ export interface GlideTableProps {
   colorMap: MapOfIdsToColors;
   columnWidths: Record<string, number>;
   comparisonViewOpen?: boolean;
-  excludedExperimentIds: Set<number>;
+  excludedExperimentIds: Loadable<Set<number>>;
   data: Loadable<ExperimentWithTrial>[];
   dataTotal: number;
   handleScroll?: (r: Rectangle) => void;
@@ -90,7 +90,7 @@ export interface GlideTableProps {
   project?: Project;
   projectColumns: Loadable<ProjectColumn[]>;
   rowHeight: RowHeight;
-  selectedExperimentIds: number[];
+  selectedExperimentIds: Loadable<number[]>;
   setExcludedExperimentIds: Dispatch<SetStateAction<Set<number>>>;
   setSelectedExperimentIds: Dispatch<SetStateAction<number[]>>;
   selectAll: boolean;

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -133,6 +133,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   data,
   dataTotal,
   clearSelectionTrigger,
+  selectedExperimentIds,
   setSelectedExperimentIds,
   sortableColumnIds,
   setSortableColumnIds,
@@ -556,6 +557,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               setStandAloneSelect(row);
 
             if (selection.rows.hasIndex(row)) {
+              selectedExperimentIds.splice(selectedExperimentIds.indexOf(rowData.experiment.id), 1);
               setSelection(({ columns, rows }: GridSelection) => ({
                 columns,
                 rows: rows.remove(row),
@@ -573,6 +575,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
                 }
               }
             } else {
+              setSelectedExperimentIds(selectedExperimentIds.concat([rowData.experiment.id]));
               setSelection(({ columns, rows }: GridSelection) => ({
                 columns,
                 rows: rows.add(row),

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -91,12 +91,12 @@ export interface GlideTableProps {
   projectColumns: Loadable<ProjectColumn[]>;
   rowHeight: RowHeight;
   selectedExperimentIds: number[];
-  setExcludedExperimentIds: Dispatch<SetStateAction<Loadable<Set<number>>>>;
-  setSelectedExperimentIds: Dispatch<SetStateAction<Loadable<number[]>>>;
+  setExcludedExperimentIds: (arg0: (arg0b: Set<number>) => Set<number>) => void;
+  setSelectedExperimentIds: (arg0: number[]) => void;
   selectAll: boolean;
   staticColumns: string[];
   setColumnWidths: (newWidths: Record<string, number>) => void;
-  setSelectAll: Dispatch<SetStateAction<boolean>>;
+  setSelectAll: Dispatch<SetStateAction<Loadable<boolean>>>;
   handleUpdateExperimentList: (action: BatchAction, successfulIds: number[]) => void;
   sorts: Sort[];
   onSortChange: (sorts: Sort[]) => void;
@@ -303,13 +303,13 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   );
 
   const deselectAllRows = useCallback(() => {
-    setSelectAll(false);
+    setSelectAll(Loaded(false));
     setSelection((prev) => ({ ...prev, rows: CompactSelection.empty() }));
   }, [setSelectAll, setSelection]);
 
   const selectAllRows = useCallback(() => {
-    setExcludedExperimentIds(Loaded(new Set()));
-    setSelectAll(true);
+    setExcludedExperimentIds(() => Loaded(new Set()));
+    setSelectAll(Loaded(true));
     setSelection(({ columns, rows }: GridSelection) => ({
       columns,
       rows: rows.add([0, data.length]),
@@ -564,11 +564,9 @@ export const GlideTable: React.FC<GlideTableProps> = ({
             if (selection.rows.hasIndex(row)) {
               const existIndex = selectedExperimentIds.indexOf(rowData.experiment.id);
               setSelectedExperimentIds(
-                Loaded(
                   selectedExperimentIds
                     .slice(0, existIndex)
                     .concat(selectedExperimentIds.slice(existIndex + 1)),
-                ),
               );
               setSelection(({ columns, rows }: GridSelection) => ({
                 columns,
@@ -589,7 +587,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               }
             } else {
               setSelectedExperimentIds(
-                Loaded(selectedExperimentIds.concat([rowData.experiment.id])),
+                selectedExperimentIds.concat([rowData.experiment.id]),
               );
               setSelection(({ columns, rows }: GridSelection) => ({
                 columns,


### PR DESCRIPTION
## Description

Stores selectAll, selectedExperimentIds, and excludedExperimentIds in persistent settings, so you can leave the new experiment list page and come back with same settings.  These will be neutral values while waiting for `isLoadingSettings`

Previously the source of truth for selection was the GlideTable and data[index] instead of experiment.id, so there are a few changes.
I kept `excludedExperimentIds` as a Set, though it's stored to settings as an array; I am uncertain about whether to keep this a Set and `selectedExperimentIds` being an Array

## Test Plan

**Test on a single page of experiments (latest-main project 107) and a multi-page experiment list (uncategorized)**

Selection
- With `?f_explist_v2=on`, select every other experiment in a list. Refresh or navigate away from the page and return; same experiments should be selected
- The count of selected experiments in the edit button, e.g. "Edit (10)" should reflect the count selected

Select All
- Check the header checkbox on the table - this should select all remaining experiments
- Reload the page; this should keep select-all state, experiments should all be selected, "Edit (10)" should reflect count

Exclusion
- While all are selected, uncheck one row to exclude it.
- Reload the page; this should keep the select-all state, and all should be selected except for the excluded; "Edit (9)" should reflect count


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.