### PR TITLE
fix: use user id for new explist user filter

### DIFF
--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -98,7 +98,7 @@ func expColumnNameToSQL(columnName string) (string, error) {
 		"state":           "e.state",
 		"numTrials":       "(SELECT COUNT(*) FROM trials t WHERE e.id = t.experiment_id)",
 		"progress":        "COALESCE(progress, 0)",
-		"user":            "COALESCE(u.display_name, u.username)",
+		"user":            "e.owner_id",
 		"forkedFrom":      "e.parent_id",
 		"resourcePool":    "e.config->'resources'->>'resource_pool'",
 		"projectId":       "project_id",

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -67,6 +67,10 @@ const FilterField = ({
 
   const [inputOpen, setInputOpen] = useState(false);
   const [fieldValue, setFieldValue] = useState<FormFieldValue>(field.value);
+  const selectedUser = Loadable.getOrElse(
+    null,
+    useObservable(userStore.getUser(Number(fieldValue))),
+  );
 
   // use this function to update field value
   const updateFieldValue = (fieldId: string, value: FormFieldValue, debounceUpdate = false) => {
@@ -172,11 +176,6 @@ const FilterField = ({
     },
     [field.type, formStore, index, inputOpen, isSpecialColumn, parentId],
   );
-
-  const selectedUser =
-    field.columnName === 'user'
-      ? Loadable.getOrElse(null, userStore.getUser(Number(field.value)).get())
-      : null;
 
   const valueSelectValue =
     field.columnName === 'user'

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -106,12 +106,8 @@ const FilterField = ({
         return SEARCHER_TYPE.map((searcher) => ({ label: searcher, value: searcher }));
       case 'user':
         return users
-          .sort((a, b) => alphaNumericSorter(a.username, b.username))
-          .map((user) => ({ label: user.username, value: user.username }));
-      default:
-        // eslint-disable-next-line no-case-declarations, @typescript-eslint/no-unused-vars
-        const _exhaustiveCheck: never = columnName;
-        throw new Error(`${columnName} is not columnName.`);
+          .map((user) => ({ label: user.displayName || user.username, value: user.id }))
+          .sort((a, b) => alphaNumericSorter(a.label, b.label));
     }
   };
 

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -67,10 +67,6 @@ const FilterField = ({
 
   const [inputOpen, setInputOpen] = useState(false);
   const [fieldValue, setFieldValue] = useState<FormFieldValue>(field.value);
-  const selectedUser = Loadable.getOrElse(
-    null,
-    useObservable(userStore.getUser(Number(fieldValue))),
-  );
 
   // use this function to update field value
   const updateFieldValue = (fieldId: string, value: FormFieldValue, debounceUpdate = false) => {
@@ -111,7 +107,10 @@ const FilterField = ({
       case 'user':
         return (
           users
-            .map((user) => ({ label: user.displayName || user.username, value: user.id }))
+            .map((user) => ({
+              label: user.displayName || user.username,
+              value: user.id.toString(),
+            }))
             // getUsers sorts the users similarly but uses nullish coalescing
             // which doesn't work because the backend sends null strings in the
             // database as empty strings
@@ -177,14 +176,6 @@ const FilterField = ({
     [field.type, formStore, index, inputOpen, isSpecialColumn, parentId],
   );
 
-  const valueSelectValue =
-    field.columnName === 'user'
-      ? {
-          label: selectedUser?.displayName || selectedUser?.username,
-          value: field.value?.toString() || '',
-        }
-      : field.value?.toString();
-
   return (
     <div className={css.base} ref={(node) => drop(node)}>
       <ConjunctionContainer
@@ -228,7 +219,7 @@ const FilterField = ({
           <div onKeyDownCapture={captureEnterKeyDown}>
             <Select
               options={getSpecialOptions(field.columnName as SpecialColumnNames)}
-              value={valueSelectValue}
+              value={fieldValue ?? undefined}
               width={'100%'}
               onChange={(value) => {
                 const val = value?.toString() ?? null;


### PR DESCRIPTION
## Description

This fixes an issue where the user filter in the new experiment list would sometimes fail to find matching experiments for users with display names set. This is because the webui would send the username, but the api was expecting the display name or username if set. To fix this, we update the frontend and backend to use the user id instead.




## Test Plan

1. With the new experiment list active, filter by a user that has a display name
2. experiments from that user should show up.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1409


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
