### PR TITLE
chore: explist_v2 feature switch should default to on

### DIFF
--- a/docs/release-notes/new-experiment-list.rst
+++ b/docs/release-notes/new-experiment-list.rst
@@ -2,13 +2,9 @@
 
 **New Features**
 
-This release includes a new experiment list page. In addition to general improved performance and stability we've added a number of new features.
-
-- Metrics and hyperparameters can be selected as columns
-- The list can be filtered on any available column
-- Allow user to specify complex filters
-- The list can be sorted on any available column
-- Display total number of experiments matching the filter
-- Compare view allows you to compare metrics, hyperparameters, and trial details across experiments
-- Toggle between pagination and infinite scroll
-- Select preferred table density 
+-  WebUI: In addition to improved performance and stability, we've added the following features to
+   the experiment list page: Metrics and hyperparameters can be selected as columns; The list can be
+   filtered on any available column; Users can specify complex filters; The list can be sorted on
+   any available column; Display total number of experiments matching the filter; Compare view
+   allows comparison metrics, hyperparameters, and trial details across experiments; Toggle between
+   pagination and infinite scroll; Select preferred table density

--- a/docs/release-notes/new-experiment-list.rst
+++ b/docs/release-notes/new-experiment-list.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+**New Features**
+
+This release includes a new experiment list page. In addition to general improved performance and stability we've added a number of new features.
+
+- Metrics and hyperparameters can be selected as columns
+- The list can be filtered on any available column
+- Allow user to specify complex filters
+- The list can be sorted on any available column
+- Display total number of experiments matching the filter
+- Compare view allows you to compare metrics, hyperparameters, and trial details across experiments
+- Toggle between pagination and infinite scroll
+- Select preferred table density 

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -8,7 +8,7 @@ export type ValidFeature = 'dashboard' | 'explist_v2' | 'chart' | 'rp_binding';
 const FeatureDefault: { [K in ValidFeature]: boolean } = {
   chart: false,
   dashboard: false,
-  explist_v2: false,
+  explist_v2: true,
   rp_binding: false,
 };
 


### PR DESCRIPTION
## Description

This PR launches the new experiment list for the general userbase by changing the default state of the feature switch to "on". Individual users can choose to disable the feature by turning the feature switch off.


## Test Plan
1. Load the app
2. Go to Uncategorized and confirm it is the new experience
3. Append ?f_explist_v2=off to the url
4. Confirm you see the old experience

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No Ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
