### PR TITLE
ci: tweak PR title matching in release tracking

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -195,9 +195,9 @@ class Actions:
             cherry_pick_pr(pr_id)
         else:
             title = gql.get_pr_title(id=pr_id)["node"]["title"]
-            if re.match("(feat|fix):", title) is not None:
+            if re.match(r"(feat|fix)\S*:", title, re.IGNORECASE) is not None:
                 print("Adding feat/fix PR")
-            elif re.match("[a-z]+:", title) is not None:
+            elif re.match(r"\S+:", title, re.IGNORECASE) is not None:
                 print("Skipping non-feat/fix PR")
                 return
             else:


### PR DESCRIPTION
## Description

Ignore case, include anything with a Conventional Commits type that starts with `feat` or `fix` (not just those exactly), exclude other types more broadly (not only things consisting of solely lowercase letters).

## Test Plan

- [x] try things with the regexes manually
