### PR TITLE
fix: harmonize python & golang GET NotFound errs [DET-9606]

### DIFF
--- a/e2e_tests/tests/cluster/test_groups.py
+++ b/e2e_tests/tests/cluster/test_groups.py
@@ -70,7 +70,7 @@ def test_group_creation(add_users: List[str]) -> None:
 
         # Can delete.
         det_cmd(["user-group", "delete", group_name, "--yes"], check=True)
-        det_cmd_expect_error(["user-group", "describe", group_name], "not find")
+        det_cmd_expect_error(["user-group", "describe", group_name], "not found")
 
 
 @pytest.mark.e2e_cpu
@@ -93,7 +93,7 @@ def test_group_updates() -> None:
         det_cmd(["user-group", "change-name", group_name, new_group_name], check=True)
 
         # Old name is gone.
-        det_cmd_expect_error(["user-group", "describe", group_name, "--json"], "not find")
+        det_cmd_expect_error(["user-group", "describe", group_name, "--json"], "not found")
 
         # New name is here.
         group_desc = det_cmd_json(["user-group", "describe", new_group_name, "--json"])
@@ -138,15 +138,15 @@ def test_group_errors() -> None:
         # Adding non existent users to groups.
         fake_user = get_random_string()
         det_cmd_expect_error(
-            ["user-group", "create", fake_group, "--add-user", fake_user], "not find"
+            ["user-group", "create", fake_group, "--add-user", fake_user], "not found"
         )
-        det_cmd_expect_error(["user-group", "add-user", group_name, fake_user], "not find")
+        det_cmd_expect_error(["user-group", "add-user", group_name, fake_user], "not found")
 
         # Removing a non existent user from group.
-        det_cmd_expect_error(["user-group", "remove-user", group_name, fake_user], "not find")
+        det_cmd_expect_error(["user-group", "remove-user", group_name, fake_user], "not found")
 
         # Removing a user not in a group.
-        det_cmd_expect_error(["user-group", "remove-user", group_name, "admin"], "NotFound")
+        det_cmd_expect_error(["user-group", "remove-user", group_name, "admin"], "Not Found")
 
         # Describing a non existent group.
-        det_cmd_expect_error(["user-group", "describe", get_random_string()], "not find")
+        det_cmd_expect_error(["user-group", "describe", get_random_string()], "not found")

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -627,8 +627,7 @@ def test_log_wait_timeout(tmp_path: Path, secrets: Dict[str, str]) -> None:
 @pytest.mark.e2e_cpu
 def test_log_argument(task_type: str) -> None:
     taskid = "28ad1623-dcf0-47d2-9faa-265aaa05b078"
-    expected = f"task {taskid} not found"
     cmd: List[str] = ["det", "-m", conf.make_master_url(), task_type, "logs", taskid]
     p = subprocess.run(cmd, stderr=subprocess.PIPE, check=False)
     assert p.stderr is not None
-    assert expected in p.stderr.decode("utf8"), p.stderr.decode("utf8")
+    assert "not found" in p.stderr.decode("utf8"), p.stderr.decode("utf8")

--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -7,6 +7,7 @@ from determined.cli._util import (
     login_sdk_client,
     print_warnings,
     wait_ntsc_ready,
+    not_found_errs,
 )
 from determined.cli import (
     agent,

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -133,3 +133,15 @@ def wait_ntsc_ready(session: api.Session, ntsc_type: api.NTSC_Kind, eid: str) ->
     loading_animator.clear(msg)
     if err_msg:
         raise errors.CliError(err_msg)
+
+
+# not_found_errs mirrors NotFoundErrs from the golang api/errors.go. In the cases where
+# Python errors override the golang errors, this ensures the error messages stay consistent.
+def not_found_errs(
+    category: str, name: str, session: api.Session
+) -> api.errors.BadRequestException:
+    resp = bindings.get_GetMaster(session)
+    msg = f"{category} '{name}' not found"
+    if not resp.to_json().get("rbacEnabled"):
+        return api.errors.NotFoundException(msg)
+    return api.errors.NotFoundException(msg + ", please check your permissions.")

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import re
-from argparse import ArgumentError, Namespace
+from argparse import Namespace
 from collections import OrderedDict, namedtuple
 from pathlib import Path
 from typing import IO, Any, Dict, Iterable, List, Optional, Tuple, Union
@@ -198,11 +198,7 @@ def list_tasks(args: Namespace) -> None:
     params: Dict[str, Any] = {}
 
     if "workspace_name" in args and args.workspace_name is not None:
-        workspace = cli.workspace.get_workspace_by_name(
-            cli.setup_session(args), args.workspace_name
-        )
-        if workspace is None:
-            raise ArgumentError(None, f'Workspace "{args.workspace_name}" not found.')
+        workspace = cli.workspace.workspace_by_name(cli.setup_session(args), args.workspace_name)
 
         params["workspaceId"] = workspace.id
 

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -591,11 +591,7 @@ def experiment_logs(args: Namespace) -> None:
     sess = cli.setup_session(args)
     trials = bindings.get_GetExperimentTrials(sess, experimentId=args.experiment_id).trials
     if len(trials) == 0:
-        print(
-            f"No trials found for experiment {args.experiment_id}. "
-            "Try again after the experiment has a trial running."
-        )
-        return
+        raise cli.not_found_errs("experiment", args.experiment_id, sess)
     first_trial_id = sorted(t_id.id for t_id in trials)[0]
     try:
         logs = api.trial_logs(

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -64,10 +64,7 @@ def project_by_name(
     w = workspace_by_name(sess, workspace_name)
     p = bindings.get_GetWorkspaceProjects(sess, id=w.id, name=project_name).projects
     if len(p) == 0:
-        raise errors.EmptyResultException(
-            f'Did not find a project with name "{project_name}"'
-            f' in workspace "{workspace_name}".'
-        )
+        raise cli.not_found_errs("project", project_name, sess)
     return (w, p[0])
 
 

--- a/harness/determined/cli/user_groups.py
+++ b/harness/determined/cli/user_groups.py
@@ -3,8 +3,8 @@ from collections import namedtuple
 from typing import Any, Dict, List, Optional
 
 import determined.cli.render
+from determined import cli
 from determined.cli import default_pagination_args, render, require_feature_flag, setup_session
-from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.experimental import Session
@@ -161,9 +161,7 @@ def usernames_to_user_ids(session: Session, usernames: List[str]) -> List[int]:
             user_ids.append(user_id)
 
     if missing_users:
-        raise api.errors.BadRequestException(
-            f"could not find users for usernames {', '.join(missing_users)}"
-        )
+        raise cli.not_found_errs("user(s)", ", ".join(missing_users), session)
     return user_ids
 
 
@@ -172,7 +170,7 @@ def group_name_to_group_id(session: Session, group_name: str) -> int:
     resp = bindings.post_GetGroups(session, body=body)
     groups = resp.groups
     if groups is None or len(groups) != 1 or groups[0].group.groupId is None:
-        raise api.errors.BadRequestException(f"could not find user group name {group_name}")
+        raise cli.not_found_errs("group", group_name, session)
     return groups[0].group.groupId
 
 

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -29,11 +29,7 @@ workspace_arg: Arg = Arg("-w", "--workspace-name", type=str, help="workspace nam
 def get_workspace_id_from_args(args: Namespace) -> Optional[int]:
     workspace_id = None
     if args.workspace_name:
-        workspace = cli.workspace.get_workspace_by_name(
-            cli.setup_session(args), args.workspace_name
-        )
-        if workspace is None:
-            raise ArgumentError(None, f'Workspace "{args.workspace_name}" not found.')
+        workspace = cli.workspace.workspace_by_name(cli.setup_session(args), args.workspace_name)
         if workspace.archived:
             raise ArgumentError(None, f'Workspace "{args.workspace_name}" is archived.')
         workspace_id = workspace.id
@@ -48,19 +44,6 @@ def get_workspace_names(session: api.Session) -> Dict[int, str]:
         assert w.id not in mapping, "workspace ids are assumed to be unique."
         mapping[w.id] = w.name
     return mapping
-
-
-def get_workspace_by_name(
-    session: api.Session, workspace_name: str
-) -> Optional[bindings.v1Workspace]:
-    """Get a workspace by name."""
-    assert workspace_name, "workspace name cannot be empty"
-    resp = bindings.get_GetWorkspaces(session, name=workspace_name)
-    assert len(resp.workspaces) <= 1, "workspace name are assumed to be unique."
-    if len(resp.workspaces) == 0:
-        return None
-    workspace = resp.workspaces[0]
-    return workspace
 
 
 def render_workspaces(
@@ -88,9 +71,11 @@ def render_workspaces(
 
 
 def workspace_by_name(sess: api.Session, name: str) -> bindings.v1Workspace:
+    assert name, "workspace name cannot be empty"
     w = bindings.get_GetWorkspaces(sess, name=name).workspaces
+    assert len(w) <= 1, "workspace name is assumed to be unique."
     if len(w) == 0:
-        raise errors.EmptyResultException(f'Did not find a workspace with name "{name}".')
+        raise cli.not_found_errs("workspace", name, sess)
     return bindings.get_GetWorkspace(sess, id=w[0].id).workspace
 
 

--- a/harness/determined/common/api/errors.py
+++ b/harness/determined/common/api/errors.py
@@ -38,7 +38,9 @@ class APIException(BadRequestException):
 
 
 class NotFoundException(APIException):
-    pass
+    def __init__(self, error_message: str) -> None:
+        self.message = error_message
+        self.status_code = 404
 
 
 class ForbiddenException(BadRequestException):

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -163,7 +163,7 @@ def do_request(
     if r.status_code == 401:
         raise errors.UnauthenticatedException(username=username)
     elif r.status_code == 404:
-        raise errors.NotFoundException(r)
+        raise errors.NotFoundException(r.reason)
     elif r.status_code >= 300:
         raise errors.APIException(r)
 

--- a/master/internal/api/error.go
+++ b/master/internal/api/error.go
@@ -58,7 +58,7 @@ please ensure the client consuming the API is up to date and report a bug if the
 
 // NotFoundErrMsg creates a formatted message about a resource not being found.
 func NotFoundErrMsg(name string, id string) string {
-	msg := fmt.Sprintf("%s %s not found%s", name, id, AddRBACSuffix())
+	msg := fmt.Sprintf(`%s '%s' not found%s`, name, id, AddRBACSuffix())
 	if id == "" {
 		msg = fmt.Sprintf("%s not found%s", name, AddRBACSuffix())
 	}

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -240,7 +240,7 @@ func TestGetCheckpointEchoExpErr(t *testing.T) {
 	for _, curCase := range cases {
 		// Checkpoint not found
 		require.Equal(t, echo.NewHTTPError(http.StatusNotFound,
-			"checkpoint 7e0bad2c-b3f6-4988-916c-eb3081b19db0 not found"),
+			`checkpoint '7e0bad2c-b3f6-4988-916c-eb3081b19db0' not found`),
 			curCase.IDToReqCall("7e0bad2c-b3f6-4988-916c-eb3081b19db0"))
 
 		// Invalid checkpoint UUID


### PR DESCRIPTION
## Description
For all cases where a Python error overrides the golang RBAC 'not found' error, we wish to output a consistent error message to users -- reminding them to check their permissions _if_ RBAC is enabled.

## Test Plan
To test this change, check out branch [9606-test-python-err](https://github.com/determined-ai/determined-ee/tree/9606-test-python-err) from EE (which has the right commit cherry-picked) & spin up your own RBAC-enabled EE cluster. Then, for each of the cases changed, follow a similar workflow:
- in the admin role, create 'X' object that a second user should not have access to.
- From the second user's perspective try to `det describe` or somehow interact with 'X' object
- Confirm that the error given is of form: `<workspace/project/etc> <id> not found, please check your permissions.`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9606