### PR TITLE
fix: Delay logviewer select responses until selection is done [WEB-1412]

### DIFF
--- a/webui/react/src/components/kit/LogViewer/LogViewerSelect.test.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewerSelect.test.tsx
@@ -104,6 +104,7 @@ describe('LogViewerFilter', () => {
     const agentOption2 = await screen.findByText(agentOptionText2);
     await user.click(agentOption1[1]);
     await user.click(agentOption2);
+    await user.click(agent);
 
     await waitFor(() => {
       expect(handleOnChange).toHaveBeenCalledWith({

--- a/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
@@ -123,7 +123,8 @@ const LogViewerSelect: React.FC<Props> = ({
   useEffect(() => {
     if (!filters) return;
     throttledChangeFilter(filters);
-  }, [filters, throttledChangeFilter]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.searchText, throttledChangeFilter]);
 
   useEffect(() => {
     return () => {
@@ -144,6 +145,7 @@ const LogViewerSelect: React.FC<Props> = ({
             placeholder={`All ${LABELS.allocationIds}`}
             value={filters.allocationIds}
             width={150}
+            onBlur={() => onChange?.(filters)}
             onChange={handleChange('allocationIds', String)}>
             {selectOptions?.allocationIds?.map((id, index) => (
               <Option key={id || `no-id-${index}`} value={id}>
@@ -159,6 +161,7 @@ const LogViewerSelect: React.FC<Props> = ({
             placeholder={`All ${LABELS.agentIds}`}
             value={filters.agentIds}
             width={150}
+            onBlur={() => onChange?.(filters)}
             onChange={handleChange('agentIds', String)}>
             {selectOptions?.agentIds?.map((id, index) => (
               <Option key={id || `no-id-${index}`} value={id}>
@@ -174,6 +177,7 @@ const LogViewerSelect: React.FC<Props> = ({
             placeholder={`All ${LABELS.containerIds}`}
             value={filters.containerIds}
             width={150}
+            onBlur={() => onChange?.(filters)}
             onChange={handleChange('containerIds', String)}>
             {selectOptions?.containerIds?.map((id, index) => (
               <Option key={id || `no-id-${index}`} value={id}>
@@ -189,6 +193,7 @@ const LogViewerSelect: React.FC<Props> = ({
             placeholder={`All ${LABELS.rankIds}`}
             value={filters.rankIds}
             width={150}
+            onBlur={() => onChange?.(filters)}
             onChange={handleChange('rankIds', Number)}>
             {selectOptions?.rankIds?.map((id, index) => (
               <Option key={id ?? `no-id-${index}`} value={id}>
@@ -203,6 +208,7 @@ const LogViewerSelect: React.FC<Props> = ({
           placeholder={`All ${LABELS.levels}`}
           value={filters.levels}
           width={150}
+          onBlur={() => onChange?.(filters)}
           onChange={handleChange('levels', String)}>
           {selectOptions?.levels.map((level) => (
             <Option key={level.value} value={level.value}>


### PR DESCRIPTION
## Description

We believe the issue is that log requests take time, and a request with old settings can overwrite the window.

This issue was observed on rank selection, but will apply to all these multiple-item dropdowns in LogViewer.
Instead of `onChange` starting a 500ms delay implemented in `throttledChangeFilter`, the changes will be applied by `onBlur` (when the user closes the dropdown)
Search by text will continue to use `throttledChangeFilter` so we don't issue requests on each keystroke

## Test Plan

If you want to use gcloud experiment 2498, open omnibar and `dev serverAddress set https://gcloud.determined.ai`
Or find an experiment which lots of log filter options

- On the logs page, select multiple options in one or more dropdowns. Logs update when you click away / clear the dropdown
- Type in the "Search logs..." text at top left of logs; after a short delay you see the text search with any other filters applied
- Use the Reset button at top right of logs; this should clear all filters to defaults

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.