### PR TITLE
fix: SDK methods don't update local on failure

### DIFF
--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -282,19 +282,6 @@ class Checkpoint:
         with open(path, "w") as f:
             json.dump(self.metadata, f, indent=2)
 
-    def _push_metadata(self) -> None:
-        # TODO: in a future version of this REST API, an entire, well-formed Checkpoint object.
-        req = bindings.v1PostCheckpointMetadataRequest(
-            checkpoint=bindings.v1Checkpoint(
-                uuid=self.uuid,
-                metadata=self.metadata,
-                resources={},
-                training=bindings.v1CheckpointTrainingMetadata(),
-                state=bindings.checkpointv1State.UNSPECIFIED,
-            ),
-        )
-        bindings.post_PostCheckpointMetadata(self._session, body=req, checkpoint_uuid=self.uuid)
-
     def add_metadata(self, metadata: Dict[str, Any]) -> None:
         """
         Adds user-defined metadata to the checkpoint. The ``metadata`` argument must be a
@@ -307,10 +294,12 @@ class Checkpoint:
         Arguments:
             metadata (dict): Dictionary of metadata to add to the checkpoint.
         """
-        for key, val in metadata.items():
-            self.metadata[key] = val
+        updated_metadata = dict(self.metadata, **metadata)
 
-        self._push_metadata()
+        req = _metadata_update_request(self.uuid, updated_metadata)
+        bindings.post_PostCheckpointMetadata(self._session, body=req, checkpoint_uuid=self.uuid)
+
+        self.metadata = updated_metadata
 
     def remove_metadata(self, keys: List[str]) -> None:
         """
@@ -323,11 +312,15 @@ class Checkpoint:
             keys (List[string]): Top-level keys to remove from the checkpoint metadata.
         """
 
+        updated_metadata = dict(self.metadata)
         for key in keys:
-            if key in self.metadata:
-                del self.metadata[key]
+            if key in updated_metadata:
+                del updated_metadata[key]
 
-        self._push_metadata()
+        req = _metadata_update_request(self.uuid, updated_metadata)
+        bindings.post_PostCheckpointMetadata(self._session, body=req, checkpoint_uuid=self.uuid)
+
+        self.metadata = updated_metadata
 
     def delete(self) -> None:
         """
@@ -382,3 +375,19 @@ class Checkpoint:
             state=CheckpointState(ckpt.state.value),
             training=CheckpointTrainingMetadata._from_bindings(ckpt.training),
         )
+
+
+def _metadata_update_request(
+    uuid: str, metadata: Dict[str, Any]
+) -> bindings.v1PostCheckpointMetadataRequest:
+    """Returns a request for updating checkpoint metadata."""
+    # TODO: in a future version of this REST API, an entire, well-formed Checkpoint object.
+    return bindings.v1PostCheckpointMetadataRequest(
+        checkpoint=bindings.v1Checkpoint(
+            uuid=uuid,
+            metadata=metadata,
+            resources={},
+            training=bindings.v1CheckpointTrainingMetadata(),
+            state=bindings.checkpointv1State.UNSPECIFIED,
+        ),
+    )

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -46,11 +46,11 @@ class ModelVersion:
             name (string): New name for model version
         """
 
-        self.name = name
         req = bindings.v1PatchModelVersion(name=name)
         bindings.patch_PatchModelVersion(
             self._session, body=req, modelName=self.model_name, modelVersionNum=self.model_version
         )
+        self.name = name
 
     def set_notes(self, notes: str) -> None:
         """
@@ -60,11 +60,11 @@ class ModelVersion:
             notes (string): Replaces notes for model version in registry
         """
 
-        self.notes = notes
         req = bindings.v1PatchModelVersion(notes=notes)
         bindings.patch_PatchModelVersion(
             self._session, body=req, modelName=self.model_name, modelVersionNum=self.model_version
         )
+        self.notes = notes
 
     def delete(self) -> None:
         """
@@ -260,11 +260,12 @@ class Model:
         Arguments:
             metadata (dict): Dictionary of metadata to add to the model.
         """
-        for key, val in metadata.items():
-            self.metadata[key] = val
+        updated_metadata = dict(self.metadata, **metadata)
 
-        req = bindings.v1PatchModel(metadata=self.metadata)
+        req = bindings.v1PatchModel(metadata=updated_metadata)
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
+
+        self.metadata = updated_metadata
 
     def remove_metadata(self, keys: List[str]) -> None:
         """
@@ -279,12 +280,15 @@ class Model:
                 f"remove_metadata() requires a list of strings as input but got: {keys}"
             )
 
+        updated_metadata = dict(self.metadata)
         for key in keys:
-            if key in self.metadata:
-                del self.metadata[key]
+            if key in updated_metadata:
+                del updated_metadata[key]
 
-        req = bindings.v1PatchModel(metadata=self.metadata)
+        req = bindings.v1PatchModel(metadata=updated_metadata)
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
+
+        self.metadata = updated_metadata
 
     def move_to_workspace(self, workspace_name: str) -> None:
         req = bindings.v1PatchModel(workspaceName=workspace_name)
@@ -301,29 +305,32 @@ class Model:
         if not isinstance(labels, Iterable):
             raise ValueError(f"set_labels() requires a list of strings as input but got: {labels}")
 
-        self.labels = list(labels)
+        labels = list(labels)
 
-        req = bindings.v1PatchModel(labels=self.labels)
+        req = bindings.v1PatchModel(labels=labels)
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
+
+        self.labels = labels
 
     def set_description(self, description: str) -> None:
-        self.description = description
-        req = bindings.v1PatchModel(description=self.description)
+        req = bindings.v1PatchModel(description=description)
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
+
+        self.description = description
 
     def archive(self) -> None:
         """
         Sets the model's state to archived
         """
-        self.archived = True
         bindings.post_ArchiveModel(self._session, modelName=self.name)
+        self.archived = True
 
     def unarchive(self) -> None:
         """
         Removes the model's archived state
         """
-        self.archived = False
         bindings.post_UnarchiveModel(self._session, modelName=self.name)
+        self.archived = False
 
     def delete(self) -> None:
         """

--- a/harness/tests/determined/common/experimental/test_model.py
+++ b/harness/tests/determined/common/experimental/test_model.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import responses
 
@@ -19,6 +21,12 @@ def sample_model(standard_session: api.Session) -> model.Model:
     return model.Model._from_bindings(bindings_model, standard_session)
 
 
+@pytest.fixture
+def sample_model_version(standard_session: api.Session) -> model.ModelVersion:
+    bindings_model_versions = api_responses.sample_get_model_versions().modelVersions
+    return model.ModelVersion._from_bindings(bindings_model_versions[0], standard_session)
+
+
 @responses.activate
 def test_get_versions_gets_all_pages(sample_model: model.Model) -> None:
     model_versions_resp = api_responses.sample_get_model_versions()
@@ -32,3 +40,89 @@ def test_get_versions_gets_all_pages(sample_model: model.Model) -> None:
 
     mvs = sample_model.get_versions()
     assert len(mvs) == len(model_versions_resp.modelVersions)
+
+
+@responses.activate
+def test_set_name_doesnt_update_local_on_rest_failure(
+    sample_model_version: model.ModelVersion,
+) -> None:
+    sample_model_version.name = "test_version_name"
+
+    responses.patch(
+        re.compile(f"{_MASTER}/api/v1/models/{sample_model_version.model_name}.*"), status=400
+    )
+
+    try:
+        sample_model_version.set_name("new_version_name")
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert sample_model_version.name == "test_version_name"
+
+
+@responses.activate
+def test_set_notes_doesnt_update_local_on_rest_failure(
+    sample_model_version: model.ModelVersion,
+) -> None:
+    sample_model_version.notes = "test notes"
+
+    responses.patch(
+        re.compile(f"{_MASTER}/api/v1/models/{sample_model_version.model_name}.*"), status=400
+    )
+
+    try:
+        sample_model_version.set_notes("new notes")
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert sample_model_version.notes == "test notes"
+
+
+@responses.activate
+def test_add_metadata_doesnt_update_local_on_rest_failure(sample_model: model.Model) -> None:
+    sample_model.metadata = {}
+
+    responses.patch(re.compile(f"{_MASTER}/api/v1/models/{sample_model.name}.*"), status=400)
+
+    try:
+        sample_model.add_metadata({"test": "test"})
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert "test" not in sample_model.metadata
+
+
+@responses.activate
+def test_remove_metadata_doesnt_update_local_on_rest_failure(sample_model: model.Model) -> None:
+    sample_model.metadata = {"test": "test"}
+
+    responses.patch(re.compile(f"{_MASTER}/api/v1/models/{sample_model.name}.*"), status=400)
+
+    try:
+        sample_model.remove_metadata(["test"])
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert "test" in sample_model.metadata
+
+
+@responses.activate
+def test_archive_doesnt_update_local_on_rest_failure(sample_model: model.Model) -> None:
+    sample_model.archived = False
+
+    responses.post(re.compile(f"{_MASTER}/api/v1/models/{sample_model.name}.*"), status=400)
+
+    try:
+        sample_model.archive()
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert sample_model.archived is False
+
+
+@responses.activate
+def test_unarchive_doesnt_update_local_on_rest_failure(sample_model: model.Model) -> None:
+    sample_model.archived = True
+
+    responses.post(re.compile(f"{_MASTER}/api/v1/models/{sample_model.name}.*"), status=400)
+
+    try:
+        sample_model.unarchive()
+        raise AssertionError("Server's 400 should raise an exception")
+    except api.errors.APIException:
+        assert sample_model.archived is True


### PR DESCRIPTION
Local objects contain copies of data that exists also in the remote master. These copies can get out of sync.

This change addresses methods that change local objects' data and post (or patch) a request to master to update the remote copies, too.

Before this change errors over the API would still change local versions. With this change, we now treat APIErrors as total failures, and no longer update local copies.

This PR also adds tests for exactly this behavior in all the "update" methods in the SDK.

[MLG-587]

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
To manually test what the new unit tests do:
1. create a Model, ModelVersion, or Checkpoint.
2. Then make sure your client can't connect to master.
3. Call one of the modified methods (like model.add_metadata).
4. Observe that no change has been made to the local copy (for example my_model.metadata).


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-587]: https://hpe-aiatscale.atlassian.net/browse/MLG-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ