### PR TITLE
fix: LogViewer request handling to avoid filter mismatch [WEB-1412]

### DIFF
--- a/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewerSelect.tsx
@@ -87,27 +87,6 @@ const LogViewerSelect: React.FC<Props> = ({
     return false;
   }, [selectOptions, values]);
 
-  const handleChange = useCallback(
-    (key: keyof Filters, caster: NumberConstructor | StringConstructor) => (value: SelectValue) => {
-      setFilters((prev) => ({
-        ...prev,
-        [key]: (value as Array<string>).map((item) => caster(item)),
-      }));
-    },
-    [],
-  );
-
-  const handleSearch = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      setFilters((prev) => ({ ...prev, searchText: e.target.value })),
-    [],
-  );
-
-  const handleReset = useCallback(() => {
-    setFilters({});
-    onReset?.();
-  }, [onReset]);
-
   const throttledChangeFilter = useMemo(
     () =>
       throttle(
@@ -121,15 +100,41 @@ const LogViewerSelect: React.FC<Props> = ({
   );
 
   useEffect(() => {
-    if (!filters) return;
-    throttledChangeFilter(filters);
-  }, [filters, throttledChangeFilter]);
-
-  useEffect(() => {
     return () => {
       throttledChangeFilter.cancel();
     };
   }, [throttledChangeFilter]);
+
+  const handleChange = useCallback(
+    (key: keyof Filters, caster: NumberConstructor | StringConstructor) => (value: SelectValue) => {
+      setFilters((prev) => {
+        const newF = {
+          ...prev,
+          [key]: (value as Array<string>).map((item) => caster(item)),
+        };
+        throttledChangeFilter(newF);
+        return newF;
+      });
+    },
+    [throttledChangeFilter],
+  );
+
+  const handleSearch = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFilters((prev) => {
+        const newF = { ...prev, searchText: e.target.value };
+        throttledChangeFilter(newF);
+        return newF;
+      });
+    },
+    [throttledChangeFilter],
+  );
+
+  const handleReset = useCallback(() => {
+    setFilters({});
+    onReset?.();
+    throttledChangeFilter({});
+  }, [onReset, throttledChangeFilter]);
 
   return (
     <>

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import LogViewer, {
   FetchConfig,
@@ -38,6 +38,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
   const { ui } = useUI();
   const [filterOptions, setFilterOptions] = useState<Filters>({});
   const confirm = useConfirm();
+  const canceler = useRef(new AbortController());
 
   const trialSettingsConfig = useMemo(() => settingsConfigForTrial(trial?.id || -1), [trial?.id]);
   const { resetSettings, settings, updateSettings } = useSettings<Settings>(trialSettingsConfig);
@@ -55,6 +56,10 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   const handleFilterChange = useCallback(
     (filters: Filters) => {
+      canceler.current.abort();
+      const newCanceler = new AbortController();
+      canceler.current = newCanceler;
+
       updateSettings({
         agentId: filters.agentIds,
         containerId: filters.containerIds,
@@ -149,7 +154,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
         options.timestampAfter ? new Date(options.timestampAfter) : undefined,
         options.orderBy as OrderBy,
         settings.searchText,
-        { signal: config.canceler.signal },
+        { signal: canceler.current.signal },
       );
     },
     [settings, trial?.id],

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -164,14 +164,17 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
     if (ui.isPageHidden) return;
     if (!trial?.id) return;
 
-    const canceler = new AbortController();
+    const fieldCanceler = new AbortController();
 
     readStream(
-      detApi.StreamingExperiments.trialLogsFields(trial.id, true, { signal: canceler.signal }),
+      detApi.StreamingExperiments.trialLogsFields(trial.id, true, { signal: fieldCanceler.signal }),
       (event) => setFilterOptions(event as Filters),
     );
 
-    return () => canceler.abort();
+    return () => {
+      fieldCanceler.abort();
+      canceler.current.abort();
+    };
   }, [trial?.id, ui.isPageHidden]);
 
   const logFilters = (


### PR DESCRIPTION
## Description

Replaces #7264 which modified log filters UI

This alternative uses its own AbortController ref to cancel the previous log requests. There are also changes to the reliability of the filters onChange call (so it won't trigger when we first load the page and cancelling the initial load of logs)

We lose access to the LogViewer component's `config.canceler` which closes the stream when navigating away, so I add an abort to the same `useEffect` cleanup callback used to close the `trialLogsFields` streaming request.

## Test Plan

If you want to use gcloud experiment 2498, open omnibar and `dev serverAddress set https://gcloud.determined.ai`
Or find an experiment which lots of log filter options

- On the logs page, select multiple options in one or more dropdowns. Logs update as you make selections in a dropdown
- Use the Reset button at top right of logs; this should clear all filters to defaults


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.