### PR TITLE
fix: no data to plot is shown sometimes incorrectly [WEB-1413]

### DIFF
--- a/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
@@ -6,7 +6,7 @@ import MetricBadgeTag from 'components/MetricBadgeTag';
 import { useTrialMetrics } from 'pages/TrialDetails/useTrialMetrics';
 import { ExperimentWithTrial, TrialItem } from 'types';
 import handleError from 'utils/error';
-import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+import { Loaded, NotLoaded } from 'utils/loadable';
 
 import { useGlasbey } from './useGlasbey';
 
@@ -18,9 +18,10 @@ interface Props {
 const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials }) => {
   const colorMap = useGlasbey(selectedExperiments.map((e) => e.experiment.id));
   const [xAxis, setXAxis] = useState<XAxisDomain>(XAxisDomain.Batches);
-  const { metrics, data, scale, hasData, isLoaded, setScale } = useTrialMetrics(trials);
+  const { metrics, data, scale, metricHasData, isLoaded, setScale } = useTrialMetrics(trials);
 
   const chartsProps = useMemo(() => {
+    const chartedMetrics: Record<string, boolean> = {};
     const out: ChartsProps = [];
     metrics.forEach((metric) => {
       const series: Serie[] = [];
@@ -28,6 +29,9 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials }) => {
       trials.forEach((t) => {
         const m = data[t?.id || 0];
         m?.[key] && t && series.push({ ...m[key], color: colorMap[t.experimentId] });
+        if (series.length > 0) {
+          chartedMetrics[key] = true;
+        }
       });
       out.push({
         series: Loaded(series),
@@ -39,21 +43,21 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials }) => {
     // In order to show the spinner for each chart in the ChartGrid until
     // metrics are visible, we must determine whether the metrics have been
     // loaded and whether the chart props have been updated.
-    // If hasData is true but no chartProps contain data, then the charts
-    // have not been updated and we need to continue to show the spinner.
-    const chartDataIsLoaded = out.some((serie) =>
-      Loadable.isLoadable(serie.series)
-        ? Loadable.getOrElse([], serie.series).length > 0
-        : serie.series.length > 0,
-    );
-    if (isLoaded && (!hasData || chartDataIsLoaded)) {
+    // If any metric has data but no chartProps contain data for the metric,
+    // then the charts have not been updated and we need to continue to show the
+    // spinner.
+    const chartDataIsLoaded = metrics.every((metric) => {
+      const metricKey = `${metric.type}|${metric.name}`;
+      return !!metricHasData?.[metricKey] && !!chartedMetrics?.[metricKey];
+    });
+    if (isLoaded && chartDataIsLoaded) {
       return Loaded(out);
     } else {
       // returns the chartProps with a NotLoaded series which enables
       // the ChartGrid to show a spinner for the loading charts.
       return Loaded(out.map((chartProps) => ({ ...chartProps, series: NotLoaded })));
     }
-  }, [metrics, data, colorMap, trials, xAxis, isLoaded, hasData]);
+  }, [metrics, data, colorMap, trials, xAxis, isLoaded, metricHasData]);
 
   return (
     <div style={{ height: 'calc(100vh - 250px)', overflow: 'auto' }}>

--- a/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
@@ -29,9 +29,7 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials }) => {
       trials.forEach((t) => {
         const m = data[t?.id || 0];
         m?.[key] && t && series.push({ ...m[key], color: colorMap[t.experimentId] });
-        if (series.length > 0) {
-          chartedMetrics[key] = true;
-        }
+        chartedMetrics[key] ||= series.length > 0;
       });
       out.push({
         series: Loaded(series),

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -74,11 +74,9 @@ const summarizedMetricToSeries = (
   // Record whether or not each metric contains at least one value for any
   // xAxis option.
   Object.keys(trialData).forEach((key) => {
-    if (!metricHasData?.[key]) {
-      metricHasData[key] = xAxisOptions.some(
-        (xAxis) => (trialData?.[key]?.data?.[xAxis]?.length ?? 0) > 0,
-      );
-    }
+    metricHasData[key] ||= xAxisOptions.some(
+      (xAxis) => (trialData?.[key]?.data?.[xAxis]?.length ?? 0) > 0,
+    );
   });
   return { data: trialData, metricHasData };
 };
@@ -147,9 +145,7 @@ export const useTrialMetrics = (
         response.forEach((r) => {
           const { data: trialData, metricHasData } = summarizedMetricToSeries(r?.metrics, metrics);
           Object.keys(metricHasData).forEach((key) => {
-            if (!metricsHaveData?.[key]) {
-              metricsHaveData[key] = metricHasData[key];
-            }
+            metricsHaveData[key] ||= metricHasData[key];
           });
           newData[r.id] = trialData;
         });


### PR DESCRIPTION
## Description

Currently, the metric charts in the `Compare` tab may flash no data to plot because the current check only ensures that the data is at least partially loaded. However, some metric charts might not have an updated data `series` causing the UI to show the `no data to plot` message. 

This PR includes an update to `useTrialMetrics` to return whether or not each individual metric contains data. The `Compare` metrics tab now uses that information to ensure that each metric's chart has been fully updated.  
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

1. Open the `Compare` tab in the new experiments list. 
2. Select experiments that do not all contain the same metrics. For example, select an experiment that has only `validation loss` then select another experiment that has `validation accuracy`. Ensure that that as the new charts for the new metrics added, `No Data To Plot` is not flashed. You should see a loading spinner until the charts have rendered with data.
You can reference: https://github.com/determined-ai/release-party-issues/issues/119#issuecomment-1611880770 to see what the undesired behavior looks like.

3. De-select the experiments from (2) one by one. Again, ensure that any metric charts do no show "no data to plot" if data is available and instead always show a loading spinner.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1413

<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
