### PR TITLE
fix: Link omnibar shortcut to new Space convention [WEB-1418]

### DIFF
--- a/webui/react/src/pages/Settings/UserSettings.settings.ts
+++ b/webui/react/src/pages/Settings/UserSettings.settings.ts
@@ -37,7 +37,7 @@ const shortCutSettingsConfig: SettingsConfig<Settings> = {
       defaultValue: {
         alt: false,
         ctrl: true,
-        key: ' ',
+        key: 'Space',
         meta: false,
         shift: false,
       },


### PR DESCRIPTION
## Description

Omnibar's Ctrl Space hotkey should use the formatted name for the key ("Space")

Thanks Emily for pointing to recent changes. Looks like one PR around omnibar and one PR which gives a name to the Space key (rather than showing a blank space in UI) led to this falling through.

## Test Plan

On the dashboard or other page, use Ctrl Space to launch the omnibar hover
For Mac users: this is "control" and not "command" key

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.