### PR TITLE
Docs: Add Swarm Learning landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@
    Jupyter Notebooks <interfaces/notebooks>
    TensorBoards <interfaces/tensorboard>
    Exposing Custom Ports <interfaces/proxy-ports>
+   Swarm Learning <swarm/index>
 
 .. toctree::
    :caption: Integrations

--- a/docs/swarm/index.rst
+++ b/docs/swarm/index.rst
@@ -1,0 +1,43 @@
+###############
+ Swarm Learning
+###############
+
+.. meta::
+   :description: Guide to using Swarm Learning including examples, the HPE Swarm Learning communit edition, and how to get started.
+
+.. raw:: html
+
+   <div class="landing">
+      <div class="tiles-flex">
+         <div class="tile-container">
+            <a class="tile" href="https://developer.hpe.com/platform/swarm-learning/home/">
+                 <h2 class="tile-title">What is HPE Swarm Learning?</h2>
+                 <p class="tile-description">HPE Swarm Learning is a decentralized, privacy-preserving Machine Learning framework.</p>
+             </a>
+         </div>
+         <div class="tile-container">
+             <a class="tile" href="https://www.hpe.com/us/en/hpe-swarm-learning.html">
+                 <h2 class="tile-title">HPE Swarm Learning Home</h2>
+                 <p class="tile-description">Visit the HPE Swarm Learning home page with links to articles, white papers, explainer videos, and more.</p>
+             </a>
+         </div>
+         <div class="tile-container">
+             <a class="tile" href="https://github.com/HewlettPackard/swarm-learning">
+                 <h2 class="tile-title">Swarm Learning Community Edition</h2>
+                 <p class="tile-description">Get started with the community edition. Visit this page for getting started instructions, documentation, and examples.</p>
+             </a>
+         </div>
+         <div class="tile-container">
+             <a class="tile" href="https://github.com/HewlettPackard/swarm-learning/tree/master/examples">
+                 <h2 class="tile-title">HPE Swarm Learning Examples</h2>
+                 <p class="tile-description">Get started using familiar examples such as MNIST, MNIST-PYT, CIFAR-10, Credit Card Fraud Detection, and more.</p>
+             </a>
+         </div>
+         <div class="tile-container">
+             <a class="tile" href="https://github.com/HewlettPackard/swarm-learning/blob/master/lib/src/README.md">
+                 <h2 class="tile-title">HPE Swarm Learning Client</h2>
+                 <p class="tile-description">The Swarm Learning client interface is a python wheels package that consists of a Swarm Callback API and an SWCI API.</p>
+             </a>
+         </div>
+      </div>
+   </div>


### PR DESCRIPTION
Closed. Replaced by #7674 

Add Swarm Learning index page and point to existing resources. The purpose is to increase visibility of Swarm Learning by adding resources to the docs home page and allowing discoverability via the Algolia search engine.

<img width="861" alt="HPE Swarm Learning landing page" src="https://github.com/determined-ai/determined/assets/122102764/f1b999ad-2e60-4c07-b21a-b72eea1ce05c">


## Checklist

- [ ] Changes have been manually QA'd
- [ ] Landing page points to major [Swarm learning resources](https://developer.hpe.com/platform/swarm-learning/home/).
- [ ] User can search for Swarm learning via Algolia search.

