### PR TITLE
fix: Improve HPC error shutdown to improve logging [FE-44]

### DIFF
--- a/master/static/srv/task-logging-setup.sh
+++ b/master/static/srv/task-logging-setup.sh
@@ -72,6 +72,9 @@ if [ "$DET_RESOURCES_TYPE" == "slurm-job" ] || [ "$DET_NO_FLUENT" == "true" ]; t
         fi
     fi
 
+    # Intercept stdout/stderr and send content to DET_MASTER via the log API.
+    # When completed, write a single character to the DET_LOG_WAIT_FIFO to signal
+    # completion of one procesor.
     exec 1> >(
         "$DET_PYTHON_EXECUTABLE" /run/determined/enrich_task_logs.py --stdtype stdout >&1
         printf x >$DET_LOG_WAIT_FIFO
@@ -105,6 +108,9 @@ fi
 # displays, here we simply replace them all with newlines to get a reasonable
 # effect in those cases. This must be after the multilog exec, since exec
 # redirections are applied in reverse order.
+#
+# When completed, write a single character to the DET_LOG_WAIT_FIFO to signal
+# completion of one processor.
 exec > >(
     stdbuf -o0 tr '\r' '\n'
     printf x >$DET_LOG_WAIT_FIFO
@@ -115,4 +121,5 @@ exec > >(
 
 ((DET_LOG_WAIT_COUNT += 2))
 
+# As shell exits, wait for stdout/stderr processors to complete
 trap 'source /run/determined/task-logging-teardown.sh' EXIT

--- a/master/static/srv/task-logging-teardown.sh
+++ b/master/static/srv/task-logging-teardown.sh
@@ -11,8 +11,24 @@ epoch_seconds() {
     printf '%(%s)T\n' -1
 }
 
-# Wait for 30 seconds total for the logging to finish, otherwise just exit.
+# Wait for up to DET_LOG_WAIT_TIME seconds for the logging to finish
+# At this point the launching entry point script has exited and we are
+# waiting for the child logging processes to complete.  The child
+# processes will exit when reaching EOF of the log stream they are
+# processing, so in the normal case they terminate quickly and
+# each stream processor writes a single character to the DET_LOG_WAIT_FIFO
+# to indicate they are no longer waiting.
+#
+# This wait time it to handle the case when log stream procesors have
+# not exited yet -- either becuase someone is still writing to the stream,
+# or the DET_MASTER is not reachable and therefor we are slow in flushing
+# the logs to the master.
+#
+# After this wait, the container entrypoint immediately exits and all
+# processing within the container is SIGKILLed without any opportunity
+# for any furhter processing, so avoiding a premature exit is important.
 waitfor="${DET_LOG_WAIT_TIME:-30}"
+
 deadline="$(($(epoch_seconds) + waitfor))"
 timeout="$((deadline - $(epoch_seconds)))"
 

--- a/master/static/srv/task-logging-teardown.sh
+++ b/master/static/srv/task-logging-teardown.sh
@@ -21,7 +21,7 @@ epoch_seconds() {
 #
 # This wait time it to handle the case when log stream procesors have
 # not exited yet -- either becuase someone is still writing to the stream,
-# or the DET_MASTER is not reachable and therefor we are slow in flushing
+# or the DET_MASTER is not reachable and therefore we are slow in flushing
 # the logs to the master.
 #
 # After this wait, the container entrypoint immediately exits and all


### PR DESCRIPTION
## Description

On Slurm job failures we have not reliably been getting the full logs
posted to the master.   When processing task-logging-teardown.sh
on error paths we commonly hit the 30sec timeout and therefore
exit the container which terminates all processing with SIGKILL.
When errors occur horovodrun/pid-server will terminate the top-level
children launched via SIGTERM, however, this only terminates the
top-level children when there are actually multiple layers.  When
only the top-level children are killed others still are holding
stdout/stderr active and therefore the log processing does not shut
down.

The change in this review is to enhance determined.utils.forward_signals
method to additionally forward the signal to the children of the specified
process in addition to the process itself.



## Test Plan

Verified logging is complete and behavior correct with distributed cifar10_pytorch with Slurm+Singularity on shuco:
* Injected SIGTERM into pid_server process
* Paused/Resumed experiment multiple times
* Stopped experiment + checkpoint
* Stopped experiment + no-checkpoint

Here is an example process tree in the non-chief rank for reference 

```
harrow@n2:~> pstree -Tap harrow
starter,36330
  ├─entrypoint.sh,36365 /run/determined/train/entrypoint.sh
  │   ├─entrypoint.sh,36451 /run/determined/train/entrypoint.sh
  │   │   └─python3,36452 /run/determined/enrich_task_logs.py --stdtype stdout
  │   ├─entrypoint.sh,36453 /run/determined/train/entrypoint.sh
  │   │   └─python3,36454 /run/determined/enrich_task_logs.py --stdtype stderr
  │   ├─entrypoint.sh,36527 /run/determined/train/entrypoint.sh
  │   │   └─tr,36529 \\r \\n
  │   ├─entrypoint.sh,36528 /run/determined/train/entrypoint.sh
  │   │   └─tr,36530 \\r \\n
  │   └─python3,36745 -m determined.exec.launch
  │       └─python3,36747 -m determined.launch.horovod --autohorovod --trial model_def:CIFARTrial
  │           └─python3,36751 -m determined.exec.pid_server --on-fail SIGTERM --on-exit SIGTERM /tmp/pid_server-335.4d83309f-d361-44e6-86f9-31f7f0b40506.1 1 -- /usr/sbin/sshd -p 12350 -f /run/determined/ssh/sshd_config -D
  │               └─sshd,36753
  │                   └─sshd,36777
  │                       └─sshd,36779
  │                           └─bash,36780 -c...
  │                               └─python3,36781 -m determined.exec.pid_client /tmp/pid_server-335.4d83309f-d361-44e6-86f9-31f7f0b40506.1 -- python3 -m determined.launch.wrap_rank HOROVOD_RANK,OMPI_COMM_WORLD_RANK,PMI_RANK -- python3 -m determined.exec.harness model_def:CIFARTrial
  │                                   └─python3,36783 -m determined.launch.wrap_rank HOROVOD_RANK,OMPI_COMM_WORLD_RANK,PMI_RANK -- python3 -m determined.exec.harness model_def:CIFARTrial
  │                                       └─python3,36785 -m determined.exec.harness model_def:CIFARTrial
  ├─fuse-overlayfs,36381 -f -o...
  └─squashfuse_ll,36378 -f -o uid=100165687,gid=100,offset=45056 /proc/self/fd/3 /opt/apptainer-1.1.8/x86_64/var/apptainer/mnt/session/rootfs
```


Verified logging is complete and behavior correct with distributed cifar10_pytorch with Slurm+Singularity on horizon.
Horizon uses mpi underneath horovodrun so there is an extra layer of processes and it exhibited the lost logging very commonly because of it:
* Injected SIGTERM sshd process (under pid_server) which triggers an MPI  communication failure
* Paused/resumed multiple times
* Stopped + checkpoint

Here is the non-chief process tree with MPI from horizon for reference:

```
harrow@nid00225:~/.launcher/jobs/environments/harrow> pstree -Tap harrow
starter-suid,12639
  `-entrypoint.sh,12663 /run/determined/train/entrypoint.sh
      |-entrypoint.sh,12728 /run/determined/train/entrypoint.sh
      |   `-python3,12730 /run/determined/enrich_task_logs.py --stdtype stdout
      |-entrypoint.sh,12729 /run/determined/train/entrypoint.sh
      |   `-python3,12732 /run/determined/enrich_task_logs.py --stdtype stderr
      |-entrypoint.sh,12780 /run/determined/train/entrypoint.sh
      |   `-tr,12782 \\r \\n
      |-entrypoint.sh,12781 /run/determined/train/entrypoint.sh
      |   `-tr,12783 \\r \\n
      `-python3,12920 -m determined.exec.launch
          `-python3,12923 -m determined.launch.horovod --autohorovod --trial model_def:CIFARTrial
              `-python3,12927 -m determined.exec.pid_server --on-fail SIGTERM --on-exit SIGTERM /tmp/pid_server-340.3612dee6-7665-42da-a3cb-d3bbb33874ff.1 1 -- /usr/sbin/sshd -p 12350 -f /run/determined/ssh/sshd_config -D
                  `-sshd,12930
                      `-sshd,12941
                          `-sshd,12944
                              `-bash,12945 -c...
                                  `-orted,12953 -mca ess env -mca ess_base_jobid 1987969024 -mca ess_base_vpid 1 -mca ess_base_num_procs 2 -mca orte_node_regex nid[5:224],[2:10].128.0.226@0(2) -mca orte_hnp_uri 1987969024.0;tcp://10.128.0.225,172.30.48.181:43427 -mca pml ob1 -mca btl ^openib -mca ...
                                      `-python3,12956 -m determined.exec.pid_client /tmp/pid_server-340.3612dee6-7665-42da-a3cb-d3bbb33874ff.1 -- python3 -m determined.launch.wrap_rank HOROVOD_RANK,OMPI_COMM_WORLD_RANK,PMI_RANK -- python3 -m determined.exec.harness model_def:CIFARTrial
                                          `-python3,12959 -m determined.launch.wrap_rank HOROVOD_RANK,OMPI_COMM_WORLD_RANK,PMI_RANK -- python3 -m determined.exec.harness model_def:CIFARTrial
                                              `-python3,12962 -m determined.exec.harness model_def:CIFARTrial
```

Verified preemption continues to work with distributed cifar10_pytorch with Slurm+Singularity on casablanca.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
