### PR TITLE
docs: Add saas directory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@
 
    Basic Setup <setup-cluster/basic>
    Setup Guides <setup-cluster/deploy-cluster/index>
+   Bring Your Own Cloud <saas/index>
    Security <setup-cluster/security/overview>
    User Accounts <setup-cluster/users>
    Workspaces and Projects <setup-cluster/workspaces>

--- a/docs/saas/bring-aws-cloud.rst
+++ b/docs/saas/bring-aws-cloud.rst
@@ -1,0 +1,373 @@
+.. _deploy-aws-cloud:
+
+###########################
+ Bring Your Own Cloud: AWS
+###########################
+
+.. meta::
+   :description: Steps for integrating your cloud provider account with Determined.
+
+*****
+ AWS
+*****
+
+Enabling Cross-Account Access
+=============================
+
+To grant Determined Cloud access to your AWS account, you will need to connect your AWS account with
+the Determined Cloud. First, setup an `AWS credentials profile
+<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html>`__ for your AWS
+account. Then, run the following detcloud command to create the role:
+
+.. code::
+
+   python -m detcloud.cli connect aws
+
+The command above creates default roles and instance profiles. If you want to customize their
+creation, run this command and replace the text delimited by ``<`` and ``>`` with desired values:
+
+.. code::
+
+   python -m detcloud.cli connect aws --xacct-role-name <cross-account role name> \
+       --master-instance-profile-name <master instance profile name> \
+       --agent-instance-profile-name <agent instance profile name>
+
+To get an explaination of the command arguments, run:
+
+.. code::
+
+   python -m detcloud.cli connect aws --help
+
+And it will print the command’s help as shown below (The output might change in newer versions of
+the command without notice):
+
+.. code::
+
+   usage: __main__.py connect aws [-h] [-a ACCOUNT_ID] [--xacct-role-name XACCT_ROLE_NAME] [--master-instance-profile-name MASTER_INSTANCE_PROFILE_NAME]
+                                  [--agent-instance-profile-name AGENT_INSTANCE_PROFILE_NAME]
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     -a ACCOUNT_ID, --account-id ACCOUNT_ID
+                           ID of the Determined Account to connect with (default: 544296492693)
+     --xacct-role-name XACCT_ROLE_NAME
+                           Name of the cross-acount role to be assumed by Determined Cloud (default: det-cloud-customer-xacct-mgmt)
+     --master-instance-profile-name MASTER_INSTANCE_PROFILE_NAME
+                           Name of the master instance profile (default: det-cloud-customer-master)
+     --agent-instance-profile-name AGENT_INSTANCE_PROFILE_NAME
+                           Name of the agent instance profile (default: det-cloud-customer-agent)
+
+If the command is run successfully, you will see output similar to the following:
+
+.. code::
+
+   Will connect your AWS account 123456789012 with Determined's AWS account 544296492693, proceed? (y/N)y
+   IAM role created: arn:aws:iam::123456789012:role/det-cloud-customer-xacct-mgmt
+   Instance profile created: arn:aws:iam::123456789012:instance-profile/det-cloud-customer-master
+   Instance profile created: arn:aws:iam::123456789012:instance-profile/det-cloud-customer-agent
+
+You will need to provide the info above when onboarding Determined Cloud.
+
+**Note**: you will want to make note of the roles and instance profiles created so that you can
+verify or reference them in the future.
+
+How Determined Cloud Manages Your Clusters
+==========================================
+
+Once Determined Cloud has access to your account, it will be able to continuously manage Determined
+clusters for you. Determined Cloud will create and manage these resources for a cluster:
+
+-  Networking:
+
+   -  Elastic IPs
+   -  Gateways
+   -  Network interfaces
+   -  Route tables
+   -  Route53 records
+   -  Security groups
+   -  Subnets
+   -  VPCs
+
+-  Compute:
+
+   -  EC2 instances
+   -  SSH key pairs
+
+-  Storage:
+
+   -  Aurora DB clusters
+   -  S3 buckets
+
+-  IAM:
+
+   -  Roles
+   -  Instance profiles
+   -  Policies
+
+-  Other:
+
+   -  KMS keys
+   -  CloudWatch log groups
+
+In general, Determined Cloud performs these operations to the resources it manages:
+
+-  Create
+-  Modify
+-  Delete
+-  Connect multiple resources
+-  Monitor resource status
+-  Save logs where applicable
+-  Create backups where applicable
+
+In order for Determined Cloud to perform the aforementioned operations, your account *must* include
+an IAM role that trusts Determined’s AWS account and includes the necessary permissions. It can be
+set up by running a command as illustrated earlier, and the role’s details are listed in the next
+section.
+
+Determined Cloud is designed to manage both existing and new accounts. Existing resources in an
+account usually do not affect the managed Determined clusters. However, in the situation below, you
+should examine existing resources for potential issues:
+
+-  Your existing resources use up a non-trivial portion of the account’s `quotas
+   <https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html>`__, and that would reduce
+   the amount of resources Determined Cloud can create. You can often increase the quota, but some
+   resources quotas have limits on how much you can increase them.
+
+-  Your existing resources interact with the Determined cluster. For example, you need to set up
+   peering between the Determiend cluster’s VPC and an existing VPC. In this case, it is recommended
+   that the two VPCs have non-overlapping IP ranges.
+
+Required Role and Instance Profiles
+===================================
+
+If you choose to create the IAM Role and Policy manually, we will need the following permissions at
+a minimum:
+
+The Cross-Account Role
+----------------------
+
+Required Trust Relationship:
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {
+                   "AWS": f"arn:aws:iam::544296492693:role/det-cloud-internal-global-mgmt-role"
+               },
+               "Action": "sts:AssumeRole",
+           },
+           {
+               "Effect": "Allow",
+               "Principal": {
+                   "AWS": f"arn:aws:iam::544296492693:role/det-cloud-internal-aws-us-west-2-mgmt-role"
+               },
+               "Action": "sts:AssumeRole",
+           }
+       ],
+   }
+
+Note: these details are for the internal preview release at ``https://internal.det-cloud.net``. The
+account number and names are subject to change and will vary between deployments.
+
+Required Permissions Policy:
+
+**Note**: you need to replaced the text delimited with ``<`` and ``>`` with desired values
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Sid": "DetCrossAccountAccess",
+               "Effect": "Allow",
+               "Action": [
+                   "cloudwatch:GetMetricData",
+                   "ec2:AllocateAddress",
+                   "ec2:AssociateAddress",
+                   "ec2:AssociateRouteTable",
+                   "ec2:AttachInternetGateway",
+                   "ec2:AuthorizeSecurityGroupEgress",
+                   "ec2:AuthorizeSecurityGroupIngress",
+                   "ec2:CreateInternetGateway",
+                   "ec2:CreateNatGateway",
+                   "ec2:CreateNetworkInterface",
+                   "ec2:CreateRoute",
+                   "ec2:CreateRouteTable",
+                   "ec2:CreateSubnet",
+                   "ec2:CreateTags",
+                   "ec2:CreateVpc",
+                   "ec2:DeleteInternetGateway",
+                   "ec2:DeleteKeyPair",
+                   "ec2:DeleteNatGateway",
+                   "ec2:DeleteNetworkInterface",
+                   "ec2:DeleteRouteTable",
+                   "ec2:DeleteSubnet",
+                   "ec2:DeleteVpc",
+                   "ec2:DescribeAddresses",
+                   "ec2:DescribeAvailabilityZones",
+                   "ec2:DescribeInstanceStatus",
+                   "ec2:DescribeInstanceTypes",
+                   "ec2:DescribeInstances",
+                   "ec2:DescribeInternetGateways",
+                   "ec2:DescribeKeyPairs",
+                   "ec2:DescribeNatGateways",
+                   "ec2:DescribeNetworkInterfaces",
+                   "ec2:DescribeRouteTables",
+                   "ec2:DescribeSecurityGroups",
+                   "ec2:DescribeSubnets",
+                   "ec2:DescribeVpcs",
+                   "ec2:DetachInternetGateway",
+                   "ec2:DisassociateRouteTable",
+                   "ec2:ImportKeyPair",
+                   "ec2:ReleaseAddress",
+                   "ec2:RunInstances",
+                   "ec2:TerminateInstances",
+                   "iam:AddRoleToInstanceProfile",
+                   "iam:AttachRolePolicy",
+                   "iam:CreateInstanceProfile",
+                   "iam:CreatePolicy",
+                   "iam:CreateRole",
+                   "iam:DeleteInstanceProfile",
+                   "iam:DeletePolicy",
+                   "iam:DeleteRole",
+                   "iam:DetachRolePolicy",
+                   "iam:GetInstanceProfile",
+                   "iam:ListPolicies",
+                   "iam:ListRoles",
+                   "iam:RemoveRoleFromInstanceProfile",
+                   "iam:SimulatePrincipalPolicy",
+                   "iam:TagInstanceProfile",
+                   "iam:TagPolicy",
+                   "iam:TagRole",
+                   "kms:CreateGrant",
+                   "kms:DescribeKey",
+                   "logs:CreateLogGroup",
+                   "logs:DeleteLogGroup",
+                   "logs:PutRetentionPolicy",
+                   "logs:TagResource",
+                   "rds:AddTagsToResource",
+                   "rds:CreateDBCluster",
+                   "rds:CreateDBSubnetGroup",
+                   "rds:DeleteDBCluster",
+                   "rds:DeleteDBSubnetGroup",
+                   "rds:DescribeDBClusters",
+                   "rds:ModifyDBCluster",
+                   "rds:RestoreDBClusterToPointInTime",
+                   "s3:CreateBucket",
+                   "s3:DeleteBucket",
+                   "s3:PutBucketPolicy",
+                   "s3:PutEncryptionConfiguration",
+                   "servicequotas:GetServiceQuota",
+                   "ssm:GetCommandInvocation",
+                   "ssm:SendCommand",
+                   "ssm:StartSession",
+                   "ssm:DeleteParameter",
+                   "ssm:PutParameter",
+               ],
+               "Resource": "*",
+           },
+           {
+               "Sid": "DetCrossPassRole",
+               "Effect": "Allow",
+               "Action": "iam:PassRole",
+               "Resource": "arn:aws:iam::<your AWS account ID>:role/<master instance profile name>",
+           },
+       ],
+   }
+
+The Master Instance Profile
+---------------------------
+
+Required Trust Relationship:
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {"Service": "ec2.amazonaws.com"},
+               "Action": "sts:AssumeRole",
+           }
+       ],
+   }
+
+Required Permissions Policy:
+
+**Note**: you need to replaced the text delimited with ``<`` and ``>`` with desired values
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Action": [
+                   "ec2:DescribeInstances",
+                   "ec2:TerminateInstances",
+                   "ec2:CreateTags",
+                   "ec2:RunInstances",
+                   "ec2:CancelSpotInstanceRequests",
+                   "ec2:RequestSpotInstances",
+                   "ec2:DescribeSpotInstanceRequests",
+                   "logs:CreateLogStream",
+                   "logs:PutLogEvents",
+               ],
+               "Effect": "Allow",
+               "Resource": "*",
+           },
+           {
+               "Action": "iam:PassRole",
+               "Resource": "arn:aws:iam::<your AWS account ID>:role/<agent instance profile name>",
+               "Effect": "Allow",
+           },
+       ],
+   }
+
+Also include the AWS managed policy ``AmazonSSMManagedEC2InstanceDefaultPolicy``.
+
+The Agent Instance Profile
+--------------------------
+
+Required Trust Relationship:
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Principal": {"Service": "ec2.amazonaws.com"},
+               "Action": "sts:AssumeRole",
+           }
+       ],
+   }
+
+Required Permissions Policy:
+
+.. code::
+
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Action": [
+                   "s3:*",
+                   "ec2:DescribeInstances",
+                   "logs:CreateLogStream",
+                   "logs:PutLogEvents",
+               ],
+               "Effect": "Allow",
+               "Resource": "*",
+           }
+       ],
+   }
+
+Also include the AWS managed policy ``AmazonSSMManagedEC2InstanceDefaultPolicy``.

--- a/docs/saas/bring-gcp-cloud.rst
+++ b/docs/saas/bring-gcp-cloud.rst
@@ -1,0 +1,57 @@
+.. _deploy-gcp-cloud:
+
+###########################
+ Bring Your Own Cloud: GCP
+###########################
+
+.. meta::
+   :description: Steps for integrating your cloud provider account with Determined.
+
+*****
+ GCP
+*****
+
+To grant Determined Cloud access to your GCP account, you will need to connect the Determined Cloud
+Service account to your GCP account. You can do this with the Google Cloud management console or
+``gcloud`` CLI.
+
+Connecting with the Google Cloud management console
+===================================================
+
+#. Navigate to the IAM page within Google Cloud console. Click `here
+   <https://console.cloud.google.com/iam-admin/iam?walkthrough_id=iam--quickstart>`__ for navigation
+   guidance to the IAM page
+
+#. Once on the IAM page, click the ``Grant Access`` button
+
+#. Enter ``saas-x-acct@determined-ai.iam.gserviceaccount.com`` as the principal
+
+#. From the ``Select a role`` drop-down menu, in the ``Quick access`` section, select ``Basic`` and
+   then ``Editor``
+
+#. Click ``Save``
+
+Connecting with the gcloud CLI
+==============================
+
+#. Install the gcloud CLI if not already installed. See the `install
+   <https://cloud.google.com/sdk/docs/install>`__ page for more information on how to do so
+
+#. Login to the project you want Determined Cloud deployed to. More information on CLI login can be
+   found on the `gcloud auth login <https://cloud.google.com/sdk/gcloud/reference/auth/login>`__
+   page
+
+#. Run
+
+.. code::
+
+   gcloud projects add-iam-policy-binding project-name --member="serviceAccount:saas-x-acct@determined-ai.iam.gserviceaccount.com" --role="roles/editor"
+
+Make sure to change ``project-name`` to the name of the project you want Determined Cloud deployed
+to.
+
+Required Roles
+==============
+
+TODO: Right now we are just setting ``roles/editor`` here. Go back in and set the required roles in
+this doc once we know what they will be.

--- a/docs/saas/get-started.rst
+++ b/docs/saas/get-started.rst
@@ -1,0 +1,123 @@
+.. _saas-cloud-get-started:
+
+##################################
+ Get Started with Determined Cloud
+##################################
+
+.. meta::
+   :description: Learn how to get started with managed cloud infrastructure.
+
+Determined Cloud provides access to managed cloud infrastructure for
+training AI models at scale. You get access to AI clusters running the
+`HPE Machine Learning Development
+Environment <https://www.hpe.com/us/en/solutions/artificial-intelligence/machine-learning-development-system.html>`__
+without having to provision or configure the hardware yourself.
+Determined Cloud clusters scale automatically with demand, so you only
+pay for what you use. This is the best way to start training
+deep-learning models at scale and collaborate with your team.
+
+********************
+ Create Your Cluster
+********************
+
+To get started, let’s create a cluster to train a model on. Click the
+``New Cluster`` button. Choose a name for your cluster, and select the
+``Standard`` configuration. You may also choose the ``Pro``
+configuration which is configured with more powerful GPUs. You may also
+customize the configuration in the ``Advanced`` menu, and modify this
+configuration later.
+
+********************
+ Train Your Model
+********************
+
+While your cluster is launching, install the Determined command-line
+tool. You must already have
+`Python <https://www.python.org/downloads/>`__ installed.
+
+.. code:: bash
+
+   pip install determined
+
+Get the cluster URL (you can copy it using the clipboard button next to
+``View Cluster``) and set the ``DET_MASTER`` environment variable. You
+may want to set this permanently for your shell (e.g. add it to
+``.bashrc``, etc.).
+
+.. code:: bash
+
+   export DET_MASTER=<master ip>
+
+Once the cluster is running, you can tell the CLI to log you into the
+cluster through your browser.
+
+.. code:: bash
+
+   det auth login
+
+Now you can download an example model and train it using your cluster.
+
+.. code:: bash
+
+   curl -O https://docs.determined.ai/latest/_downloads/61c6df286ba829cb9730a0407275ce50/mnist_pytorch.tgz
+   tar xzf mnist_pytorch.tgz
+   cd mnist_pytorch
+   det experiment create const.yaml .
+
+The experiment, its progress and metrics can now be found in the
+cluster’s web UI.
+
+You can replace ``const.yaml`` with ``distributed.yaml`` to demonstrate
+distributed training over multiple GPUs, and ``adaptive.yaml`` to
+demonstrate automatic hyperparameter optimization.
+
+You can visit the ``Docs`` tab in your cluster for complete
+documentation for model developers on your specific version.
+
+Working with Checkpoints
+========================
+
+Please consult the `Determined
+docs <https://docs.determined.ai/latest/training/model-management/checkpoints.html>`__
+for full details on working with checkpoints.
+
+Your experiments will likely generate checkpoints. You can use the
+command line below to view all checkpoints associated with an
+experiment:
+
+.. code:: bash
+
+   det experiment list-checkpoints <experiment-id>
+
+To download them on Determined Cloud, use this command line:
+
+.. code:: bash
+
+   det checkpoint download --mode=master <checkpoint UUID>
+
+The option ``--mode=master`` explicitly specifies the download is
+proxied through the cluster master, which is the only supported download
+mode on Determined Cloud.
+
+For consistency with the open-source Determined, you can also omit
+``--mode=master``:
+
+.. code:: bash
+
+   det checkpoint download <checkpoint UUID>
+
+**Caveat**: When ``--mode`` is not specified, it defaults to ``auto``.
+The CLI will first attempt to download checkpoints from its storage
+directly and then will fail over to proxied download through the cluster
+master. This command line is easier to remember but has a small
+overhead. In some occasions, it might fail to automatically switch to
+proxied download.
+
+Add Your Team
+=============
+
+Back in the Determined Cloud web portal, click the ``Members`` tab. Your
+user is currently an ``admin`` of the organization and has all
+permissions. This includes the ability to add other team members. Click
+``New Member`` and enter their email address. Send them a link, and
+they’ll be able to log in and collaborate with you!

--- a/docs/saas/index.rst
+++ b/docs/saas/index.rst
@@ -1,0 +1,36 @@
+.. _saas-cloud-index:
+
+######################
+ Bring Your Own Cloud
+######################
+
+.. meta::
+   :description: Learn how to bring your own cloud so you can develop models at-scale and deploy in your environment.
+
+Develop models at-scale, without requiring upfront investments in tooling or hardware. With support
+for multiple clouds you can quickly deploy in your environment and scale from experimentation to
+production.
+
+To get started with your own cloud, choose one of the deployment guides below.
+
++--------------------------------------------------------+
+| Environment                                            |
++========================================================+
+| :ref:`deploy-aws-cloud`                                |
++--------------------------------------------------------+
+| :ref:`deploy-gcp-cloud`                                |
++--------------------------------------------------------+
+
+.. note::
+
+   To install Determined using the CLI, visit :ref:`Set Up Determined <setup-via-cli-index>`.
+
+.. toctree::
+   :caption: Bring Your Own Cloud
+   :hidden:
+
+   Deploy via AWS Cloud <bring-aws-cloud>
+   Deploy via GCP Cloud <bring-gcp-cloud>
+   Get Started <get-started>
+   Controlling Access <team-mgmt>
+   Using Your Cluster <usage>

--- a/docs/saas/team-mgmt.rst
+++ b/docs/saas/team-mgmt.rst
@@ -1,0 +1,69 @@
+.. _saas-cloud-team-admin:
+
+###################
+ Controlling Access
+###################
+
+.. meta::
+   :description: Controlling access to your managed cloud infrastructure involves managing roles.
+
+Every member of an organization has a role within that organization, and
+may have a role on each cluster. Cluster-level roles can be set on each
+cluster, but users also have a default cluster role.
+
+Users cannot modify their own access control roles, even to lower their
+permissions (to ensure organizations cannot lock themselves out). For
+this reason it is recommended to have 2 administrators for your
+organization.
+
+The organization members and their roles can be edited from the
+``Members`` tab in the UI.
+
+Organization Roles
+==================
+
+The ``admin`` role in an organization enables a user to create clusters
+and perform all other administrative actions on them, and edit both
+organization and cluster-level access for other users. This role
+overrides any other cluster-level access and grants a user full access
+to everything in the organization.
+
+The ``user`` role in an organization enables a user to log in and see a
+directory of clusters and team members. But they must also have access
+to specific clusters to do anything more.
+
+Users with the ``admin`` role also have the privileges of the ``user``
+role.
+
+Cluster Roles
+=============
+
+The ``admin`` role on a cluster enables a user to perform management
+actions on that cluster such as pausing, resuming, reconfiguring,
+deleting, etc. It also enables a user to modify the access control
+settings for that particular cluster.
+
+The ``user`` role on a cluster enables a user to interact with that
+cluster through the web portal or the CLI. Users can browse experiment
+history and results, submit workloads, etc.
+
+Users with the ``admin`` role also have the privileges of the ``user``
+role.
+
+Editing User Roles
+==================
+
+The ``Members`` tab in an organization allows organization
+administrators to add and remove users in the organization, modify their
+role within the organization, and modify their default cluster role.
+
+Access control settings for a specific cluster can be accessed by users
+who have the ``admin`` role on that cluster (or the organization). The
+``User Access`` option in the cluster context menu
+
+Removing Pending Invites
+========================
+
+Organization administrators should also have access to the ``Invites``
+tab from the ``Members`` page. From here administrators can view and
+cancel pending invites to the organization.

--- a/docs/saas/usage.rst
+++ b/docs/saas/usage.rst
@@ -1,0 +1,40 @@
+.. _saas-cloud-cluster:
+
+###################
+ Using Your Cluster
+###################
+
+.. meta::
+   :description: Using your cloud cluster.
+
+
+***************
+ Authentication
+***************
+
+Your cluster can be accessed in one of two ways: through the Determined
+Cloud web portal, or through the CLI.
+
+In the web portal, click ``View Cluster`` to access the cluster’s web
+interface.
+
+To use the CLI, set the ``DET_MASTER`` environment variable to the
+cluster’s URL (you can copy it using the clipboard button next to
+``View Cluster``) and run ``det auth login``. This will open a page in
+your browser to authenticate before returning to your terminal.
+
+
+*************************
+ Access Your Own Datasets
+*************************
+
+If you have training datasets in S3, you can easily access them from
+your Determined Cloud clusters. The recommended method for doing this is
+to configure your S3 buckets with a policy that grants access to your
+Determined Cloud cluster. The required details and a template for this
+policy can be accessed from the cluster menu. Click the ⋮ symbol, then
+``Access Training Data``.
+
+To access other storage, you may want to place the required credentials
+in the environment variables for your experiment. However, be aware that
+these will also be accessibly to your team.

--- a/docs/setup-cluster/deploy-cluster/index.rst
+++ b/docs/setup-cluster/deploy-cluster/index.rst
@@ -1,3 +1,5 @@
+.. _setup-via-cli-index:
+
 ###################
  Set Up Determined
 ###################
@@ -15,9 +17,15 @@ To set up Determined, start by following the cluster deployment guide for your e
 | -  :doc:`on-prem/homebrew`                             |
 | -  :doc:`on-prem/wsl`                                  |
 +--------------------------------------------------------+
-| :doc:`aws/overview`                                    |
+| :ref:`topic_guide_aws`                                 |
+|                                                        |
+| -  :ref:`Cloud <deploy-aws-cloud>`                     |
+| -  :ref:`CLI <install-aws>`                            |
 +--------------------------------------------------------+
-| :doc:`gcp/overview`                                    |
+| :ref:`topic_guide_gcp`                                 |
+|                                                        |
+| -  :ref:`Cloud <deploy-gcp-cloud>`                     |
+| -  :ref:`CLI <install-gcp>`                            |
 +--------------------------------------------------------+
 | :doc:`k8s/overview`                                    |
 |                                                        |


### PR DESCRIPTION
@mackrorysd and @bonominijl let's close this PR. we'll need to first create a new docs hub home page that supports allowing a user to choose product documentation for more than one product (e.g., MLDE and SaaS).

tasks:

- [x] convert the markdown files from https://github.com/determined-ai/saas/blob/main/docs/src/
- [ ] reformat and apply style guide
- [ ] technical QA
