### PR TITLE
fix: Table header context menu enabled [WEB-1382]

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -321,7 +321,8 @@ export const GlideTable: React.FC<GlideTableProps> = ({
   }, [data, previousData, selectAll]);
 
   const onHeaderClicked: DataEditorProps['onHeaderClicked'] = React.useCallback(
-    (col: number, { bounds }: HeaderClickedEventArgs) => {
+    (col: number, { bounds, preventDefault }: HeaderClickedEventArgs) => {
+      preventDefault();
       const columnId = columnIds[col];
 
       if (columnId === MULTISELECT) {
@@ -789,6 +790,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           onColumnMoved={onColumnMoved}
           onColumnResize={onColumnResize}
           onHeaderClicked={onHeaderClicked}
+          onHeaderContextMenu={onHeaderClicked}
           onItemHovered={onColumnHovered}
           onVisibleRegionChanged={handleScroll}
         />

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -790,7 +790,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
           onColumnMoved={onColumnMoved}
           onColumnResize={onColumnResize}
           onHeaderClicked={onHeaderClicked}
-          onHeaderContextMenu={onHeaderClicked}
+          onHeaderContextMenu={onHeaderClicked} // right-click
           onItemHovered={onColumnHovered}
           onVisibleRegionChanged={handleScroll}
         />


### PR DESCRIPTION
## Description

In the new Glide Table, we had a context menu appear when left-clicking on a column header.
This also allows right-click , without the default browser context menu from appearing.

## Test Plan

On `/det/projects/1/experiments?f_explist_v2=on`
Left click on a column header to view context menu
Left click on other columns' headers to confirm the menu options match the column type
Select a sort option from the menu, confirm it sorts table
Right click on a column header to view context menu
Right click on other columns' headers to confirm the menu options match the column type
Select a sort option from this menu, confirm it sorts table

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.