### PR TITLE
chore: Add new UserSettings store [WEB-1353]

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -31,6 +31,7 @@ import authStore from 'stores/auth';
 import clusterStore from 'stores/cluster';
 import determinedStore from 'stores/determinedInfo';
 import userStore from 'stores/users';
+import userSettings from 'stores/userSettings';
 import workspaceStore from 'stores/workspaces';
 import { correctViewportHeight, refreshPage } from 'utils/browser';
 import { notification } from 'utils/dialogApi';
@@ -63,6 +64,7 @@ const AppView: React.FC = () => {
 
   useEffect(() => (isAuthenticated ? userStore.fetchCurrentUser() : undefined), [isAuthenticated]);
   useEffect(() => (isAuthenticated ? clusterStore.startPolling() : undefined), [isAuthenticated]);
+  useEffect(() => (isAuthenticated ? userSettings.startPolling() : undefined), [isAuthenticated]);
   useEffect(
     () => (isAuthenticated ? userStore.startPolling({ delay: 60_000 }) : undefined),
     [isAuthenticated],

--- a/webui/react/src/hooks/useSettings.test.tsx
+++ b/webui/react/src/hooks/useSettings.test.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from 'react-router-dom';
 import authStore from 'stores/auth';
 import { StoreProvider as UIProvider } from 'stores/contexts/UI';
 import userStore from 'stores/users';
+import userSettings from 'stores/userSettings';
 
 import * as hook from './useSettings';
 import { SettingsProvider } from './useSettingsProvider';
@@ -103,6 +104,7 @@ const Container: React.FC<{ children: JSX.Element }> = ({ children }) => {
     authStore.setAuth({ isAuthenticated: true });
     authStore.setAuthChecked();
     userStore.updateCurrentUser(CURRENT_USER);
+    return userSettings.startPolling();
   }, []);
 
   return (
@@ -179,9 +181,6 @@ describe('useSettings', () => {
 
   it('should update settings', async () => {
     const { result } = setup();
-
-    // assure isLoading becomes true, which will allow useLayoutEffect, which will start watching for updates
-    await waitFor(() => expect(result.container.current.isLoading).toStrictEqual(true));
 
     act(() => result.container.current.updateSettings(newSettings));
 

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -1,3 +1,4 @@
+import { Map } from 'immutable';
 import * as t from 'io-ts';
 import { useObservable } from 'micro-observables';
 import { useCallback, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
@@ -162,8 +163,11 @@ const queryToSettings = <T>(config: SettingsConfig<T>, params: URLSearchParams) 
 };
 
 const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
-  const { isLoading: isLoadingOb, querySettings, state: stateOb } = useContext(UserSettings);
-  const initialLoading = useObservable(isLoadingOb);
+  const { isLoading: isLoading, querySettings, state: rawState } = useContext(UserSettings);
+  const stateOb = rawState.select((settings) =>
+    Loadable.getOrElse(Map<string, Settings>(), settings),
+  );
+  const initialLoading = isLoading;
   const derivedOb = useMemo(
     () => stateOb.select((s) => s.get(config.storagePath)),
     [stateOb, config.storagePath],
@@ -257,45 +261,49 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
 
       const array = settingsArray ?? Object.keys(config.settings);
 
-      stateOb.update((s) => {
-        return s.update(config.storagePath, (old) => {
-          const news = { ...old };
-          array.forEach((setting) => {
-            let defaultSetting: SettingsConfigProp<T[Extract<keyof T, string>]> | undefined =
-              undefined;
+      rawState.update((s) => {
+        return Loadable.map(s, (s) => {
+          return s.update(config.storagePath, (old) => {
+            const news = { ...old };
+            array.forEach((setting) => {
+              let defaultSetting: SettingsConfigProp<T[Extract<keyof T, string>]> | undefined =
+                undefined;
 
-            for (const key in config.settings) {
-              const conf = config.settings[key];
+              for (const key in config.settings) {
+                const conf = config.settings[key];
 
-              if (conf.storageKey === setting) {
-                defaultSetting = conf;
-                break;
+                if (conf.storageKey === setting) {
+                  defaultSetting = conf;
+                  break;
+                }
               }
-            }
 
-            if (!defaultSetting || !news) return;
+              if (!defaultSetting || !news) return;
 
-            news[setting] = defaultSetting.defaultValue;
+              news[setting] = defaultSetting.defaultValue;
+            });
+            return news;
           });
-          return news;
         });
       });
     },
-    [config, currentUser, stateOb],
+    [config, currentUser, rawState],
   );
 
   const updateSettings = useCallback(
     (updates: Partial<Settings>) => {
-      stateOb.update((s) => {
-        const oldSettings = s.get(config.storagePath) ?? {};
-        const newSettings = { ...s.get(config.storagePath), ...updates };
-        return s.set(
-          config.storagePath,
-          isEqual(oldSettings, newSettings) ? oldSettings : newSettings,
-        );
+      rawState.update((s) => {
+        return Loadable.map(s, (s) => {
+          const oldSettings = s.get(config.storagePath) ?? {};
+          const newSettings = { ...s.get(config.storagePath), ...updates };
+          return s.set(
+            config.storagePath,
+            isEqual(oldSettings, newSettings) ? oldSettings : newSettings,
+          );
+        });
       });
     },
-    [config, stateOb],
+    [config, rawState],
   );
 
   // parse navigation url to state

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -163,14 +163,13 @@ const queryToSettings = <T>(config: SettingsConfig<T>, params: URLSearchParams) 
 };
 
 const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
-  const { isLoading: isLoading, querySettings, state: rawState } = useContext(UserSettings);
-  const stateOb = rawState.select((settings) =>
-    Loadable.getOrElse(Map<string, Settings>(), settings),
-  );
-  const initialLoading = isLoading;
+  const { isLoading: initialLoading, querySettings, state: rawState } = useContext(UserSettings);
   const derivedOb = useMemo(
-    () => stateOb.select((s) => s.get(config.storagePath)),
-    [stateOb, config.storagePath],
+    () =>
+      rawState.select((s) =>
+        Loadable.getOrElse(Map<string, Settings>(), s).get(config.storagePath),
+      ),
+    [rawState, config.storagePath],
   );
   const state = useObservable(derivedOb);
   const navigate = useNavigate();

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -163,7 +163,7 @@ const queryToSettings = <T>(config: SettingsConfig<T>, params: URLSearchParams) 
 };
 
 const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
-  const { isLoading: initialLoading, querySettings, state: rawState } = useContext(UserSettings);
+  const { isLoading, querySettings, state: rawState } = useContext(UserSettings);
   const derivedOb = useMemo(
     () =>
       rawState.select((s) =>
@@ -314,7 +314,7 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
   }, [config, querySettings, updateSettings]);
 
   useLayoutEffect(() => {
-    if (initialLoading) return;
+    if (isLoading) return;
     return derivedOb.subscribe(async (cur, prev) => {
       if (!cur || !currentUser || isEqual(cur, prev)) return;
 
@@ -331,11 +331,11 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
       const url = mappedSettings ? `?${mappedSettings}` : '';
       navigate(url, { replace: true });
     });
-  }, [currentUser, derivedOb, navigate, config, updateDB, initialLoading]);
+  }, [currentUser, derivedOb, navigate, config, updateDB, isLoading]);
 
   return {
     activeSettings,
-    isLoading: initialLoading,
+    isLoading: isLoading,
     resetSettings,
     settings,
     updateSettings,

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -34,7 +34,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
   const isAuthChecked = useObservable(authStore.isChecked);
   const querySettings = useRef(new URLSearchParams(''));
-  const isLoading = Loadable.isLoading(useObservable(userSettings._forUserSettingsOnly()));
+  const isLoading = Loadable.isLoading(useObservable(userSettings._forUseSettingsOnly()));
 
   useEffect(() => {
     querySettings.current = new URLSearchParams(window.location.search);
@@ -46,7 +46,7 @@ export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }
         value={{
           isLoading,
           querySettings: querySettings.current,
-          state: userSettings._forUserSettingsOnly(),
+          state: userSettings._forUseSettingsOnly(),
         }}>
         {children}
       </UserSettings.Provider>

--- a/webui/react/src/hooks/useSettingsProvider.tsx
+++ b/webui/react/src/hooks/useSettingsProvider.tsx
@@ -1,14 +1,12 @@
 import { Map } from 'immutable';
-import { observable, useObservable, WritableObservable } from 'micro-observables';
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useEffect, useRef } from 'react';
 
 import Spinner from 'components/Spinner';
-import { getUserSetting } from 'services/api';
 import authStore from 'stores/auth';
 import userStore from 'stores/users';
-import { ErrorType } from 'utils/error';
-import handleError from 'utils/error';
-import { Loadable } from 'utils/loadable';
+import userSettings from 'stores/userSettings';
+import { Loadable, NotLoaded } from 'utils/loadable';
+import { observable, useObservable, WritableObservable } from 'utils/observable';
 
 /*
  * UserSettingsState contains all the settings for a user
@@ -21,76 +19,34 @@ type UserSettingsState = Map<string, Settings>;
 export type Settings = { [key: string]: any }; //TODO: find a way to use a better type here
 
 type UserSettingsContext = {
-  isLoading: WritableObservable<boolean>;
+  isLoading: boolean;
   querySettings: URLSearchParams;
-  state: WritableObservable<UserSettingsState>;
+  state: WritableObservable<Loadable<UserSettingsState>>;
 };
 
 export const UserSettings = createContext<UserSettingsContext>({
-  isLoading: observable(false),
+  isLoading: true,
   querySettings: new URLSearchParams(''),
-  state: observable(Map<string, Settings>()),
+  state: observable(NotLoaded),
 });
 
 export const SettingsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
   const isAuthChecked = useObservable(authStore.isChecked);
-  const [canceler] = useState(new AbortController());
-  const [isLoading] = useState(() => observable(true));
   const querySettings = useRef(new URLSearchParams(''));
-  const [settingsState] = useState(() => observable(Map<string, Settings>()));
-
-  useEffect(() => {
-    if (!isAuthChecked) return;
-
-    getUserSetting({}, { signal: canceler.signal })
-      .then((response) => {
-        isLoading.set(false);
-        settingsState.update((currentState) => {
-          return currentState.withMutations((state) => {
-            response.settings.forEach((setting) => {
-              const value = setting.value ? JSON.parse(setting.value) : undefined;
-              let key = setting.storagePath || setting.key; // falls back to the setting key due to storagePath being optional.
-
-              if (key.includes('u:2/')) key = key.replace(/u:2\//g, '');
-
-              const entry = state.get(key);
-              if (!entry) {
-                state.set(key, { [setting.key]: value });
-              } else {
-                state.set(key, Object.assign({}, entry, { [setting.key]: value }));
-              }
-            });
-          });
-        });
-      })
-      .catch((error) => {
-        handleError(error, {
-          isUserTriggered: false,
-          publicMessage: 'Unable to fetch user settings.',
-          type: ErrorType.Api,
-        });
-      })
-      .finally(() => {
-        isLoading.set(false);
-      });
-
-    return () => canceler.abort();
-  }, [canceler, isAuthChecked, isLoading, settingsState]);
+  const isLoading = Loadable.isLoading(useObservable(userSettings._forUserSettingsOnly()));
 
   useEffect(() => {
     querySettings.current = new URLSearchParams(window.location.search);
   }, []);
 
   return (
-    <Spinner
-      spinning={useObservable(isLoading) && !(isAuthChecked && !currentUser)}
-      tip="Loading Page">
+    <Spinner spinning={isLoading && !(isAuthChecked && !currentUser)} tip="Loading Page">
       <UserSettings.Provider
         value={{
-          isLoading: isLoading,
+          isLoading,
           querySettings: querySettings.current,
-          state: settingsState,
+          state: userSettings._forUserSettingsOnly(),
         }}>
         {children}
       </UserSettings.Provider>

--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -68,7 +68,9 @@ const JobQueue: React.FC<Props> = ({ selectedRp, jobState }) => {
   const [pageState, setPageState] = useState<{ isLoading: boolean }>({ isLoading: true });
   const pageRef = useRef<HTMLElement>(null);
 
-  const { settings, updateSettings } = useSettings<Settings>(settingsConfig(jobState));
+  const { settings, updateSettings } = useSettings<Settings>(
+    useMemo(() => settingsConfig(jobState), [jobState]),
+  );
   const settingsColumns = useMemo(() => [...settings.columns], [settings.columns]);
 
   const isJobOrderAvailable = orderedSchedulers.has(selectedRp.schedulerType);

--- a/webui/react/src/pages/SignOut.tsx
+++ b/webui/react/src/pages/SignOut.tsx
@@ -11,6 +11,7 @@ import determinedStore from 'stores/determinedInfo';
 import permissionStore from 'stores/permissions';
 import roleStore from 'stores/roles';
 import userStore from 'stores/users';
+import userSettings from 'stores/userSettings';
 import workspaceStore from 'stores/workspaces';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
@@ -30,6 +31,7 @@ const SignOut: React.FC = () => {
       permissionStore.reset();
       userStore.reset();
       workspaceStore.reset();
+      userSettings.reset();
       try {
         await logout({});
       } catch (e) {

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -16,7 +16,7 @@ import PollingStore from './polling';
 // TODO define a proper JSON type.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Json = any;
-type State = Map<string, Record<string, unknown>>;
+type State = Map<string, { string: unknown }>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
@@ -136,7 +136,7 @@ class UserSettingsStore extends PollingStore {
       newSettings = newSettings.withMutations((newSettings) => {
         for (const setting of response.settings) {
           const pathKey = (setting.storagePath || setting.key).replace(/u:2\//g, '');
-          const oldPathSettings = newSettings.get(pathKey) || {};
+          const oldPathSettings = newSettings.get(pathKey) || ({} as { string: unknown });
           const newPathSettings = {
             [setting.key]: setting.value ? JSON.parse(setting.value) : undefined,
           };

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -24,10 +24,22 @@ function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
   return (codec as any)._tag === 'InterfaceType';
 }
 
+/**
+ * This stores per-user settings. These are values that affect how the UI functions
+ * and are limited in scope to the logged-in user.
+ */
 class UserSettingsStore extends PollingStore {
   readonly #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
 
-  public get<T>(type: t.Type<T>, key: string): Observable<Loadable<T | null>> {
+  /**
+   *
+   * @param type Type of the value to be returned or a decoder from JSON to that type
+   * @param key Unique key to store and retrieve the settings
+   * @returns An observable of the setting value. If that setting has never been set
+   *          (or has been removed) this is `null`.
+   */
+  public get<T>(type: t.Type<T>, key: string): Observable<Loadable<T | null>>;
+  public get<T>(type: t.Decoder<Json, T>, key: string): Observable<Loadable<T | null>> {
     return this.#settings.select((settings) => {
       return Loadable.map(settings, (settings) => {
         const value = settings.get(key);
@@ -79,6 +91,7 @@ class UserSettingsStore extends PollingStore {
     });
   }
 
+  /** Clears the setting, returning it to `null`. */
   public remove(key: string) {
     this.updateUserSetting(key, null);
     this.#settings.update((loadable) => {
@@ -88,6 +101,9 @@ class UserSettingsStore extends PollingStore {
     });
   }
 
+  /**
+   * This resets the store to its initial state, useful for logging the user out.
+   */
   public reset() {
     this.#settings.set(NotLoaded);
   }
@@ -178,6 +194,11 @@ class UserSettingsStore extends PollingStore {
     );
   }
 
+  /**
+   * DO NOT USE
+   *
+   * This is a temporary bridge for the old useSettings function
+   */
   public _forUseSettingsOnly(): WritableObservable<Loadable<State>> {
     return this.#settings;
   }

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -25,7 +25,7 @@ function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
 }
 
 class UserSettingsStore extends PollingStore {
-  #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
+  readonly #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
 
   public get<T>(type: t.Type<T>, key: string): Observable<Loadable<T | null>> {
     return this.#settings.select((settings) => {
@@ -178,7 +178,7 @@ class UserSettingsStore extends PollingStore {
     );
   }
 
-  public _forUserSettingsOnly(): WritableObservable<Loadable<State>> {
+  public _forUseSettingsOnly(): WritableObservable<Loadable<State>> {
     return this.#settings;
   }
 }

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -1,0 +1,186 @@
+import { match } from 'fp-ts/Either';
+import { pipe } from 'fp-ts/function';
+import { Map } from 'immutable';
+import * as t from 'io-ts';
+
+import { getUserSetting, updateUserSetting } from 'services/api';
+import { V1GetUserSettingResponse } from 'services/api-ts-sdk';
+import { UpdateUserSettingParams } from 'services/types';
+import { isObject } from 'utils/data';
+import handleError, { ErrorType } from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+import { observable, Observable, WritableObservable } from 'utils/observable';
+
+import PollingStore from './polling';
+
+// TODO define a proper JSON type.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Json = any;
+type State = Map<string, Record<string, unknown>>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (codec as any)._tag === 'InterfaceType';
+}
+
+class UserSettingsStore extends PollingStore {
+  #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
+
+  public get<T>(type: t.Type<T>, key: string): Observable<Loadable<T | null>> {
+    return this.#settings.select((settings) => {
+      return Loadable.map(settings, (settings) => {
+        const value = settings.get(key);
+        if (key === undefined) {
+          return null;
+        }
+        return pipe(
+          value,
+          type.decode,
+          match(
+            () => null, // Silently swallow decoding errors
+            (v) => v,
+          ),
+        );
+      });
+    });
+  }
+
+  /**
+   * This sets the value of a setting and persists it for future sessions.
+   * If the setting value is an object you can pass a partial value and
+   * if will be merged with the previous value.
+   * @param type The type of the value or an encoder of the value to JSON.
+   * @param key Unique key to store and retrieve the settings
+   * @param value New value of the setting
+   */
+  public set<T>(type: t.Type<T>, key: string, value: T): void;
+  public set<T extends t.Props>(type: t.TypeC<T>, key: string, value: Partial<T>): void;
+  public set<T>(type: t.Encoder<T, Json>, key: string, value: T): void {
+    const encodedValue = isTypeC(type)
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        t.partial(type.props).encode(value as any)
+      : type.encode(value);
+    // This is non-blocking. If the API call fails we don't want to block
+    // the user from interacting, just let them know that their settings
+    // are not persisting. It's also important to update the value immediately
+    // for good rendering performance.
+    this.updateUserSetting(key, encodedValue);
+    this.#settings.update((settings) => {
+      return Loadable.map(settings, (settings) => {
+        return settings.update(key, (oldValue) => {
+          let newValue = encodedValue;
+          if (isTypeC(type)) {
+            newValue = { ...oldValue, ...encodedValue };
+          }
+          return newValue;
+        });
+      });
+    });
+  }
+
+  public remove(key: string) {
+    this.updateUserSetting(key, null);
+    this.#settings.update((loadable) => {
+      return Loadable.map(loadable, (map) => {
+        return map.removeAll(key);
+      });
+    });
+  }
+
+  public reset() {
+    this.#settings.set(NotLoaded);
+  }
+
+  protected async poll() {
+    try {
+      const response = await getUserSetting({ signal: this.canceler?.signal });
+      this.updateSettingsFromResponse(response);
+    } catch (error) {
+      handleError(error, {
+        isUserTriggered: false,
+        publicMessage: 'Unable to fetch user settings, try refreshing.',
+        type: ErrorType.Api,
+      });
+    } finally {
+      this.#settings.update((settings) =>
+        Loadable.match(settings, {
+          Loaded: (settings) => Loaded(settings),
+          // If we are unable to load settings just notify the user and unblock them.
+          NotLoaded: () => Loaded(Map()),
+        }),
+      );
+    }
+  }
+
+  protected updateSettingsFromResponse(response: V1GetUserSettingResponse) {
+    this.#settings.update((loadable) => {
+      let newSettings: State = Loadable.getOrElse(Map(), loadable);
+
+      newSettings = newSettings.withMutations((newSettings) => {
+        for (const setting of response.settings) {
+          const pathKey = (setting.storagePath || setting.key).replace(/u:2\//g, '');
+          const oldPathSettings = newSettings.get(pathKey) || {};
+          const newPathSettings = {
+            [setting.key]: setting.value ? JSON.parse(setting.value) : undefined,
+          };
+          newSettings.set(pathKey, { ...oldPathSettings, ...newPathSettings });
+        }
+      });
+      return Loaded(newSettings);
+    });
+  }
+
+  // TODOs:
+  // - We shouldn't be JSON.stringifying stuff before sending it to the API
+  //   DB is perfectly capable of storing JSON and we'll get better performance
+  //   and flexibility that way
+  // - API should support setting non-objects as values directly like a regular
+  //   key/value store.
+  protected updateUserSetting<T>(key: string, value: T) {
+    const dbUpdates: Array<UpdateUserSettingParams> = [];
+    if (isObject(value)) {
+      const settings = value as unknown as { string: unknown };
+      dbUpdates.push(
+        ...Object.keys(settings).reduce<UpdateUserSettingParams[]>((acc, setting) => {
+          return [
+            ...acc,
+            {
+              setting: {
+                key: setting,
+                storagePath: key,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                value: JSON.stringify((settings as any)[setting]),
+              },
+              storagePath: key,
+            },
+          ];
+        }, []),
+      );
+    } else {
+      dbUpdates.push({
+        setting: { key: '_ROOT', storagePath: key, value: JSON.stringify(value) },
+        storagePath: key,
+      });
+    }
+    Promise.allSettled(
+      dbUpdates.map((update) => {
+        return updateUserSetting(update);
+      }),
+    ).catch((e) =>
+      handleError(e, {
+        isUserTriggered: false,
+        publicMessage: `Unable to update user settings for key: ${key}.`,
+        publicSubject: 'Some POST user settings failed.',
+        silent: true,
+        type: ErrorType.Api,
+      }),
+    );
+  }
+
+  public _forUserSettingsOnly(): WritableObservable<Loadable<State>> {
+    return this.#settings;
+  }
+}
+
+export default new UserSettingsStore();


### PR DESCRIPTION
## Description
This PR adds a new store that provides a more idiomatic way of reading and writing user settings. It temporarily shares state with the old `useSettings` hook until that is replaced with this. Main features:
- Reduced complexity (no checking equality before writing, handling query params, etc)
- Improved serialization (settings can be anything)
- Impossible to accidentally access settings while they're still loading


## Test Plan
- Check if all settings data is fetched when page is loaded
- Check if there no infinite settings calls in network tab
- Check if settings POST call is invoked when user changes the settings and check DB
  - ex: changing filters in the new exp table, close filter popup, refresh page, check if filters persist
- Check if there's no console error in console tab (should be debug mode)

## Checklist

- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1353


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
