### PR TITLE
ci: track unreleased cherry-picked PRs during release

### DIFF
--- a/tools/scripts/gql.py
+++ b/tools/scripts/gql.py
@@ -236,3 +236,34 @@ mutation($project: ID!, $item: ID!) {
 }
 """
 )
+
+
+list_project_prs = GraphQLQuery(
+    """
+query($project: ID!, $after: String) {
+  node(id: $project) {
+    ... on ProjectV2 {
+      items(first: 100, after: $after) {
+        nodes {
+          id
+          fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              name
+            }
+          }
+          content {
+            ... on PullRequest {
+              id
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+}
+"""
+)

--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -46,6 +46,8 @@ CHERRY_PICK_LABEL = "to-cherry-pick"
 NEEDS_TESTING_STATUS = "Needs testing"
 FIX_OPEN_STATUS = "Fix (open)"
 FIX_CONFLICT_STATUS = "Fix (conflict)"
+FIX_UNRELEASED_STATUS = "Fix (unreleased)"
+FIX_RELEASED_STATUS = "Fix (released)"
 
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 CASPER_TOKEN = os.environ["CASPER_TOKEN"]
@@ -76,13 +78,25 @@ def make_issue_for_pr(issue_repo_id: str, pr_id: str) -> str:
     )["createIssue"]["issue"]["id"]
 
 
-def add_item_to_project(project_id: str, item_id: str, status: str) -> None:
+def get_project_status_ids(project_id: str, status: str):
     status_info = gql.get_status_field_info(project=project_id)["node"]["field"]
-    status_field_id = status_info["id"]
-    status_value_id = next(v["id"] for v in status_info["options"] if v["name"] == status)
+    field_id = status_info["id"]
+    value_id = next(v["id"] for v in status_info["options"] if v["name"] == status)
+    return field_id, value_id
+
+
+def add_item_to_project(project_id: str, item_id: str, status: str) -> None:
+    status_field_id, status_value_id = get_project_status_ids(project_id, status)
     item_id = gql.add_item_to_project(project=project_id, item=item_id)["addProjectV2ItemById"][
         "item"
     ]["id"]
+    gql.set_project_item_status(
+        project=project_id, item=item_id, field=status_field_id, value=status_value_id
+    )
+
+
+def set_project_item_status(project_id: str, item_id: str, status: str) -> None:
+    status_field_id, status_value_id = get_project_status_ids(project_id, status)
     gql.set_project_item_status(
         project=project_id, item=item_id, field=status_field_id, value=status_value_id
     )
@@ -174,8 +188,8 @@ def cherry_pick_pr(pr_id: str) -> None:
         if not is_ee_pr:
             run("git", "push", ee_remote, f"{ee_release_branch}:{ee_release_branch}")
 
-        print("Cherry-pick succeeded, adding tracking item for testing")
-        add_tracking_issue_to_project(current_project_id(), pr_id, NEEDS_TESTING_STATUS)
+        print("Cherry-pick succeeded, updating item status")
+        set_project_item_status(current_project_id(), pr_id, FIX_UNRELEASED_STATUS)
     except subprocess.CalledProcessError:
         import traceback
 
@@ -243,8 +257,25 @@ class Actions:
     def cherry_pick_conflict_resolved(pr_id: str):
         # TODO Use Git to confirm the cherry-pick was done.
         project_id = current_project_id()
-        gql.delete_project_item(project=project_id, item=pr_id)
-        add_tracking_issue_to_project(project_id, pr_id, NEEDS_TESTING_STATUS)
+        set_project_item_status(project_id, pr_id, FIX_UNRELEASED_STATUS)
+
+    @staticmethod
+    def release_unreleased_prs():
+        after_cursor = None
+        project = current_project_id()
+        while True:
+            items = gql.list_project_prs(project=project, after=after_cursor)["node"]["items"]
+            print("batch:", len(items["nodes"]))
+            for item in items["nodes"]:
+                if item["fieldValueByName"]["name"] == FIX_UNRELEASED_STATUS and item["content"]:
+                    print(project, item["content"])
+                    add_tracking_issue_to_project(
+                        project, item["content"]["id"], NEEDS_TESTING_STATUS
+                    )
+                    set_project_item_status(project, item["id"], FIX_RELEASED_STATUS)
+            if not items["pageInfo"]["hasNextPage"]:
+                break
+            after_cursor = items["pageInfo"]["endCursor"]
 
 
 def main(args):


### PR DESCRIPTION
## Description

We've gotten the feedback that it would be nice to know what PRs have been cherry-picked but are not yet available to test. Cherry-picked PRs are now moved to a new unreleased status; adding tracking issues is delayed until `track-pr release-unreleased-prs` is run (which happens when an RC is cut). The PRs are then moved to a new released status instead of being deleted. The process doesn't touch them after that, but after a few releases I've found myself wanting to see what fixes have been merged as part of the project view.

## Test Plan

- [x] run `track-pr release-unreleased-prs` on the test project
