### PR TITLE
fix: Download to existing directory from shared_fs source [MLG-672]

### DIFF
--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -4,6 +4,7 @@ import json
 import logging
 import pathlib
 import shutil
+import sys
 import tarfile
 from typing import Any, Dict, List, Optional
 
@@ -229,7 +230,15 @@ class Checkpoint:
     ) -> None:
         if checkpoint_storage["type"] == "shared_fs":
             src_ckpt_dir = self._find_shared_fs_path(checkpoint_storage)
-            shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir), dirs_exist_ok=True)
+            # TODO: remove version check once we drop support for Python 3.7
+            if sys.version_info.minor >= 8:
+                shutil.copytree(
+                    str(src_ckpt_dir),
+                    str(local_ckpt_dir),
+                    dirs_exist_ok=True,
+                )  # type: ignore
+            else:
+                shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir))
         else:
             local_ckpt_dir.mkdir(parents=True, exist_ok=True)
             manager = storage.build(

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -229,7 +229,7 @@ class Checkpoint:
     ) -> None:
         if checkpoint_storage["type"] == "shared_fs":
             src_ckpt_dir = self._find_shared_fs_path(checkpoint_storage)
-            shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir))
+            shutil.copytree(str(src_ckpt_dir), str(local_ckpt_dir), dirs_exist_ok=True)
         else:
             local_ckpt_dir.mkdir(parents=True, exist_ok=True)
             manager = storage.build(


### PR DESCRIPTION
When copying checkpoint files coming from shared-fs storage, we now no longer error when the destination checkpoint directory already exists. Instead, when metadata.json doesn't already exist in the destination, we'll write/overwrite files from the checkpoint into the destination. This new behavior mirrors what we already do when the checkpoint is stored in S3.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

One way or another, find a checkpoint that has `checkpoint_storage.type: shared_fs`. Then try downloading the checkpoint to a local path that does or does not already exist.

Helpful snippets follow.

In the experiment config YAML:
```yaml
checkpoint_storage:
  type: shared_fs
  host_path: /path/to/master/checkpoints
```

Download:
```shell
det t download --latest -o <path> <trial-id>
```
or
```python
from determined.experimental import client
ckpt = client.get_checkpoint(<checkpoint_id>)
ckpt.download(<path>)
```

It's also worth testing that you can still download a checkpoint via shared_fs using python 3.7. In this case, you will not be able to download to an existing directory, but you _should_ be able to download to a directory that `Checkpoint.download` creates.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
