### PR TITLE
set up the migration script to validate the new migration num

### DIFF
--- a/master/static/migrations/migration-move-to-top.sh
+++ b/master/static/migrations/migration-move-to-top.sh
@@ -4,13 +4,33 @@ set -e
 
 name="$1"
 
+# get the current max migration number
+function get_max() {
+    local max=0
+    for f in *.tx.*.sql; do
+        local num=$(echo $f | cut -d'_' -f1)
+        if [ $num -gt $max ]; then
+            max=$num
+        fi
+    done
+    echo $max
+}
+
 if [ -z "$name" ]; then
     echo "usage: $0 NAME"
     echo "where NAME for '20200401000000_initial.up.sql' would be 'initial'"
     exit 1
 fi
 
-new_base="$(date +%Y%m%d%H%M%S)_$name"
+new_time=$(date +%Y%m%d%H%M%S)
+new_full_name="${new_time}_$name"
 
-mv *"_$name.tx.up.sql" "$new_base.tx.up.sql"
-mv *"_$name.tx.down.sql" "$new_base.tx.down.sql"
+cur_max=$(get_max)
+if [ "$new_time" -le "$cur_max" ]; then
+    # potentially a timezone difference
+    echo "new migration $new_time is not greater than existing max $cur_max"
+    exit 1
+fi
+
+mv *"_$name.tx.up.sql" "$new_full_name.tx.up.sql"
+mv *"_$name.tx.down.sql" "$new_full_name.tx.down.sql"


### PR DESCRIPTION
## Description

DET-9643

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

rename one of the migrations to be ahead of the current time in your machine then run move-to-top

```
.rw-r--r--   193 hmd  10 Jul 13:28  20240612120719_rename-new-username-fix.tx.down.sql
.rw-r--r--   106 hmd  10 Jul 13:28  20240612120719_rename-new-username-fix.tx.up.sql
.rw-r--r--   132 hmd  10 Jul 13:28  20230613164813_add-rp-workspace-bindings.tx.down.sql
.rw-r--r--   338 hmd  10 Jul 13:28  20230613164813_add-rp-workspace-bindings.tx.up.sql
.rw-r--r--   211 hmd  10 Jul 13:28  20230614134612_fix-gen-metric-unique-constraint.tx.down.sql
.rw-r--r--  2.3k hmd  10 Jul 13:28  20230614134612_fix-gen-metric-unique-constraint.tx.up.sql
.rw-r--r--     0 hmd  10 Jul 13:28  20230615134125_sanitize-generic-metric-types.tx.down.sql
.rw-r--r--   102 hmd  10 Jul 13:28  20230615134125_sanitize-generic-metric-types.tx.up.sql
.rwxr-xr-x   777 hmd  11 Jul 16:03  migration-move-to-top.sh
(determined) hbp ➜ migrations git:(hz-migration-script) ✗ ./migration-move-to-top.sh sanitize-generic-metric-types
new migration 20230712103146 is not greater than existing max 20240612120719
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

we expect out of order migrations be get caught by ci GHA checks separate from this work.

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
