### PR TITLE
fix: install sigusr1 on main thread only.

### DIFF
--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -74,7 +74,7 @@ def _install_stacktrace_on_sigusr1() -> None:
         return
 
     # Signal handlers can only be registered on main threads.
-    if threading.current_thread() is threading.main_thread():
+    if threading.current_thread() is not threading.main_thread():
         return
 
     old_handler = None


### PR DESCRIPTION
## Description

The condition in the code was inverted. 
I've hit this while trying to use ray tune in the detached mode, because it spawns the "trials" outside of the main thread. 
The SIGUSR1 handler has been broken [since 0.23.0](https://github.com/determined-ai/determined/commit/cb52a196f4dbab64a1a020a13e4c971fb067f278).

## Test Plan

- Try using SIGUSR1 for debugging.
- Once detached mode lands, this will be exercised by ray tune examples.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
