### PR TITLE
fix: Cleared date field removed from filters [WEB-1408]

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -265,7 +265,7 @@ const FilterField = ({
                   value={dayjs(fieldValue).isValid() ? dayjs(fieldValue).utc() : null}
                   onChange={(value: DatePickerProps['value']) => {
                     const dateString = dayjs(value).utc().startOf('date').format();
-                    updateFieldValue(field.id, dateString);
+                    updateFieldValue(field.id, value === null ? null : dateString);
                   }}
                   onOpenChange={setInputOpen}
                 />

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -264,8 +264,8 @@ const FilterField = ({
                 <DatePicker
                   value={dayjs(fieldValue).isValid() ? dayjs(fieldValue).utc() : null}
                   onChange={(value: DatePickerProps['value']) => {
-                    const dateString = dayjs(value).utc().startOf('date').format();
-                    updateFieldValue(field.id, value === null ? null : dateString);
+                    const dt = dayjs(value).utc().startOf('date');
+                    updateFieldValue(field.id, dt.isValid() ? dt.format() : null);
                   }}
                   onOpenChange={setInputOpen}
                 />


### PR DESCRIPTION
## Description

Bug in Glide Table FilterForm - if you have a valid date field, and then clear the date input with its [x] button, it continues to send the null date as a string ("df"). This zombie filter causes a 500 error.

![image](https://github.com/determined-ai/determined/assets/643918/88695cb4-7c11-4a1c-bfe4-48004a7915b2)


## Test Plan

After applying this change:
- Above-left of the glide table, click the Filter button
- Set the start date filter to be after July 30th (or other future date)
- 0 experiments match filter; button label is "Filter (1)"
- Hover over date input and click the small x to clear it
- Experiments are shown again; button label is "Filter" again

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.