### PR TITLE
fix: reverting not-found-errs change to python user-groups

### DIFF
--- a/e2e_tests/tests/cluster/test_groups.py
+++ b/e2e_tests/tests/cluster/test_groups.py
@@ -70,7 +70,7 @@ def test_group_creation(add_users: List[str]) -> None:
 
         # Can delete.
         det_cmd(["user-group", "delete", group_name, "--yes"], check=True)
-        det_cmd_expect_error(["user-group", "describe", group_name], "not found")
+        det_cmd_expect_error(["user-group", "describe", group_name], "not find")
 
 
 @pytest.mark.e2e_cpu
@@ -93,7 +93,7 @@ def test_group_updates() -> None:
         det_cmd(["user-group", "change-name", group_name, new_group_name], check=True)
 
         # Old name is gone.
-        det_cmd_expect_error(["user-group", "describe", group_name, "--json"], "not found")
+        det_cmd_expect_error(["user-group", "describe", group_name, "--json"], "not find")
 
         # New name is here.
         group_desc = det_cmd_json(["user-group", "describe", new_group_name, "--json"])
@@ -138,15 +138,15 @@ def test_group_errors() -> None:
         # Adding non existent users to groups.
         fake_user = get_random_string()
         det_cmd_expect_error(
-            ["user-group", "create", fake_group, "--add-user", fake_user], "not found"
+            ["user-group", "create", fake_group, "--add-user", fake_user], "not find"
         )
-        det_cmd_expect_error(["user-group", "add-user", group_name, fake_user], "not found")
+        det_cmd_expect_error(["user-group", "add-user", group_name, fake_user], "not find")
 
         # Removing a non existent user from group.
-        det_cmd_expect_error(["user-group", "remove-user", group_name, fake_user], "not found")
+        det_cmd_expect_error(["user-group", "remove-user", group_name, fake_user], "not find")
 
         # Removing a user not in a group.
         det_cmd_expect_error(["user-group", "remove-user", group_name, "admin"], "Not Found")
 
         # Describing a non existent group.
-        det_cmd_expect_error(["user-group", "describe", get_random_string()], "not found")
+        det_cmd_expect_error(["user-group", "describe", get_random_string()], "not find")

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -352,7 +352,7 @@ def test_rbac_permission_assignment_errors() -> None:
             "--username-to-assign",
             "admin",
         ],
-        "not find a workspace",
+        "not found",
     )
     det_cmd_expect_error(
         [
@@ -364,7 +364,7 @@ def test_rbac_permission_assignment_errors() -> None:
             "--username-to-assign",
             "admin",
         ],
-        "not find a workspace",
+        "not found",
     )
 
     api_utils.configure_token_store(ADMIN_CREDENTIALS)
@@ -386,7 +386,7 @@ def test_rbac_permission_assignment_errors() -> None:
 
         # Unassigned role group doesn't have.
         det_cmd_expect_error(
-            ["rbac", "unassign-role", "Editor", "--group-name-to-assign", group_name], "not found"
+            ["rbac", "unassign-role", "Editor", "--group-name-to-assign", group_name], "Not Found"
         )
         det_cmd_expect_error(
             [
@@ -398,13 +398,13 @@ def test_rbac_permission_assignment_errors() -> None:
                 "--workspace-name",
                 "Uncategorized",
             ],
-            "not found",
+            "Not Found",
         )
 
         # Unassigned role user doesn't have.
         det_cmd_expect_error(
             ["rbac", "unassign-role", "Editor", "--username-to-assign", test_user_creds.username],
-            "not found",
+            "Not Found",
         )
         det_cmd_expect_error(
             [
@@ -416,7 +416,7 @@ def test_rbac_permission_assignment_errors() -> None:
                 "--workspace-name",
                 "Uncategorized",
             ],
-            "not found",
+            "Not Found",
         )
 
 

--- a/harness/determined/cli/user_groups.py
+++ b/harness/determined/cli/user_groups.py
@@ -3,8 +3,8 @@ from collections import namedtuple
 from typing import Any, Dict, List, Optional
 
 import determined.cli.render
-from determined import cli
 from determined.cli import default_pagination_args, render, require_feature_flag, setup_session
+from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.experimental import Session
@@ -161,7 +161,9 @@ def usernames_to_user_ids(session: Session, usernames: List[str]) -> List[int]:
             user_ids.append(user_id)
 
     if missing_users:
-        raise cli.not_found_errs("user(s)", ", ".join(missing_users), session)
+        raise api.errors.BadRequestException(
+            f"could not find users for usernames {', '.join(missing_users)}"
+        )
     return user_ids
 
 
@@ -170,7 +172,7 @@ def group_name_to_group_id(session: Session, group_name: str) -> int:
     resp = bindings.post_GetGroups(session, body=body)
     groups = resp.groups
     if groups is None or len(groups) != 1 or groups[0].group.groupId is None:
-        raise cli.not_found_errs("group", group_name, session)
+        raise api.errors.BadRequestException(f"could not find user group name {group_name}")
     return groups[0].group.groupId
 
 


### PR DESCRIPTION
## Description
Undoing instance of `not_found_errs` in the python user_groups code to resolve testing discrepancy in EE & standardize not-found-errs coverage in the same modules across golang & python.

Relates to https://github.com/determined-ai/determined/pull/6937, https://github.com/determined-ai/determined/pull/7252.


## Test Plan
Test in EE against branch 9606-test-python-err, but also make sure CI checks pass here.
https://app.circleci.com/pipelines/github/determined-ai/determined-ee?branch=9606-test-python-err

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9606
