### PR TITLE
fix: Fix issue in user settings store

### DIFF
--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -145,7 +145,7 @@ class UserSettingsStore extends PollingStore {
 
       newSettings = newSettings.withMutations((newSettings) => {
         for (const setting of response.settings) {
-          const pathKey = (setting.storagePath || setting.key).replace(/u:2\//g, '');
+          const pathKey = setting.storagePath || setting.key;
           const oldPathSettings = newSettings.get(pathKey);
           if (oldPathSettings && isJsonObject(oldPathSettings)) {
             const newPathSettings = {

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -152,8 +152,12 @@ class UserSettingsStore extends PollingStore {
               [setting.key]: setting.value ? JSON.parse(setting.value) : undefined,
             };
             newSettings.set(pathKey, { ...oldPathSettings, ...newPathSettings });
-          } else {
+          } else if (setting.key === '_ROOT') {
             newSettings.set(pathKey, setting.value ? JSON.parse(setting.value) : undefined);
+          } else {
+            newSettings.set(pathKey, {
+              [setting.key]: setting.value ? JSON.parse(setting.value) : undefined,
+            });
           }
         }
       });


### PR DESCRIPTION
## Description
Fixes an issue with how user settings store constructs objects.


## Test Plan
Visit the new experiment listing page and confirm that the settings load correctly first try.


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No Ticket

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
