### PR TITLE
fix: use DEFAULT_COLUMNS in GroupManagement table

### DIFF
--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -27,10 +27,7 @@ import handleError from 'utils/error';
 import { useObservable } from 'utils/observable';
 
 import css from './GroupManagement.module.scss';
-import settingsConfig, {
-  DEFAULT_COLUMN_WIDTHS,
-  DEFAULT_COLUMNS,
-} from './GroupManagement.settings';
+import settingsConfig, { DEFAULT_COLUMN_WIDTHS, DEFAULT_COLUMNS } from './GroupManagement.settings';
 
 interface DropdownProps {
   expanded: boolean;

--- a/webui/react/src/pages/Settings/GroupManagement.tsx
+++ b/webui/react/src/pages/Settings/GroupManagement.tsx
@@ -27,7 +27,10 @@ import handleError from 'utils/error';
 import { useObservable } from 'utils/observable';
 
 import css from './GroupManagement.module.scss';
-import settingsConfig, { DEFAULT_COLUMN_WIDTHS } from './GroupManagement.settings';
+import settingsConfig, {
+  DEFAULT_COLUMN_WIDTHS,
+  DEFAULT_COLUMNS,
+} from './GroupManagement.settings';
 
 interface DropdownProps {
   expanded: boolean;
@@ -296,7 +299,10 @@ const GroupManagement: React.FC = () => {
         )}
         rowClassName={defaultRowClassName({ clickable: false })}
         rowKey={(r) => r.group.groupId || 0}
-        settings={settings}
+        settings={{
+          ...settings,
+          columns: DEFAULT_COLUMNS,
+        }}
         showSorterTooltip={false}
         size="small"
         updateSettings={updateSettings}


### PR DESCRIPTION
## Description

Refreshing `GroupManagement` page should load columns as expected

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
WEB-1438