### PR TITLE
ci: fix some bugs in tracking of cherry-picked PRs

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -195,7 +195,7 @@ def cherry_pick_pr(pr_id: str) -> None:
 
         traceback.print_exc()
         print("Cherry-pick failed, adding PR as conflicted")
-        add_item_to_project(current_project_id(), pr_id, FIX_CONFLICT_STATUS)
+        set_project_item_status(current_project_id(), pr_id, FIX_CONFLICT_STATUS)
         requests.post(
             "https://casper.internal.infra.determined.ai/hubot/conflict",
             headers={"X-Casper-Token": CASPER_TOKEN},
@@ -237,6 +237,7 @@ class Actions:
             # TODO Maybe delete the tracking issue in the next release that was
             # created when this merged without a label.
             print("Cherry-picking labeled merged PR")
+            add_item_to_project(current_project_id(), pr_id, FIX_OPEN_STATUS)
             cherry_pick_pr(pr_id)
         elif state == "CLOSED":
             print("Ignoring label addition to closed PR")


### PR DESCRIPTION
## Description

- When a PR was labeled with the cherry-pick marker only after merging, it was never added as an open item, and so there was nothing to mark as unreleased and then released later on.

- When a PR ran into a conflict during cherry-picking, it was added as a conflicting item, whereas that should be assuming that the PR already exists as an item and only changing its status instead.

## Test Plan

- [x] eh... let's say n/a
