### PR TITLE
ci: make CASPER_TOKEN optional in `track-pr` script

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -50,7 +50,7 @@ FIX_UNRELEASED_STATUS = "Fix (unreleased)"
 FIX_RELEASED_STATUS = "Fix (released)"
 
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-CASPER_TOKEN = os.environ["CASPER_TOKEN"]
+CASPER_TOKEN = os.environ.get("CASPER_TOKEN", "")
 
 
 def run(*args, check=True, quiet=False, **kwargs):


### PR DESCRIPTION
## Description

`track-pr` is called by `rph` for some things, but those operations don't need this token value, so it should not be required.

## Test Plan

- [x] run `track-pr` without the variable present and see that it doesn't crash
