### PR TITLE
docs: update aria labelling for sidebar toggles and toctree groups

### DIFF
--- a/docs/_templates/search-field.html
+++ b/docs/_templates/search-field.html
@@ -9,7 +9,7 @@
       type="search"
       class="form-control"
       name="q"
-      id="search-input"
+      id="search-input-fallback"
       placeholder="Search..."
       aria-label="Search..."
       autocomplete="off"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,8 +13,10 @@ myst_parser
 # Theme
 sphinx-book-theme==1.0.0
 
-# pin pydata-sphinx-theme at 0.13.1 to avoid extension import issue
-pydata-sphinx-theme==0.13.1
+# forked version of pydata-sphinx-theme
+# - pinned to 0.13.1
+# - Includes some aria labelling changes to satisfy compliance
+pydata-sphinx-theme @ git+https://github.com/determined-ai/pydata-sphinx-theme@chore/WEB-1292/hpe-accessibility-patches
 
 # live.py
 watchdog


### PR DESCRIPTION
## Description

This updates the docs to fix the accessibility issues highlighted in the levelaccess tool.

- The sidebar toggles as well as the labels controlling the expansion and collapse of the table of contents have been given screenreader labels
- the inputs controlling the sidebar visibility have been updated to indicate that they control the primary/secondary sidebars as well as a pointer to a descriptive label

In order to do this properly, we fork the pydata-sphinx-theme python package and make the changes there. The changes to the package can be seen in https://github.com/determined-ai/pydata-sphinx-theme/pull/1 -- once approved, we can change the branch this PR is pointing to to main.


## Test Plan

Docs site should not have any 10 severity accessibility issues in levelaccess.



## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1292


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
