### PR TITLE
fix: new exp detail crash [WEB-1444]

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -16,6 +16,8 @@ import { timeSeries } from 'services/api';
 import { Metric, MetricContainer, Scale } from 'types';
 import { glasbeyColor } from 'utils/color';
 
+import handleError, { ErrorType } from '../../utils/error';
+
 interface Props {
   defaultMetricNames: Metric[];
   id?: string;
@@ -45,13 +47,21 @@ const TrialChart: React.FC<Props> = ({
 
   const fetchTrialSummary = useCallback(async () => {
     if (trialId) {
-      const summ = await timeSeries({
-        maxDatapoints: screen.width > 1600 ? 1500 : 1000,
-        metricNames: metricNames,
-        startBatches: 0,
-        trialIds: [trialId],
-      });
-      setTrialSummary(summ[0].metrics);
+      try {
+        const trialSummary = await timeSeries({
+          maxDatapoints: screen.width > 1600 ? 1500 : 1000,
+          metricNames: metricNames,
+          startBatches: 0,
+          trialIds: [trialId],
+        });
+        setTrialSummary(trialSummary[0].metrics);
+      } catch (e) {
+        handleError(e, {
+          publicMessage: `Failed to load trial summary for trial ${trialId}.`,
+          publicSubject: 'Trial summary fail to load.',
+          type: ErrorType.Api,
+        });
+      }
     }
   }, [metricNames, trialId]);
 

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -43,7 +43,8 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
   );
 
   const loadableMetricNames = useMetricNames([experiment.id], handleMetricNamesError);
-  const metricNames = Loadable.getOrElse([], loadableMetricNames);
+  const defaultMetricNames = useMemo(() => [], []);
+  const metricNames = Loadable.getOrElse(defaultMetricNames, loadableMetricNames);
 
   const { defaultMetrics, metrics } = useMemo(() => {
     const validationMetric = experiment?.config?.searcher.metric;


### PR DESCRIPTION
## Description

### PROBLEM

When user forks or creates a new experiment and then proceeds to view the experiment detail page, after it comes off of the queue and proceeds to run, the page will render `Unable to fetch experiment` error message.

After diagnosing, the effect is that there are a bunch of `time-series` calls that gets called by `TrialChart` followed by a uncaught error thrown. It turns out when the loadable is returned as `NotLoaded` an empty `[]` is provided as a default `MetricNames` value. The problem lied in the fact that the empty default `[]` value is created as a new reference each time.

### SOLUTION

1. Wrap the api call in a `try/catch` block to prevent uncaught error.
2. Create a memoized `[]` empty metric names list as a default.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- [ ] Navigate to a completed experiment (successfully) and fork the experiment.
- [ ] Verify that the app navigates to the newly forked experiment page.
- [ ] Wait for the experiment to move from `Queued` state to `Running` state.
- [ ] Verify that the page does not enter in to the `Unable to fetch experiments` error page.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1444
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
