### PR TITLE
chore: Clean up redundant aria-labels, correct wrong aria-labels [WEB-1379]

### DIFF
--- a/webui/react/src/components/ActionSheet.tsx
+++ b/webui/react/src/components/ActionSheet.tsx
@@ -43,7 +43,7 @@ const ActionSheet: React.FC<Props> = ({ onCancel, ...props }: Props) => {
         <Link className={css.item} key={action.label} path={action.path} {...action}>
           {action.icon && typeof action.icon === 'string' ? (
             <div className={css.icon}>
-              <Icon name={action.icon} size="large" title={action.label} />
+              <Icon decorative name={action.icon} size="large" />
             </div>
           ) : (
             <div className={css.icon}>{action.icon}</div>
@@ -77,7 +77,7 @@ const ActionSheet: React.FC<Props> = ({ onCancel, ...props }: Props) => {
           {!props.hideCancel && (
             <Link className={css.item} key="cancel" onClick={handleCancelClick}>
               <div className={css.icon}>
-                <Icon name="error" size="large" title="Cancel" />
+                <Icon decorative name="error" size="large" />
               </div>
               <div className={css.label}>Cancel</div>
             </Link>

--- a/webui/react/src/components/FilterForm/TableFilter.tsx
+++ b/webui/react/src/components/FilterForm/TableFilter.tsx
@@ -50,7 +50,7 @@ const TableFilter = ({
         placement="bottomLeft"
         trigger="click"
         onOpenChange={onIsOpenFilterChange}>
-        <Button icon={<Icon name="filter" title="filter" />}>
+        <Button icon={<Icon decorative name="filter" />}>
           Filter{fieldCount > 0 && <span>({fieldCount})</span>}
         </Button>
       </Popover>

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -274,7 +274,7 @@ const FilterField = ({
           </>
         )}
         <Button
-          icon={<Icon name="close" title="close field" />}
+          icon={<Icon name="close" title="Close Field" />}
           type="text"
           onClick={() => formStore.removeChild(field.id)}
         />

--- a/webui/react/src/components/FilterForm/components/FilterGroup.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterGroup.tsx
@@ -147,7 +147,7 @@ const FilterGroup = ({
                 <Button icon={<PlusOutlined />} type="text" />
               </Dropdown>
               <Button
-                icon={<Icon name="close" title="close group" />}
+                icon={<Icon name="close" title="Close Group" />}
                 type="text"
                 onClick={() => formStore.removeChild(group.id)}
               />

--- a/webui/react/src/components/NavigationSideBar.tsx
+++ b/webui/react/src/components/NavigationSideBar.tsx
@@ -89,7 +89,7 @@ export const NavigationItem: React.FC<ItemProps> = ({
       <Link className={classes.join(' ')} path={path} {...props}>
         {typeof props.icon === 'string' ? (
           <div className={css.icon}>
-            <Icon name={props.icon} size={props.iconSize ?? 'large'} title={props.label} />
+            <Icon decorative name={props.icon} size={props.iconSize ?? 'large'} />
           </div>
         ) : (
           <div className={css.icon}>{props.icon}</div>

--- a/webui/react/src/components/RadioGroup.tsx
+++ b/webui/react/src/components/RadioGroup.tsx
@@ -118,7 +118,7 @@ const RadioGroup: React.FC<Props> = ({
             </Tooltip>
           )}>
           <Radio.Button className={css.option} value={option.id}>
-            {option.icon && <Icon name={option.icon} size={option.iconSize} title={option.label} />}
+            {option.icon && <Icon decorative name={option.icon} size={option.iconSize} />}
             {option.label && showLabels && !iconOnly && (
               <span className={css.label}>{option.label}</span>
             )}

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -178,7 +178,7 @@ const ResourcePoolCard: React.FC<Props> = ({ resourcePool: pool }: Props) => {
                 <section className={css.resoucePoolBoundContainer}>
                   <div>Bound to:</div>
                   <div className={css.resoucePoolBoundCount}>
-                    <Icon name="lock" title="lock" />
+                    <Icon name="lock" title="Bound Workspaces" />
                     {resourcePoolBindings.length} workspace
                   </div>
                 </section>

--- a/webui/react/src/components/Table/TableFilterDropdown.tsx
+++ b/webui/react/src/components/Table/TableFilterDropdown.tsx
@@ -111,7 +111,7 @@ const TableFilterDropdown: React.FC<Props> = ({
           style={style}
           onClick={handleOptionClick}>
           {isJSX ? data[index].text : <span>{data[index].text}</span>}
-          <Icon name="checkmark" title="checkmark" />
+          <Icon name="checkmark" title="Selected" />
         </div>
       );
     },

--- a/webui/react/src/components/kit/Empty.tsx
+++ b/webui/react/src/components/kit/Empty.tsx
@@ -15,7 +15,7 @@ const Empty: React.FC<EmptyProps> = ({ icon, title, description }: EmptyProps) =
     <div className={css.emptyBase}>
       {icon ? (
         <div className={css.icon}>
-          <Icon name={icon} size="mega" title="Empty" />
+          <Icon decorative name={icon} size="mega" />
         </div>
       ) : null}
       {title ? <h4>{title}</h4> : null}

--- a/webui/react/src/components/kit/Icon.test.tsx
+++ b/webui/react/src/components/kit/Icon.test.tsx
@@ -17,7 +17,9 @@ const svgIcons = [
 
 const setup = (props?: Props) => {
   const user = userEvent.setup();
-  const view = render(<Icon name="star" showTooltip title="Icon" {...props} />);
+  const view = render(
+    <Icon color={props?.color} name="star" showTooltip size={props?.size} title="Icon" />,
+  );
   return { user, view };
 };
 

--- a/webui/react/src/components/kit/Icon.test.tsx
+++ b/webui/react/src/components/kit/Icon.test.tsx
@@ -17,8 +17,16 @@ const svgIcons = [
 
 const setup = (props?: Props) => {
   const user = userEvent.setup();
+  const props_: Partial<Props> = props ?? {};
+  const title = ('title' in props_ ? props_.title : undefined) ?? 'Icon';
   const view = render(
-    <Icon color={props?.color} name="star" showTooltip size={props?.size} title="Icon" />,
+    <Icon
+      color={props?.color}
+      name={props?.name ?? 'star'}
+      showTooltip
+      size={props?.size}
+      title={title}
+    />,
   );
   return { user, view };
 };

--- a/webui/react/src/components/kit/Icon.tsx
+++ b/webui/react/src/components/kit/Icon.tsx
@@ -204,21 +204,22 @@ const FourSquaresIcon: React.FC = () => (
 
 export type IconName = (typeof IconNameArray)[number];
 
-export type Props =
-  | {
-      color?: 'cancel' | 'error' | 'success';
-      name: IconName;
-      showTooltip?: boolean;
-      size?: IconSize;
-      title: string;
-    }
-  | {
-      color?: 'cancel' | 'error' | 'success';
-      name: IconName;
-      size?: IconSize;
-      decorative: true;
-    };
-
+type CommonProps = {
+  color?: 'cancel' | 'error' | 'success';
+  name: IconName;
+  size?: IconSize;
+  showTooltip?: boolean;
+};
+export type Props = CommonProps &
+  (
+    | {
+        title: string;
+        decorative?: never;
+      }
+    | {
+        decorative: true;
+      }
+  );
 const Icon: React.FC<Props> = (props: Props) => {
   const { name, size = 'medium', color } = props;
   const showTooltip = 'decorative' in props ? false : props.showTooltip ?? false;

--- a/webui/react/src/components/kit/Icon.tsx
+++ b/webui/react/src/components/kit/Icon.tsx
@@ -204,21 +204,26 @@ const FourSquaresIcon: React.FC = () => (
 
 export type IconName = (typeof IconNameArray)[number];
 
-export interface Props {
-  color?: 'cancel' | 'error' | 'success';
-  name: IconName;
-  showTooltip?: boolean;
-  size?: IconSize;
-  title: string;
-}
+export type Props =
+  | {
+      color?: 'cancel' | 'error' | 'success';
+      name: IconName;
+      showTooltip?: boolean;
+      size?: IconSize;
+      title: string;
+    }
+  | {
+      color?: 'cancel' | 'error' | 'success';
+      name: IconName;
+      size?: IconSize;
+      decorative: true;
+    };
 
-const Icon: React.FC<Props> = ({
-  name,
-  showTooltip = false,
-  size = 'medium',
-  title,
-  color,
-}: Props) => {
+const Icon: React.FC<Props> = (props: Props) => {
+  const { name, size = 'medium', color } = props;
+  const showTooltip = 'decorative' in props ? false : props.showTooltip ?? false;
+  const title = 'decorative' in props ? undefined : props.title;
+  const decorative = 'decorative' in props;
   const classes = [css.base];
 
   const svgIcon = useMemo(() => {
@@ -240,7 +245,7 @@ const Icon: React.FC<Props> = ({
   if (color) classes.push(css[color]);
 
   const icon = (
-    <span aria-label={title} className={classes.join(' ')}>
+    <span aria-label={decorative ? undefined : title} className={classes.join(' ')}>
       {svgIcon}
     </span>
   );

--- a/webui/react/src/components/kit/InputShortcut.tsx
+++ b/webui/react/src/components/kit/InputShortcut.tsx
@@ -45,6 +45,7 @@ const InputShortcut: React.FC<InputShortcutProps> = ({
   const onClearInput = useCallback(() => {
     value ? onChange?.(undefined) : setInputValue(undefined);
   }, [value, onChange]);
+
   return (
     <div className={css.shortcut_input_conatiner}>
       <Input
@@ -55,7 +56,7 @@ const InputShortcut: React.FC<InputShortcutProps> = ({
         {...props}
       />
       <Button icon={<Icon name="checkmark" title="save" />} type="primary" />
-      <Button icon={<Icon name="close" title="save" />} onClick={onClearInput} />
+      <Button icon={<Icon name="close" title="clear" />} onClick={onClearInput} />
     </div>
   );
 };

--- a/webui/react/src/components/kit/Modal.tsx
+++ b/webui/react/src/components/kit/Modal.tsx
@@ -156,7 +156,7 @@ export const Modal: React.FC<ModalProps> = ({
               <Icon name="warning-large" size="large" title="Danger" />
             </div>
           ) : (
-            icon && <Icon name={icon} size="large" title={icon} />
+            icon && <Icon decorative name={icon} size="large" />
           )}
           <div className={css.headerTitle}>{title}</div>
           <div className={css.headerLink}>

--- a/webui/react/src/components/kit/internal/Spinner/Spinner.tsx
+++ b/webui/react/src/components/kit/internal/Spinner/Spinner.tsx
@@ -34,7 +34,7 @@ const Spinner: React.FC<Props> = ({
         data-testid="custom-spinner"
         indicator={
           <div className={css.spin}>
-            <Icon name="spinner" size={size} title="Spinner" />
+            <Icon name="spinner" size={size} title="Loading" />
           </div>
         }
         spinning={!!spinning}

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -402,7 +402,7 @@ export const GlideTable: React.FC<GlideTableProps> = ({
               ...sortMenuItemsForColumn(column, sorts, onSortChange),
               { type: 'divider' as const },
               {
-                icon: <Icon name="filter" title="filter" />,
+                icon: <Icon decorative name="filter" />,
                 key: 'filter',
                 label: 'Filter by this column',
                 onClick: () => {

--- a/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/MultiSortMenu.tsx
@@ -239,7 +239,7 @@ const MultiSort: React.FC<MultiSortProps> = ({ sorts, columns, onChange }) => {
       </div>
       <div className={css.actions}>
         <Button
-          icon={<Icon name="add-small" size="tiny" title="Add sort" />}
+          icon={<Icon decorative name="add-small" size="tiny" />}
           type="text"
           onClick={addRow}>
           Add sort

--- a/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
@@ -358,7 +358,7 @@ const TableActionBar: React.FC<Props> = ({
           />
           {(selectAll || selectedExperimentIds.length > 0) && (
             <Dropdown menu={editMenuItems} onClick={handleAction}>
-              <Button icon={<Icon name="pencil" title="Edit" />}>
+              <Button icon={<Icon decorative name="pencil" />}>
                 Edit (
                 {selectAll
                   ? Loadable.isLoaded(total)

--- a/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.tsx
+++ b/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.tsx
@@ -19,7 +19,7 @@ const TrialHeaderLeft: React.FC<Props> = ({ experiment, trial }: Props) => {
       <Link className={css.experiment} to={paths.experimentDetails(trial.experimentId)}>
         Experiment {trial.experimentId} | {experiment.name}
       </Link>
-      <Icon name="arrow-right" size="tiny" title="Trial" />
+      <Icon decorative name="arrow-right" size="tiny" />
       <div className={css.trial}>
         <ExperimentIcons state={trial.state} />
         <div>Trial {trial.id}</div>

--- a/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsHeader.tsx
@@ -61,7 +61,7 @@ const TrialDetailsHeader: React.FC<Props> = ({ experiment, fetchTrialDetails, tr
 
     if (!trialNeverData) {
       options.push({
-        icon: <Icon name="tensor-board" size="small" title={Action.OpenTensorBoard} />,
+        icon: <Icon decorative name="tensor-board" size="small" />,
         isLoading: isRunningTensorBoard,
         key: Action.OpenTensorBoard,
         label: 'TensorBoard',
@@ -81,14 +81,14 @@ const TrialDetailsHeader: React.FC<Props> = ({ experiment, fetchTrialDetails, tr
     if (canActionExperiment(ExperimentAction.ContinueTrial, experiment, trial)) {
       if (trial.bestAvailableCheckpoint !== undefined) {
         options.push({
-          icon: <Icon name="fork" size="small" title={Action.Fork} />,
+          icon: <Icon decorative name="fork" size="small" />,
           key: Action.ContinueTrial,
           label: 'Continue Trial',
           onClick: ExperimentCreateModal.open,
         });
       } else {
         options.push({
-          icon: <Icon name="fork" size="small" title={Action.Fork} />,
+          icon: <Icon decorative name="fork" size="small" />,
           key: Action.ContinueTrial,
           label: 'Continue Trial',
           tooltip: 'No checkpoints found. Cannot continue trial',


### PR DESCRIPTION
## Description
This PR allows Icons to be labeled as decorative and thus hidden from screen readers. I went through and marked all the decorative icons I could find and corrected a few aria-labels that were incorrect.

## Test Plan
1. Go to the new experiment list and select an experiment
2. Via console tools confirm that the icon on the edit button has no aria label.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1379

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
