### PR TITLE
chore: reload only when explicit

### DIFF
--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -168,7 +168,9 @@ class Checkpoint:
         """
         if self.state not in [CheckpointState.COMPLETED, CheckpointState.PARTIALLY_DELETED]:
             if self.state is None:
-                raise ValueError("Checkpoint state is unknown. Please reload the checkpoint.")
+                raise ValueError(
+                    "Checkpoint state is unknown. Please call Checkpoint.reload to refresh."
+                )
             raise errors.CheckpointStateException(
                 "Only COMPLETED or PARTIALLY_DELETED checkpoints can be downloaded. "
                 f"Checkpoint state: {self.state.value}"

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -166,12 +166,9 @@ class Checkpoint:
             mode (DownloadMode, optional): Governs how a checkpoint is downloaded. Defaults to
                 ``AUTO``.
         """
-        self.reload()
-        assert self.state
-        if (
-            self.state != CheckpointState.COMPLETED
-            and self.state != CheckpointState.PARTIALLY_DELETED
-        ):
+        if self.state not in [CheckpointState.COMPLETED, CheckpointState.PARTIALLY_DELETED]:
+            if self.state is None:
+                raise ValueError("Checkpoint state is unknown. Please reload the checkpoint.")
             raise errors.CheckpointStateException(
                 "Only COMPLETED or PARTIALLY_DELETED checkpoints can be downloaded. "
                 f"Checkpoint state: {self.state.value}"
@@ -301,7 +298,6 @@ class Checkpoint:
         where you are accessing the checkpoint files directly (not via Checkpoint.download) you may
         use this method directly to obtain the latest metadata.
         """
-        self.reload()
         with open(path, "w") as f:
             json.dump(self.metadata, f, indent=2)
 
@@ -337,8 +333,6 @@ class Checkpoint:
         bindings.post_PostCheckpointMetadata(self._session, body=req, checkpoint_uuid=self.uuid)
 
         self.metadata = updated_metadata
-        self.reload()
-        assert self.metadata
 
     def remove_metadata(self, keys: List[str]) -> None:
         """
@@ -360,8 +354,6 @@ class Checkpoint:
         bindings.post_PostCheckpointMetadata(self._session, body=req, checkpoint_uuid=self.uuid)
 
         self.metadata = updated_metadata
-        self.reload()
-        assert self.metadata
 
     def delete(self) -> None:
         """

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -61,7 +61,6 @@ class ModelVersion:
             self._session, body=req, modelName=self.model_name, modelVersionNum=self.model_version
         )
         self.name = name
-        self.reload()
 
     def set_notes(self, notes: str) -> None:
         """
@@ -75,7 +74,6 @@ class ModelVersion:
             self._session, body=req, modelName=self.model_name, modelVersionNum=self.model_version
         )
         self.notes = notes
-        self.reload()
 
     def delete(self) -> None:
         """
@@ -289,8 +287,6 @@ class Model:
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
 
         self.metadata = updated_metadata
-        self.reload()
-        assert self.metadata is not None
 
     def remove_metadata(self, keys: List[str]) -> None:
         """
@@ -314,8 +310,6 @@ class Model:
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
 
         self.metadata = updated_metadata
-        self.reload()
-        assert self.metadata is not None
 
     def move_to_workspace(self, workspace_name: str) -> None:
         req = bindings.v1PatchModel(workspaceName=workspace_name)
@@ -338,12 +332,10 @@ class Model:
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
 
         self.labels = labels
-        self.reload()
 
     def set_description(self, description: str) -> None:
         req = bindings.v1PatchModel(description=description)
         bindings.patch_PatchModel(self._session, body=req, modelName=self.name)
-        self.reload()
 
         self.description = description
 
@@ -353,7 +345,6 @@ class Model:
         """
         bindings.post_ArchiveModel(self._session, modelName=self.name)
         self.archived = True
-        self.reload()
 
     def unarchive(self) -> None:
         """
@@ -361,7 +352,6 @@ class Model:
         """
         bindings.post_UnarchiveModel(self._session, modelName=self.name)
         self.archived = False
-        self.reload()
 
     def delete(self) -> None:
         """


### PR DESCRIPTION
Earlier design: reload eagerly, whenever we're already making a call to master anyway.

Current design: reload only when the user calls for it (or in Experiment.wait).

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
