### PR TITLE
fix: userSettings store should function correctly when useSettings is active

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -62,6 +62,7 @@
         "@types/express": "^4.17.17",
         "@types/humanize-duration": "^3.27.1",
         "@types/js-yaml": "^4.0.5",
+        "@types/lodash": "^4.14.195",
         "@types/morgan": "^1.9.4",
         "@types/node": "^18.11.9",
         "@types/react": "^18.0.21",
@@ -2076,6 +2077,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==",
       "dev": true
     },
     "node_modules/@types/mime": {

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -97,6 +97,7 @@
     "@types/express": "^4.17.17",
     "@types/humanize-duration": "^3.27.1",
     "@types/js-yaml": "^4.0.5",
+    "@types/lodash": "^4.14.195",
     "@types/morgan": "^1.9.4",
     "@types/node": "^18.11.9",
     "@types/react": "^18.0.21",

--- a/webui/react/src/hooks/useSettings.test.tsx
+++ b/webui/react/src/hooks/useSettings.test.tsx
@@ -16,6 +16,7 @@ const CURRENT_USER = { id: 1, isActive: true, isAdmin: false, username: 'bunny' 
 
 vi.mock('services/api', () => ({
   getUserSetting: () => Promise.resolve({ settings: [] }),
+  updateUserSetting: () => Promise.resolve(),
 }));
 
 interface Settings {

--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -1,17 +1,17 @@
 import { Map } from 'immutable';
 import * as t from 'io-ts';
 import { useObservable } from 'micro-observables';
-import { useCallback, useContext, useEffect, useLayoutEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { updateUserSetting } from 'services/api';
-import { UpdateUserSettingParams } from 'services/types';
 import userStore from 'stores/users';
+import userSettings from 'stores/userSettings';
 import { Primitive } from 'types';
 import { isEqual } from 'utils/data';
 import { ErrorType } from 'utils/error';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
+import { useValueMemoizedObservable } from 'utils/observable';
 
 import { Settings, SettingsProvider, UserSettings } from './useSettingsProvider';
 
@@ -25,10 +25,6 @@ export interface SettingsConfigProp<A> {
 export interface SettingsConfig<T> {
   settings: { [K in keyof T]: SettingsConfigProp<T[K]> };
   storagePath: string;
-}
-
-interface UserSettingUpdate extends UpdateUserSettingParams {
-  userId: number;
 }
 
 export type UpdateSettings<T> = (newSettings: Partial<T>) => void;
@@ -171,7 +167,7 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
       ),
     [rawState, config.storagePath],
   );
-  const state = useObservable(derivedOb);
+  const state = useValueMemoizedObservable(derivedOb);
   const navigate = useNavigate();
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
 
@@ -212,48 +208,6 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
     [config.settings, settings],
   );
 
-  const updateDB = useCallback(
-    async (newSettings: Settings, oldSettings: SettingsRecord<T>) => {
-      const dbUpdates = Object.keys(newSettings).reduce<UserSettingUpdate[]>((acc, setting) => {
-        const newSetting = newSettings[setting];
-        const stateSetting = oldSettings?.[setting as keyof T];
-        if (currentUser?.id && !isEqual(newSetting, stateSetting)) {
-          acc.push({
-            setting: {
-              key: setting,
-              storagePath: config.storagePath,
-              value: JSON.stringify(newSettings[setting]),
-            },
-            storagePath: config.storagePath,
-            userId: currentUser.id,
-          });
-        }
-
-        return acc;
-      }, []);
-
-      if (dbUpdates.length !== 0) {
-        try {
-          // Persist storage to backend.
-          await Promise.allSettled(
-            dbUpdates.map((update) => {
-              updateUserSetting(update);
-            }),
-          );
-        } catch (e) {
-          handleError(e, {
-            isUserTriggered: false,
-            publicMessage: 'Unable to update user settings.',
-            publicSubject: 'Some POST user settings failed.',
-            silent: true,
-            type: ErrorType.Api,
-          });
-        }
-      }
-    },
-    [config.storagePath, currentUser],
-  );
-
   const resetSettings = useCallback(
     (settingsArray?: string[]) => {
       if (!currentUser) return;
@@ -291,18 +245,30 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
 
   const updateSettings = useCallback(
     (updates: Partial<Settings>) => {
+      // Fake update to get access to old state without race conditions.
       rawState.update((s) => {
-        return Loadable.map(s, (s) => {
+        Loadable.forEach(s, (s) => {
           const oldSettings = s.get(config.storagePath) ?? {};
           const newSettings = { ...s.get(config.storagePath), ...updates };
-          return s.set(
-            config.storagePath,
-            isEqual(oldSettings, newSettings) ? oldSettings : newSettings,
-          );
+          if (!isEqual(oldSettings, newSettings)) {
+            setTimeout(() => userSettings.set(t.any, config.storagePath, newSettings), 0);
+
+            if (
+              (Object.values(config.settings) as SettingsConfigProp<typeof config>[]).every(
+                (setting) => !!setting.skipUrlEncoding,
+              )
+            ) {
+              return;
+            }
+            const mappedSettings = settingsToQuery(config, newSettings);
+            const url = mappedSettings ? `?${mappedSettings}` : '';
+            navigate(url, { replace: true });
+          }
         });
+        return s;
       });
     },
-    [config, rawState],
+    [config, rawState, navigate],
   );
 
   // parse navigation url to state
@@ -312,26 +278,6 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
     const parsedSettings = queryToSettings<T>(config, querySettings);
     updateSettings(parsedSettings);
   }, [config, querySettings, updateSettings]);
-
-  useLayoutEffect(() => {
-    if (isLoading) return;
-    return derivedOb.subscribe(async (cur, prev) => {
-      if (!cur || !currentUser || isEqual(cur, prev)) return;
-
-      await updateDB(cur, prev as unknown as SettingsRecord<T>);
-
-      if (
-        (Object.values(config.settings) as SettingsConfigProp<typeof config>[]).every(
-          (setting) => !!setting.skipUrlEncoding,
-        )
-      ) {
-        return;
-      }
-      const mappedSettings = settingsToQuery(config, cur);
-      const url = mappedSettings ? `?${mappedSettings}` : '';
-      navigate(url, { replace: true });
-    });
-  }, [currentUser, derivedOb, navigate, config, updateDB, isLoading]);
 
   return {
     activeSettings,

--- a/webui/react/src/utils/observable.ts
+++ b/webui/react/src/utils/observable.ts
@@ -1,7 +1,6 @@
+import _ from 'lodash';
 import { Observable, observable, useObservable, WritableObservable } from 'micro-observables';
 import React from 'react';
-
-import { isEqual } from 'utils/data';
 
 // type comparator<T> = (current: T, previous: T) => boolean;
 
@@ -26,7 +25,7 @@ const useValueMemoizedObservable = <T>(o: Observable<T>): T => {
       forceRender({});
     }
     return o.subscribe((value, prevValue) => {
-      if (!isEqual(value, prevValue)) {
+      if (!_.isEqual(value, prevValue)) {
         forceRender({});
       }
     });


### PR DESCRIPTION
## Description
This PR fixes an issue that occurs when useSettings is active while settings it controls are being updated directly via the user settings store. This is tricky because `useSettings` guards all updates with `isEqual` which means it needs access to the _directly_ previous version of the state to work, opening the possibility for race conditions. I managed to rewrite it over to make all writes via the user settings store using some hacky nonsense.


## Test Plan
1. Test changing the old and new versions of the experiment listing page, toggling features and adjusting columns.
2. Refresh and confirm the changed settings persist

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
