### PR TITLE
fix: All metrics viewable in the glide table compare tab [WEB-1372] [WEB-1394]

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -364,10 +364,7 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
                 <FixedSizeGrid
                   columnCount={columnCount}
                   columnWidth={Math.floor(width / columnCount)}
-                  height={Math.min(
-                    height - 40,
-                    (chartsProps.length > columnCount ? 2.1 : 1.05) * 480,
-                  )}
+                  height={height - 40}
                   itemData={{ chartsProps: chartsProps, columnCount, handleError, scale, xAxis }}
                   rowCount={Math.ceil(chartsProps.length / columnCount)}
                   rowHeight={480}

--- a/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
@@ -31,7 +31,7 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials, metricDa
       trials.forEach((t) => {
         const m = data[t?.id || 0];
         m?.[key] && t && series.push({ ...m[key], color: colorMap[t.experimentId] });
-        chartedMetrics[key] ||= series.length > 0;
+        chartedMetrics[key] ||= series.length > 0 || !!t.endTime;
       });
       out.push({
         series: Loaded(series),
@@ -48,7 +48,7 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials, metricDa
     // spinner.
     const chartDataIsLoaded = metrics.every((metric) => {
       const metricKey = `${metric.type}|${metric.name}`;
-      return !!metricHasData?.[metricKey] && !!chartedMetrics?.[metricKey];
+      return !!chartedMetrics?.[metricKey];
     });
     if (isLoaded && chartDataIsLoaded) {
       return Loaded(out);

--- a/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
@@ -22,7 +22,7 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials, metricDa
   const { scale, setScale } = metricData;
 
   const chartsProps = useMemo(() => {
-    const { metrics, data, metricHasData, isLoaded } = metricData;
+    const { metrics, data, isLoaded } = metricData;
     const chartedMetrics: Record<string, boolean> = {};
     const out: ChartsProps = [];
     metrics.forEach((metric) => {

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -27,7 +27,6 @@ export interface TrialMetricData {
   metrics: Metric[];
   scale: Scale;
   setScale: React.Dispatch<React.SetStateAction<Scale>>;
-  metricHasData: Record<string, boolean>;
 }
 
 const summarizedMetricToSeries = (

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -117,7 +117,6 @@ export const useTrialMetrics = (trials: (TrialDetails | undefined)[]): TrialMetr
   const [loadableData, setLoadableData] =
     useState<Loadable<Record<number, Record<string, Serie>>>>(NotLoaded);
   const [scale, setScale] = useState<Scale>(Scale.Linear);
-  const [metricHasData, setMetricHasData] = useState<Record<string, boolean>>({});
 
   const previousTrials = usePrevious(trials, []);
 
@@ -151,16 +150,11 @@ export const useTrialMetrics = (trials: (TrialDetails | undefined)[]): TrialMetr
         setLoadableData((prev) =>
           isEqual(Loadable.getOrElse([], prev), newData) ? prev : Loaded(newData),
         );
-        // Wait until the metric names are loaded
-        // to determine if trials have data for any metric
-        if (Loadable.isLoaded(loadableMetrics)) {
-          setMetricHasData(metricsHaveData);
-        }
       } catch (e) {
         message.error('Error fetching metrics');
       }
     }
-  }, [metrics, trials, loadableMetrics, previousTrials]);
+  }, [metrics, trials, previousTrials]);
 
   const fetchAll = useCallback(async () => {
     await Promise.allSettled([fetchTrialSummary()]);
@@ -181,7 +175,6 @@ export const useTrialMetrics = (trials: (TrialDetails | undefined)[]): TrialMetr
   return {
     data: Loadable.getOrElse({}, loadableData),
     isLoaded: metricNamesLoaded && Loadable.isLoaded(loadableData),
-    metricHasData,
     metrics,
     scale,
     setScale,


### PR DESCRIPTION
## Description

Addresses an issue where the ChartGrid component was not loading new rows as the user scrolls through.

I think the old height logic here was used in old examples where we had small charts, or non-Loadable data.

## Test Plan

Visit `/det/projects/1/experiments?f_explist_v2=on`
Open the Compare view
Select multiple types of experiments (mnist, cifar, fashion), adding multiple metrics charts to the ComparisonView
Scroll down the metrics chart on the ComparisonView - count 6 or more charts
There should be no additional space to scroll down past the last metric

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.