### PR TITLE
fix: clear table selection when changing pages

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -433,9 +433,12 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     (cPage: number, cPageSize: number) => {
       updateSettings({ pageLimit: cPageSize });
       // Pagination component is assuming starting index of 1.
+      if (cPage - 1 !== page) {
+        setClearSelectionTrigger((t) => t + 1);
+      }
       setPage(cPage - 1);
     },
-    [updateSettings],
+    [page, updateSettings],
   );
 
   const handleToggleComparisonView = useCallback(() => {

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -434,6 +434,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
       updateSettings({ pageLimit: cPageSize });
       // Pagination component is assuming starting index of 1.
       if (cPage - 1 !== page) {
+        setExperiments(Array(cPageSize).fill(NotLoaded));
         setClearSelectionTrigger((t) => t + 1);
       }
       setPage(cPage - 1);


### PR DESCRIPTION


## Description

This fixes an issue where the selection in the new experiment list experience is preserved when navigating between pages.



## Test Plan

With the experiment list v2 flag enabled
- [ ] visit the experiment list
- [ ] ensure the infinite scroll setting is disabled
- [ ] select the first row of the table
- [ ] change the page
- [ ] the selection should be cleared



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1371


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
