### PR TITLE
fix: Correctly sequence updates in useSettings bridge code [WEB-1462]

### DIFF
--- a/webui/react/src/hooks/useSettings.ts
+++ b/webui/react/src/hooks/useSettings.ts
@@ -251,7 +251,16 @@ const useSettings = <T>(config: SettingsConfig<T>): UseSettingsReturn<T> => {
           const oldSettings = s.get(config.storagePath) ?? {};
           const newSettings = { ...s.get(config.storagePath), ...updates };
           if (!isEqual(oldSettings, newSettings)) {
-            setTimeout(() => userSettings.set(t.any, config.storagePath, newSettings), 0);
+            const props: { [k: string]: t.Type<unknown> } = {};
+            Object.keys(updates).forEach((key) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const t = (config.settings as any)[key]?.type;
+              if (t !== undefined) {
+                props[key] = t;
+              }
+            });
+            const type = t.type(props);
+            setTimeout(() => userSettings.set(type, config.storagePath, updates), 0);
 
             if (
               (Object.values(config.settings) as SettingsConfigProp<typeof config>[]).every(


### PR DESCRIPTION
## Description
This PR fixes an issue where useSettings would incorrectly override settings under a race condition.


## Test Plan
1. Go to the new experiment listing
2. Pin a column, observe it pins in the rightmost spot
3. Unpin any column but the last one, observe it unpins successfully


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1462


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
