### PR TITLE
fix(cli): compound keys in --config opts for commands

### DIFF
--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -321,15 +321,17 @@ def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> 
             )
 
         key, value = config_arg.split("=", maxsplit=1)  # type: Tuple[str, Any]
+        print(key, value, type(value), value.startswith(("[", "{")))
 
         # Complex objects may contain commas but are not intended to be split
         # on commas and have their parts parsed separately.
         if value.startswith(("[", "{")):
-            value = yaml.load(value)
             # Certain configurations keys are expected to have list values.
             # Convert a single value to a singleton list if needed.
             if key in _CONFIG_PATHS_COERCE_TO_LIST and value.startswith("{"):
-                value = [value]
+                value = [yaml.load(value)]
+            else:
+                value = yaml.load(value)
         # Separate values if a comma exists. Use yaml.load() to cast
         # the value(s) to the type YAML would use, e.g., "4" -> 4.
         elif "," in value:

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -321,7 +321,6 @@ def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> 
             )
 
         key, value = config_arg.split("=", maxsplit=1)  # type: Tuple[str, Any]
-        print(key, value, type(value), value.startswith(("[", "{")))
 
         # Complex objects may contain commas but are not intended to be split
         # on commas and have their parts parsed separately.


### PR DESCRIPTION
## Description
This code had a bug where keys starting with`[, {` would be parsed as yaml, the we would call `.startswith` on the yaml and explode. Fix it by not calling string methods on any types.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [x] test manually
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
I tested this when I landed it, I am unsure how this broke since then. Error stack:
```
(det) ➜  harness git:(trial_one_to_many_tasks) ✗ det shell start --config 'bind_mounts=[{host_path: "/tmp", container_path: "/tmp"}]'
bind_mounts [{host_path: "/tmp", container_path: "/tmp"}] <class 'str'> True
Traceback (most recent call last):
  File "/Users/bradleylaney/Code/determined/harness/determined/cli/cli.py", line 288, in main
    parsed_args.func(parsed_args)
  File "/Users/bradleylaney/Code/determined/harness/determined/common/api/authentication.py", line 475, in f
    return func(namespace)
  File "/Users/bradleylaney/Code/determined/harness/determined/cli/shell.py", line 31, in start_shell
    config = command.parse_config(args.config_file, None, args.config, args.volume)
  File "/Users/bradleylaney/Code/determined/harness/determined/cli/command.py", line 381, in parse_config
    config = parse_config_overrides(config, overrides)
  File "/Users/bradleylaney/Code/determined/harness/determined/cli/command.py", line 333, in parse_config_overrides
    if key in _CONFIG_PATHS_COERCE_TO_LIST and value.startswith("{"):
AttributeError: 'list' object has no attribute 'startswith'
```
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
