### PR TITLE
fix: update get agents call for agent disable all [MLG-724]

### DIFF
--- a/harness/determined/cli/agent.py
+++ b/harness/determined/cli/agent.py
@@ -166,8 +166,8 @@ def patch_agent(enabled: bool) -> Callable[[argparse.Namespace], None]:
         if args.agent_id:
             agent_ids = [args.agent_id]
         else:
-            r = api.get(args.master, "agents")
-            agent_ids = sorted(local_id(a) for a in r.json().keys())
+            resp = bindings.get_GetAgents(cli.setup_session(args))
+            agent_ids = sorted(local_id(a.id) for a in resp.agents or [])
 
         drain_mode = None if enabled else args.drain
 
@@ -232,8 +232,8 @@ def patch_slot(enabled: bool) -> Callable[[argparse.Namespace], None]:
 
 
 def agent_id_completer(_1: str, parsed_args: argparse.Namespace, _2: Any) -> List[str]:
-    r = api.get(parsed_args.master, "agents")
-    return list(r.json().keys())
+    resp = bindings.get_GetAgents(cli.setup_session(parsed_args))
+    return [a.id for a in resp.agents or []]
 
 
 # fmt: off


### PR DESCRIPTION
## Description

Fix calls to old agents API.

I think this was missed here: d2b43de57d69be20a13654bb8e2e0b9963e77f6e

## Test Plan

- Ensure `det agent disable --all` works and doesn't throw an error like it did before.
- Maybe ensure that the autocompleter works? (I couldn't get this to work and I assume this is something I need to setup in order for this to work)

## Ticket
MLG-724
