### PR TITLE
feat: sort resource pools by name when creating new jupyterlab sessions [WEB-1138]

### DIFF
--- a/webui/react/src/components/JupyterLabModal.tsx
+++ b/webui/react/src/components/JupyterLabModal.tsx
@@ -432,7 +432,7 @@ const JupyterLabForm: React.FC<{
         <Input placeholder="Name (optional)" />
       </Form.Item>
       <Form.Item initialValue={defaults?.pool} label="Resource Pool" name="pool">
-        <Select allowClear placeholder="Pick the best option">
+        <Select allowClear placeholder="Pick the best option" showSearch>
           {resourcePools.map((pool) => (
             <Option key={pool.name} value={pool.name}>
               {pool.name}

--- a/webui/react/src/stores/cluster.tsx
+++ b/webui/react/src/stores/cluster.tsx
@@ -101,8 +101,13 @@ class ClusterStore extends PollingStore {
   #resourcePoolBindings: WritableObservable<Map<string, number[]>> = observable(Map());
 
   public readonly agents = this.#agents.readOnly();
-  public readonly resourcePools = this.#resourcePools.readOnly();
   public readonly resourcePoolBindings = this.#resourcePoolBindings.readOnly();
+
+  public readonly resourcePools = this.#resourcePools.select((loadable) => {
+    return Loadable.map(loadable, (pools) => {
+      return pools.sort((a, b) => a.name.localeCompare(b.name));
+    });
+  });
 
   public readonly clusterOverview = this.#agents.select((agents) =>
     Loadable.map(agents, (agents) => {


### PR DESCRIPTION
## Description

Update resource pool picker under create JupyterLab session modal to be alphabetically sorted.
Update resource pool picker to allow name search.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- [ ] navigate to a task list page (can also be under workspac)
- [ ] click on `Launch JupyterLab` button
- [ ] click on the resource pool picker
- [ ] verify that the resource pools are alphabetically sorted
- [ ] verify that the picker supports search when the picker is active

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1138
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
