### PR TITLE
docs: Reset home page tiles and sidebar

### DIFF
--- a/docs/_templates/toggle-primary-sidebar.html
+++ b/docs/_templates/toggle-primary-sidebar.html
@@ -1,4 +1,3 @@
-{% if pagename != "index" %}
   <label
     class="sidebar-toggle primary-toggle btn btn-sm"
     for="__primary"
@@ -8,7 +7,6 @@
   >
     <span class="fa-solid fa-bars"></span>
   </label>
-{% endif %}
 
 <div class="header-links-left">
   <a href="{{ pathto("cluster-setup-guide/deploy-cluster/index") }}">Set Up</a>

--- a/docs/_templates/toggle-primary-sidebar.html
+++ b/docs/_templates/toggle-primary-sidebar.html
@@ -1,12 +1,12 @@
-  <label
-    class="sidebar-toggle primary-toggle btn btn-sm"
-    for="__primary"
-    title="Toggle primary sidebar"
-    data-bs-placement="bottom"
-    data-bs-toggle="tooltip"
-  >
-    <span class="fa-solid fa-bars"></span>
-  </label>
+<label
+  class="sidebar-toggle primary-toggle btn btn-sm"
+  for="__primary"
+  title="Toggle primary sidebar"
+  data-bs-placement="bottom"
+  data-bs-toggle="tooltip"
+>
+  <span class="fa-solid fa-bars"></span>
+</label>
 
 <div class="header-links-left">
   <a href="{{ pathto("cluster-setup-guide/deploy-cluster/index") }}">Set Up</a>

--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -119,53 +119,28 @@ html[data-theme="dark"] {
   width: 24px;
 }
 .tile-container:nth-child(6n - 5) > .tile {
-  background-color: #ededed;
+  background-color: #f2f2f3;
 }
 
 .tile-container:nth-child(6n - 4) > .tile {
-  background-color: #ffffff;
+  background-color: #c8caca;
 }
 
 .tile-container:nth-child(6n - 3) > .tile {
-  background-color: #ededed;
+  background-color: #f2f2f3;
 }
 
 .tile-container:nth-child(6n - 2) > .tile {
-  background-color: #ffffff;
+  background-color: #c8caca;
 }
 
 .tile-container:nth-child(6n - 1) > .tile {
-  background-color: #ededed;
+  background-color: #f2f2f3;
 }
 
 .tile-container:nth-child(6n) > .tile {
-  background-color: #ffffff;
+  background-color: #c8caca;
 }
-/*
-.tile-container:nth-child(6n - 5) > .tile {
-  background-color: #FEC901;
-}
-
-.tile-container:nth-child(6n - 4) > .tile {
-  background-color: #32DAC8;
-}
-
-.tile-container:nth-child(6n - 3) > .tile {
-  background-color: #fdc6a7;
-}
-
-.tile-container:nth-child(6n - 2) > .tile {
-  background-color: #b98cf4;
-}
-
-.tile-container:nth-child(6n - 1) > .tile {
-  background-color: #ededed;
-}
-
-.tile-container:nth-child(6n) > .tile {
-  background-color: #a0da70;
-}
-*/
 .tile:hover {
   -webkit-transform: translate3d(0, -6px, 0);
   transform: translate3d(0, -6px, 0);

--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -118,7 +118,7 @@ html[data-theme="dark"] {
   height: 24px;
   width: 24px;
 }
-
+/*
 .tile-container:nth-child(6n - 5) > .tile {
   background-color: #FEC901;
 }
@@ -142,7 +142,7 @@ html[data-theme="dark"] {
 .tile-container:nth-child(6n) > .tile {
   background-color: #a0da70;
 }
-
+*/
 .tile:hover {
   -webkit-transform: translate3d(0, -6px, 0);
   transform: translate3d(0, -6px, 0);

--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -118,6 +118,29 @@ html[data-theme="dark"] {
   height: 24px;
   width: 24px;
 }
+.tile-container:nth-child(6n - 5) > .tile {
+  background-color: #ededed;
+}
+
+.tile-container:nth-child(6n - 4) > .tile {
+  background-color: #ffffff;
+}
+
+.tile-container:nth-child(6n - 3) > .tile {
+  background-color: #ededed;
+}
+
+.tile-container:nth-child(6n - 2) > .tile {
+  background-color: #ffffff;
+}
+
+.tile-container:nth-child(6n - 1) > .tile {
+  background-color: #ededed;
+}
+
+.tile-container:nth-child(6n) > .tile {
+  background-color: #ffffff;
+}
 /*
 .tile-container:nth-child(6n - 5) > .tile {
   background-color: #FEC901;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,8 @@ html_sidebars = {
         "search-field.html",
         "sbt-sidebar-nav.html",
     ],
-    "index": [],
+# to suppress sidebar on home page uncomment this line:
+#    "index": [],
 }
 
 pygments_style = "sphinx"


### PR DESCRIPTION
We want to show the sidebar and the search on the home page (i.e., we do not want to suppress it). We want to use the gray color palette rather than the multi-color (secondary brand colors) palette.

(Note: this reverses some of the changes that were made via PR #7169. )