### PR TITLE
fix: Metrics with dot in name appear correctly in trial view [DET-9691]

### DIFF
--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -500,7 +500,7 @@ func TestUnusualMetricNames(t *testing.T) {
 	req := &apiv1.CompareTrialsRequest{
 		TrialIds:      []int32{int32(trial.ID)},
 		MaxDatapoints: 3,
-		MetricNames:   []string{"a.loss", "b/loss"},
+		MetricNames:   []string{"a.loss", "b/loss", asciiSweep},
 		StartBatches:  0,
 		EndBatches:    1000,
 		MetricType:    apiv1.MetricType_METRIC_TYPE_VALIDATION,

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -477,7 +477,7 @@ func TestUnusualMetricNames(t *testing.T) {
 		"b/loss": 2.5,
 	}
 	asciiSweep := ""
-	for i := 0; i <= 255; i++ {
+	for i := 1; i <= 255; i++ {
 		asciiSweep += fmt.Sprintf("%c", i)
 	}
 	expectedMetricsMap[asciiSweep] = 3

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -476,6 +476,11 @@ func TestUnusualMetricNames(t *testing.T) {
 		"a.loss": 1.5,
 		"b/loss": 2.5,
 	}
+	asciiSweep := ""
+	for i := 0; i <= 255; i++ {
+		asciiSweep += fmt.Sprintf("%c", i)
+	}
+	expectedMetricsMap[asciiSweep] = 3
 	expectedMetrics, err := structpb.NewStruct(expectedMetricsMap)
 	require.NoError(t, err)
 

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -39,7 +39,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	case "time":
 		queryColumn = "end_time"
 	default:
-		queryColumn = timeSeriesColumn
+		queryColumn = strings.ReplaceAll(timeSeriesColumn, ".", "·")
 	}
 	subq := db.BunSelectMetricsQuery(metricGroup, false).Table("metrics").
 		ColumnExpr("(select setseed(1)) as _seed").
@@ -86,7 +86,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 			Where("total_batches <= 0 OR total_batches <= ?", endBatches).
 			Where("end_time > ?", startTime)
 	default:
-		orderColumn = timeSeriesColumn
+		orderColumn = strings.ReplaceAll(timeSeriesColumn, ".", "·")
 		subq, err = db.ApplyPolymorphicFilter(subq, queryColumn, timeSeriesFilter)
 		if err != nil {
 			return metricMeasurements, errors.Wrapf(err, "failed to get metrics to sample for experiment")

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -74,7 +74,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 			cast = "boolean"
 		}
 		subq = subq.ColumnExpr("(metrics->?->>?)::? as ?", metricsObjectName,
-			metricName, bun.Safe(cast), bun.Ident(strings.ReplaceAll(metricName, ".", "")))
+			metricName, bun.Safe(cast), bun.Ident(strings.ReplaceAll(metricName, ".", "·")))
 	}
 
 	subq = subq.Where("trial_id = ?", trialID).OrderExpr("random()").
@@ -104,7 +104,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	selectMetrics := map[string]string{}
 
 	for i := range metricNames {
-		selectMetrics[strings.ReplaceAll(metricNames[i], ".", "")] = metricNames[i]
+		selectMetrics[strings.ReplaceAll(metricNames[i], ".", "·")] = metricNames[i]
 	}
 
 	for i := range results {


### PR DESCRIPTION
## Description

Fixes an issue where `bun.Ident`, which we used to allow metrics names with /, was writing metric names such as `val.loss` into SQL as `AS "val"."loss"`

Example experiment with API error: http://latest-main.determined.ai:8080/det/experiments/3246/overview

The fix renames the metric for the query (i.e. `val·loss`) for the query, and restores the original name in the JSON response

## Test Plan

In an experiment such as `examples/tutorials/mnist_pytorch`, rename `validation_loss` in `const.yaml` and `model_def.py` to `val.loss`

Run the experiment and observe you can plot `val.loss` with valid API responses

Update: verify that included unit test covers the issue of metric names with a "." , "/" , or other special characters

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.


## Ticket

DET-9691