### PR TITLE
fix: Improve HPC error shutdown to improve logging [FE-44]

### DIFF
--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -54,7 +54,7 @@ def launch(experiment_config: det.ExperimentConfig) -> int:
 
     logging.info(f"Launching: {entrypoint}")
 
-    p = subprocess.Popen(entrypoint)
+    p = subprocess.Popen(entrypoint, start_new_session=True)
     # Convert from signal names to Signal enums because SIGBREAK is windows-specific
     forwaded_signals = [getattr(signal, name) for name in sig_names if hasattr(signal, name)]
     with det.util.forward_signals(p, *forwaded_signals):

--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -128,7 +128,7 @@ def start_tensorboard(
         # Build Tensorboard args and launch process.
         tb_args = get_tensorboard_args(tb_version, local_dir, add_tb_args)
         logger.debug(f"tensorboard args: {tb_args}")
-        tensorboard_process = subprocess.Popen(tb_args)
+        tensorboard_process = subprocess.Popen(tb_args, start_new_session=True)
         tb_fetch_manager = TBFetchManager()
         work_queue: queue.Queue = queue.Queue(maxsize=WORK_QUEUE_MAX_SIZE)
 

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -445,7 +445,7 @@ class PIDServer:
         on_exit: Optional[signal.Signals] = None,
         grace_period: int = 3,
     ) -> int:
-        p = subprocess.Popen(cmd)
+        p = subprocess.Popen(cmd, start_new_session=True)
 
         class HealthCheckFail(Exception):
             def __init__(self, exit_code: int):
@@ -538,7 +538,7 @@ class PIDClient:
         self.sock.send(b"k")
 
     def run_subprocess(self, cmd: List[str]) -> int:
-        p = subprocess.Popen(cmd)
+        p = subprocess.Popen(cmd, start_new_session=True)
 
         with det.util.forward_signals(p):
             while True:

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -281,7 +281,7 @@ def main(script: List[str]) -> int:
             f"Non-chief [{info.container_rank}] training process launch "
             f"command: {run_sshd_command}."
         )
-        p = subprocess.Popen(pid_server_cmd + run_sshd_command)
+        p = subprocess.Popen(pid_server_cmd + run_sshd_command, start_new_session=True)
         with det.util.forward_signals(p):
             return p.wait()
 
@@ -311,7 +311,7 @@ def main(script: List[str]) -> int:
     full_cmd = pid_server_cmd + cmd + pid_client_cmd + log_redirect_cmd + harness_cmd
 
     if not multi_machine:
-        p = subprocess.Popen(full_cmd)
+        p = subprocess.Popen(full_cmd, start_new_session=True)
         with det.util.forward_signals(p):
             return p.wait()
 
@@ -337,7 +337,7 @@ def main(script: List[str]) -> int:
         for peer_addr in info.container_addrs:
             util.check_sshd(peer_addr, deadline, constants.DTRAIN_SSH_PORT)
 
-        p = subprocess.Popen(full_cmd)
+        p = subprocess.Popen(full_cmd, start_new_session=True)
         with det.util.forward_signals(p):
             return p.wait()
     finally:

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -97,7 +97,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
 
     # When --autohorovod was set, detect single-slot and zero-slot trials.
     if autohorovod and len(info.container_addrs) == 1 and len(info.slot_ids) <= 1:
-        p = subprocess.Popen(script)
+        p = subprocess.Popen(script, start_new_session=True)
         with det.util.forward_signals(p):
             return p.wait()
 

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -143,7 +143,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
             f"Non-chief [{info.container_rank}] training process launch "
             f"command: {run_sshd_command}."
         )
-        p = subprocess.Popen(pid_server_cmd + run_sshd_command)
+        p = subprocess.Popen(pid_server_cmd + run_sshd_command, start_new_session=True)
         with det.util.forward_signals(p):
             return p.wait()
 
@@ -196,7 +196,9 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
     # up wanting to launch all -np# processes on the local causing an oversubscription
     # error ("There are not enough slots available in the system").
     os.environ.pop("SLURM_JOBID", None)
-    p = subprocess.Popen(pid_server_cmd + hvd_cmd + worker_wrapper_cmd + script)
+    p = subprocess.Popen(
+        pid_server_cmd + hvd_cmd + worker_wrapper_cmd + script, start_new_session=True
+    )
     with det.util.forward_signals(p):
         return p.wait()
 

--- a/harness/determined/launch/torch_distributed.py
+++ b/harness/determined/launch/torch_distributed.py
@@ -99,7 +99,7 @@ def main(override_args: List[str], script: List[str]) -> int:
 
     logging.debug(f"Torch distributed launching with: {launch_cmd}")
 
-    p = subprocess.Popen(launch_cmd)
+    p = subprocess.Popen(launch_cmd, start_new_session=True)
     with det.util.forward_signals(p):
         return p.wait()
 

--- a/harness/determined/launch/wrap_rank.py
+++ b/harness/determined/launch/wrap_rank.py
@@ -92,7 +92,9 @@ def main() -> int:
     if cwd.endswith("/run/determined/workdir"):
         os.chdir("/run/determined/workdir")
 
-    proc = subprocess.Popen(args.script, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        args.script, stdout=subprocess.PIPE, stderr=subprocess.PIPE, start_new_session=True
+    )
     with det.util.forward_signals(proc):
         with contextlib.ExitStack() as exit_stack:
             if os.path.exists(constants.CONTAINER_STDOUT) and not args.no_redirect_stdio:

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -90,7 +90,9 @@ def test_launch_multi_slot_chief(
         f"-p {constants.DTRAIN_SSH_PORT} -2 -a -x %h"
     )
 
-    mock_subprocess.assert_has_calls([mock.call(sshd_cmd), mock.call(launch_cmd)])
+    mock_subprocess.assert_has_calls(
+        [mock.call(sshd_cmd), mock.call(launch_cmd, start_new_session=True)]
+    )
 
     assert mock_check_sshd.call_count == len(cluster_info.container_addrs)
     mock_check_sshd.assert_has_calls(
@@ -210,7 +212,7 @@ def test_launch_one_slot(
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
     assert os.environ["USE_DEEPSPEED"] == "1"
 
-    mock_subprocess.assert_called_once_with(launch_cmd)
+    mock_subprocess.assert_called_once_with(launch_cmd, start_new_session=True)
 
 
 @mock.patch("subprocess.Popen")
@@ -240,7 +242,7 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
     assert os.environ["USE_DEEPSPEED"] == "1"
 
-    mock_subprocess.assert_called_once_with(launch_cmd)
+    mock_subprocess.assert_called_once_with(launch_cmd, start_new_session=True)
 
 
 @mock.patch("subprocess.Popen")
@@ -265,7 +267,7 @@ def test_launch_worker(
     sshd_cmd = launch.deepspeed.create_sshd_cmd()
 
     expected_cmd = pid_server_cmd + sshd_cmd
-    mock_subprocess.assert_called_once_with(expected_cmd)
+    mock_subprocess.assert_called_once_with(expected_cmd, start_new_session=True)
 
 
 def test_filter_env_vars() -> None:

--- a/harness/tests/launch/test_horovod.py
+++ b/harness/tests/launch/test_horovod.py
@@ -89,7 +89,7 @@ def test_horovod_chief(
 
     if autohorovod and nnodes == 1 and nslots == 1:
         # Single-slot --autohorovod: we should have just called the script directly.
-        mock_popen.assert_has_calls([mock.call(script)])
+        mock_popen.assert_has_calls([mock.call(script, start_new_session=True)])
         mock_check_sshd.assert_not_called()
     else:
         # Multi-slot or non --autohorovod: expect a full horovodrun command.
@@ -97,7 +97,7 @@ def test_horovod_chief(
         assert os.environ["DET_CHIEF_IP"] == info.container_addrs[0]
         assert os.environ["USE_HOROVOD"] == "1"
 
-        mock_popen.assert_has_calls([mock.call(launch_cmd)])
+        mock_popen.assert_has_calls([mock.call(launch_cmd, start_new_session=True)])
 
         assert mock_check_sshd.call_count == len(info.container_addrs[1:])
         mock_check_sshd.assert_has_calls(
@@ -142,7 +142,7 @@ def test_sshd_worker(
     assert os.environ["DET_CHIEF_IP"] == info.container_addrs[0]
     assert os.environ["USE_HOROVOD"] == "1"
 
-    mock_popen.assert_has_calls([mock.call(launch_cmd)])
+    mock_popen.assert_has_calls([mock.call(launch_cmd, start_new_session=True)])
 
     mock_api_post.assert_has_calls(
         [

--- a/harness/tests/launch/test_launch.py
+++ b/harness/tests/launch/test_launch.py
@@ -15,7 +15,7 @@ def do_test_launch(config: Dict[str, Any], cmd: List[str], mock_popen: mock.Magi
     mock_proc.wait.return_value = 99
     mock_popen.return_value = mock_proc
     assert launch.launch(det.ExperimentConfig(config)) == 99
-    mock_popen.assert_called_once_with(cmd)
+    mock_popen.assert_called_once_with(cmd, start_new_session=True)
 
 
 def test_launch_trial() -> None:

--- a/harness/tests/launch/test_torch_distributed.py
+++ b/harness/tests/launch/test_torch_distributed.py
@@ -56,7 +56,7 @@ def test_launch_single_slot(
     launch_cmd += launch.torch_distributed.create_log_redirect_cmd()
     launch_cmd += script
 
-    mock_subprocess.assert_called_once_with(launch_cmd)
+    mock_subprocess.assert_called_once_with(launch_cmd, start_new_session=True)
 
     assert os.environ.get("USE_TORCH_DISTRIBUTED") == "True"
 
@@ -96,7 +96,7 @@ def test_launch_distributed(
     launch_cmd += launch.torch_distributed.create_log_redirect_cmd()
     launch_cmd += script
 
-    mock_subprocess.assert_called_once_with(launch_cmd)
+    mock_subprocess.assert_called_once_with(launch_cmd, start_new_session=True)
 
     assert os.environ["USE_TORCH_DISTRIBUTED"] == "True"
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]


### PR DESCRIPTION
On Slurm job failures we have not reliably been getting the full logs
posted to the master.   When processing task-logging-teardown.sh
on error paths we commonly hit the 30sec timeout and therefore
exit the container which terminates all processing with SIGKILL.
When errors occur horovodrun/pid-server will terminate the top-level
children launched via SIGTERM, however, this only terminates the
top-level children when there are actually multiple layers.  When
only the top-level children are killed others still are holding
stdout/stderr active and therefore the log processing does not shut
down.

The change in this review is to enhance determined.utils.forward_signals method to send the process group of the specified subprocess, instead of just the target process itself.   Additionally, all calls to
subprocess.Popen that are passed to forward_signals have been updated
to include the start_new_session=True parameter which causes a new session and process group to be assigned.


## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
