### PR TITLE
fix: use friendly names for user settings

### DIFF
--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -332,7 +332,8 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                     key={feature}
                     label={
                       <Space>
-                        {feature} <Icon name="info" showTooltip title={description.description} />
+                        {description.friendlyName}
+                        <Icon name="info" showTooltip title={description.description} />
                       </Space>
                     }
                     valueFormatter={(value) => (value ? 'On' : 'Off')}


### PR DESCRIPTION
## Description

This uses the friendly names in the features config for the user settings labels



## Test Plan

- open the settings sidebar
- the feature flags should be labeled with the friendly names, not the flags themselves.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

no ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
