### PR TITLE
chore: Add new `update` function to userSettings store

### DIFF
--- a/webui/react/src/stores/userSettings.test.tsx
+++ b/webui/react/src/stores/userSettings.test.tsx
@@ -86,6 +86,9 @@ describe('userSettings', () => {
       expect(spy).toBeCalledTimes(1);
       const result = store.get(Config, configPath).get();
       expect(Loadable.map(result, (r) => r?.string)).toStrictEqual(Loaded(expectedValue));
+      expect(Loadable.map(result, (r) => r?.stringArray)).toStrictEqual(
+        Loaded(expectedSettings.stringArray),
+      );
     });
   });
 });

--- a/webui/react/src/stores/userSettings.test.tsx
+++ b/webui/react/src/stores/userSettings.test.tsx
@@ -1,0 +1,54 @@
+import * as t from 'io-ts';
+
+import authStore from 'stores/auth';
+import userStore from 'stores/users';
+
+import { UserSettingsStore } from './userSettings';
+
+const CURRENT_USER = { id: 1, isActive: true, isAdmin: false, username: 'bunny' };
+
+vi.mock('services/api', () => ({
+  getUserSetting: () => Promise.resolve({ settings: [] }),
+  updateUserSetting: () => Promise.resolve(),
+}));
+
+const Config = t.type({
+  boolean: t.boolean,
+  booleanArray: t.union([t.array(t.boolean), t.undefined]),
+  number: t.union([t.undefined, t.number]),
+  numberArray: t.array(t.number),
+  string: t.union([t.undefined, t.string]),
+  stringArray: t.union([t.undefined, t.array(t.string)]),
+});
+const configPath = 'settings-normal';
+
+const setup = () => {
+  authStore.setAuth({ isAuthenticated: true });
+  authStore.setAuthChecked();
+  userStore.updateCurrentUser(CURRENT_USER);
+  return new UserSettingsStore();
+};
+
+describe('userSettings', () => {
+  const newSettings = {
+    boolean: false,
+    booleanArray: [false, true],
+    number: 3.14e-12,
+    numberArray: [0, 100, -5280],
+    string: 'Hello World',
+    stringArray: ['abc', 'def', 'ghi'],
+  };
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('should update settings', async () => {
+    const store = setup();
+
+    const p = store
+      .get(Config, configPath)
+      .toPromise()
+      .then((n) => expect(n).toStrictEqual(newSettings));
+    store.set(Config, configPath, newSettings);
+    await p;
+  });
+});

--- a/webui/react/src/stores/userSettings.test.tsx
+++ b/webui/react/src/stores/userSettings.test.tsx
@@ -17,11 +17,11 @@ vi.mock('services/api', () => ({
 
 const Config = t.type({
   boolean: t.boolean,
-  booleanArray: t.union([t.array(t.boolean), t.undefined]),
-  number: t.union([t.undefined, t.number]),
+  booleanArray: t.union([t.array(t.boolean), t.null]),
+  number: t.union([t.null, t.number]),
   numberArray: t.array(t.number),
-  string: t.union([t.undefined, t.string]),
-  stringArray: t.union([t.undefined, t.array(t.string)]),
+  string: t.union([t.null, t.string]),
+  stringArray: t.union([t.null, t.array(t.string)]),
 });
 const configPath = 'settings-normal';
 

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -139,7 +139,7 @@ export class UserSettingsStore extends PollingStore {
       // the user from interacting, just let them know that their settings
       // are not persisting. It's also important to update the value immediately
       // for good rendering performance.
-      setTimeout(() => this.updateUserSetting(key, encodedValue), 0);
+      this.updateUserSetting(key, encodedValue);
       this.#settings.update((settings) => {
         return Loadable.map(settings, (settings) => {
           return settings.set(key, encodedValue);
@@ -173,7 +173,7 @@ export class UserSettingsStore extends PollingStore {
           // the user from interacting, just let them know that their settings
           // are not persisting. It's also important to update the value immediately
           // for good rendering performance.
-          setTimeout(() => this.updateUserSetting(key, newValue), 0);
+          this.updateUserSetting(key, newValue);
           return type.encode(newValue);
         });
       });

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -48,7 +48,10 @@ export class UserSettingsStore extends PollingStore {
           value,
           type.decode,
           match(
-            () => null, // Silently swallow decoding errors
+            () => {
+              console.error(`Setting at key '${key}' could not be decoded as ${type.name}`);
+              return null; // Silently swallow decoding errors
+            },
             (v) => v,
           ),
         );
@@ -161,6 +164,8 @@ export class UserSettingsStore extends PollingStore {
             // Silently discard incorrectly formatted values
             if (isRight(attempt)) {
               value = attempt.right;
+            } else {
+              console.error(`Setting at key '${key}' could not be decoded as ${type.name}`);
             }
           }
           const newValue = fn(value);

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -106,7 +106,11 @@ export class UserSettingsStore extends PollingStore {
    * @param value New value of the setting
    */
   public set<T>(type: t.Type<T>, key: string, value: T): void;
-  public set<T extends t.Props>(type: t.TypeC<T>, key: string, value: Partial<T>): void;
+  public set<T extends t.Props>(
+    type: t.TypeC<T>,
+    key: string,
+    value: t.TypeOfPartialProps<T>,
+  ): void;
   public set<T>(type: t.Encoder<T, Json>, key: string, value: T): void;
   public set<T>(type: t.Encoder<T, Json> | t.TypeC<t.Props>, key: string, value: T): void {
     if (isTypeC(type)) {
@@ -143,12 +147,15 @@ export class UserSettingsStore extends PollingStore {
 
   /**
    * This updates the value of a setting and persists it for future sessions.
-   * If the setting value is an object you can pass a partial value and
-   * if will be merged with the previous value.
    * @param type The type of the value or an encoder of the value to JSON.
    * @param key Unique key to store and retrieve the settings
    * @param fn Function to update the value of the setting at `key`
    */
+  public update<T extends t.Props, U = t.TypeOfProps<T>>(
+    type: t.TypeC<T>,
+    key: string,
+    fn: (value: U | undefined) => U,
+  ): void;
   public update<T>(type: t.Type<T, Json>, key: string, fn: (value: T | undefined) => T): void {
     this.#settings.update((settings) => {
       return Loadable.map(settings, (settings) => {

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -1,4 +1,4 @@
-import { match } from 'fp-ts/Either';
+import { isRight, match } from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import { Map } from 'immutable';
 import * as t from 'io-ts';
@@ -7,7 +7,7 @@ import { getUserSetting, resetUserSetting, updateUserSetting } from 'services/ap
 import { V1GetUserSettingResponse, V1UserWebSetting } from 'services/api-ts-sdk';
 import { Json, JsonObject } from 'types';
 import { isJsonObject, isObject } from 'utils/data';
-import handleError, { ErrorType } from 'utils/error';
+import handleError, { DetError, ErrorType } from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import { observable, Observable, WritableObservable } from 'utils/observable';
 
@@ -25,7 +25,7 @@ function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
  * This stores per-user settings. These are values that affect how the UI functions
  * and are limited in scope to the logged-in user.
  */
-class UserSettingsStore extends PollingStore {
+export class UserSettingsStore extends PollingStore {
   readonly #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
 
   /**
@@ -60,7 +60,7 @@ class UserSettingsStore extends PollingStore {
     return this.#settings.readOnly();
   }
 
-  public async overwrite(settings: State) {
+  public async overwrite(settings: State): Promise<void> {
     const settingsArray = Object.entries(settings.toJS()).flatMap(([storagePath, settings]) =>
       !!settings && isObject(settings)
         ? Object.entries(settings).map(([key, value]) => ({
@@ -84,7 +84,7 @@ class UserSettingsStore extends PollingStore {
     }
   }
 
-  public async clear() {
+  public async clear(): Promise<void> {
     try {
       await resetUserSetting({});
       this.#settings.set(Loaded(Map()));
@@ -132,7 +132,7 @@ class UserSettingsStore extends PollingStore {
       // the user from interacting, just let them know that their settings
       // are not persisting. It's also important to update the value immediately
       // for good rendering performance.
-      this.updateUserSetting(key, encodedValue);
+      setTimeout(() => this.updateUserSetting(key, encodedValue), 0);
       this.#settings.update((settings) => {
         return Loadable.map(settings, (settings) => {
           return settings.set(key, encodedValue);
@@ -141,8 +141,39 @@ class UserSettingsStore extends PollingStore {
     }
   }
 
+  /**
+   * This updates the value of a setting and persists it for future sessions.
+   * If the setting value is an object you can pass a partial value and
+   * if will be merged with the previous value.
+   * @param type The type of the value or an encoder of the value to JSON.
+   * @param key Unique key to store and retrieve the settings
+   * @param fn Function to update the value of the setting at `key`
+   */
+  public update<T>(type: t.Type<T, Json>, key: string, fn: (value: T | undefined) => T): void {
+    this.#settings.update((settings) => {
+      return Loadable.map(settings, (settings) => {
+        return settings.update(key, (jsonValue) => {
+          let value: T | undefined = undefined;
+          if (jsonValue !== undefined) {
+            const attempt = type.decode(jsonValue);
+            if (isRight(attempt)) {
+              value = attempt.right;
+            }
+          }
+          const newValue = fn(value);
+          // This is non-blocking. If the API call fails we don't want to block
+          // the user from interacting, just let them know that their settings
+          // are not persisting. It's also important to update the value immediately
+          // for good rendering performance.
+          setTimeout(() => this.updateUserSetting(key, newValue), 0);
+          return type.encode(newValue);
+        });
+      });
+    });
+  }
+
   /** Clears the setting, returning it to `null`. */
-  public remove(key: string) {
+  public remove(key: string): void {
     this.updateUserSetting(key, null);
     this.#settings.update((loadable) => {
       return Loadable.map(loadable, (map) => {
@@ -154,11 +185,11 @@ class UserSettingsStore extends PollingStore {
   /**
    * This resets the store to its initial state, useful for logging the user out.
    */
-  public reset() {
+  public reset(): void {
     this.#settings.set(NotLoaded);
   }
 
-  protected async poll() {
+  protected async poll(): Promise<void> {
     try {
       const response = await getUserSetting({ signal: this.canceler?.signal });
       this.updateSettingsFromResponse(response);
@@ -179,7 +210,7 @@ class UserSettingsStore extends PollingStore {
     }
   }
 
-  protected updateSettingsFromResponse(response: V1GetUserSettingResponse) {
+  protected updateSettingsFromResponse(response: V1GetUserSettingResponse): void {
     this.#settings.update((loadable) => {
       let newSettings: State = Loadable.getOrElse(Map(), loadable);
 
@@ -211,10 +242,10 @@ class UserSettingsStore extends PollingStore {
   //   and flexibility that way
   // - API should support setting non-objects as values directly like a regular
   //   key/value store.
-  protected updateUserSetting<T>(key: string, value: T) {
+  protected updateUserSetting<T>(key: string, value: T): Promise<void | DetError> {
     const dbUpdates: Array<V1UserWebSetting> = [];
     if (isObject(value)) {
-      const settings = value as { [key: string]: unknown };
+      const settings = value as unknown as { [key: string]: unknown };
       dbUpdates.push(
         ...Object.keys(settings).reduce<V1UserWebSetting[]>((acc, setting) => {
           return [

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -163,6 +163,7 @@ export class UserSettingsStore extends PollingStore {
           let value: T | undefined = undefined;
           if (jsonValue !== undefined) {
             const attempt = type.decode(jsonValue);
+            // Silently discard incorrectly formatted values
             if (isRight(attempt)) {
               value = attempt.right;
             }

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -151,11 +151,6 @@ export class UserSettingsStore extends PollingStore {
    * @param key Unique key to store and retrieve the settings
    * @param fn Function to update the value of the setting at `key`
    */
-  public update<T extends t.Props, U = t.TypeOfProps<T>>(
-    type: t.TypeC<T>,
-    key: string,
-    fn: (value: U | undefined) => U,
-  ): void;
   public update<T>(type: t.Type<T, Json>, key: string, fn: (value: T | undefined) => T): void {
     this.#settings.update((settings) => {
       return Loadable.map(settings, (settings) => {

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -21,7 +21,7 @@ export type JsonArray = Array<Json>;
 export interface JsonObject {
   [key: string]: Json;
 }
-export type Json = string | number | null | JsonArray | JsonObject;
+export type Json = string | number | boolean | null | JsonArray | JsonObject;
 
 export interface Pagination {
   limit: number;


### PR DESCRIPTION
## Description

This adds a new update function to the userSettings store which allows updating the settings at a storageKey given an updater function, similar to `setState((oldState) => newState)`



## Test Plan

Unit tests should pass



## Commentary (optional)

During testing, I found that the types for `set` and `update` did not work for the test interface, so those are updated as well.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
no ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
