### PR TITLE
chore: remove double newline in cli error messages

### DIFF
--- a/harness/determined/cli/cli.py
+++ b/harness/determined/cli/cli.py
@@ -193,7 +193,7 @@ def die(message: str, always_print_traceback: bool = False, exit_code: int = 1) 
 
         traceback.print_exc(file=sys.stderr)
 
-    print(colored(message + "\n", "red"), file=sys.stderr)
+    print(colored(message, "red"), file=sys.stderr, end="\n")
     exit(exit_code)
 
 


### PR DESCRIPTION
## Description

we used to print at least two newline characters at the end of every exception handled by the CLI that called the `die` handler. Here we remove one of those.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

call a cli command that errors out
```
det e describe a2341
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

```
parser.exit(exit_code, colored(message + "\n", "red"))
```
was changed to print as part of some good refactoring and I think we unintentionally introduced double `\n` 

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
