### PR TITLE
test: fix rbac test failures

### DIFF
--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -283,94 +283,100 @@ def test_rbac_permission_assignment() -> None:
 @pytest.mark.e2e_cpu_rbac
 @pytest.mark.skipif(roles_not_implemented(), reason="ee is required for this test")
 def test_rbac_permission_assignment_errors() -> None:
-    # Specifying args incorrectly.
-    det_cmd_expect_error(["rbac", "assign-role", "Viewer"], "must provide exactly one of")
-    det_cmd_expect_error(["rbac", "unassign-role", "Viewer"], "must provide exactly one of")
-    det_cmd_expect_error(
-        [
-            "rbac",
-            "assign-role",
-            "Viewer",
-            "--username-to-assign",
-            "u",
-            "--group-name-to-assign",
-            "g",
-        ],
-        "must provide exactly one of",
-    )
-    det_cmd_expect_error(
-        [
-            "rbac",
-            "unassign-role",
-            "Viewer",
-            "--username-to-assign",
-            "u",
-            "--group-name-to-assign",
-            "g",
-        ],
-        "must provide exactly one of",
-    )
-
-    # Non existent role.
-    det_cmd_expect_error(
-        ["rbac", "assign-role", "fakeRoleNameThatDoesntExist", "--username-to-assign", "admin"],
-        "could not find role name",
-    )
-    det_cmd_expect_error(
-        ["rbac", "unassign-role", "fakeRoleNameThatDoesntExist", "--username-to-assign", "admin"],
-        "could not find role name",
-    )
-
-    # Non existent user
-    det_cmd_expect_error(
-        ["rbac", "assign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
-        "could not find user",
-    )
-    det_cmd_expect_error(
-        ["rbac", "unassign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
-        "could not find user",
-    )
-
-    # Non existent group.
-    det_cmd_expect_error(
-        ["rbac", "assign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
-        "could not find user group",
-    )
-    det_cmd_expect_error(
-        ["rbac", "unassign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
-        "could not find user group",
-    )
-
-    # Non existent workspace
-    det_cmd_expect_error(
-        [
-            "rbac",
-            "assign-role",
-            "Viewer",
-            "--workspace-name",
-            "fakeWorkspace",
-            "--username-to-assign",
-            "admin",
-        ],
-        "not found",
-    )
-    det_cmd_expect_error(
-        [
-            "rbac",
-            "unassign-role",
-            "Viewer",
-            "--workspace-name",
-            "fakeWorkspace",
-            "--username-to-assign",
-            "admin",
-        ],
-        "not found",
-    )
-
     api_utils.configure_token_store(ADMIN_CREDENTIALS)
-    test_user_creds = api_utils.create_test_user()
-    group_name = get_random_string()
     with logged_in_user(ADMIN_CREDENTIALS):
+        # Specifying args incorrectly.
+        det_cmd_expect_error(["rbac", "assign-role", "Viewer"], "must provide exactly one of")
+        det_cmd_expect_error(["rbac", "unassign-role", "Viewer"], "must provide exactly one of")
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--username-to-assign",
+                "u",
+                "--group-name-to-assign",
+                "g",
+            ],
+            "must provide exactly one of",
+        )
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "unassign-role",
+                "Viewer",
+                "--username-to-assign",
+                "u",
+                "--group-name-to-assign",
+                "g",
+            ],
+            "must provide exactly one of",
+        )
+
+        # Non existent role.
+        det_cmd_expect_error(
+            ["rbac", "assign-role", "fakeRoleNameThatDoesntExist", "--username-to-assign", "admin"],
+            "could not find role name",
+        )
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "unassign-role",
+                "fakeRoleNameThatDoesntExist",
+                "--username-to-assign",
+                "admin",
+            ],
+            "could not find role name",
+        )
+
+        # Non existent user
+        det_cmd_expect_error(
+            ["rbac", "assign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
+            "could not find user",
+        )
+        det_cmd_expect_error(
+            ["rbac", "unassign-role", "Viewer", "--username-to-assign", "fakeUserNotExist"],
+            "could not find user",
+        )
+
+        # Non existent group.
+        det_cmd_expect_error(
+            ["rbac", "assign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
+            "could not find user group",
+        )
+        det_cmd_expect_error(
+            ["rbac", "unassign-role", "Viewer", "--group-name-to-assign", "fakeGroupNotExist"],
+            "could not find user group",
+        )
+
+        # Non existent workspace
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "assign-role",
+                "Viewer",
+                "--workspace-name",
+                "fakeWorkspace",
+                "--username-to-assign",
+                "admin",
+            ],
+            "not found",
+        )
+        det_cmd_expect_error(
+            [
+                "rbac",
+                "unassign-role",
+                "Viewer",
+                "--workspace-name",
+                "fakeWorkspace",
+                "--username-to-assign",
+                "admin",
+            ],
+            "not found",
+        )
+
+        test_user_creds = api_utils.create_test_user()
+        group_name = get_random_string()
         det_cmd(["user-group", "create", group_name], check=True)
         det_cmd(["rbac", "assign-role", "Viewer", "--group-name-to-assign", group_name], check=True)
         det_cmd(
@@ -569,7 +575,7 @@ def test_rbac_describe_role() -> None:
             check=True,
         )
 
-        sess = api_utils.determined_test_session()
+        sess = api_utils.determined_test_session(ADMIN_CREDENTIALS)
         user_id = usernames_to_user_ids(sess, [test_user_creds.username])[0]
         group_id = group_name_to_group_id(sess, group_name)
 


### PR DESCRIPTION
## Description

RBAC test failures that occurred when we switched these tests from running on OSS permission model to RBAC model.


## Test Plan

Tests pass here https://github.com/determined-ai/determined-ee/pull/969/files



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
