### PR TITLE
ci: Conda bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,16 +384,15 @@ commands:
                   bash "./${CONDA_INSTALLER}" -u -b -p "${CONDA_DIR}"
                   rm -f "./${CONDA_INSTALLER}"
 
-                  ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION}
+                  ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION} requests==2.27.0
                   ${CONDA_DIR}/bin/conda update --prefix ${CONDA_DIR} --all -y
                   ${CONDA_DIR}/bin/conda clean --all -y
-                  
-                  pip install requests==2.27.0
                   EOF
 
             - run:
                 name: run conda install_python.sh
                 command: |
+                  pip install requests==2.27.0
                   sudo bash /tmp/install_python.sh <<parameters.python-version>>
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ commands:
 
                   CONDA_DIR="/opt/conda"
                   CONDA_INSTALLER="Miniconda3-py39_23.5.2-0-Linux-x86_64.sh"
-                  CONDA_MD5="9829d95f639bd0053b2ed06d1204e60644617bf37dd5cc57523732e0e8d64516"
+                  CONDA_SHA256="9829d95f639bd0053b2ed06d1204e60644617bf37dd5cc57523732e0e8d64516"
                   CONDA_URL="https://repo.anaconda.com/miniconda"
 
                   mkdir -p /etc/determined/conda.d
@@ -380,7 +380,7 @@ commands:
 
                   cd /tmp
                   curl --retry 3 -fsSL -O "${CONDA_URL}/${CONDA_INSTALLER}"
-                  echo "${CONDA_MD5}  ${CONDA_INSTALLER}" | md5sum -c -
+                  echo "${CONDA_SHA256}  ${CONDA_INSTALLER}" | sha256sum ${CONDA_INSTALLER}
                   bash "./${CONDA_INSTALLER}" -u -b -p "${CONDA_DIR}"
                   rm -f "./${CONDA_INSTALLER}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,8 @@ commands:
                   ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION}
                   ${CONDA_DIR}/bin/conda update --prefix ${CONDA_DIR} --all -y
                   ${CONDA_DIR}/bin/conda clean --all -y
+                  
+                  pip install requests==2.27.0
                   EOF
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,6 @@ commands:
             - run:
                 name: run conda install_python.sh
                 command: |
-                  pip install requests==2.27.0
                   sudo bash /tmp/install_python.sh <<parameters.python-version>>
 
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,8 +371,8 @@ commands:
                   PYTHON_VERSION="${1}"
 
                   CONDA_DIR="/opt/conda"
-                  CONDA_INSTALLER="Miniconda3-py39_4.10.3-Linux-x86_64.sh"
-                  CONDA_MD5="8c69f65a4ae27fb41df0fe552b4a8a3b"
+                  CONDA_INSTALLER="Miniconda3-py39_23.5.2-0-Linux-x86_64.sh"
+                  CONDA_MD5="9829d95f639bd0053b2ed06d1204e60644617bf37dd5cc57523732e0e8d64516"
                   CONDA_URL="https://repo.anaconda.com/miniconda"
 
                   mkdir -p /etc/determined/conda.d
@@ -384,7 +384,6 @@ commands:
                   bash "./${CONDA_INSTALLER}" -u -b -p "${CONDA_DIR}"
                   rm -f "./${CONDA_INSTALLER}"
 
-                  ${CONDA_DIR}/bin/conda install requests==2.27.0
                   ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION}
                   ${CONDA_DIR}/bin/conda update --prefix ${CONDA_DIR} --all -y
                   ${CONDA_DIR}/bin/conda clean --all -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,8 @@ commands:
                   bash "./${CONDA_INSTALLER}" -u -b -p "${CONDA_DIR}"
                   rm -f "./${CONDA_INSTALLER}"
 
-                  ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION} requests==2.27.0
+                  ${CONDA_DIR}/bin/conda install requests==2.27.0
+                  ${CONDA_DIR}/bin/conda install python=${PYTHON_VERSION}
                   ${CONDA_DIR}/bin/conda update --prefix ${CONDA_DIR} --all -y
                   ${CONDA_DIR}/bin/conda clean --all -y
                   EOF


### PR DESCRIPTION
## Description

Fix `install_python.sh` script. Conda no longer supports `requests<2.27.0`, but the particular version of conda that we were using is force installing `requests==2.25.1`. Bump `conda` version to latest stable.



## Test Plan

`test_ing` must be green.


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
