### PR TITLE
fix: Improve HPC error shutdown to improve logging [FE-44]

### DIFF
--- a/harness/determined/exec/pid_server.py
+++ b/harness/determined/exec/pid_server.py
@@ -23,6 +23,12 @@ if __name__ == "__main__":
     parser.add_argument("-x", "--on-fail", dest="on_fail", action="store", default="SIGTERM")
     parser.add_argument("-e", "--on-exit", dest="on_exit", action="store", default="WAIT")
     parser.add_argument("--grace-period", dest="grace_period", type=int, default=3)
+    parser.add_argument(
+        "--signal-children",
+        dest="signal_children",
+        action="store_true",
+        help="When sending signals, forward to children as well.",
+    )
     parser.add_argument("addr")
     parser.add_argument("num_workers", type=int)
     parser.add_argument("cmd")
@@ -40,5 +46,6 @@ if __name__ == "__main__":
                 on_fail=on_fail,
                 on_exit=on_exit,
                 grace_period=args.grace_period,
+                signal_children=args.signal_children,
             ),
         )

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -444,6 +444,7 @@ class PIDServer:
         on_fail: Optional[signal.Signals] = None,
         on_exit: Optional[signal.Signals] = None,
         grace_period: int = 3,
+        signal_children: bool = False,
     ) -> int:
         p = subprocess.Popen(cmd)
 
@@ -457,7 +458,7 @@ class PIDServer:
             if ret is not None:
                 raise HealthCheckFail(ret)
 
-        with det.util.forward_signals(p):
+        with det.util.forward_signals(p, signal_children=signal_children):
             try:
                 self.run(health_check)
             except HealthCheckFail as e:
@@ -467,6 +468,8 @@ class PIDServer:
                 if on_fail is not None:
                     # Let things finish logging, exiting on their own, etc.
                     time.sleep(grace_period)
+                    if signal_children:
+                        det.util.signal_process_tree(p, on_fail)
                     p.send_signal(on_fail)
                     if on_fail != signal.SIGKILL:
                         try:

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -93,6 +93,7 @@ def create_pid_server_cmd(allocation_id: str, num_workers: int) -> List[str]:
         "SIGTERM",
         "--grace-period",
         "5",
+        "--signal-children",
         f"/tmp/pid_server-{allocation_id}",
         str(num_workers),
         "--",

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -34,6 +34,7 @@ def create_sshd_worker_cmd(
         "SIGTERM",
         "--on-exit",
         "SIGTERM",
+        "--signal-children",
         f"/tmp/pid_server-{allocation_id}",
         str(num_slot_ids),
         "--",

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -34,6 +34,8 @@ from typing import (
     cast,
 )
 
+import psutil
+
 import determined as det
 from determined import constants
 from determined.common import check, util
@@ -406,15 +408,39 @@ def force_create_symlink(src: str, dst: str) -> None:
             logging.warning(f"{err} trying to remove {dst}")
 
 
+def signal_process_tree(p: subprocess.Popen, signum: Any) -> None:
+    """Send a signal to all children under the specified process, but
+    not the process itself.  This was specifically added for SIGTERM
+    which may leave some children running due to multiple layers of
+    processes (particularly children of sshd).
+    """
+
+    try:
+        children = psutil.Process(p.pid).children(recursive=True)
+        for cp in children:
+            cp.send_signal(signum)
+    except Exception as err:
+        logging.error(f"{err} trying to forward signal {signum} to children")
+        pass
+
+
 @contextlib.contextmanager
-def forward_signals(p: subprocess.Popen, *signums: signal.Signals) -> Iterator[None]:
-    """Forward a list of signals to a subprocess, restoring the original handlers afterwards."""
+def forward_signals(
+    p: subprocess.Popen, *signums: signal.Signals, signal_children: bool = False
+) -> Iterator[None]:
+    """Forward a list of signals to a subprocess (and optionally all its children),
+    restoring the original handlers afterwards.
+
+    @param signal_children If true forward the signal to all the children as well.
+    """
     if not signums:
         # Pick a useful default for wrapper processes.
         names = ["SIGINT", "SIGTERM", "SIGHUP", "SIGUSR1", "SIGUSR2", "SIGWINCH", "SIGBREAK"]
         signums = tuple(getattr(signal, name) for name in names if hasattr(signal, name))
 
     def signal_passthru(signum: Any, frame: Any) -> None:
+        if signal_children:
+            signal_process_tree(p, signum)
         p.send_signal(signum)
 
     old_handlers = [None for n in signums]  # type: List[Any]

--- a/master/static/srv/task-logging-teardown.sh
+++ b/master/static/srv/task-logging-teardown.sh
@@ -11,8 +11,24 @@ epoch_seconds() {
     printf '%(%s)T\n' -1
 }
 
-# Wait for 30 seconds total for the logging to finish, otherwise just exit.
+# Wait for up to DET_LOG_WAIT_TIME seconds for the logging to finish
+# At this point the launching entry point script has exited and we are
+# waiting for the child logging processes to complete.  The child
+# processes will exit when reaching EOF of the log stream they are
+# processing, so in the normal case they terminate quickly and
+# each stream processor writes a single character to the DET_LOG_WAIT_FIFO
+# to indicate they are no longer waiting.
+#
+# This wait time it to handle the case when log stream procesors have
+# not exited yet -- either becuase someone is still writing to the stream,
+# or the DET_MASTER is not reachable and therefor we are slow in flushing
+# the logs to the master.
+#
+# After this wait, the container entrypoint immediately exits and all
+# processing within the container is SIGKILLed without any opportunity
+# for any furhter processing, so avoiding a premature exit is important.
 waitfor="${DET_LOG_WAIT_TIME:-30}"
+
 deadline="$(($(epoch_seconds) + waitfor))"
 timeout="$((deadline - $(epoch_seconds)))"
 


### PR DESCRIPTION
## Description

On Slurm job failures we do not reliably get the full logs
posted to the master from non-chief ranks.   When processing task-logging-teardown.sh
on error paths we commonly hit the 30sec timeout and therefore
end up with the entrypoint returning which which results in
termination of all processing with SIGKILL.
When errors occur pid-server will terminate the top-level
children launched via SIGTERM, however, this only terminates the
top-level children when there are actually multiple layers with
various process groups under the sshd.  When
only the top-level children are killed others still are holding
stdout/stderr active and therefore the log processing does not shut
down cleanly leading to potential message loss.

This change adds --signal-children support to the pid_server such that whenever a signal is forwarded it is also forwarded to all children launched under that the subprocess.  When deepspeed/horovod launch the remote sshd, this option is
added so that on shutdown we ensure that children under the sshd are shutdown as well as the sshd itself which enables logging to get flushed properly.

This impact of this change is limited to failure cases with sshd (non-chief nodes) in distributed (deepspeed/horovod) jobs where --signal-children is now specified.   When a signal targets the pid_server it is forwarded to all children of sshd as well.  If the --on-failed signal is sent, it too forwarded to all children of sshd.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

## Test Plan

1. With a distributed horovod job simulate a failure with kill -TERM {pid_server} and verify proper job cleanup and that Determined logs end with the same output as the Slurm logs.   Verified on shuco (3 nodes, 2 slots per node) & horizon.
2. Verified successful distributed horovod job on shuco (3 nodes, 2 slots per node)
3. Pause/Resume distributed horovod job on shuco (3 nodes, 2 slots per node)
4. Stop distributed horovod job on shuco (3 nodes, 2 slots per node)
5. Kill distributed horovod job on shuco (3 nodes, 2 slots per node)



<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

FE-44
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
