### PR TITLE
fix: det tunnel should work with proxy port exposed [FE-121]

### DIFF
--- a/master/static/srv/command-entrypoint.sh
+++ b/master/static/srv/command-entrypoint.sh
@@ -14,6 +14,10 @@ fi
 
 set -e
 
+if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
+    "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+fi
+
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy
 
 trap_and_forward_signals

--- a/master/static/srv/command-entrypoint.sh
+++ b/master/static/srv/command-entrypoint.sh
@@ -3,22 +3,31 @@
 source /run/determined/task-signal-handling.sh
 source /run/determined/task-logging-setup.sh
 
+set -e
+
 if [ -z "$DET_PYTHON_EXECUTABLE" ]; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
-if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1; then
-    echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
+
+# Check if Python is available in the container.
+if which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1; then
+    # In order to be able to use a proxy when running a command, Python must be
+    # available in the container, and the "determined*.whl" must be installed,
+    # which contains the "determined/exec/prep_container.py" script that's needed
+    # to register the proxy with the Determined master.
+    if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
+        "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
+    fi
+
+    "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy
+else
+    # Not all commands will require that Python be installed in the container.
+    # Some of the e2e tests use an image that does not contain Python, so we
+    # don't want to fail the test in those cases.  Therefore, issue a warning,
+    # but do not exit the script.
+    echo "warn: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
     echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
-    exit 1
 fi
-
-set -e
-
-if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
-    "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
-fi
-
-"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy
 
 trap_and_forward_signals
 if [ "$#" -eq 1 ]; then

--- a/master/static/srv/command-entrypoint.sh
+++ b/master/static/srv/command-entrypoint.sh
@@ -3,7 +3,18 @@
 source /run/determined/task-signal-handling.sh
 source /run/determined/task-logging-setup.sh
 
+if [ -z "$DET_PYTHON_EXECUTABLE" ]; then
+    export DET_PYTHON_EXECUTABLE="python3"
+fi
+if ! which "$DET_PYTHON_EXECUTABLE" >/dev/null 2>&1; then
+    echo "error: unable to find python3 as \"$DET_PYTHON_EXECUTABLE\"" >&2
+    echo "please install python3 or set the environment variable DET_PYTHON_EXECUTABLE=/path/to/python3" >&2
+    exit 1
+fi
+
 set -e
+
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy
 
 trap_and_forward_signals
 if [ "$#" -eq 1 ]; then


### PR DESCRIPTION
## Description

**Note:** Some e2e tests, such as `tests/command/test_run.py::test_image_pull_after_remove` use an image (e.g., `environment.image=archlinux:base-20211010.0.36274`) that does not contain Python.  Therefore, in order to prevent the test from failing, I've changed `command-entrypoint.sh` to not exit if Python is not installed.

Anoop reported that when running a command from the MAC laptop with the Determined devcluster (i.e., `tools/slurmcluster.sh`) pointing to the `grenoble` cluster, tunneling wasn't working when the proxy port was configured.

To reproduce the issue observed by Anoop, perform the following steps:

1. On your MAC laptop, start the dev launcher and point it to the `grenoble` cluster.

```
(base) rcorujo@C02FJ0T8MD6Q hpc-ard-capsules-core % ./loadDevLauncher.sh -d o184i054.gre.smktg.hpecorp.net
```

2. On your MAC laptop, start the Determined devcluster and point it to the `grenoble` cluster.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q determined-ee % tools/slurmcluster.sh -d o184i054
```

3. Create the following `config-client.yaml` file. It references the `mlde_cpus` pool on the `grenoble` cluster.  If you are pointing to a different cluster, then use a resource pool that is appropriate for that cluster.  For example, if you were referencing the `casablanca-login` cluster, you would use the resource pool `cpuQ`.

```
resources:
  resource_pool: mlde_cpus
environment:
  environment_variables:
    - https_proxy=http://web-proxy.bbn.hpecorp.net:8088
    - http_proxy=http://web-proxy.bbn.hpecorp.net:8088
    - GRADIO_NUM_PORTS=1
    - MODEL_INF_END_POINT=http://16.16.186.225:8080
  proxy_ports:
    - proxy_port: 7860
      proxy_tcp: true
      unauthenticated: true
  image:
    cpu: anoophpe/tgi-client:1.0 
```

4. Run the command using the `config-client.yaml` file shown above.

```
det command run --config-file config-client.yaml "cd /app && python app.py"
Launched command (id: 06e05fd4-c482-48d5-9dda-6c37f81543ec).
...
```

5. Start your Determined tunnel, which is supposed to allow you to access a port on the container by referencing `localhost:port` from your MAC laptop.  Make sure you set your `DET_MASTER` environment variable appropriately (e.g.,`DET_MASTER=localhost:8081`) and set `TASK_ID` to the ID returned by the command (e.g., `06e05fd4-c482-48d5-9dda-6c37f81543ec` in the example above).

```
python -m determined.cli.tunnel --listener 7860 $DET_MASTER $TASK_ID:7860
```
6. Trying to access `http://localhost:7860` from a browser on your MAC laptop will fail.

7. Similarly, running `wget http://localhost:7860` from a bash shell on your MAC laptop will also fail.



The root cause of problem is two-fold. 

The first issue is that the `command-entrypoint.sh` does not contain the `prep_container --proxy`, like the `shell-entrypoint.sh` does, so the proxies are not registered in the master.

However, even after adding `prep_container --proxy` to `command-entrypoint.sh`, an attempt to connect to `http://localhost:7860` still fails.

To further analyze the second issue as to why we still can't connect, we have to exec into Anoop's container to see what the `gradio` application that we're trying to connect to is doing.  We can do this from our MAC laptop.

```
docker run -it anoophpe/tgi-client:1.0 /bin/bash 
```

In `/opt/conda/lib/python3.8/site-packages/gradio/networking.py` inside the container, we can see that it’s binding to `127.0.0.1` if the `GRADIO_SERVER_NAME` environment variable is not set.  This means that the `gradio` application will only accept connections originating from the localhost, which explains the reason why we cannot connect.

```
INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
TRY_NUM_PORTS = int(os.getenv("GRADIO_NUM_PORTS", "100"))
LOCALHOST_NAME = os.getenv("GRADIO_SERVER_NAME", "127.0.0.1")

...

         s = socket.socket()
         s.bind((LOCALHOST_NAME, server_port))
```

To resolve this, we can set `GRADIO_SERVER_NAME=0.0.0.0` in the `config-client.yaml` to bind to all available IPv4 addresses (i.e., accept connections from any network interface).

```
resources:
  resource_pool: mlde_cpus
  #resource_pool: cpuQ
environment:
  environment_variables:
    - https_proxy=http://web-proxy.bbn.hpecorp.net:8088
    - http_proxy=http://web-proxy.bbn.hpecorp.net:8088
    - GRADIO_NUM_PORTS=1
    - MODEL_INF_END_POINT=http://16.16.186.225:8080
    - GRADIO_SERVER_NAME=0.0.0.0
  proxy_ports:
    - proxy_port: 7860
      proxy_tcp: true
      unauthenticated: true
  image:
    cpu: anoophpe/tgi-client:1.0 
```

Now when I run the Determined command, you can see it says `Running on local URL:  http://0.0.0.0:7860`.

```
(base) rcorujo@C02FJ0T8MD6Q documents % PYTHONPATH=$HOME/IdeaProjects/FE-121_det_tunnel_should_work_with_proxy_port_exposed/determined-ee/harness  DET_MASTER=localhost:8081 det command run --config-file config-client_rig.yaml "cd /app && python app.py"
Launched command (id: b7d90efd-044d-4fde-b180-b9e615701cd9).
[2023-07-26T21:32:09.962151Z]          || INFO: Scheduling Command (virtually-rare-collie) (id: b7d90efd-044d-4fde-b180-b9e615701cd9)
[2023-07-26T21:32:20.797635Z]          || INFO: HPC Job ID: 138
[2023-07-26T21:32:20.797766Z]          || INFO: Command (virtually-rare-collie) was assigned to an agent
[2023-07-26T21:32:25.055339Z] [cont=0] || WARNING: [302891] root: falling back to naive proxy ip resolution (error=None)
[2023-07-26T21:32:30.661529Z]          || INFO: Resources for Command (virtually-rare-collie) have started
[2023-07-26T21:32:34.007477Z] [cont=0] || Running on local URL:  http://0.0.0.0:7860
[2023-07-26T21:32:34.007575Z] [cont=0] || 
[2023-07-26T21:32:34.007612Z] [cont=0] || To create a public link, set `share=True` in `launch()`.
```

Then I start the Determined tunnel.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q NOTES % python3 -m determined.cli.tunnel --listener 7860 $DET_MASTER b7d90efd-044d-4fde-b180-b9e615701cd9:7860
```

From my MAC laptop, I am now able to connect to the `gradio` application running on the compute node.

```
(base) rcorujo@C02FJ0T8MD6Q ~ % wget http://localhost:7860
--2023-07-26 17:33:14--  http://localhost:7860/
Resolving localhost (localhost)... ::1, 127.0.0.1
Connecting to localhost (localhost)|::1|:7860... failed: Connection refused.
Connecting to localhost (localhost)|127.0.0.1|:7860... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7428 (7.3K) [text/html]
Saving to: ‘index.html’

index.html                                                 100%[========================================================================================================================================>]   7.25K  --.-KB/s    in 0s      

2023-07-26 17:33:14 (354 MB/s) - ‘index.html’ saved [7428/7428]
```

I can also now connect to the UI from a browser on my MAC laptop.


![image](https://github.com/determined-ai/determined/assets/90728398/0cc71a1c-6aae-4323-b54e-57099ffe0d13)


## Test Plan

Performed the steps mentioned above on both the `casablanca-login` and `grenoble` clusters.  In both cases, I was able to connect to the `gradio` application that's running in Anoop's container on the compute node using`http://localhost:7860` from a browser on my MAC laptop.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
