### PR TITLE
feat: Replace sum and count training metrics with mean in new experiment list

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -245,7 +245,7 @@ func (a *apiServer) getProjectColumnsByID(
 						}
 						// don't surface aggregates that don't make sense for non-numbers
 						if columnType == projectv1.ColumnType_COLUMN_TYPE_NUMBER {
-							aggregates := []string{"count", "last", "max", "min", "sum"}
+							aggregates := []string{"last", "max", "mean", "min"}
 							for _, aggregate := range aggregates {
 								columns = append(columns, &projectv1.ProjectColumn{
 									Column:   fmt.Sprintf("training.%s.%s", key, aggregate),

--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -416,28 +416,34 @@ func (e experimentFilter) toSQL(q *bun.SelectQuery,
 				"."+metricQualifier)
 			if !slices.Contains(SummaryMetricStatistics, metricQualifier) {
 				return nil, status.Errorf(codes.InvalidArgument,
-					"sort training metrics by statistic: count, last, max, min, or sum")
+					"sort training metrics by statistic: last, max, min, or mean")
 			}
-			col := `trials.summary_metrics->'avg_metrics'->?->>?`
+			var col string
 			var queryArgs []interface{}
 			var queryString string
-			switch queryColumnType {
-			case projectv1.ColumnType_COLUMN_TYPE_NUMBER.String():
+			if metricQualifier == "mean" {
+				locator := bun.Safe(fmt.Sprintf(`trials.summary_metrics->'avg_metrics'->'%s'`, metricName))
+				col = fmt.Sprintf(`(?->>'sum')::float8 / (?->>'count')::int`)
+				queryArgs = append(queryArgs, locator, locator)
+			} else {
+				col = `trials.summary_metrics->'avg_metrics'->?->>?`
+				queryArgs = append(queryArgs, metricName, metricQualifier)
+			}
+			if queryColumnType == projectv1.ColumnType_COLUMN_TYPE_NUMBER.String() {
 				col = fmt.Sprintf(`(%v)::float8`, col)
 			}
 			switch *e.Operator {
 			case contains:
-				queryArgs = append(queryArgs, metricName, metricQualifier, fmt.Sprintf("%%%s%%", *e.Value))
+				queryArgs = append(queryArgs, fmt.Sprintf("%%%s%%", *e.Value))
 				queryString = fmt.Sprintf("%s LIKE ?", col)
 			case doesNotContain:
-				queryArgs = append(queryArgs, metricName, metricQualifier, fmt.Sprintf("%%%s%%", *e.Value))
+				queryArgs = append(queryArgs, fmt.Sprintf("%%%s%%", *e.Value))
 				queryString = fmt.Sprintf("%s NOT LIKE ?", col)
 			case empty, notEmpty:
-				queryArgs = append(queryArgs, metricName, metricQualifier, bun.Safe(oSQL))
+				queryArgs = append(queryArgs, bun.Safe(oSQL))
 				queryString = fmt.Sprintf("%s ?", col)
 			default:
-				queryArgs = append(queryArgs, metricName, metricQualifier,
-					bun.Safe(oSQL), *e.Value)
+				queryArgs = append(queryArgs, bun.Safe(oSQL), *e.Value)
 				queryString = fmt.Sprintf("%s ? ?", col)
 			}
 			if c != nil && *c == or {

--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -422,9 +422,9 @@ func (e experimentFilter) toSQL(q *bun.SelectQuery,
 			var queryArgs []interface{}
 			var queryString string
 			if metricQualifier == "mean" {
-				locator := bun.Safe(fmt.Sprintf(`trials.summary_metrics->'avg_metrics'->'%s'`, metricName))
-				col = fmt.Sprintf(`(?->>'sum')::float8 / (?->>'count')::int`)
-				queryArgs = append(queryArgs, locator, locator)
+				locator := bun.Safe("trials.summary_metrics->'avg_metrics'")
+				col = fmt.Sprintf(`(?->?->>'sum')::float8 / (?->?->>'count')::int`)
+				queryArgs = append(queryArgs, locator, metricName, locator, metricName)
 			} else {
 				col = `trials.summary_metrics->'avg_metrics'->?->>?`
 				queryArgs = append(queryArgs, metricName, metricQualifier)

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -153,9 +153,10 @@ const ioMetric = io.record(io.string, ioMetricValue);
 export type ioTypeMetric = io.TypeOf<typeof ioMetric>;
 
 const ioMetricSummary = io.type({
-  count: optional(io.union([io.number, io.undefined])),
-  last: optional(io.union([io.number, io.string, io.boolean])),
+  count: optional(io.number),
+  last: optional(io.any),
   max: optional(float),
+  median: optional(float),
   min: optional(float),
   sum: optional(float),
   type: io.union([

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -156,7 +156,7 @@ const ioMetricSummary = io.type({
   count: optional(io.number),
   last: optional(io.any),
   max: optional(float),
-  median: optional(float),
+  mean: optional(float),
   min: optional(float),
   sum: optional(float),
   type: io.union([


### PR DESCRIPTION

## Description

This replaces the sum and count metric columns for training metrics with a `mean` column that returns the arithmetic mean of the training metrics. The Columns API and experiment search api are updated with support for the new column. the runtime type of the metric config is updated a little to ensure the new format checks but also to fix issues with non-pointer values.




## Test Plan

with the new experiment list flag turned on, visit an experiment listing page.
- [ ] the metrics column menu should contain mean columns for each training metric
- [ ] adding a mean column to the view should show the mean of the metric (sum divided by count)
- [ ] sorting the column should sort the mean as a number both ascending and descending
- [ ] filtering the column should filter the mean as a number for all operators



## Commentary (optional)

Note that the validation metrics are currently untouched because the column api and sort and filter automatically choose between max and min based on the experiment config.


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1480


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
