### PR TITLE
test: skip `test_efficientdet_coco_pytorch_const`.

### DIFF
--- a/e2e_tests/tests/nightly/test_capability.py
+++ b/e2e_tests/tests/nightly/test_capability.py
@@ -46,6 +46,7 @@ def test_detr_coco_pytorch_const() -> None:
 
 
 @pytest.mark.nightly
+@pytest.mark.skip(reason="this test is disabled awaiting the example pruning effort")
 def test_efficientdet_coco_pytorch_const() -> None:
     config = conf.load_config(conf.cv_examples_path("efficientdet_pytorch/const_fake.yaml"))
     config = conf.set_max_length(config, {"batches": 200})


### PR DESCRIPTION
## Description

This example is currently broken, and we are deliberating whether it's useful and worth fixing.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
