### PR TITLE
ci: avoid latest responses==0.23.2

### DIFF
--- a/harness/setup.py
+++ b/harness/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         # Common:
         "certifi",
         "filelock",
+        "requests",
         "google-cloud-storage",
         "lomond>=0.3.3",
         "pathspec>=0.6.0",

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -1,7 +1,8 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 mypy==0.910
-responses
+# responses 0.23.2 requires urllib3>=2, which breaks several other dependencies
+responses<=0.23.1
 requests_mock
 coverage
 pytorch_lightning==1.5.9


### PR DESCRIPTION
responses==0.23.2 means urllib3>=2, and most of our dependencies are 
not ready for urllib3 version 2.