### PR TITLE
ci: put all GHA jobs for release tracking in a concurrency group

### DIFF
--- a/.github/workflows/track-prs-for-release.yml
+++ b/.github/workflows/track-prs-for-release.yml
@@ -10,6 +10,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
 
+concurrency:
+  group: track-prs-for-release
+
 # All jobs require a specifically generated token to run, since we want to
 # access org-level projects and the normal GITHUB_TOKEN only has access to this
 # repository.


### PR DESCRIPTION
## Description

These are all potentially modifying the release branch, so we want them to not run simultaneously. The groups could probably be made more fine-grained, but the jobs are fast enough that keeping it simple should be fine.

## Test Plan

- [x] make sure GHA doesn't complain about the syntax
