### PR TITLE
feat: Enable disabling Tensorboard logging [MLG-22]

### DIFF
--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -222,7 +222,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
 
         self._enable_tensorboard_logging = enable_tensorboard_logging
 
-    def get_enable_tensorboard_logging(self):
+    def get_enable_tensorboard_logging(self) -> bool:
         """
         Return whether automatic tensorboard logging is enabled
         """

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -128,7 +128,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         self._stop_requested = False
 
         self._tbd_writer = None  # type: Optional[Any]
-        self._enable_tensorboard_logging = False
+        self._enable_tensorboard_logging = True
 
     def get_global_batch_size(self) -> int:
         """
@@ -218,13 +218,13 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         Set a flag to indicate whether automatic upload to tensorboard is enabled.
         """
         if not isinstance(enable_tensorboard_logging, bool):
-            raise AssertionError("disable_tensorboard_logging must be a boolean")
+            raise AssertionError("enable_tensorboard_logging must be a boolean")
 
         self._enable_tensorboard_logging = enable_tensorboard_logging
 
     def get_enable_tensorboard_logging(self):
         """
-        Return whether automatic tensorboard logging is disabled
+        Return whether automatic tensorboard logging is enabled
         """
         return self._enable_tensorboard_logging
 

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -128,6 +128,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         self._stop_requested = False
 
         self._tbd_writer = None  # type: Optional[Any]
+        self._enable_tensorboard_logging = False
 
     def get_global_batch_size(self) -> int:
         """
@@ -211,6 +212,21 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
             "at the end of the current step."
         )
         self._stop_requested = stop_requested
+
+    def set_enable_tensorboard_logging(self, enable_tensorboard_logging: bool) -> None:
+        """
+        Set a flag to indicate whether automatic upload to tensorboard is enabled.
+        """
+        if not isinstance(enable_tensorboard_logging, bool):
+            raise AssertionError("disable_tensorboard_logging must be a boolean")
+
+        self._enable_tensorboard_logging = enable_tensorboard_logging
+
+    def get_enable_tensorboard_logging(self):
+        """
+        Return whether automatic tensorboard logging is disabled
+        """
+        return self._enable_tensorboard_logging
 
     def autocast_forward_pass(self, to_wrap: torch.nn.Module) -> torch.nn.Module:
         # First, ensure the forward pass is wrapped in an autocast context:

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -59,6 +59,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         steps_completed: int,
         managed_training: bool,
         debug_enabled: bool,
+        enable_tensorboard_logging: bool = True,
     ) -> None:
         self._core = core_context
         self.distributed = self._core.distributed
@@ -128,7 +129,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         self._stop_requested = False
 
         self._tbd_writer = None  # type: Optional[Any]
-        self._enable_tensorboard_logging = True
+        self._enable_tensorboard_logging = enable_tensorboard_logging
 
     def get_global_batch_size(self) -> int:
         """

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -72,7 +72,6 @@ class Trainer:
         latest_checkpoint: Optional[str] = None,
         step_zero_validation: bool = False,
         test_mode: bool = False,
-        enable_tensorboard_logging: bool = True,
     ) -> None:
         """
         ``fit()`` trains a ``PyTorchTrial`` configured from the ``Trainer`` and handles
@@ -169,12 +168,6 @@ class Trainer:
             if global_batch_size:
                 global_batch_size = int(global_batch_size)
 
-        # Tensorboard logging is enabled by default
-        # We only need to call set_enable_tensorboard_logging on the trial object of user pass in
-        # enable_tensorboard_logging = False
-        if not enable_tensorboard_logging:
-            self._context.set_enable_tensorboard_logging(enable_tensorboard_logging)
-
         trial_controller = pytorch._PyTorchTrialController(
             trial_inst=self._trial,
             context=self._context,
@@ -237,6 +230,7 @@ def init(
     exp_conf: Optional[Dict[str, Any]] = None,
     distributed: Optional[core.DistributedContext] = None,
     aggregation_frequency: int = 1,
+    enable_tensorboard_logging: bool = True,
 ) -> Iterator[pytorch.PyTorchTrialContext]:
     """
     Creates a PyTorchTrialContext for use with a PyTorchTrial. All trainer.* calls must be within
@@ -296,5 +290,11 @@ def init(
             managed_training=managed_training,
             debug_enabled=debug_enabled,
         )
+
+        # Tensorboard logging is enabled by default
+        # We only need to call set_enable_tensorboard_logging on the trial object of user pass in
+        # enable_tensorboard_logging = False
+        if not enable_tensorboard_logging:
+            context.set_enable_tensorboard_logging(enable_tensorboard_logging)
 
         yield context

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -72,6 +72,7 @@ class Trainer:
         latest_checkpoint: Optional[str] = None,
         step_zero_validation: bool = False,
         test_mode: bool = False,
+        enable_tensorboard_logging: bool = True,
     ) -> None:
         """
         ``fit()`` trains a ``PyTorchTrial`` configured from the ``Trainer`` and handles
@@ -114,6 +115,7 @@ class Trainer:
                 before training.
             test_mode: Runs a minimal loop of training for testing and debugging purposes. Will
                 train and validate one batch. Defaults to false.
+            enable_tensorboard_logging: Configures if upload to tensorboard is enabled
         """
         # Set defaults.
         if checkpoint_period is None:
@@ -166,6 +168,8 @@ class Trainer:
             global_batch_size = self._info.trial.hparams.get("global_batch_size", None)
             if global_batch_size:
                 global_batch_size = int(global_batch_size)
+
+        self._trial.set_enable_tensorboard_logging(enable_tensorboard_logging)
 
         trial_controller = pytorch._PyTorchTrialController(
             trial_inst=self._trial,

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -289,12 +289,7 @@ def init(
             steps_completed=steps_completed,
             managed_training=managed_training,
             debug_enabled=debug_enabled,
+            enable_tensorboard_logging=enable_tensorboard_logging,
         )
-
-        # Tensorboard logging is enabled by default
-        # We only need to call set_enable_tensorboard_logging on the trial object of user pass in
-        # enable_tensorboard_logging = False
-        if not enable_tensorboard_logging:
-            context.set_enable_tensorboard_logging(enable_tensorboard_logging)
 
         yield context

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -173,7 +173,7 @@ class Trainer:
         # We only need to call set_enable_tensorboard_logging on the trial object of user pass in
         # enable_tensorboard_logging = False
         if not enable_tensorboard_logging:
-            self._trial.set_enable_tensorboard_logging(enable_tensorboard_logging)
+            self._context.set_enable_tensorboard_logging(enable_tensorboard_logging)
 
         trial_controller = pytorch._PyTorchTrialController(
             trial_inst=self._trial,

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -169,7 +169,11 @@ class Trainer:
             if global_batch_size:
                 global_batch_size = int(global_batch_size)
 
-        self._trial.set_enable_tensorboard_logging(enable_tensorboard_logging)
+        # Tensorboard logging is enabled by default
+        # We only need to call set_enable_tensorboard_logging on the trial object of user pass in
+        # enable_tensorboard_logging = False
+        if not enable_tensorboard_logging:
+            self._trial.set_enable_tensorboard_logging(enable_tensorboard_logging)
 
         trial_controller = pytorch._PyTorchTrialController(
             trial_inst=self._trial,

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -378,7 +378,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
 
         self._enable_tensorboard_logging = enable_tensorboard_logging
 
-    def get_enable_tensorboard_logging(self):
+    def get_enable_tensorboard_logging(self) -> bool:
         """
         Return whether automatic tensorboard logging is enabled
         """

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -104,6 +104,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         self._check_experiment_config_optimizations()
 
         self._tbd_writer = None  # type: Optional[Any]
+        self._enable_tensorboard_logging = True
 
     def _check_experiment_config_optimizations(self) -> None:
         """
@@ -367,3 +368,18 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
     def _maybe_reset_tbd_writer(self) -> None:
         if self._tbd_writer is not None:
             self._tbd_writer.close()
+
+    def set_enable_tensorboard_logging(self, enable_tensorboard_logging: bool) -> None:
+        """
+        Set a flag to indicate whether automatic upload to tensorboard is enabled.
+        """
+        if not isinstance(enable_tensorboard_logging, bool):
+            raise AssertionError("enable_tensorboard_logging must be a boolean")
+
+        self._enable_tensorboard_logging = enable_tensorboard_logging
+
+    def get_enable_tensorboard_logging(self):
+        """
+        Return whether automatic tensorboard logging is enabled
+        """
+        return self._enable_tensorboard_logging

--- a/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_trial.py
@@ -494,13 +494,14 @@ class DeepSpeedTrialController(det.TrialController):
             )
             self.prof.set_training(False)
 
-            det.pytorch._log_tb_metrics(
-                self.context.get_tensorboard_writer(),
-                "train",
-                self.steps_completed,
-                metrics["avg_metrics"],
-                metrics["batch_metrics"],
-            )
+            if self.context.get_enable_tensorboard_logging():
+                det.pytorch._log_tb_metrics(
+                    self.context.get_tensorboard_writer(),
+                    "train",
+                    self.steps_completed,
+                    metrics["avg_metrics"],
+                    metrics["batch_metrics"],
+                )
 
         if not self.is_chief:
             return {}
@@ -598,9 +599,10 @@ class DeepSpeedTrialController(det.TrialController):
                 )
             )
 
-            det.pytorch._log_tb_metrics(
-                self.context.get_tensorboard_writer(), "val", self.steps_completed, metrics
-            )
+            if self.context.get_enable_tensorboard_logging():
+                det.pytorch._log_tb_metrics(
+                    self.context.get_tensorboard_writer(), "val", self.steps_completed, metrics
+                )
 
         if not self.is_chief:
             return {}
@@ -608,9 +610,10 @@ class DeepSpeedTrialController(det.TrialController):
         return {"num_inputs": num_inputs, "validation_metrics": metrics}
 
     def on_validation_step_end(self, metrics: Dict[str, Any]) -> None:
-        det.pytorch._log_tb_metrics(
-            self.context.get_tensorboard_writer(), "val", self.steps_completed, metrics
-        )
+        if self.context.get_enable_tensorboard_logging():
+            det.pytorch._log_tb_metrics(
+                self.context.get_tensorboard_writer(), "val", self.steps_completed, metrics
+            )
 
     def _load(self, load_path: pathlib.Path) -> None:
         # Right now we will load all checkpoint shards on each node regardless of which


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

### Unit tests
Added new unit tests

### End 2 end testing - Deepspeed

**Case 1: When logging is disabled**
Added line `self.context.set_enable_tensorboard_logging(False)` to the init function of the trial class in this [example](https://github.com/determined-ai/determined/tree/main/examples/deepspeed/cifar10_cpu_offloading).

Verified that:
(1) From the UI, tensorboard would not finish loading as there is no tensorboard data

(2) Also verified that the underlying s3 storage has no tensorboard file for this trial (experiment id is 906 and we see that no folder exist for it)
<img width="576" alt="Screen Shot 2023-07-31 at 11 10 41 AM" src="https://github.com/determined-ai/determined/assets/16422598/0b4a4da9-6a08-4dd5-beea-a45807d99544">


Case 2: When logging is enabled (default behavior)
Using the [example](https://github.com/determined-ai/determined/tree/main/examples/deepspeed/cifar10_cpu_offloading) as is:
Verified that:
(1) From the UI, we can open tensorboard with metrics
<img width="1267" alt="Screen Shot 2023-07-31 at 11 07 21 AM" src="https://github.com/determined-ai/determined/assets/16422598/af7459e2-ee4c-4801-97b2-271bcd869633">

(2) Also verified that the underlying s3 storage has the tensorboard files for this trial (experiment id is 905)
<img width="576" alt="Screen Shot 2023-07-31 at 11 10 41 AM" src="https://github.com/determined-ai/determined/assets/16422598/0b4a4da9-6a08-4dd5-beea-a45807d99544">

### End 2 end testing - Trainer API

**Case 1: logging disabled**
modified trainer [API example in the documentation](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-pytorch-ug.html#pytorch-trainer) adding this line and using a CIFAR10 PyTorch trial from other examples.
        
```
trial_inst = model.CIFARTrial(train_context)
trainer = det.pytorch.Trainer(trial_inst, train_context)
trainer.fit(
            ....
            enable_tensorboard_logging=False,
        )
```
Verified that:
(1) From the UI, tensorboard would not finish loading as there is no tensorboard data

(2) Also verified that the underlying s3 storage has no tensorboard file for this trial (experiment id is 904 and we see that no folder exist for it)
<img width="576" alt="Screen Shot 2023-07-31 at 11 10 41 AM" src="https://github.com/determined-ai/determined/assets/16422598/0b4a4da9-6a08-4dd5-beea-a45807d99544">

** Case 2: logging enabled**
Same setup as above except that we do not include the line `enable_tensorboard_logging=False,` when calling trainer.fit.
Default behavior should enable logging to tensorboard.

verified that:
(1) from the UI, we can open tensorboard
<img width="1723" alt="Screen Shot 2023-07-31 at 11 41 23 AM" src="https://github.com/determined-ai/determined/assets/16422598/21a7102c-18a1-430b-b2af-f21b0fd641f7">


(2) We see corresponding folder in underlying TB s3 storage (the experiment id is 907)
<img width="714" alt="Screen Shot 2023-07-31 at 11 42 03 AM" src="https://github.com/determined-ai/determined/assets/16422598/b08370e8-f10d-47cf-9b7d-b30b0184b6f7">


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
