### PR TITLE
fix: rp-workspace mapping RP not found [WEB-1508]

### DIFF
--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -80,8 +80,13 @@ func (a *apiServer) BindRPToWorkspace(
 				curUser.Username))
 	}
 
+	rpConfigs, err := a.getResourcePoolConfigs()
+	if err != nil {
+		return nil, err
+	}
+
 	err = db.AddRPWorkspaceBindings(ctx, allWorkspaceIDs, req.ResourcePoolName,
-		config.GetMasterConfig().ResourceConfig.ResourcePools)
+		rpConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -118,9 +123,12 @@ func (a *apiServer) OverwriteRPWorkspaceBindings(
 				curUser.Username))
 	}
 
-	masterConfig := config.GetMasterConfig()
+	rpConfigs, err := a.getResourcePoolConfigs()
+	if err != nil {
+		return nil, err
+	}
 	err = db.OverwriteRPWorkspaceBindings(ctx, allWorkspaceIDs, req.ResourcePoolName,
-		masterConfig.ResourcePools)
+		rpConfigs)
 	if err != nil {
 		return nil, err
 	}
@@ -161,9 +169,13 @@ func (a *apiServer) UnbindRPFromWorkspace(
 func (a *apiServer) ListWorkspacesBoundToRP(
 	ctx context.Context, req *apiv1.ListWorkspacesBoundToRPRequest,
 ) (*apiv1.ListWorkspacesBoundToRPResponse, error) {
+	rpConfigs, err := a.getResourcePoolConfigs()
+	if err != nil {
+		return nil, err
+	}
 	rpWorkspaceBindings, pagination, err := db.ReadWorkspacesBoundToRP(
 		ctx, req.ResourcePoolName, req.Offset, req.Limit,
-		config.GetMasterConfig().ResourcePools,
+		rpConfigs,
 	)
 	if err != nil {
 		return nil, err
@@ -189,6 +201,25 @@ func (a *apiServer) ListWorkspacesBoundToRP(
 	return &apiv1.ListWorkspacesBoundToRPResponse{
 		WorkspaceIds: workspaceIDs, Pagination: pagination,
 	}, nil
+}
+
+func (a *apiServer) getResourcePoolConfigs() ([]config.ResourcePoolConfig, error) {
+	resp, err := a.m.rm.GetResourcePools(a.m.system, &apiv1.GetResourcePoolsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return []config.ResourcePoolConfig{}, nil
+	}
+
+	var rpConfigs []config.ResourcePoolConfig
+	for _, rp := range resp.ResourcePools {
+		rpConfigs = append(rpConfigs, config.ResourcePoolConfig{
+			PoolName: rp.Name,
+		})
+	}
+
+	return rpConfigs, nil
 }
 
 func combineWorkspaceIDsAndNames(ctx context.Context, ids []int32, names []string,

--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -80,7 +80,7 @@ func (a *apiServer) BindRPToWorkspace(
 				curUser.Username))
 	}
 
-	rpConfigs, err := a.getResourcePoolConfigs()
+	rpConfigs, err := a.resourcePoolsAsConfigs()
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (a *apiServer) OverwriteRPWorkspaceBindings(
 				curUser.Username))
 	}
 
-	rpConfigs, err := a.getResourcePoolConfigs()
+	rpConfigs, err := a.resourcePoolsAsConfigs()
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (a *apiServer) UnbindRPFromWorkspace(
 func (a *apiServer) ListWorkspacesBoundToRP(
 	ctx context.Context, req *apiv1.ListWorkspacesBoundToRPRequest,
 ) (*apiv1.ListWorkspacesBoundToRPResponse, error) {
-	rpConfigs, err := a.getResourcePoolConfigs()
+	rpConfigs, err := a.resourcePoolsAsConfigs()
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (a *apiServer) ListWorkspacesBoundToRP(
 	}, nil
 }
 
-func (a *apiServer) getResourcePoolConfigs() ([]config.ResourcePoolConfig, error) {
+func (a *apiServer) resourcePoolsAsConfigs() ([]config.ResourcePoolConfig, error) {
 	resp, err := a.m.rm.GetResourcePools(a.m.system, &apiv1.GetResourcePoolsRequest{})
 	if err != nil {
 		return nil, err

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -16,7 +16,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
-	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/workspace"
@@ -649,9 +648,12 @@ func (a *apiServer) ListRPsBoundToWorkspace(
 		return nil, err
 	}
 
-	masterConfig := config.GetMasterConfig()
+	rpConfigs, err := a.getResourcePoolConfigs()
+	if err != nil {
+		return nil, err
+	}
 	rpNames, pagination, err := db.ReadRPsAvailableToWorkspace(
-		ctx, req.WorkspaceId, req.Offset, req.Limit, masterConfig.ResourceConfig.ResourcePools,
+		ctx, req.WorkspaceId, req.Offset, req.Limit, rpConfigs,
 	)
 	if err != nil {
 		return nil, err

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -648,7 +648,7 @@ func (a *apiServer) ListRPsBoundToWorkspace(
 		return nil, err
 	}
 
-	rpConfigs, err := a.getResourcePoolConfigs()
+	rpConfigs, err := a.resourcePoolsAsConfigs()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
in HPC clusters, some resource pools will be created without an explicit configuration in the master config. Previously, the rp-workspace mapping feature assumed that the config had all resource pools defined, which led to errors on the cluster page. 

This is a temporary patch - a permanent fix would require a bigger refactor, which will be done next sprint.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
