### PR TITLE
feat: Pytorch2 necessary changes

### DIFF
--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -124,7 +124,7 @@ class DataLoader:
         multiprocessing_context: Any = None,
         generator: Any = None,
         *,
-        prefetch_factor: int = 2,
+        prefetch_factor: Optional[int] = None,
         persistent_workers: bool = False,
     ):
         # Don't allow IterableDatasets in our DataLoader.
@@ -159,12 +159,15 @@ class DataLoader:
         if timeout < 0:
             raise ValueError("timeout option should be non-negative")
 
-        if num_workers == 0 and prefetch_factor != 2:
+        if num_workers == 0 and prefetch_factor is not None:
             raise ValueError(
                 "prefetch_factor option could only be specified in multiprocessing. "
                 "let num_workers > 0 to enable multiprocessing."
             )
-        assert prefetch_factor > 0
+        elif num_workers > 0 and prefetch_factor is None:
+            prefetch_factor = 2
+        elif prefetch_factor is not None and prefetch_factor < 0:
+            raise ValueError("prefetch_factor option should be non-negative")
 
         if persistent_workers and num_workers == 0:
             raise ValueError("persistent_workers option needs num_workers > 0")
@@ -245,13 +248,18 @@ class DataLoader:
             batch_sampler, repeat=repeat, skip=skip, num_replicas=num_replicas, rank=rank
         )
 
-        # Try to no break any torch version as old as v1.0.
+        # Try to not break any torch version as old as v1.0.
         extra_kwargs = {}
         if version.parse(torch.__version__) >= version.parse("1.2.0"):
             extra_kwargs["multiprocessing_context"] = self.multiprocessing_context
         if version.parse(torch.__version__) >= version.parse("1.6.0"):
             extra_kwargs["generator"] = self.generator
         if version.parse(torch.__version__) >= version.parse("1.7.0"):
+            if version.parse(torch.__version__) < version.parse("2.0.0"):
+                # prefetch_factor became optional in 2.0.
+                if self.prefetch_factor is None and self.num_workers == 0:
+                    self.prefetch_factor = 2
+
             extra_kwargs["prefetch_factor"] = self.prefetch_factor
             extra_kwargs["persistent_workers"] = self.persistent_workers
 

--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -204,11 +204,7 @@ class DataLoader:
 
         if sampler is None:  # give default samplers
             if shuffle:
-                # The generator arg to RandomSampler was added in torch 1.6.
-                if version.parse(torch.__version__) >= version.parse("1.6.0"):
-                    sampler = RandomSampler(dataset, generator=generator)  # type: ignore
-                else:
-                    sampler = RandomSampler(dataset)  # type: ignore
+                sampler = RandomSampler(dataset, generator=generator)  # type: ignore
             else:
                 sampler = SequentialSampler(dataset)  # type: ignore
 
@@ -248,20 +244,16 @@ class DataLoader:
             batch_sampler, repeat=repeat, skip=skip, num_replicas=num_replicas, rank=rank
         )
 
-        # Try to not break any torch version as old as v1.0.
         extra_kwargs = {}
-        if version.parse(torch.__version__) >= version.parse("1.2.0"):
-            extra_kwargs["multiprocessing_context"] = self.multiprocessing_context
-        if version.parse(torch.__version__) >= version.parse("1.6.0"):
-            extra_kwargs["generator"] = self.generator
-        if version.parse(torch.__version__) >= version.parse("1.7.0"):
-            if version.parse(torch.__version__) < version.parse("2.0.0"):
-                # prefetch_factor became optional in 2.0.
-                if self.prefetch_factor is None and self.num_workers == 0:
-                    self.prefetch_factor = 2
+        if version.parse(torch.__version__) < version.parse("2.0.0"):
+            # prefetch_factor became optional in 2.0.
+            if self.prefetch_factor is None and self.num_workers == 0:
+                self.prefetch_factor = 2
 
-            extra_kwargs["prefetch_factor"] = self.prefetch_factor
-            extra_kwargs["persistent_workers"] = self.persistent_workers
+        extra_kwargs["multiprocessing_context"] = self.multiprocessing_context
+        extra_kwargs["generator"] = self.generator
+        extra_kwargs["prefetch_factor"] = self.prefetch_factor
+        extra_kwargs["persistent_workers"] = self.persistent_workers
 
         return torch.utils.data.DataLoader(
             self.dataset,

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -8,7 +8,7 @@ coverage
 pytorch_lightning==1.5.9
 deepspeed==0.8.3
 transformers>=4.8.2,<4.29.0
-attrdict
+attrdict3
 moto
 # Pydantic V2 has changes that break existing tests
 pydantic<2

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -37,11 +37,9 @@ PROJECT = "environments"
 BASE_URL = f"https://circleci.com/api/v1.1/project/github/{USER}/{PROJECT}"
 
 JOB_SUFFIXES = [
-    "tf1-cpu",
     "tf2-cpu",
     "tf28-cpu",
     "pt-cpu",
-    "tf1-gpu",
     "tf2-gpu",
     "tf28-gpu",
     "pt-gpu",


### PR DESCRIPTION
## Description

A few changes preceding the advent of `pytorch==2.0.1` images:
1. A versioning conditional on our PyTorch DataLoader
2. Deprecated `attrdict` replaced with `attrdict3` in harness. This is necessary for `python>=3.9`. Either library is fine for `python==3.8`.

I've also thrown in a small update to `update-bumpenvs-yaml.py` to remove checking for `tf1` images following an update to our environments repo.


## Test Plan

All PyTorch and DeepSpeed related tests should pass in CI.


## Commentary (optional)

Upgrading our task environment to `pytorch==2.0.1` is not as impossible as it seems, but we will have to take a look at `apex.amp` and our old, version pinned examples, as those are the key blockers of this from an OSS standpoint.



## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.
