### PR TITLE
chore: deprecate `apex` support.

### DIFF
--- a/docs/release-notes/deprecate-apex.rst
+++ b/docs/release-notes/deprecate-apex.rst
@@ -5,7 +5,7 @@
 -  API: ``PyTorchTrial`` support for mixed precision using ``NVIDIA/apex`` library is deprecated and
    will be removed in a future version. We recommend users to migrate to Torch Automatic Mixed
    Precision (``torch.cuda.amp``). For more, refer to the
-   `examples<https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`__.
+   `examples <https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`_.
 
 -  Images: Environment images will also no longer include ``NVIDIA/apex`` package in a future
    version. User may install this package from the official repository instead.

--- a/docs/release-notes/deprecate-apex.rst
+++ b/docs/release-notes/deprecate-apex.rst
@@ -4,8 +4,8 @@
 
 -  API: ``PyTorchTrial`` support for mixed precision using ``NVIDIA/apex`` library is deprecated and
    will be removed in a future version. We recommend users to migrate to Torch Automatic Mixed
-   Precision (``torch.cuda.amp``). For more, refer to the
-   `examples <https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`_.
+   Precision (``torch.cuda.amp``). For more, refer to the `examples
+   <https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`_.
 
 -  Images: Environment images will also no longer include ``NVIDIA/apex`` package in a future
    version. User may install this package from the official repository instead.

--- a/docs/release-notes/deprecate-apex.rst
+++ b/docs/release-notes/deprecate-apex.rst
@@ -2,10 +2,10 @@
 
 **Deprecated Features**
 
--  API: ``PyTorchTrial`` support for mixed precision using ``NVIDIA/apex`` library is deprecated and
-   will be removed in a future version. We recommend users to migrate to Torch Automatic Mixed
-   Precision (``torch.cuda.amp``). For more, refer to the `examples
+-  API: Support for mixed precision in ``PyTorchTrial`` using the ``NVIDIA/apex`` library is
+   deprecated and will be removed in a future version of Determined. Users should transition to
+   Torch Automatic Mixed Precision (``torch.cuda.amp``). For examples, refer to the `examples
    <https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`_.
 
--  Images: Environment images will also no longer include ``NVIDIA/apex`` package in a future
-   version. User may install this package from the official repository instead.
+-  Images: Likewise, environment images will no longer include the ``NVIDIA/apex`` package in a
+   future version of Determined. If needed, users can install it from the official repository.

--- a/docs/release-notes/deprecate-apex.rst
+++ b/docs/release-notes/deprecate-apex.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+**Deprecated Features**
+
+-  API: ``PyTorchTrial`` support for mixed precision using ``NVIDIA/apex`` library is deprecated and
+   will be removed in a future version. We recommend users to migrate to Torch Automatic Mixed
+   Precision (``torch.cuda.amp``). For more, refer to the
+   `examples<https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`__.
+
+-  Images: Environment images will also no longer include ``NVIDIA/apex`` package in a future
+   version. User may install this package from the official repository instead.

--- a/docs/release-notes/deprecate-apex.rst
+++ b/docs/release-notes/deprecate-apex.rst
@@ -5,7 +5,7 @@
 -  API: Support for mixed precision in ``PyTorchTrial`` using the ``NVIDIA/apex`` library is
    deprecated and will be removed in a future version of Determined. Users should transition to
    Torch Automatic Mixed Precision (``torch.cuda.amp``). For examples, refer to the `examples
-   <https://github.com/determined-ai/determined/tree/0.23.4/harness/tests/experiment/fixtures/pytorch_amp>`_.
+   <https://github.com/determined-ai/determined/tree/0.26.1/harness/tests/experiment/fixtures/pytorch_amp>`_.
 
 -  Images: Likewise, environment images will no longer include the ``NVIDIA/apex`` package in a
    future version of Determined. If needed, users can install it from the official repository.

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import pathlib
+import warnings
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 
 import torch
@@ -628,6 +629,13 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
 
         if self._scaler is not None and self._scaler.is_enabled():
             raise det.errors.InvalidExperimentException("Do not mix APEX with PyTorch AMP.")
+
+        warnings.warn(
+            "PyTorchTrial support for NVIDIA/apex has been deprecated and will be removed "
+            "in a future version. We recommend users to migrate to Torch AMP (`torch.cuda.amp`).",
+            FutureWarning,
+            stacklevel=2,
+        )
 
         if self._use_apex:
             raise det.errors.InvalidExperimentException("Please only call configure_apex_amp once.")


### PR DESCRIPTION
## Description

Notice of deprecation for `apex`.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
