### PR TITLE
fix: Groups modal does not include inactive users [WEB-1256]

### DIFF
--- a/webui/react/src/components/CreateGroupModal.tsx
+++ b/webui/react/src/components/CreateGroupModal.tsx
@@ -169,6 +169,8 @@ const CreateGroupModalComponent: React.FC<Props> = ({ onClose, users, group }: P
     }
   };
 
+  const currentGroupMembers = form.getFieldValue(USERS_NAME);
+
   return (
     <Modal
       cancel
@@ -192,11 +194,13 @@ const CreateGroupModalComponent: React.FC<Props> = ({ onClose, users, group }: P
           </Form.Item>
           <Form.Item label={USERS_LABEL} name={USERS_NAME}>
             <Select mode="multiple" optionFilterProp="children" placeholder="Add Users" showSearch>
-              {users?.map((u) => (
-                <Select.Option disabled={!u.isActive} key={u.id} value={u.id}>
-                  {getDisplayName(u)}
-                </Select.Option>
-              ))}
+              {users
+                ?.filter((u) => u.isActive || currentGroupMembers?.includes(u.id))
+                ?.map((u) => (
+                  <Select.Option key={u.id} value={u.id}>
+                    {getDisplayName(u)}
+                  </Select.Option>
+                ))}
             </Select>
           </Form.Item>
           {rbacEnabled && canModifyPermissions && group && (

--- a/webui/react/src/components/CreateGroupModal.tsx
+++ b/webui/react/src/components/CreateGroupModal.tsx
@@ -193,7 +193,7 @@ const CreateGroupModalComponent: React.FC<Props> = ({ onClose, users, group }: P
           <Form.Item label={USERS_LABEL} name={USERS_NAME}>
             <Select mode="multiple" optionFilterProp="children" placeholder="Add Users" showSearch>
               {users?.map((u) => (
-                <Select.Option key={u.id} value={u.id}>
+                <Select.Option disabled={!u.isActive} key={u.id} value={u.id}>
                   {getDisplayName(u)}
                 </Select.Option>
               ))}


### PR DESCRIPTION
## Description

In RBAC mode, the admin can add and remove users from groups.
The ticket is to keep deactivated users from being newly added to groups.
Current code uses the `disabled` attribute; this means a deactivated user cannot be added or removed from groups.

I tried filtering out deactivated users from the component, but then the antd.Select component shows an inactive user as their number id ("44").

## Test Plan

As admin of an EE / RBAC server, on `/det/admin/group-management`

Click "New Group" and click under the Users label. You should see a list of many users which you can add to the group
For an existing group with users, click the row's three-dot menu and Edit to see users who can be added or removed from the group

On the users management page, create a test user and deactivate that account.
In the "New Group" modal, that user is greyed out / unselectable.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

WEB-1256