### PR TITLE
fix: custom proxies do not work for trials in slurm [DET-9718]

### DIFF
--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -305,7 +305,8 @@ func (a *allocation) SetProxyAddress(_ context.Context, address string) error {
 	defer a.mu.Unlock()
 
 	if len(a.req.ProxyPorts) == 0 {
-		return ErrBehaviorUnsupported{Behavior: "proxying"}
+		a.syslog.Debug("No ports to proxy. Skipping proxy registration.")
+		return nil
 	}
 	a.model.ProxyAddress = &address
 	if err := a.db.UpdateAllocationProxyAddress(a.model); err != nil {

--- a/master/static/srv/entrypoint.sh
+++ b/master/static/srv/entrypoint.sh
@@ -34,7 +34,7 @@ if [ -z "$DET_SKIP_PIP_INSTALL" ]; then
     "$DET_PYTHON_EXECUTABLE" -m pip install -q --user /opt/determined/wheels/determined*.whl
 fi
 
-"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --trial --resources
+"$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --trial --resources --proxy
 
 set -x
 test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"


### PR DESCRIPTION
## Description

https://github.com/determined-ai/determined/pull/7492 broke `det command run` (and possibly other tasks) that didn't specify a proxy port in the config file.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q determined-ee % PYTHONPATH=/Users/rcorujo/IdeaProjects/JUNK/determined-ee/harness det --master=localhost:8081 command run echo hello 
Launched command (id: 121e2f03-43d5-4f41-b538-eca806ab82ff).
[2023-08-01T15:00:08.851187Z]          || INFO: Scheduling Command (certainly-allowing-sole) (id: 121e2f03-43d5-4f41-b538-eca806ab82ff)
[2023-08-01T15:00:11.245390Z]          || INFO: HPC Job ID: 311
[2023-08-01T15:00:11.245454Z]          || INFO: Command (certainly-allowing-sole) was assigned to an agent
[2023-08-01T15:00:25.186271Z] [cont=0] || WARNING: [2315368] root: falling back to naive proxy ip resolution (error=None)
[2023-08-01T15:00:25.466890Z] [cont=0] || Traceback (most recent call last):
[2023-08-01T15:00:25.466950Z] [cont=0] ||   File "/opt/conda/lib/python3.8/runpy.py", line 194, in _run_module_as_main
[2023-08-01T15:00:25.467615Z] [cont=0] ||     return _run_code(code, main_globals, None,
[2023-08-01T15:00:25.467665Z] [cont=0] ||   File "/opt/conda/lib/python3.8/runpy.py", line 87, in _run_code
[2023-08-01T15:00:25.467714Z] [cont=0] ||     exec(code, run_globals)
[2023-08-01T15:00:25.467752Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/exec/prep_container.py", line 358, in <module>
[2023-08-01T15:00:25.467959Z] [cont=0] ||     do_proxy(sess, info.allocation_id)
[2023-08-01T15:00:25.467994Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/exec/prep_container.py", line 281, in do_proxy
[2023-08-01T15:00:25.468114Z] [cont=0] ||     set_proxy_address(sess, allocation_id)
[2023-08-01T15:00:25.468148Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/exec/prep_container.py", line 265, in set_proxy_address
[2023-08-01T15:00:25.468275Z] [cont=0] ||     bindings.post_PostAllocationProxyAddress(
[2023-08-01T15:00:25.468318Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/common/api/bindings.py", line 16610, in post_PostAllocationProxyAddress
[2023-08-01T15:00:25.470444Z] [cont=0] ||     _resp = session._do_request(
[2023-08-01T15:00:25.470475Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/common/api/_session.py", line 36, in _do_request
[2023-08-01T15:00:25.470633Z] [cont=0] ||     return request.do_request(
[2023-08-01T15:00:25.470653Z] [cont=0] ||   File "/run/determined/pythonuserbase/lib/python3.8/site-packages/determined/common/api/request.py", line 180, in do_request
[2023-08-01T15:00:25.470769Z] [cont=0] ||     raise errors.APIException(r)
[2023-08-01T15:00:25.470791Z] [cont=0] || determined.common.api.errors.APIException: {"error":{"code":13,"reason":"Internal","error":"task.SetAllocationProxyAddress not supported for this allocation or resource manager"}}
[2023-08-01T15:00:25.470802Z] [cont=0] || 
[2023-08-01T15:00:30.392855Z]          || INFO: Resources for Command (certainly-allowing-sole) have started
```

This is because when `prep_container --proxy` is called in `command-entrypoint.sh`, the Determined master gets a notification to register the proxy, but when it sees that no proxy ports are specified, it issues an error.

Instead of having the Determined master error out when no proxy ports are specified, the solution is to simply have it issue a debug level message and skip the proxy port registration.

## Test Plan

Tested changes on EE branch.  I was able to run "det command run" with and without a proxy configured. I was also able to successfully run an experiment.

When no proxy config was given, the master log showed:

```
master: DEBU[2023-08-01T16:10:17-04:00] No ports to proxy. Skipping proxy registration.  job-id=e10a9bb4-2d39-4d21-9844-3cc5d8412bce task-id=97390b8e-ae38-4d73-a0b9-05e0a0f73e63 task-type=COMMAND
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
