### PR TITLE
feat: Move new charts into always-on Metrics tab [WEB-1522] [WEB-1523]

### DIFF
--- a/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/closestPointPlugin.ts
@@ -1,7 +1,7 @@
 import { throttle } from 'throttle-debounce';
 import uPlot, { Plugin } from 'uplot';
 
-import { CheckpointsDict } from 'pages/TrialDetails/F_TrialDetailsOverview';
+import { CheckpointsDict } from 'pages/TrialDetails/TrialDetailsMetrics';
 import { findInsertionIndex } from 'utils/array';
 import { distance } from 'utils/chart';
 import { isEqual } from 'utils/data';

--- a/webui/react/src/components/UPlot/UPlotChart/drawPointsPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotChart/drawPointsPlugin.ts
@@ -1,6 +1,6 @@
 import uPlot, { Plugin } from 'uplot';
 
-import { CheckpointsDict } from 'pages/TrialDetails/F_TrialDetailsOverview';
+import { CheckpointsDict } from 'pages/TrialDetails/TrialDetailsMetrics';
 import { isNumber } from 'utils/data';
 
 const NUM_POINTS = 4;

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -7,7 +7,7 @@ import userSettings from 'stores/userSettings';
 import { Loadable } from 'utils/loadable';
 
 // add new feature switches here
-export type ValidFeature = 'chart' | 'explist_v2' | 'rp_binding';
+export type ValidFeature = 'explist_v2' | 'rp_binding';
 
 type FeatureDescription = {
   friendlyName: string;
@@ -16,11 +16,6 @@ type FeatureDescription = {
 };
 
 export const FEATURES: Record<ValidFeature, FeatureDescription> = {
-  chart: {
-    defaultValue: false,
-    description: 'Enable improved learning curve charts for experiment visualizations',
-    friendlyName: 'New Charts',
-  },
   explist_v2: {
     defaultValue: false,
     description: 'Enable improved experiment listing, filtering, and comparison',

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -49,7 +49,7 @@ import ResponsiveTable from 'components/Table/ResponsiveTable';
 import ThemeToggle from 'components/ThemeToggle';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
-import { CheckpointsDict } from 'pages/TrialDetails/F_TrialDetailsOverview';
+import { CheckpointsDict } from 'pages/TrialDetails/TrialDetailsMetrics';
 import { serverAddress } from 'routes/utils';
 import { V1LogLevel } from 'services/api-ts-sdk';
 import { mapV1LogsResponse } from 'services/decoder';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -10,13 +10,12 @@ import Spinner from 'components/kit/Spinner';
 import Message, { MessageType } from 'components/Message';
 import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
-import useFeature from 'hooks/useFeature';
 import useModalHyperparameterSearch from 'hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch';
 import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import usePrevious from 'hooks/usePrevious';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
-import F_TrialDetailsOverview from 'pages/TrialDetails/F_TrialDetailsOverview';
+import TrialDetailsMetrics from 'pages/TrialDetails/TrialDetailsMetrics';
 import { paths } from 'routes/utils';
 import { getExpTrials, getTrialDetails, patchExperiment } from 'services/api';
 import { ValueOf } from 'types';
@@ -37,6 +36,7 @@ const TabType = {
   Code: 'code',
   Hyperparameters: 'hyperparameters',
   Logs: 'logs',
+  Metrics: 'metrics',
   Notes: 'notes',
   Overview: 'overview',
   Profiler: 'profiler',
@@ -80,7 +80,6 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     contextHolder: modalHyperparameterSearchContextHolder,
     modalOpen: openHyperparameterSearchModal,
   } = useModalHyperparameterSearch({ experiment });
-  const chartFlagOn = useFeature().isOn('chart');
 
   const waitingForTrials = !trialId && !wontHaveTrials;
 
@@ -241,13 +240,20 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
           <Spinner spinning tip="Waiting for trials..." />
         ) : wontHaveTrials ? (
           <NeverTrials />
-        ) : chartFlagOn ? (
-          <F_TrialDetailsOverview experiment={experiment} trial={trialDetails} />
         ) : (
           <TrialDetailsOverview experiment={experiment} trial={trialDetails} />
         ),
         key: TabType.Overview,
         label: 'Overview',
+      },
+      {
+        children: wontHaveTrials ? (
+          <NeverTrials />
+        ) : (
+          <TrialDetailsMetrics experiment={experiment} trial={trialDetails} />
+        ),
+        key: TabType.Metrics,
+        label: 'Metrics',
       },
       {
         children: wontHaveTrials ? (
@@ -325,7 +331,6 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     trialDetails,
     waitingForTrials,
     wontHaveTrials,
-    chartFlagOn,
   ]);
 
   return (

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -250,15 +250,6 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
         children: wontHaveTrials ? (
           <NeverTrials />
         ) : (
-          <TrialDetailsMetrics experiment={experiment} trial={trialDetails} />
-        ),
-        key: TabType.Metrics,
-        label: 'Metrics',
-      },
-      {
-        children: wontHaveTrials ? (
-          <NeverTrials />
-        ) : (
           <TrialDetailsHyperparameters pageRef={pageRef} trial={trialDetails as TrialDetails} />
         ),
         key: TabType.Hyperparameters,
@@ -267,6 +258,15 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
     ];
 
     if (showExperimentArtifacts) {
+      items.splice(1, 0, {
+        children: wontHaveTrials ? (
+          <NeverTrials />
+        ) : (
+          <TrialDetailsMetrics experiment={experiment} trial={trialDetails} />
+        ),
+        key: TabType.Metrics,
+        label: 'Metrics',
+      });
       items.push({
         children: <ExperimentCheckpoints experiment={experiment} pageRef={pageRef} />,
         key: TabType.Checkpoints,

--- a/webui/react/src/pages/TrialDetails.tsx
+++ b/webui/react/src/pages/TrialDetails.tsx
@@ -9,12 +9,11 @@ import Page from 'components/Page';
 import RoutePagination from 'components/RoutePagination';
 import TrialLogPreview from 'components/TrialLogPreview';
 import { terminalRunStates } from 'constants/states';
-import useFeature from 'hooks/useFeature';
 import usePolling from 'hooks/usePolling';
-import F_TrialDetailsOverview from 'pages/TrialDetails/F_TrialDetailsOverview';
 import TrialDetailsHeader from 'pages/TrialDetails/TrialDetailsHeader';
 import TrialDetailsHyperparameters from 'pages/TrialDetails/TrialDetailsHyperparameters';
 import TrialDetailsLogs from 'pages/TrialDetails/TrialDetailsLogs';
+import TrialDetailsMetrics from 'pages/TrialDetails/TrialDetailsMetrics';
 import TrialDetailsOverview from 'pages/TrialDetails/TrialDetailsOverview';
 import TrialDetailsProfiles from 'pages/TrialDetails/TrialDetailsProfiles';
 import { paths } from 'routes/utils';
@@ -34,6 +33,7 @@ import MultiTrialDetailsHyperparameters from './TrialDetails/MultiTrialDetailsHy
 const TabType = {
   Hyperparameters: 'hyperparameters',
   Logs: 'logs',
+  Metrics: 'metrics',
   Overview: 'overview',
   Profiler: 'profiler',
   Workloads: 'workloads',
@@ -64,7 +64,6 @@ const TrialDetailsComp: React.FC = () => {
     error: undefined,
   });
   const pageRef = useRef<HTMLElement>(null);
-  const chartFlagOn = useFeature().isOn('chart');
   const workspaces = Loadable.getOrElse([], useObservable(workspaceStore.workspaces));
   const basePath = paths.trialDetails(trialId, experimentId);
   const trial = trialDetails.data;
@@ -135,13 +134,14 @@ const TrialDetailsComp: React.FC = () => {
 
     return [
       {
-        children: chartFlagOn ? (
-          <F_TrialDetailsOverview experiment={experiment} trial={trial} />
-        ) : (
-          <TrialDetailsOverview experiment={experiment} trial={trial} />
-        ),
+        children: <TrialDetailsOverview experiment={experiment} trial={trial} />,
         key: TabType.Overview,
         label: 'Overview',
+      },
+      {
+        children: <TrialDetailsMetrics experiment={experiment} trial={trial} />,
+        key: TabType.Metrics,
+        label: 'Metrics',
       },
       {
         children: isSingleTrialExperiment(experiment) ? (
@@ -167,7 +167,7 @@ const TrialDetailsComp: React.FC = () => {
         label: 'Logs',
       },
     ];
-  }, [experiment, trial, chartFlagOn]);
+  }, [experiment, trial]);
 
   const { stopPolling } = usePolling(fetchTrialDetails);
 

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -2,12 +2,12 @@ import React, { useMemo, useState } from 'react';
 
 import { ChartGrid, ChartsProps, Serie } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
+import Spinner from 'components/kit/Spinner';
 import { UPlotPoint } from 'components/UPlot/types';
 import { closestPointPlugin } from 'components/UPlot/UPlotChart/closestPointPlugin';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
 import { useCheckpointFlow } from 'hooks/useModal/Checkpoint/useCheckpointFlow';
-import usePermissions from 'hooks/usePermissions';
 import {
   CheckpointWorkloadExtended,
   ExperimentBase,
@@ -38,9 +38,6 @@ type XAxisVal = number;
 export type CheckpointsDict = Record<XAxisVal, CheckpointWorkloadExtended>;
 
 const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
-  const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
-    workspace: { id: experiment.workspaceId },
-  });
   const [xAxis, setXAxis] = useState<XAxisDomain>(XAxisDomain.Batches);
 
   const checkpoint: CheckpointWorkloadExtended | undefined = useMemo(
@@ -182,7 +179,7 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   return (
     <>
-      {showExperimentArtifacts ? (
+      {isMetricsLoaded ? (
         <ChartGrid
           chartsProps={chartsProps}
           handleError={handleError}
@@ -191,7 +188,9 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
           xAxis={xAxis}
           onXAxisChange={setXAxis}
         />
-      ) : null}
+      ) : (
+        <Spinner spinning />
+      )}
       {contextHolders.map((contextHolder, i) => (
         <React.Fragment key={i}>{contextHolder}</React.Fragment>
       ))}

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -16,6 +16,7 @@ import {
   TrialDetails,
 } from 'types';
 import handleError from 'utils/error';
+import { Loaded, NotLoaded } from 'utils/loadable';
 import { metricSorter, metricToKey } from 'utils/metric';
 
 import { useTrialMetrics } from './useTrialMetrics';
@@ -59,7 +60,13 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   const trials: (TrialDetails | undefined)[] = useMemo(() => [trial], [trial]);
 
-  const { metrics, data: allData, scale, setScale } = useTrialMetrics(trials);
+  const {
+    metrics,
+    isLoaded: metricsLoaded,
+    data: allData,
+    scale,
+    setScale,
+  } = useTrialMetrics(trials);
   const data = useMemo(() => allData?.[trial?.id || 0], [allData, trial?.id]);
 
   const checkpointsDict = useMemo<CheckpointsDict>(() => {
@@ -106,6 +113,9 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   const chartsProps = useMemo(() => {
     const out: ChartsProps = [];
+    if (!metricsLoaded) {
+      return NotLoaded;
+    }
 
     pairedMetrics?.forEach(([trainingMetric, valMetric]) => {
       // this code doesnt depend on their being training or validation metrics
@@ -166,8 +176,8 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
         xLabel: String(xAxis),
       });
     });
-    return out;
-  }, [pairedMetrics, data, xAxis, checkpointsDict, openCheckpoint]);
+    return Loaded(out);
+  }, [pairedMetrics, metricsLoaded, data, xAxis, checkpointsDict, openCheckpoint]);
 
   return (
     <>

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -1,17 +1,13 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { ChartGrid, ChartsProps, Serie } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
-import Spinner from 'components/kit/Spinner';
 import { UPlotPoint } from 'components/UPlot/types';
 import { closestPointPlugin } from 'components/UPlot/UPlotChart/closestPointPlugin';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
-import useMetricNames from 'hooks/useMetricNames';
 import { useCheckpointFlow } from 'hooks/useModal/Checkpoint/useCheckpointFlow';
 import usePermissions from 'hooks/usePermissions';
-import { useSettings } from 'hooks/useSettings';
-import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
 import {
   CheckpointWorkloadExtended,
   ExperimentBase,
@@ -19,13 +15,9 @@ import {
   MetricType,
   TrialDetails,
 } from 'types';
-import { ErrorType } from 'utils/error';
 import handleError from 'utils/error';
-import { Loadable } from 'utils/loadable';
 import { metricSorter, metricToKey } from 'utils/metric';
 
-import { Settings, settingsConfigForExperiment } from './TrialDetailsOverview.settings';
-import TrialDetailsWorkloads from './TrialDetailsWorkloads';
 import { useTrialMetrics } from './useTrialMetrics';
 
 export interface Props {
@@ -44,15 +36,10 @@ const isMetricNameMatch = (t: Metric, v: Metric) => {
 type XAxisVal = number;
 export type CheckpointsDict = Record<XAxisVal, CheckpointWorkloadExtended>;
 
-const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => {
+const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
   const showExperimentArtifacts = usePermissions().canViewExperimentArtifacts({
     workspace: { id: experiment.workspaceId },
   });
-  const { settings, updateSettings } = useSettings<Settings>(
-    Object.assign(settingsConfigForExperiment(experiment.id), {
-      storagePath: `trial-detail/experiment/${experiment.id}`,
-    }),
-  );
   const [xAxis, setXAxis] = useState<XAxisDomain>(XAxisDomain.Batches);
 
   const checkpoint: CheckpointWorkloadExtended | undefined = useMemo(
@@ -182,64 +169,17 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     return out;
   }, [pairedMetrics, data, xAxis, checkpointsDict, openCheckpoint]);
 
-  const handleMetricNamesError = useCallback(
-    (e: unknown) => {
-      handleError(e, {
-        publicMessage: `Failed to load metric names for experiment ${experiment.id}.`,
-        publicSubject: 'Experiment metric name stream failed.',
-        type: ErrorType.Api,
-      });
-    },
-    [experiment.id],
-  );
-
-  const loadableMetricNames = useMetricNames([experiment.id], handleMetricNamesError);
-  const metricNames = Loadable.getOrElse([], loadableMetricNames);
-
-  const { defaultMetrics, workloadMetrics } = useMemo(() => {
-    const validationMetric = experiment?.config?.searcher.metric;
-    const defaultValidationMetric = metricNames.find(
-      (metricName) =>
-        metricName.name === validationMetric && metricName.type === MetricType.Validation,
-    );
-    const fallbackMetric = metricNames[0];
-    const defaultMetric = defaultValidationMetric || fallbackMetric;
-    const defaultMetrics = defaultMetric ? [defaultMetric] : [];
-    const settingMetrics: Metric[] = (settings.metric || []).map((metric) => {
-      const splitMetric = metric.split('|');
-      return { name: splitMetric[1], type: splitMetric[0] as MetricType };
-    });
-    const metrics = settingMetrics.length !== 0 ? settingMetrics : defaultMetrics;
-    return { defaultMetrics, workloadMetrics: metrics };
-  }, [experiment?.config?.searcher, metricNames, settings.metric]);
-
   return (
     <>
-      <TrialInfoBox experiment={experiment} trial={trial} />
       {showExperimentArtifacts ? (
-        <>
-          <ChartGrid
-            chartsProps={chartsProps}
-            handleError={handleError}
-            scale={scale}
-            setScale={setScale}
-            xAxis={xAxis}
-            onXAxisChange={setXAxis}
-          />
-          {settings ? (
-            <TrialDetailsWorkloads
-              defaultMetrics={defaultMetrics}
-              experiment={experiment}
-              metricNames={metricNames}
-              metrics={workloadMetrics}
-              settings={settings}
-              trial={trial}
-              updateSettings={updateSettings}
-            />
-          ) : (
-            <Spinner spinning />
-          )}
-        </>
+        <ChartGrid
+          chartsProps={chartsProps}
+          handleError={handleError}
+          scale={scale}
+          setScale={setScale}
+          xAxis={xAxis}
+          onXAxisChange={setXAxis}
+        />
       ) : null}
       {contextHolders.map((contextHolder, i) => (
         <React.Fragment key={i}>{contextHolder}</React.Fragment>
@@ -250,4 +190,4 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
   );
 };
 
-export default TrialDetailsOverview;
+export default TrialDetailsMetrics;

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -62,7 +62,7 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   const {
     metrics,
-    isLoaded: metricsLoaded,
+    isLoaded: isMetricsLoaded,
     data: allData,
     scale,
     setScale,
@@ -112,10 +112,11 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
   }, [metrics]);
 
   const chartsProps = useMemo(() => {
-    const out: ChartsProps = [];
-    if (!metricsLoaded) {
+    if (!isMetricsLoaded) {
       return NotLoaded;
     }
+
+    const out: ChartsProps = [];
 
     pairedMetrics?.forEach(([trainingMetric, valMetric]) => {
       // this code doesnt depend on their being training or validation metrics
@@ -177,7 +178,7 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
       });
     });
     return Loaded(out);
-  }, [pairedMetrics, metricsLoaded, data, xAxis, checkpointsDict, openCheckpoint]);
+  }, [pairedMetrics, isMetricsLoaded, data, xAxis, checkpointsDict, openCheckpoint]);
 
   return (
     <>


### PR DESCRIPTION
## Description

Trials will have a "Metrics" tab which shows the new charts / `ChartGrid` view.
Uses `isLoaded` from `useTrialMetrics` to reduce time that view shows "No data to plot"

Turning this on everywhere means we can also remove the charts feature flag

Visuals:

<img width="508" alt="Screen Shot 2023-08-02 at 11 16 37 AM" src="https://github.com/determined-ai/determined/assets/643918/92f74489-4d93-4fc2-ae67-051d1037de8d">

<img width="1158" alt="Screen Shot 2023-08-02 at 11 16 45 AM" src="https://github.com/determined-ai/determined/assets/643918/1f0827e9-27c7-470d-9dd6-89ff39622d7c">


In experiments which ended with 0 trials, this will show the NeverTrials message which we also show in Overview and Hyperparameter tabs

<img width="759" alt="Screen Shot 2023-08-02 at 11 17 23 AM" src="https://github.com/determined-ai/determined/assets/643918/a32b857b-04d3-462d-9f56-06cd2a173bdf">


## Test Plan

If you use the latest-main backend:

- A single-trial experiment: `/det/experiments/1651/overview`
- Clicking the best checkpoint in the chart opens up the checkpoint modal
- Many metrics: `/det/experiments/2146/metrics`
- Trial of a multi-trial experiment: `/det/experiments/1757/trials/6322/metrics`
- An experiment which errored without any trials: `/det/experiments/1363/metrics`
- Successful experiment with no metrics `/det/experiments/3248/overview`

When you click on user icon in top left, and go to Settings... "Chart" does not appear 

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

WEB-1522
WEB-1523