### PR TITLE
ci: setup CODEOWNERS for ml-sys team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,5 +22,6 @@
 /schemas                          @determined-ai/ml-sys
 /bindings/generate_bindings_py.py @determined-ai/ml-sys
 /e2e_tests/tests/*.py             @determined-ai/ml-sys
+/e2e_tests/tests/requirements.txt @determined-ai/ml-sys
 /e2e_tests/tests/experiment/      @determined-ai/ml-sys
 /e2e_tests/tests/nightly/         @determined-ai/ml-sys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,18 @@
 /master   @determined-ai/backend
 /agent    @determined-ai/backend
 /proto    @determined-ai/backend
+
+# Harness is mapped to ml-sys by default, except for `cli`, `deploy`,
+# and auto-generated bindings and version files.
+/harness  @determined-ai/ml-sys
+/harness/determined/deploy
+/harness/determined/cli
+/harness/tests/cli
+/harness/determined/common/api/bindings.py
+/harness/determined/__version__.py
+
+/schemas                          @determined-ai/ml-sys
+/bindings/generate_bindings_py.py @determined-ai/ml-sys
+/e2e_tests/tests/*.py             @determined-ai/ml-sys
+/e2e_tests/tests/experiment/      @determined-ai/ml-sys
+/e2e_tests/tests/nightly/         @determined-ai/ml-sys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,6 @@
 /bindings/generate_bindings_py.py @determined-ai/ml-sys
 /e2e_tests/tests/*.py             @determined-ai/ml-sys
 /e2e_tests/tests/requirements.txt @determined-ai/ml-sys
-/e2e_tests/tests/command         @determined-ai/ml-sys
-/e2e_tests/tests/experiment      @determined-ai/ml-sys
-/e2e_tests/tests/nightly         @determined-ai/ml-sys
+/e2e_tests/tests/command          @determined-ai/ml-sys
+/e2e_tests/tests/experiment       @determined-ai/ml-sys
+/e2e_tests/tests/nightly          @determined-ai/ml-sys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,6 @@
 # Harness is mapped to ml-sys by default, except for `cli`, `deploy`,
 # and auto-generated bindings and version files.
 /harness  @determined-ai/ml-sys
-/harness/determined/deploy
-/harness/determined/cli
-/harness/tests/cli
 /harness/determined/common/api/bindings.py
 /harness/determined/__version__.py
 
@@ -23,5 +20,6 @@
 /bindings/generate_bindings_py.py @determined-ai/ml-sys
 /e2e_tests/tests/*.py             @determined-ai/ml-sys
 /e2e_tests/tests/requirements.txt @determined-ai/ml-sys
-/e2e_tests/tests/experiment/      @determined-ai/ml-sys
-/e2e_tests/tests/nightly/         @determined-ai/ml-sys
+/e2e_tests/tests/command         @determined-ai/ml-sys
+/e2e_tests/tests/experiment      @determined-ai/ml-sys
+/e2e_tests/tests/nightly         @determined-ai/ml-sys


### PR DESCRIPTION
## Description

Setup codeowners for ml-sys areas:
- harness except for autogen
- expconf
- python bindings generator
- select e2e_tests (e.g. `experiment` (core UX tests) or `command` (mostly CLI tests), but not `cluster`)

As a next step, we'll need to:

- check if we like the assignment process: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment
- TBD: enable branch protection
- iterate: if other high-traffic or auto-generated files will surface up, remove them.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
