### PR TITLE
chore: retroactively address feedback from RP<>workspace mapping PR

### DIFF
--- a/harness/determined/common/experimental/resource_pool.py
+++ b/harness/determined/common/experimental/resource_pool.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List, Optional
 
 from determined.common import api
@@ -15,7 +16,7 @@ class ResourcePool:
     def __init__(
         self,
         session: api.Session,
-        name: str = "",
+        name: str,
     ):
         """Create a resource pool object.
 
@@ -80,12 +81,14 @@ class ResourcePool:
             )
 
         resps = api.read_paginated(get_with_offset)
-        workspace_names = [
-            workspace.Workspace(session=self._session, workspace_id=w).name
-            for r in resps
-            if r.workspaceIds is not None
-            for w in r.workspaceIds
-        ]
+
+        workspace_names = []
+        for r in resps:
+            if r.workspaceIds is not None:
+                for w in r.workspaceIds:
+                    workspace_names.append(
+                        workspace.Workspace(session=self._session, workspace_id=w).name
+                    )
 
         return workspace_names
 

--- a/harness/determined/common/experimental/resource_pool.py
+++ b/harness/determined/common/experimental/resource_pool.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import List, Optional
 
 from determined.common import api

--- a/harness/tests/determined/common/experimental/test_workspace.py
+++ b/harness/tests/determined/common/experimental/test_workspace.py
@@ -25,6 +25,7 @@ def single_item_workspaces() -> bindings.v1GetWorkspacesResponse:
 
 @pytest.fixture
 def single_item_rps_bound_to_workspace() -> bindings.v1ListRPsBoundToWorkspaceResponse:
+    """Create a dummy ListRPsBoundToWorkspaceResponse containing 1 resource pool."""
     single_item_pagination = bindings.v1Pagination(endIndex=1, startIndex=0, total=1)
     return bindings.v1ListRPsBoundToWorkspaceResponse(
         resourcePools=["foo"], pagination=single_item_pagination
@@ -33,6 +34,7 @@ def single_item_rps_bound_to_workspace() -> bindings.v1ListRPsBoundToWorkspaceRe
 
 @pytest.fixture
 def multi_item_rps_bound_to_workspace() -> bindings.v1ListRPsBoundToWorkspaceResponse:
+    """Create a dummy ListRPsBoundToWorkspaceResponse containing 2 resource pools."""
     multi_items_pagination = bindings.v1Pagination(endIndex=2, startIndex=0, total=2)
     return bindings.v1ListRPsBoundToWorkspaceResponse(
         resourcePools=["foo", "bar"], pagination=multi_items_pagination
@@ -90,7 +92,7 @@ def test_workspace_constructor_doesnt_populate_name_from_id(standard_session: ap
 
 
 @responses.activate
-def test_list_bounded_resource_pools(
+def test_get_available_resource_pools_single_response(
     standard_session: api.Session,
     single_item_workspaces: bindings.v1GetWorkspacesResponse,
     single_item_rps_bound_to_workspace: bindings.v1ListRPsBoundToWorkspaceResponse,

--- a/harness/tests/determined/common/experimental/test_workspace.py
+++ b/harness/tests/determined/common/experimental/test_workspace.py
@@ -92,7 +92,7 @@ def test_workspace_constructor_doesnt_populate_name_from_id(standard_session: ap
 
 
 @responses.activate
-def test_get_available_resource_pools_single_response(
+def test_workspace_get_available_resource_pools_reads_single_binding_no_pagination(
     standard_session: api.Session,
     single_item_workspaces: bindings.v1GetWorkspacesResponse,
     single_item_rps_bound_to_workspace: bindings.v1ListRPsBoundToWorkspaceResponse,


### PR DESCRIPTION
## Description
Address @wes-turner's feedback from #7461. 

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
