### PR TITLE
chore: add linter for google style guide-compliant python imports.

### DIFF
--- a/e2e_tests/.flake8
+++ b/e2e_tests/.flake8
@@ -4,9 +4,57 @@ max-line-length = 100
 # We ignore F401 in __init__.py because it is expected for there to be
 # "unused imports" when defining a "regular" package. (This file is
 # implicitly executed when the package is imported, and the imports would
-# be used by the importer.) We ignore patch_saver_restore.py because it includes
-# a near-verbatim TensorFlow function with a small patch.
-per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
+# be used by the importer.)
+per-file-ignores =
+  __init__.py:F401,I2041
+  tests/api_utils.py:I2041
+  tests/cluster/abstract_cluster.py:I2041
+  tests/cluster/managed_cluster.py:I2041
+  tests/cluster/managed_cluster_k8s.py:I2041
+  tests/cluster/test_agent.py:I2041
+  tests/cluster/test_agent_disable.py:I2041
+  tests/cluster/test_agent_restart.py:I2041
+  tests/cluster/test_agent_user_group.py:I2041
+  tests/cluster/test_checkpoints.py:I2041
+  tests/cluster/test_groups.py:I2041
+  tests/cluster/test_job_queue.py:I2041
+  tests/cluster/test_master_restart.py:I2041
+  tests/cluster/test_model_registry.py:I2041
+  tests/cluster/test_oauth2_scim_client.py:I2041
+  tests/cluster/test_priority_scheduler.py:I2041
+  tests/cluster/test_proxy.py:I2041
+  tests/cluster/test_rbac.py:I2041
+  tests/cluster/test_resource_manager.py:I2041
+  tests/cluster/test_users.py:I2041
+  tests/cluster/test_webhooks.py:I2041
+  tests/cluster/test_workspace_org.py:I2041
+  tests/cluster/utils.py:I2041
+  tests/cluster_log_manager.py:I2041
+  tests/command/command.py:I2041
+  tests/command/test_notebook.py:I2041
+  tests/command/test_run.py:I2041
+  tests/command/test_shell.py:I2041
+  tests/command/test_tensorboard.py:I2041
+  tests/config.py:I2041
+  tests/conftest.py:I2041
+  tests/deploy/test_local.py:I2041
+  tests/experiment/experiment.py:I2041
+  tests/experiment/record_profiling.py:I2041
+  tests/experiment/test_allocation_csv.py:I2041
+  tests/experiment/test_api.py:I2041
+  tests/experiment/test_core.py:I2041
+  tests/experiment/test_noop.py:I2041
+  tests/experiment/test_port_registry.py:I2041
+  tests/experiment/test_profiling.py:I2041
+  tests/filetree.py:I2041
+  tests/fixtures/mnist_estimator/model_def.py:I2041
+  tests/fixtures/mnist_pytorch/layers.py:I2041
+  tests/fixtures/mnist_pytorch/model_def.py:I2041
+  tests/fixtures/mnist_pytorch/stop_requested_model_def.py:I2041
+  tests/fixtures/trial_error/model_def.py:I2041
+  tests/nightly/compute_stats.py:I2041
+  tests/template/test_template.py:I2041
+  tests/test_sdk.py:I2041
 
 # Explanations for ignored error codes:
 # - D1* (no missing docstrings): too much effort to start enforcing

--- a/e2e_tests/Makefile
+++ b/e2e_tests/Makefile
@@ -20,7 +20,7 @@ check:
 		-s ./tests/fixtures/pytorch_lightning_amp/mnist.py \
 		-s ./tests/fixtures/pytorch_lightning_amp/data.py
 	black . --check
-	flake8
+	python -m flake8
 	mypy --exclude fixtures tests
 
 test:

--- a/e2e_tests/tests/__init__.py
+++ b/e2e_tests/tests/__init__.py
@@ -1,1 +1,0 @@
-from . import api_utils

--- a/e2e_tests/tests/cluster/managed_cluster.py
+++ b/e2e_tests/tests/cluster/managed_cluster.py
@@ -31,7 +31,7 @@ class ManagedCluster(Cluster):
 
     def __init__(self, config: Union[str, Dict[str, Any]]) -> None:
         # Strategically only import devcluster on demand to avoid having it as a hard dependency.
-        from devcluster import Devcluster
+        from devcluster import Devcluster  # noqa: I2000
 
         self.dc = Devcluster(config=config)
 

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -161,8 +161,8 @@ def test_unets_tf_keras_accuracy(client: _client.Determined) -> None:
 
 @pytest.mark.nightly
 def test_gbt_titanic_estimator_accuracy(client: _client.Determined) -> None:
-    import tensorflow as tf
-    from packaging import version
+    import tensorflow as tf  # noqa: I2000
+    from packaging import version  # noqa: I2000
 
     if version.parse(tf.__version__) >= version.parse("2.11.0"):
         pytest.skip("# TODO [MLG-442], see comment in gbt_titanic_estimator model_def")

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -2,9 +2,9 @@ from typing import Optional, Tuple
 
 import pytest
 
-import tests.api_utils as api_utils
 from determined.common import yaml
 from determined.common.api import Session, bindings, errors
+from tests import api_utils
 from tests import command as cmd
 from tests import config as conf
 from tests import template as tpl

--- a/examples/computer_vision/mnist_pl/mnist.py
+++ b/examples/computer_vision/mnist_pl/mnist.py
@@ -20,7 +20,7 @@ import pytorch_lightning as pl
 import torch
 import torchmetrics
 from torch import nn
-from torch.nn import functional as F
+from torch.nn import functional as F  # noqa: I2001
 from torchvision import transforms
 
 

--- a/examples/tests/.flake8
+++ b/examples/tests/.flake8
@@ -20,6 +20,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
 ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+# Disable flake8-import-restrictions
+extend-ignore = I20
 
 show_source = true
 

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -7,4 +7,4 @@ fmt:
 check:
 	isort . --check-only
 	black . --check
-	flake8
+	python -m flake8

--- a/harness/.flake8
+++ b/harness/.flake8
@@ -1,5 +1,6 @@
 # Note: This should be kept in sync with the .flake8 file in the root of the repo.
 [flake8]
+jobs = 8
 max-line-length = 100
 exclude =
     .git,
@@ -12,9 +13,145 @@ exclude =
 # We ignore F401 in __init__.py because it is expected for there to be
 # "unused imports" when defining a "regular" package. (This file is
 # implicitly executed when the package is imported, and the imports would
-# be used by the importer.) We ignore patch_saver_restore.py because it includes
-# a near-verbatim TensorFlow function with a small patch.
-per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
+# be used by the importer.)
+per-file-ignores =
+  __init__.py:F401,I2041
+  determined/cli/agent.py:I2041
+  determined/cli/checkpoint.py:I2041
+  determined/cli/cli.py:I2041
+  determined/cli/command.py:I2041
+  determined/cli/dev.py:I2041
+  determined/cli/experiment.py:I2041
+  determined/cli/job.py:I2041
+  determined/cli/master.py:I2041
+  determined/cli/model.py:I2041
+  determined/cli/notebook.py:I2041
+  determined/cli/oauth.py:I2041
+  determined/cli/project.py:I2041
+  determined/cli/proxy.py:I2041
+  determined/cli/rbac.py:I2041
+  determined/cli/remote.py:I2041
+  determined/cli/render.py:I2041
+  determined/cli/resource_pool.py:I2041
+  determined/cli/resources.py:I2041
+  determined/cli/shell.py:I2041
+  determined/cli/sso.py:I2041
+  determined/cli/task.py:I2041
+  determined/cli/template.py:I2041
+  determined/cli/tensorboard.py:I2041
+  determined/cli/top_arg_descriptions.py:I2041
+  determined/cli/trial.py:I2041
+  determined/cli/tunnel.py:I2041
+  determined/cli/user.py:I2041
+  determined/cli/user_groups.py:I2041
+  determined/cli/version.py:I2041
+  determined/cli/workspace.py:I2041
+  determined/common/declarative_argparse.py:I2041
+  determined/common/experimental/session.py:I2041
+  determined/common/storage/azure_client.py:I2041
+  determined/common/storage/boto3_credential_manager.py:I2041
+  determined/common/storage/gcs.py:I2041
+  determined/deploy/aws/aws.py:I2041
+  determined/deploy/aws/cli.py:I2041
+  determined/deploy/aws/deployment_types/base.py:I2041
+  determined/deploy/aws/deployment_types/govcloud.py:I2041
+  determined/deploy/aws/deployment_types/secure.py:I2041
+  determined/deploy/aws/gen_vcpu_mapping.py:I2041
+  determined/deploy/aws/master_config_inject.py:I2041
+  determined/deploy/aws/preflight.py:I2041
+  determined/deploy/cli.py:I2041
+  determined/deploy/gcp/cli.py:I2041
+  determined/deploy/gcp/gcp.py:I2041
+  determined/deploy/gcp/preflight.py:I2041
+  determined/deploy/gke/cli.py:I2041
+  determined/deploy/healthcheck.py:I2041
+  determined/deploy/local/cli.py:I2041
+  determined/deploy/local/cluster_utils.py:I2041
+  determined/deploy/local/preflight.py:I2041
+  determined/estimator/_estimator_context.py:I2041
+  determined/estimator/_estimator_trial.py:I2041
+  determined/estimator/_load.py:I2041
+  determined/estimator/_util.py:I2041
+  determined/experimental/client.py:I2041
+  determined/experimental/unmanaged.py:I2041
+  determined/keras/_load.py:I2041
+  determined/keras/_tf_keras_context.py:I2041
+  determined/keras/_tf_keras_trial.py:I2041
+  determined/launch/deepspeed.py:I2041
+  determined/launch/horovod.py:I2041
+  determined/profiler.py:I2041
+  determined/pytorch/_data.py:I2041
+  determined/pytorch/_pytorch_context.py:I2041
+  determined/pytorch/_pytorch_trial.py:I2041
+  determined/pytorch/_trainer.py:I2041
+  determined/pytorch/deepspeed/_deepspeed_context.py:I2041
+  determined/pytorch/deepspeed/_mpu.py:I2041
+  determined/pytorch/dsat/_dsat_search_method.py:I2041
+  determined/pytorch/dsat/_run_dsat.py:I2041
+  determined/pytorch/dsat/_utils.py:I2041
+  determined/pytorch/lightning/_adapter.py:I2041
+  determined/searcher/_remote_search_runner.py:I2041
+  determined/searcher/_search_method.py:I2041
+  determined/searcher/_search_runner.py:I2041
+  determined/tensorboard/base.py:I2041
+  determined/tensorboard/build.py:I2041
+  determined/tensorboard/fetchers/azure.py:I2041
+  determined/tensorboard/fetchers/gcs.py:I2041
+  determined/tensorboard/fetchers/s3.py:I2041
+  determined/tensorboard/fetchers/shared.py:I2041
+  determined/tensorboard/gcs.py:I2041
+  determined/tensorboard/metric_writers/pytorch.py:I2041
+  determined/tensorboard/metric_writers/tensorflow.py:I2041
+  determined/tensorboard/s3.py:I2041
+  determined/transformers/_hf_callback.py:I2041
+  determined/workload.py:I2041
+  tests/checkpoints/test_checkpoint.py:I2041
+  tests/cli/filetree.py:I2041
+  tests/cli/test_auth.py:I2041
+  tests/cli/test_cli.py:I2041
+  tests/cli/test_experiment.py:I2041
+  tests/common/api_server.py:I2041
+  tests/common/test_api_server.py:I2041
+  tests/common/test_multimaster.py:I2041
+  tests/confdir.py:I2041
+  tests/conftest.py:I2041
+  tests/custom_search_mocks.py:I2041
+  tests/determined/common/experimental/test_determined.py:I2041
+  tests/experiment/fixtures/ancient_keras_ckpt.py:I2041
+  tests/experiment/fixtures/estimator_xor_model.py:I2041
+  tests/experiment/fixtures/keras_no_op/model_def.py:I2041
+  tests/experiment/fixtures/keras_tf2_disabled_no_op/model_def.py:I2041
+  tests/experiment/fixtures/lightning_adapter_onevar_model.py:I2041
+  tests/experiment/fixtures/pytorch_amp/apex_amp_model_def.py:I2041
+  tests/experiment/fixtures/pytorch_amp/auto_amp_model_def.py:I2041
+  tests/experiment/fixtures/pytorch_amp/layers.py:I2041
+  tests/experiment/fixtures/pytorch_amp/manual_amp_model_def.py:I2041
+  tests/experiment/fixtures/pytorch_amp/model_def.py:I2041
+  tests/experiment/fixtures/pytorch_lightning_amp/apex_amp_model_def.py:I2041
+  tests/experiment/fixtures/pytorch_lightning_amp/auto_amp_model_def.py:I2041
+  tests/experiment/fixtures/pytorch_lightning_amp/data.py:I2041
+  tests/experiment/fixtures/pytorch_lightning_amp/model_def.py:I2041
+  tests/experiment/fixtures/tf_keras_one_var_model.py:I2041
+  tests/experiment/fixtures/tf_keras_xor_model.py:I2041
+  tests/experiment/integrations/test_pytorch_lightning.py:I2041
+  tests/experiment/keras/test_keras_data.py:I2041
+  tests/experiment/keras/test_tf_keras_trial.py:I2041
+  tests/experiment/pytorch/test_deepspeed_autotuning.py:I2041
+  tests/experiment/pytorch/test_pytorch_data.py:I2041
+  tests/experiment/pytorch/test_reducer.py:I2041
+  tests/experiment/tensorflow/test_util.py:I2041
+  tests/experiment/test_local.py:I2041
+  tests/experiment/utils.py:I2041
+  tests/filetree.py:I2041
+  tests/launch/test_deepspeed.py:I2041
+  tests/search_methods.py:I2041
+  tests/storage/test_azure.py:I2041
+  tests/storage/test_gcs.py:I2041
+  tests/storage/test_s3.py:I2041
+  tests/storage/test_shared_fs.py:I2041
+  tests/tensorboard/test_util.py:I2041
+  tests/test_custom_searcher.py:I2041
+  tests/test_gc_harness.py:I2041
 
 # Explanations for ignored error codes:
 # - D1* (no missing docstrings): too much effort to start enforcing
@@ -28,7 +165,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
 # - A003 (class attribute is shadowing a python builtin): not a high risk of causing issues.
-ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A003
+# - I2000 Imports are only allowed on module level: often useful for optional imports or import perf
+ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A003,I2000
 
 show_source = true
 

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -19,7 +19,10 @@ fmt:
 check: check-gen
 	isort . --check-only
 	black . --exclude $(py_bindings_dest) --check
-	flake8
+	# Note: plain `flake8` command does not add current directory to sys.path, which causes the
+	# flake8-import-restrictions plugin to fail to import the code.
+	# https://github.com/atollk/flake8-import-restrictions/issues/13
+	python -m flake8
 	mypy .
 
 .PHONY: test-cpu

--- a/harness/determined/cli/__main__.py
+++ b/harness/determined/cli/__main__.py
@@ -1,4 +1,4 @@
-from determined.cli.cli import main
+from determined.cli.cli import main  # noqa: I2041
 
 if __name__ == "__main__":
     main()

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -10,8 +10,6 @@ from determined.common import api, declarative_argparse, util
 from determined.common.api import authentication, bindings, certs
 from determined.experimental import client
 
-from .errors import FeatureFlagDisabled
-
 output_format_args: Dict[str, declarative_argparse.Arg] = {
     "json": declarative_argparse.Arg(
         "--json",
@@ -109,7 +107,7 @@ def require_feature_flag(feature_flag: str, error_message: str) -> Callable[...,
         def wrapper(args: argparse.Namespace) -> None:
             resp = bindings.get_GetMaster(setup_session(args))
             if not resp.to_json().get("rbacEnabled"):
-                raise FeatureFlagDisabled(error_message)
+                raise errors.FeatureFlagDisabled(error_message)
             function(args)
 
         return wrapper

--- a/harness/determined/cli/checkpoint.py
+++ b/harness/determined/cli/checkpoint.py
@@ -3,11 +3,10 @@ from argparse import Namespace
 from typing import Any, List, Optional
 
 from determined import cli, errors, experimental
+from determined.cli import render
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.experimental.client import DownloadMode
-
-from . import render
 
 
 def render_checkpoint(checkpoint: experimental.Checkpoint, path: Optional[str] = None) -> None:

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -4,12 +4,11 @@ from typing import Any, List
 
 import determined.cli.render
 from determined import cli
+from determined.cli import render
 from determined.common import api
 from determined.common.api import authentication
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.experimental import Determined, Model, ModelOrderBy, ModelSortBy, ModelVersion
-
-from . import render
 
 
 def render_model(model: Model) -> None:

--- a/harness/determined/cli/project.py
+++ b/harness/determined/cli/project.py
@@ -4,11 +4,11 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import determined.cli.render
 from determined import cli
+from determined.cli import render
 from determined.common import api
 from determined.common.api import authentication, bindings, errors
 from determined.common.declarative_argparse import Arg, Cmd
 
-from . import render
 from .workspace import list_workspace_projects, pagination_args, workspace_by_name
 
 

--- a/harness/determined/cli/template.py
+++ b/harness/determined/cli/template.py
@@ -5,12 +5,11 @@ from typing import Any, Dict, List
 from termcolor import colored
 
 from determined import cli
+from determined.cli import render
 from determined.cli.workspace import get_workspace_id_from_args, workspace_arg
 from determined.common import api, util, yaml
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
-
-from . import render
 
 TemplateClean = namedtuple("TemplateClean", ["name", "workspace"])
 TemplateAll = namedtuple("TemplateAll", ["name", "workspace", "config"])

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -3,13 +3,11 @@ from argparse import Namespace
 from collections import namedtuple
 from typing import Any, List
 
-from determined.cli import errors, login_sdk_client, setup_session
+from determined.cli import errors, login_sdk_client, render, setup_session
 from determined.common import api
 from determined.common.api import authentication, bindings, certs
 from determined.common.declarative_argparse import Arg, Cmd
 from determined.experimental import client
-
-from . import render
 
 FullUser = namedtuple(
     "FullUser",

--- a/harness/determined/cli/version.py
+++ b/harness/determined/cli/version.py
@@ -8,10 +8,9 @@ from packaging import version
 
 import determined
 import determined.cli
+from determined.cli import render
 from determined.common import api
 from determined.common.declarative_argparse import Cmd
-
-from . import render
 
 
 def get_version(host: str) -> Dict[str, Any]:

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -5,12 +5,11 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import determined.cli.render
 from determined import cli
+from determined.cli import render
 from determined.cli.user import AGENT_USER_GROUP_ARGS
 from determined.common import api, util
 from determined.common.api import authentication, bindings, errors
 from determined.common.declarative_argparse import Arg, Cmd
-
-from . import render
 
 PROJECT_HEADERS = ["ID", "Name", "Description", "# Experiments", "# Active Experiments"]
 WORKSPACE_HEADERS = [

--- a/harness/determined/common/api/_util.py
+++ b/harness/determined/common/api/_util.py
@@ -4,7 +4,7 @@ from typing import Callable, Iterator, Optional, Set, Tuple, TypeVar, Union
 import urllib3
 
 from determined.common import api, util
-from determined.common.api import Session, bindings
+from determined.common.api import bindings
 
 # from determined.cli.render import Animator
 
@@ -79,7 +79,7 @@ all_ntsc: Set[NTSC_Kind] = {
 proxied_ntsc: Set[NTSC_Kind] = {NTSC_Kind.notebook, NTSC_Kind.tensorboard}
 
 
-def get_ntsc_details(session: Session, typ: NTSC_Kind, ntsc_id: str) -> AnyNTSC:
+def get_ntsc_details(session: api.Session, typ: NTSC_Kind, ntsc_id: str) -> AnyNTSC:
     if typ == NTSC_Kind.notebook:
         return bindings.get_GetNotebook(session, notebookId=ntsc_id).notebook
     elif typ == NTSC_Kind.tensorboard:
@@ -93,7 +93,7 @@ def get_ntsc_details(session: Session, typ: NTSC_Kind, ntsc_id: str) -> AnyNTSC:
 
 
 def wait_for_ntsc_state(
-    session: Session,
+    session: api.Session,
     typ: NTSC_Kind,
     ntsc_id: str,
     predicate: Callable[[bindings.taskv1State], bool],

--- a/harness/determined/common/api/request.py
+++ b/harness/determined/common/api/request.py
@@ -1,7 +1,7 @@
 import json as _json
 import os
+import types
 import webbrowser
-from types import TracebackType
 from typing import Any, Dict, Iterator, Optional, Tuple, Union
 from urllib import parse
 
@@ -353,7 +353,7 @@ class WebSocket:
         self,
         exc_type: Optional[type],
         exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_tb: Optional[types.TracebackType],
     ) -> None:
         if not self.socket.is_closed:
             self.socket.close()

--- a/harness/determined/common/context.py
+++ b/harness/determined/common/context.py
@@ -5,9 +5,8 @@ import pathlib
 import tarfile
 from typing import Any, Dict, Iterable, List, Optional
 
-from determined.common import constants
+from determined.common import constants, util
 from determined.common.api import bindings
-from determined.common.util import sizeof_fmt
 
 LegacyContext = List[Dict[str, Any]]
 
@@ -69,7 +68,7 @@ class _Builder:
         self.limit = limit
         self.size = 0
         self.items = []  # type: List[bindings.v1File]
-        self.msg = f"Preparing files to send to master... {sizeof_fmt(0)} and 0 files"
+        self.msg = f"Preparing files to send to master... {util.sizeof_fmt(0)} and 0 files"
         print(self.msg, end="\r", flush=True)
 
     def add_v1File(self, f: bindings.v1File) -> None:
@@ -78,7 +77,7 @@ class _Builder:
         if self.size > self.limit:
             raise ValueError(
                 "The total size of context directory and included files and directories exceeds "
-                f" the maximum allowed size {sizeof_fmt(self.limit)}.\n"
+                f" the maximum allowed size {util.sizeof_fmt(self.limit)}.\n"
                 "Consider using either .detignore files inside directories to specify that certain "
                 "files or subdirectories should be omitted."
             )
@@ -87,7 +86,7 @@ class _Builder:
         print(" " * len(self.msg), end="\r")
         self.msg = (
             "Preparing files to send to master... "
-            f"{sizeof_fmt(self.size)} and {len(self.items)} files"
+            f"{util.sizeof_fmt(self.size)} and {len(self.items)} files"
         )
         print(self.msg, end="\r", flush=True)
 

--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import enum
 import hashlib
 import json
@@ -6,7 +7,6 @@ import logging
 import os
 import pathlib
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from determined import core, tensorboard
@@ -698,7 +698,7 @@ class CheckpointContext:
             taskId=self._task_id,
             training=bindings.v1CheckpointTrainingMetadata(),
             uuid=storage_id,
-            reportTime=datetime.now(timezone.utc).isoformat(),
+            reportTime=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             state=bindings.checkpointv1State.COMPLETED,
         )
         bindings.post_ReportCheckpoint(self._session, body=ckpt)

--- a/harness/determined/core/_train.py
+++ b/harness/determined/core/_train.py
@@ -4,10 +4,9 @@ import pathlib
 from typing import Any, Callable, Dict, List, Optional, Set
 
 import determined as det
-from determined import tensorboard
+from determined import core, tensorboard
 from determined.common import api, util
 from determined.common.api import bindings, errors
-from determined.core import DistributedContext, TensorboardMode
 
 logger = logging.getLogger("determined.core")
 
@@ -30,8 +29,8 @@ class TrainContext:
         trial_id: int,
         run_id: int,
         exp_id: int,
-        distributed: DistributedContext,
-        tensorboard_mode: TensorboardMode,
+        distributed: core.DistributedContext,
+        tensorboard_mode: core.TensorboardMode,
         tensorboard_manager: tensorboard.TensorboardManager,
         tbd_writer: Optional[tensorboard.BatchMetricWriter],
     ) -> None:
@@ -98,7 +97,7 @@ class TrainContext:
         bindings.post_ReportTrialMetrics(self._session, body=body, metrics_trialId=self._trial_id)
 
         # Also sync tensorboard (all metrics, not just json-serializable ones).
-        if self._tensorboard_mode == TensorboardMode.AUTO:
+        if self._tensorboard_mode == core.TensorboardMode.AUTO:
             if self._tbd_writer:
                 if group == util._LEGACY_VALIDATION:
                     self._tbd_writer.on_validation_step_end(total_batches, metrics)
@@ -140,7 +139,7 @@ class TrainContext:
                 If not provided, all files are uploaded.
             mangler: optional function modifying the destination file names based on rank.
         """
-        if self._tensorboard_mode == TensorboardMode.AUTO:
+        if self._tensorboard_mode == core.TensorboardMode.AUTO:
             raise RuntimeError("upload_tensorboard_files can only be used in MANUAL mode")
 
         self._tensorboard_manager.sync(selector, mangler, self._distributed.rank)

--- a/harness/determined/deploy/__init__.py
+++ b/harness/determined/deploy/__init__.py
@@ -1,1 +1,1 @@
-from . import cli, aws, gcp, gke, local
+from determined.deploy import cli, aws, gcp, gke, local

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -11,9 +11,9 @@ from termcolor import colored
 
 from determined.cli.errors import CliError
 from determined.common.declarative_argparse import Arg, ArgGroup, BoolOptArg, Cmd
+from determined.deploy.aws import aws, constants
 from determined.deploy.errors import MasterTimeoutExpired
 
-from . import aws, constants
 from .deployment_types import base, govcloud, secure, simple, vpc
 from .preflight import check_quotas, get_default_cf_parameter
 

--- a/harness/determined/deploy/aws/preflight.py
+++ b/harness/determined/deploy/aws/preflight.py
@@ -8,9 +8,9 @@ from botocore.exceptions import ClientError
 from termcolor import colored
 
 from determined.common import util, yaml
+from determined.deploy.aws import constants
 from determined.deploy.errors import PreflightFailure
 
-from . import constants
 from .deployment_types.base import DeterminedDeployment
 
 # There's no reliable way to map instance type to its quota category via an API.

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -5,8 +5,8 @@ from typing import Callable, Dict
 
 import determined
 from determined.common.declarative_argparse import Arg, BoolOptArg, Cmd, Group
+from determined.deploy.local import cluster_utils
 
-from . import cluster_utils
 from .preflight import check_docker_install
 
 

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -14,10 +14,10 @@ import psutil
 import urllib3
 
 import determined as det
+import determined.util
 from determined import constants, gpu
 from determined.common import api, util
 from determined.common.api import bindings, certs
-from determined.util import force_create_symlink
 
 
 def trial_prep(sess: api.Session, info: det.ClusterInfo) -> None:
@@ -63,7 +63,7 @@ def trial_prep(sess: api.Session, info: det.ClusterInfo) -> None:
         model_def.extractall(path=".")
 
     # pre-0.18.3 code wrote tensorboard stuff under /tmp/tensorboard
-    force_create_symlink(f"/tmp/tensorboard-{info.allocation_id}-0", "/tmp/tensorboard")
+    det.util.force_create_symlink(f"/tmp/tensorboard-{info.allocation_id}-0", "/tmp/tensorboard")
 
 
 def do_rendezvous_rm_provided(

--- a/harness/determined/pytorch/_experimental.py
+++ b/harness/determined/pytorch/_experimental.py
@@ -3,7 +3,7 @@ from typing import Any
 
 # AMP is only available in PyTorch 1.6+
 try:
-    import torch.cuda.amp as amp
+    from torch.cuda import amp
 
     HAVE_AMP = True
 except ImportError:  # pragma: no cover

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 import determined as det
 from determined import profiler, pytorch, util
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover
 
 # AMP is only available in PyTorch 1.6+
 try:
-    import torch.cuda.amp as amp
+    from torch.cuda import amp
 
     HAVE_AMP = True
 except ImportError:  # pragma: no cover

--- a/harness/tests/cli/test_cli.py
+++ b/harness/tests/cli/test_cli.py
@@ -11,9 +11,7 @@ import pytest
 import requests
 import requests_mock
 
-import determined.cli.cli as cli
-import determined.cli.command as command
-from determined.cli import render
+from determined.cli import cli, command, render
 from determined.common import constants, context
 from tests.filetree import FileTree
 

--- a/harness/tests/experiment/pytorch/test_metric_utils.py
+++ b/harness/tests/experiment/pytorch/test_metric_utils.py
@@ -6,8 +6,8 @@ import pytest
 import torch
 
 import determined.errors
-import determined.pytorch as pytorch
 import determined.pytorch._metric_utils as metric_utils
+from determined import pytorch
 
 logger = logging.getLogger(__name__)
 

--- a/harness/tests/test_imports.py
+++ b/harness/tests/test_imports.py
@@ -93,10 +93,10 @@ def test_import_from_path() -> None:
 
         # Execute from the a/ directory like we were in a normal interactive interpreter.
         with chdir(fixture / "a"), prepend_sys_path(""):
-            import model_def as a
+            import model_def as a  # noqa: I2001
 
             with det.import_from_path(fixture / "b"):
-                import model_def as b
+                import model_def as b  # noqa: I2001
 
                 # Nesting is not supported.
                 with pytest.raises(RuntimeError, match="does not support nesting"):
@@ -104,7 +104,7 @@ def test_import_from_path() -> None:
                         pass
 
             with det.import_from_path(fixture / "c"):
-                import model_def as c
+                import model_def as c  # noqa: I2001
 
         # Import lib2 after the checkpoints do.
         import lib2

--- a/model_hub/.flake8
+++ b/model_hub/.flake8
@@ -27,6 +27,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - W503 (no line breaks before binary operator): not PEP8-compliant; triggered by Black-formatted code
 # - C812-C816 (missing trailing comma): stylistic choice
 ignore = A003,D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816
+# Disable flake8-import-restrictions
+extend-ignore = I20
 
 show_source = true
 

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -76,7 +76,7 @@ fmt:
 check:
 	isort . --check-only
 	black . --check
-	flake8
+	python -m flake8
 	mypy .
 
 .PHONY: test

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ flake8-colors>=0.1.6
 flake8-commas==2.0.0
 flake8-comprehensions>=2.2.0
 flake8-docstrings>=1.4.0
+flake8-import-restrictions==1.1.1
 flake8-quotes>=2.1.0
 flake8-tuple>=0.4.0
 isort==5.11.5 # Note: this should be kept in sync with the version in `.pre-commit-config.yaml`.

--- a/schemas/Makefile
+++ b/schemas/Makefile
@@ -11,5 +11,5 @@ check:
 	./lint.py --check `find expconf -name '*.json'`
 	isort . --check-only
 	black . --check
-	flake8
+	python -m flake8
 	mypy `find . -name '*.py'`

--- a/tools/.flake8
+++ b/tools/.flake8
@@ -26,6 +26,8 @@ per-file-ignores = __init__.py:F401 patch_saver_restore.py:E111,E114,
 # - C812-C816 (missing trailing comma): stylistic choice
 # - A001-A003 (flake8-builtins): disable plugin
 ignore = D1,D200,D202,D203,D205,D212,D4,E203,W503,C812,C813,C814,C815,C816,A001,A002,A003
+# Disable flake8-import-restrictions
+extend-ignore = I20
 
 show_source = true
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -23,5 +23,5 @@ fmt:
 check:
 	isort . --check-only
 	black . --check
-	flake8
+	python -m flake8
 	mypy scripts

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -25,8 +25,8 @@ import argparse
 import collections
 import itertools
 import os
+import pathlib
 import sys
-from pathlib import Path
 from typing import Any, Dict
 
 import requests
@@ -217,7 +217,7 @@ def update_tag_for_image_type(subconf: Dict[str, str], new_tag: str) -> bool:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("path", type=Path, help="path/to/bumpenvs.yaml")
+    parser.add_argument("path", type=pathlib.Path, help="path/to/bumpenvs.yaml")
     parser.add_argument("commit", help="environments commit id")
     parser.add_argument(
         "--no-cloud-images",


### PR DESCRIPTION
## Description

I've just been reminded once again that we have to follow google style guide on python imports: https://google.github.io/styleguide/pyguide.html#22-imports

>Use import statements for packages and modules only, not for individual classes or functions.

This PR adds `flake8-import-restrictions` plugin which checks for these violations.

We had 689 violations for this rule in `harness/`. Since I don't have courage to write a script to fix this automatically, I've fixed all violations in the Core API `determined/core/*` and added the remaining violating files to the ignore list. Thus, all new files under `harness/` will be checked.

One more thing this style guide rule disallows is relative imports: `Do not use relative names in imports. Even if the module is in the same package, use the full package name`. This flake8 plugin crashes on `from . import ...`, so I had to fix this in a few places to prevent it from crashing.

The error is fully ignored in `model_hub`, `e2e_tests`, and `examples/tests`.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
