### PR TITLE
chore: linting now less verbose

### DIFF
--- a/agent/internal/containers/spec.go
+++ b/agent/internal/containers/spec.go
@@ -184,8 +184,8 @@ func (m *Manager) unmakeContainerDockerLabels(cont types.Container) (
 ) {
 	// TODO(ilia): Shim old versions whenever possible, when we'll have them.
 	if cont.Labels[docker.ContainerVersionLabel] != docker.ContainerVersionValue {
-		return nil, errors.New(fmt.Sprintf(
-			"can't parse container labels version %s", cont.Labels[docker.ContainerVersionLabel]))
+		return nil, fmt.Errorf(
+			"can't parse container labels version %s", cont.Labels[docker.ContainerVersionLabel])
 	}
 
 	devicesLabel := cont.Labels[docker.ContainerDevicesLabel]

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -68,8 +68,8 @@ linters-settings:
     line-length: 100
   misspell:
     locale: US
-  exhaustivestruct:
-    struct-patterns:
+  exhaustruct:
+    include:
       - 'github.com/determined-ai/determined/master/pkg/schemas/expconf.*Config*'
   forbidigo:
     forbid:
@@ -90,6 +90,7 @@ linters:
     - godox
     - goerr113
     - gofumpt
+    - golint
     - gomnd
     - maligned
     - nestif
@@ -124,7 +125,7 @@ linters:
     - paralleltest
     - predeclared
     - promlinter
-    - revive
+    # - revive
     - tagliatelle
     - tenv
     - thelper
@@ -150,7 +151,10 @@ linters:
     - prealloc
     - interfacer
     - structcheck
-    - unused
+    # - unused
     - nolintlint
     - usestdlibvars
+    - exhaustivestruct
     - exhaustruct
+    - varcheck
+    - deadcode

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -81,7 +81,9 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - deadcode
     - exhaustive
+    - exhaustivestruct
     - funlen
     - gochecknoglobals
     - gochecknoinits
@@ -99,6 +101,7 @@ linters:
     - testpackage
     - unparam
     - wsl
+    - varcheck
 
     # Below here are new linters from upgrading to 1.43.0. Since we enable all and disable
     # selectively, when we upgrade we get a ton of new linters. For convenience next upgrade,
@@ -125,7 +128,6 @@ linters:
     - paralleltest
     - predeclared
     - promlinter
-    # - revive
     - tagliatelle
     - tenv
     - thelper
@@ -151,10 +153,7 @@ linters:
     - prealloc
     - interfacer
     - structcheck
-    # - unused
     - nolintlint
     - usestdlibvars
-    - exhaustivestruct
     - exhaustruct
-    - varcheck
-    - deadcode
+

--- a/master/Makefile
+++ b/master/Makefile
@@ -112,7 +112,7 @@ build-race: gen
 check: check-gen
 	go mod tidy
 	git diff --quiet go.mod go.sum
-	golangci-lint --build-tags integration run -v --timeout 10m
+	golangci-lint --build-tags integration run --timeout 10m
 
 .PHONY: check-all
 check-all: check check-sql

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -305,7 +305,7 @@ func (a *apiServer) DeleteExperiment(
 
 	// report any error on the individual experiment
 	if len(results) == 0 {
-		return nil, errors.Errorf("DeleteExperiments returned neither pass nor fail on delete query.")
+		return nil, errors.Errorf("DeleteExperiments returned neither pass nor fail on delete query")
 	}
 	if results[0].Error != nil {
 		return nil, results[0].Error
@@ -900,7 +900,7 @@ func (a *apiServer) PauseExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("PauseExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("PauseExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -923,7 +923,7 @@ func (a *apiServer) CancelExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("CancelExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("CancelExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -946,7 +946,7 @@ func (a *apiServer) KillExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("KillExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("KillExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -969,7 +969,7 @@ func (a *apiServer) ArchiveExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("ArchiveExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("ArchiveExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -992,7 +992,7 @@ func (a *apiServer) UnarchiveExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("UnarchiveExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("UnarchiveExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -1034,7 +1034,7 @@ func (a *apiServer) PatchExperiment(
 		madeChanges = true
 		if len(strings.TrimSpace(req.Experiment.Name.Value)) == 0 {
 			return nil, status.Errorf(codes.InvalidArgument,
-				"`name` must not be an empty or whitespace string.")
+				"`name` must not be an empty or whitespace string")
 		}
 		exp.Name = req.Experiment.Name.Value
 	}
@@ -1939,7 +1939,7 @@ func (a *apiServer) MoveExperiment(
 		return nil, err
 	}
 	if exp.Archived {
-		return nil, errors.Errorf("experiment (%v) is archived and cannot be moved.", exp.ID)
+		return nil, errors.Errorf("experiment (%v) is archived and cannot be moved", exp.ID)
 	}
 
 	// check that user can view source project
@@ -1948,7 +1948,7 @@ func (a *apiServer) MoveExperiment(
 		return nil, err
 	}
 	if srcProject.Archived {
-		return nil, errors.Errorf("project (%v) is archived and cannot have experiments moved from it.",
+		return nil, errors.Errorf("project (%v) is archived and cannot have experiments moved from it",
 			srcProject.Id)
 	}
 
@@ -1958,7 +1958,7 @@ func (a *apiServer) MoveExperiment(
 		return nil, err
 	}
 	if destProject.Archived {
-		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments.",
+		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments",
 			req.DestinationProjectId)
 	}
 	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, curUser, destProject); err != nil {
@@ -1970,7 +1970,7 @@ func (a *apiServer) MoveExperiment(
 
 	if err == nil {
 		if len(results) == 0 {
-			return nil, errors.Errorf("MoveExperiments returned neither pass nor fail on query.")
+			return nil, errors.Errorf("MoveExperiments returned neither pass nor fail on query")
 		} else if results[0].Error != nil {
 			return nil, results[0].Error
 		}
@@ -1993,7 +1993,7 @@ func (a *apiServer) MoveExperiments(
 		return nil, err
 	}
 	if destProject.Archived {
-		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments.",
+		return nil, errors.Errorf("project (%v) is archived and cannot add new experiments",
 			req.DestinationProjectId)
 	}
 	if err = exputil.AuthZProvider.Get().CanCreateExperiment(ctx, *curUser, destProject); err != nil {

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -83,7 +83,7 @@ func (a *apiServer) GetModel(
 	if err = modelauth.AuthZProvider.Get().CanGetModel(ctx, *curUser, m,
 		m.WorkspaceId); err != nil {
 		return nil, authz.SubIfUnauthorized(err,
-			errors.Errorf("current user %q doesn't have permissions to get model %q.",
+			errors.Errorf("current user %q doesn't have permissions to get model %q",
 				curUser.Username, m.Name))
 	}
 	return &apiv1.GetModelResponse{Model: m}, err
@@ -158,7 +158,7 @@ func (a *apiServer) GetModels(
 		CanGetModels(ctx, *curUser, workspaceIdsGiven)
 	if err != nil {
 		return nil, authz.SubIfUnauthorized(err, errors.Errorf(
-			"current user doesn't have view permissions in related workspaces."))
+			"current user doesn't have view permissions in related workspaces"))
 	}
 	var workspaceIds []string
 	var workspaceIdsWithPermsAndFilter string
@@ -305,7 +305,7 @@ func (a *apiServer) PatchModel(
 	}
 
 	if currModel.Archived {
-		return nil, errors.Errorf("model %q is archived and cannot have attributes updated.",
+		return nil, errors.Errorf("model %q is archived and cannot have attributes updated",
 			currModel.Name)
 	}
 
@@ -567,7 +567,7 @@ func (a *apiServer) GetModelVersion(
 	if err = modelauth.AuthZProvider.Get().CanGetModel(ctx, *curUser, currModel,
 		currModel.WorkspaceId); err != nil {
 		return nil, authz.SubIfUnauthorized(err,
-			errors.Errorf("current user %q doesn't have permissions to get model %q.",
+			errors.Errorf("current user %q doesn't have permissions to get model %q",
 				curUser.Username, currModel.Name))
 	}
 
@@ -592,7 +592,7 @@ func (a *apiServer) GetModelVersions(
 	if err := modelauth.AuthZProvider.Get().CanGetModel(ctx, *curUser, parentModel,
 		parentModel.WorkspaceId); err != nil {
 		return nil, authz.SubIfUnauthorized(err,
-			errors.Errorf("current user %q doesn't have permissions to get model %q.",
+			errors.Errorf("current user %q doesn't have permissions to get model %q",
 				curUser.Username, parentModel.Name))
 	}
 
@@ -625,7 +625,7 @@ func (a *apiServer) PostModelVersion(
 	}
 
 	if modelResp.Archived {
-		return nil, errors.Errorf("model %q is archived and cannot register new versions.",
+		return nil, errors.Errorf("model %q is archived and cannot register new versions",
 			modelResp.Name)
 	}
 

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -39,7 +39,7 @@ func setupNTSCAuthzTest(t *testing.T) (
 	*apiServer, *mocks.NSCAuthZ, model.User, context.Context,
 ) {
 	api, curUser, ctx := setupAPITest(t, nil)
-	var master *Master = api.m
+	master := api.m
 	command.RegisterAPIHandler(
 		master.system,
 		nil,

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -595,11 +595,11 @@ func (a *apiServer) PatchProject(
 		return nil, err
 	}
 	if currProject.Archived {
-		return nil, errors.Errorf("project (%d) is archived and cannot have attributes updated.",
+		return nil, errors.Errorf("project (%d) is archived and cannot have attributes updated",
 			currProject.Id)
 	}
 	if currProject.Immutable {
-		return nil, errors.Errorf("project (%v) is immutable and cannot have attributes updated.",
+		return nil, errors.Errorf("project (%v) is immutable and cannot have attributes updated",
 			currProject.Id)
 	}
 

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -88,10 +88,10 @@ func (a *apiServer) GetWorkspaceByID(
 	}
 
 	if rejectImmutable && w.Immutable {
-		return nil, errors.Errorf("workspace (%v) is immutable and cannot add new projects.", w.Id)
+		return nil, errors.Errorf("workspace (%v) is immutable and cannot add new projects", w.Id)
 	}
 	if rejectImmutable && w.Archived {
-		return nil, errors.Errorf("workspace (%v) is archived and cannot add new projects.", w.Id)
+		return nil, errors.Errorf("workspace (%v) is archived and cannot add new projects", w.Id)
 	}
 	return w, nil
 }

--- a/master/internal/cache/cache.go
+++ b/master/internal/cache/cache.go
@@ -132,7 +132,7 @@ func (f *FileCache) genPathWithValidation(expID int, path string) (string, error
 		return "", err
 	}
 	if strings.HasPrefix(rp, "..") {
-		return "", errors.Errorf("%s is not a valid path.", path)
+		return "", errors.Errorf("%s is not a valid path", path)
 	}
 	return p, nil
 }

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -205,21 +205,20 @@ func validateMaxSpotPrice(spotMaxPriceInput string) error {
 	// Must have 1 or 0 decimalPoints. All other characters must be digits
 	numDecimalPoints := strings.Count(spotMaxPriceInput, ".")
 	if numDecimalPoints != 0 && numDecimalPoints != 1 {
-		return errors.New(
-			fmt.Sprintf("spot max price should have either 0 or 1 decimal points. "+
-				"Received %s, which has %d decimal points",
-				spotMaxPriceInput,
-				numDecimalPoints))
+		return fmt.Errorf("spot max price should have either 0 or 1 decimal points. "+
+			"Received %s, which has %d decimal points",
+			spotMaxPriceInput,
+			numDecimalPoints)
 	}
 
 	priceWithoutDecimalPoint := strings.ReplaceAll(spotMaxPriceInput, ".", "")
 	for _, char := range priceWithoutDecimalPoint {
 		if !unicode.IsDigit(char) {
-			return errors.New(
-				fmt.Sprintf("spot max price should only contain digits and, optionally, one decimal point. "+
+			return fmt.Errorf(
+				"spot max price should only contain digits and, optionally, one decimal point. "+
 					"Received %s, which has the non-digit character %s",
-					spotMaxPriceInput,
-					string(char)))
+				spotMaxPriceInput,
+				string(char))
 		}
 	}
 	return nil

--- a/master/internal/db/migrations.go
+++ b/master/internal/db/migrations.go
@@ -86,14 +86,13 @@ func ensureMigrationUpgrade(tx *pg.Tx) error {
 
 	// Unrecognized table state.
 	if len(rows) != 1 {
-		return errors.New(fmt.Sprintf("schema_migrations table has %d entries", len(rows)))
+		return fmt.Errorf("schema_migrations table has %d entries", len(rows))
 	}
 
 	goMigrateEntry := rows[0]
 
 	if goMigrateEntry.Dirty {
-		return errors.New(
-			fmt.Sprintf("schema_migrations entry dirty, version %s", goMigrateEntry.Version))
+		return fmt.Errorf("schema_migrations entry dirty, version %s", goMigrateEntry.Version)
 	}
 	goMigrateVersion, err := strconv.ParseInt(goMigrateEntry.Version, 10, 64)
 	if err != nil {
@@ -164,7 +163,7 @@ func (db *PgDB) Migrate(migrationURL string, actions []string) error {
 	re := regexp.MustCompile(`file://(.+)`)
 	match := re.FindStringSubmatch(migrationURL)
 	if len(match) != 2 {
-		return errors.New(fmt.Sprintf("failed to parse migrationsURL: %s", migrationURL))
+		return fmt.Errorf("failed to parse migrationsURL: %s", migrationURL)
 	}
 
 	collection := migrations.NewCollection()

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -72,7 +72,7 @@ func ResolveNewPostgresDatabase() (*PgDB, func(), error) {
 	url, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, nil, errors.Wrapf(
-			err, "failed to parse DET_INTEGRATION_POSTGRES_URL (%q):", baseURL,
+			err, "failed to parse DET_INTEGRATION_POSTGRES_URL (%q)", baseURL,
 		)
 	}
 

--- a/master/internal/db/postgres_trial_metrics.go
+++ b/master/internal/db/postgres_trial_metrics.go
@@ -79,7 +79,7 @@ func newMetricsBody(
 	batchMetrics []*structpb.Struct,
 	isValidation bool,
 ) *metricsBody {
-	var bMetrics any = nil
+	var bMetrics any
 	if len(batchMetrics) != 0 {
 		bMetrics = batchMetrics
 	}

--- a/master/internal/proxy/proxy.go
+++ b/master/internal/proxy/proxy.go
@@ -198,7 +198,7 @@ func setUpProxy(serviceURL *url.URL) (*httputil.ReverseProxy, error) {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(masterCaBytes)
 
-	//nolint:gosec,G402
+	//nolint:gosec
 	proxy.Transport = &http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs:            caCertPool,

--- a/master/internal/proxy/ws.go
+++ b/master/internal/proxy/ws.go
@@ -68,7 +68,7 @@ func newSingleHostReverseWebSocketProxy(c echo.Context, t *url.URL) http.Handler
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(masterCaBytes)
 
-			//nolint:gosec,G402
+			//nolint:gosec
 			tlsConfig := &tls.Config{
 				ServerName:         "127.0.0.1",
 				Certificates:       []tls.Certificate{cert},

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -481,17 +481,6 @@ func (a *agentResourceManager) getPoolJobStats(
 	return jobStats, nil
 }
 
-func (a *agentResourceManager) aggregateTaskHandler(
-	resps map[*actor.Ref]actor.Message,
-) (*actor.Ref, error) {
-	for _, resp := range resps {
-		if typed, ok := resp.(*actor.Ref); ok && typed != nil {
-			return typed, nil
-		}
-	}
-	return nil, errors.New("task handler not found on any resource pool")
-}
-
 func (a *agentResourceManager) aggregateTaskSummary(
 	resps map[*actor.Ref]actor.Message,
 ) *sproto.AllocationSummary {

--- a/master/internal/rm/agentrm/agent_state.go
+++ b/master/internal/rm/agentrm/agent_state.go
@@ -448,12 +448,10 @@ func (a *agentState) patchSlotState(
 ) (model.SlotSummary, error) {
 	s, ok := a.slotStates[msg.id]
 	if !ok {
-		return model.SlotSummary{}, errors.New(
-			fmt.Sprintf(
-				"bad updateSlotDeviceView on device: %d (%s): not found",
-				msg.id,
-				a.string(),
-			),
+		return model.SlotSummary{}, fmt.Errorf(
+			"bad updateSlotDeviceView on device: %d (%s): not found",
+			msg.id,
+			a.string(),
 		)
 	}
 	return a.patchSlotStateInner(ctx, msg, s), nil
@@ -494,19 +492,6 @@ func (a *agentState) persist() error {
 		On("CONFLICT (agent_id) DO UPDATE").
 		Exec(context.TODO())
 	return err
-}
-
-func (a *agentState) restore() error {
-	snapshot := agentSnapshot{}
-	err := db.Bun().NewSelect().Model(&snapshot).
-		Where("agent_id = ?", a.Handler.Address().Local()).
-		Scan(context.TODO())
-	if err != nil {
-		return err
-	}
-	log.Debugf("restored agent state snapshot: %v", snapshot)
-
-	return nil
 }
 
 func (a *agentState) delete() error {

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -190,7 +190,7 @@ func (rp *resourcePool) restoreResources(
 	for _, cs := range containerSnapshots {
 		agentState, ok := agentStateMap[cs.AgentID]
 		if !ok {
-			return errors.New(fmt.Sprintf("can't find restorable agent %s", cs.AgentID))
+			return fmt.Errorf("can't find restorable agent %s", cs.AgentID)
 		}
 
 		cr := containerResources{
@@ -389,15 +389,6 @@ func (rp *resourcePool) getOrCreateGroup(
 		actors.NotifyOnStop(ctx, handler, tasklist.GroupActorStopped{Ref: handler})
 	}
 	return g
-}
-
-func (rp *resourcePool) notifyOnStop(
-	ctx *actor.Context, ref *actor.Ref, msg actor.Message,
-) {
-	done := actors.NotifyOnStop(ctx, ref, msg)
-	if rp.saveNotifications {
-		rp.notifications = append(rp.notifications, done)
-	}
 }
 
 func (rp *resourcePool) updateScalingInfo() bool {

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -611,17 +611,6 @@ func (k *kubernetesResourceManager) fetchAvgQueuedTime(pool string) (
 	return res, nil
 }
 
-func (k *kubernetesResourceManager) aggregateTaskHandler(
-	resps map[*actor.Ref]actor.Message,
-) (*actor.Ref, error) {
-	for _, resp := range resps {
-		if typed, ok := resp.(*actor.Ref); ok && typed != nil {
-			return typed, nil
-		}
-	}
-	return nil, errors.New("task handler not found on any resource pool")
-}
-
 func (k *kubernetesResourceManager) aggregateTaskSummary(
 	resps map[*actor.Ref]actor.Message,
 ) *sproto.AllocationSummary {

--- a/master/internal/rm/kubernetesrm/pod_test.go
+++ b/master/internal/rm/kubernetesrm/pod_test.go
@@ -814,10 +814,10 @@ func TestResourceCreationCancelled(t *testing.T) {
 			reflect.TypeOf(message))
 	}
 
-	var correctContainerStarted *sproto.ResourcesStarted = nil
+	var correctContainerStarted *sproto.ResourcesStarted
 	correctFailType := "task failed without an associated exit code"
 	correctErrMsg := "pod actor exited while pod was running"
-	var correctCode *sproto.ExitCode = nil
+	var correctCode *sproto.ExitCode
 
 	assert.Equal(t, containerMsg.ResourcesStarted, correctContainerStarted)
 	assert.Equal(t, containerMsg.ResourcesStopped.Failure.FailureType,
@@ -856,8 +856,8 @@ func TestResourceDeletionFailed(t *testing.T) {
 			reflect.TypeOf(message))
 	}
 
-	var correctContainerStarted *sproto.ResourcesStarted = nil
-	var correctCode *sproto.ExitCode = nil
+	var correctContainerStarted *sproto.ResourcesStarted
+	var correctCode *sproto.ExitCode
 
 	assert.Equal(t, containerMsg.ResourcesStarted, correctContainerStarted)
 	assert.Equal(t, containerMsg.ResourcesStopped.Failure.FailureType,

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1058,19 +1058,19 @@ func (p *pods) getNodeResourcePoolMapping(nodeSummaries map[string]model.AgentSu
 			if len(p.resourcePoolConfigs) <= 1 &&
 				(tcd == nil || (tcd.CPUPodSpec == nil && tcd.GPUPodSpec == nil)) {
 				if slotType == device.CUDA {
-					//nolint:gocritic,appendAssign
+					//nolint:gocritic
 					poolTolerations = append(defaultTolerations, gpuTolerations...)
 				} else if slotType == device.CPU {
-					//nolint:gocritic,appendAssign
+					//nolint:gocritic
 					poolTolerations = append(defaultTolerations, cpuTolerations...)
 				}
 			} else if tcd != nil {
 				// Decide which poolTolerations to use based on slot device type
 				if slotType == device.CUDA && tcd.GPUPodSpec != nil {
-					//nolint:gocritic,appendAssign
+					//nolint:gocritic
 					poolTolerations = append(tcd.GPUPodSpec.Spec.Tolerations, gpuTolerations...)
 				} else if tcd.CPUPodSpec != nil {
-					//nolint:gocritic,appendAssign
+					//nolint:gocritic
 					poolTolerations = append(tcd.CPUPodSpec.Spec.Tolerations, cpuTolerations...)
 				}
 			}

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -698,19 +698,15 @@ func (t *trial) maybeRestoreAllocation(ctx *actor.Context) (*model.Allocation, e
 		for _, alloc := range allocations[0:mathx.Min(len(allocations), maxAllocsToLog)] {
 			allocIDs = append(allocIDs, alloc.AllocationID.String())
 		}
-		return nil, errors.New(
-			fmt.Sprintf(
-				"discovered %d open allocations on restore: %s",
-				len(allocations),
-				strings.Join(allocIDs, " "),
-			),
+		return nil, fmt.Errorf(
+			"discovered %d open allocations on restore: %s",
+			len(allocations),
+			strings.Join(allocIDs, " "),
 		)
 	default:
-		return nil, errors.New(
-			fmt.Sprintf(
-				"discovered %d open allocations on restore",
-				len(allocations),
-			),
+		return nil, fmt.Errorf(
+			"discovered %d open allocations on restore",
+			len(allocations),
 		)
 	}
 }

--- a/master/pkg/archive/archive.go
+++ b/master/pkg/archive/archive.go
@@ -26,7 +26,7 @@ type (
 	Archive []Item
 )
 
-var defaultModifiedTime UnixTime = func() UnixTime {
+var defaultModifiedTime = func() UnixTime {
 	t, err := time.Parse(time.RFC3339, pkg.DeterminedBirthday)
 	if err != nil {
 		panic(err)

--- a/master/pkg/cproto/state.go
+++ b/master/pkg/cproto/state.go
@@ -110,6 +110,6 @@ func ParseStateFromDocker(cont types.Container) (State, error) {
 	case "running":
 		return Running, nil
 	default:
-		return Unknown, errors.New(fmt.Sprintf("unknown container state: %s", cont.State))
+		return Unknown, fmt.Errorf("unknown container state: %s", cont.State)
 	}
 }

--- a/master/pkg/logger/log_buffer_test.go
+++ b/master/pkg/logger/log_buffer_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/assert"
 )
@@ -12,33 +11,25 @@ import (
 func checkIDRange(entries []*Entry, expectedStartID int, expectedEndID int) error {
 	startID := entries[0].ID
 	if startID != expectedStartID {
-		return errors.New(
-			fmt.Sprintf("unexpected startID: %v != %v",
-				startID, expectedStartID))
+		return fmt.Errorf("unexpected startID: %v != %v", startID, expectedStartID)
 	}
 
 	endID := entries[len(entries)-1].ID
 	if endID != expectedEndID {
-		return errors.New(
-			fmt.Sprintf("unexpected endID: %v != %v",
-				endID, expectedEndID))
+		return fmt.Errorf("unexpected endID: %v != %v", endID, expectedEndID)
 	}
 
 	actualLen := len(entries)
 	expectedLen := expectedEndID - expectedStartID + 1
 	if actualLen != expectedLen {
-		return errors.New(
-			fmt.Sprintf("unexpected length of entries: %v != %v",
-				actualLen, expectedLen))
+		return fmt.Errorf("unexpected length of entries: %v != %v", actualLen, expectedLen)
 	}
 
 	// Check the order of all IDs.
 	for index, entry := range entries {
 		expected := index + expectedStartID
 		if entry.ID != expected {
-			return errors.New(
-				fmt.Sprintf("unexpected entryID: %v != %v",
-					entry.ID, expected))
+			return fmt.Errorf("unexpected entryID: %v != %v", entry.ID, expected)
 		}
 	}
 

--- a/master/pkg/schemas/expconf/length.go
+++ b/master/pkg/schemas/expconf/length.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/determined-ai/determined/master/pkg/check"
 )
 
@@ -77,7 +75,7 @@ func (l *LengthV0) UnmarshalJSON(b []byte) error {
 	case !rOk && !bOk && eOk:
 		*l = NewLengthInEpochs(epochs)
 	default:
-		return errors.New(fmt.Sprintf("invalid length: %s", b))
+		return fmt.Errorf("invalid length: %s", b)
 	}
 
 	return nil

--- a/master/pkg/schemas/expconf/parse.go
+++ b/master/pkg/schemas/expconf/parse.go
@@ -57,7 +57,7 @@ func ParseAnyExperimentConfigJSON(byts []byte) (ExperimentConfig, error) {
 	// 	}
 
 	default:
-		return out, errors.New(fmt.Sprintf("invalid version: %d", version))
+		return out, fmt.Errorf("invalid version: %d", version)
 	}
 
 	// Call shim on each old versions, walking our way to the latest version.

--- a/master/pkg/searcher/custom_search.go
+++ b/master/pkg/searcher/custom_search.go
@@ -19,7 +19,6 @@ type (
 	}
 
 	customSearch struct {
-		defaultSearchMethod
 		expconf.CustomConfig
 		customSearchState
 	}

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -103,13 +103,3 @@ func (defaultSearchMethod) validationCompleted(
 ) ([]Operation, error) {
 	return nil, nil
 }
-
-func (defaultSearchMethod) trialClosed(context, model.RequestID) ([]Operation, error) {
-	return nil, nil
-}
-
-func (defaultSearchMethod) trialExitedEarly(
-	context, model.RequestID, model.ExitedReason,
-) ([]Operation, error) {
-	return []Operation{Shutdown{Failure: true}}, nil
-}

--- a/master/pkg/searcher/search_method.go
+++ b/master/pkg/searcher/search_method.go
@@ -103,3 +103,15 @@ func (defaultSearchMethod) validationCompleted(
 ) ([]Operation, error) {
 	return nil, nil
 }
+
+// nolint:unused
+func (defaultSearchMethod) trialClosed(context, model.RequestID) ([]Operation, error) {
+	return nil, nil
+}
+
+// nolint:unused
+func (defaultSearchMethod) trialExitedEarly(
+	context, model.RequestID, model.ExitedReason,
+) ([]Operation, error) {
+	return []Operation{Shutdown{Failure: true}}, nil
+}

--- a/master/pkg/set/set.go
+++ b/master/pkg/set/set.go
@@ -31,19 +31,23 @@ func FromKeys[M ~map[K]V, K comparable, V any](m M) Set[K] {
 	return set
 }
 
+// Contains checks whether the passed-in value is present in the Set.
 func (s *Set[T]) Contains(val T) bool {
 	_, ok := (map[T]unit)(*s)[val]
 	return ok
 }
 
+// Insert adds the passed-in value to the Set.
 func (s *Set[T]) Insert(val T) {
 	(map[T]unit)(*s)[val] = unit{}
 }
 
+// Remove removes the passed-in value from the Set.
 func (s *Set[T]) Remove(val T) {
 	delete((map[T]unit)(*s), val)
 }
 
+// ToSlice builds a new slice, populates it with the contents of the Set, and returns it.
 func (s Set[T]) ToSlice() []T {
 	res := make([]T, 0, len(s))
 	for val := range s {

--- a/master/pkg/ws/ws.go
+++ b/master/pkg/ws/ws.go
@@ -32,9 +32,8 @@ const (
 // thread-safe API by specializing for JSON encoding/decoding and using channels for read/write. The
 // Close method must be called or resources will be leaked.
 type WebSocket[TIn, TOut any] struct {
-	log      *logrus.Entry
-	conn     *websocket.Conn
-	connLock sync.Mutex
+	log  *logrus.Entry
+	conn *websocket.Conn
 
 	cancel    context.CancelFunc
 	errLock   sync.Mutex

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -67,7 +67,6 @@ func trialDetailAPITests(
 ) {
 	type testCase struct {
 		name    string
-		req     *apiv1.GetTrialRequest
 		metrics map[string]interface{}
 	}
 


### PR DESCRIPTION
## Description

Running `make check` was very verbose, with lots of output and warnings—especially about deprecated linters. I'm a big fan of "no news is good news," so I updated our linters to the recommended replacements and fixed the spots in code where those linters complained.

I also changed the call to `golangci-lint` to no longer use the `-v` flag to avoid some additional output bloat. Let me know if that seems like a problem.

Example output before when there were no problems:
```
max@dmpb [~/projects/determined/master] (main) $ make check
rm -f build/schema_gen.stamp
go generate ./pkg/schemas/...
mkdir -p build
touch build/schema_gen.stamp
# Checking that committed, generated code is up-to-date by ensuring that
# git reports the files as unchanged after forcibly regenerating the files:
test -z ""
test -z ""
go mod tidy
git diff --quiet go.mod go.sum
golangci-lint --build-tags integration run -v --timeout 10m
INFO [config_reader] Config search paths: [./ /Users/max/projects/determined/master /Users/max/projects/determined /Users/max/projects /Users/max /Users /] 
INFO [config_reader] Used config file .golangci.yml 
INFO [lintersdb] Active 42 linters: [asasalint asciicheck bodyclose deadcode depguard dogsled dupl dupword errcheck execinquery exhaustivestruct exportloopref forbidigo ginkgolinter gocheckcompilerdirectives goconst gocritic godot gofmt goheader goimports golint gomodguard goprintffuncname gosec govet ineffassign lll loggercheck misspell nakedret nosprintfhostport reassign rowserrcheck sqlclosecheck staticcheck stylecheck testableexamples typecheck unconvert varcheck whitespace] 
INFO [loader] Using build tags: [integration]     
INFO [loader] Go packages loading at mode 575 (deps|imports|name|types_sizes|compiled_files|exports_file|files) took 1.657384s 
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'exhaustivestruct' is deprecated (since v1.46.0) due to: The owner seems to have abandoned the linter.  Replaced by exhaustruct. 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 26.583084ms 
INFO [linters_context/goanalysis] analyzers took 4.729428183s with top 10 stages: buildir: 1.079259714s, buildssa: 615.475708ms, goimports: 297.763ms, dupl: 275.736001ms, gosec: 192.336832ms, gocritic: 166.286708ms, gofmt: 128.277292ms, golint: 121.360792ms, forbidigo: 115.736876ms, asasalint: 69.974251ms 
WARN [runner/nolint] Found unknown linters in //nolint directives: appendassign, g402 
INFO [runner] Issues before processing: 2666, after processing: 0 
INFO [runner] Processors filtering stat (out/in): exclude-rules: 377/377, cgo: 2666/2666, filename_unadjuster: 2666/2666, skip_dirs: 2622/2622, skip_files: 2622/2666, exclude: 377/1259, nolint: 0/377, autogenerated_exclude: 1259/2622, path_prettifier: 2666/2666, identifier_marker: 1259/1259 
INFO [runner] processing took 61.033042ms with stages: nolint: 28.078041ms, identifier_marker: 11.599124ms, autogenerated_exclude: 9.338499ms, exclude: 5.713334ms, path_prettifier: 5.391001ms, skip_dirs: 652.25µs, skip_files: 110.958µs, cgo: 100.375µs, filename_unadjuster: 46.584µs, max_same_issues: 1µs, severity-rules: 334ns, uniq_by_line: 292ns, diff: 250ns, sort_results: 209ns, path_shortener: 207ns, source_code: 167ns, max_from_linter: 125ns, path_prefixer: 125ns, exclude-rules: 125ns, max_per_file_from_linter: 42ns 
INFO [runner] linters took 1.808320708s with stages: goanalysis_metalinter: 1.747237166s 
INFO File cache stats: 60 entries of total size 774.9KiB 
INFO Memory: 37 samples, avg is 255.1MB, max is 1095.2MB 
INFO Execution took 3.50181475s
```

## Test Plan

No changes should come from this PR.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
