### PR TITLE
fix: Don't seek min and max on projects with 0 experiments [WEB-1533]

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -461,11 +461,13 @@ func (a *apiServer) GetProjectNumericMetricsRange(
 		})
 	}
 
-	ranges = append(ranges, &projectv1.MetricsRange{
-		MetricsName: "searcherMetricsVal",
-		Min:         mathx.Min(searcherMetricsValue...),
-		Max:         mathx.Max(searcherMetricsValue...),
-	})
+	if len(searcherMetricsValue) > 0 {
+		ranges = append(ranges, &projectv1.MetricsRange{
+			MetricsName: "searcherMetricsVal",
+			Min:         mathx.Min(searcherMetricsValue...),
+			Max:         mathx.Max(searcherMetricsValue...),
+		})
+	}
 
 	return &apiv1.GetProjectNumericMetricsRangeResponse{Ranges: ranges}, nil
 }


### PR DESCRIPTION
## Description

On projects without experiments, such as http://latest-main.determined.ai:8080/det/projects/628/experiments?f_explist_v2=on , I get the server error "Unable to fetch project heatmap"

There is a small server-side fix to prevent us from adding to the ranges list, when none are available

## Test Plan

Verify that the API request (such as `/api/v1/projects/7/experiments/metric-ranges`) returns successfully when a project has no experiments.


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.