### PR TITLE
chore: Make explist_v2 generally available

### DIFF
--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -22,7 +22,7 @@ export const FEATURES: Record<ValidFeature, FeatureDescription> = {
     friendlyName: 'New Charts',
   },
   explist_v2: {
-    defaultValue: false,
+    defaultValue: true,
     description: 'Enable improved experiment listing, filtering, and comparison',
     friendlyName: 'New Experiment List',
   },

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -104,7 +104,7 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
       type: string,
     },
   },
-  storagePath: `f_project-details-${id}`,
+  storagePath: `experimentListingForProject${id}`,
 });
 
 export interface F_ExperimentListGlobalSettings {
@@ -124,7 +124,7 @@ export const experimentListGlobalSettingsDefaults = {
   rowHeight: RowHeight.MEDIUM,
 } as const;
 
-export const experimentListGlobalSettingsPath = 'f_project-details-global';
+export const experimentListGlobalSettingsPath = 'globalTableSettings';
 
 export const settingsConfigGlobal: SettingsConfig<F_ExperimentListGlobalSettings> = {
   settings: {
@@ -141,5 +141,5 @@ export const settingsConfigGlobal: SettingsConfig<F_ExperimentListGlobalSettings
       type: ioRowHeight,
     },
   },
-  storagePath: 'f_project-details-global',
+  storagePath: experimentListGlobalSettingsPath,
 };


### PR DESCRIPTION
## Description
This updates the default for the `explist_v2` feature switch to on. Additionally I changed the storage paths for the settings since they shouldn't have a `f_` prefix.

## Test Plan
1. Clear settings for your user
2. Test that the feature is on by default
3. Test that adding a new column works and persists after refresh
4. Test that changing row height works and persists after refresh
5. Test that row height is reflected in the settings drawer

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No Ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
