### PR TITLE
Remove link to mailing list from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ with the latest news about Determined, please join the Determined community!
 * [Slack](https://determined-community.slack.com) is the best place to
   ask questions about Determined and get support. [Click here to join our Slack](
   https://join.slack.com/t/determined-community/shared_invite/zt-cnj7802v-KcVbaUrIzQOwmkmY7gP0Ew).
-* You can also join the [community mailing list](https://groups.google.com/a/determined.ai/forum/#!forum/community)
-  to ask questions about the project and receive announcements.
 * To report a bug, [file an issue](https://github.com/determined-ai/determined/issues) on GitHub.
 * To report a security issue, email [`security@determined.ai`](mailto:security@determined.ai).
 


### PR DESCRIPTION
## Description

This PR removes a link to a Google Group page that doesn't seem to have any activity: https://groups.google.com/a/determined.ai/g/community


