### PR TITLE
fix: ensure selected file path matches loaded file in codeeditor

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -17,7 +17,6 @@ import { DetError, ErrorLevel, ErrorType, isDetError, isError } from 'utils/erro
 import handleError, { handleWarning } from 'utils/error';
 import { trialHParamsToExperimentHParams } from 'utils/experiment';
 import { upgradeConfig } from 'utils/experiment';
-import { Loaded } from 'utils/loadable';
 import { routeToReactUrl } from 'utils/routes';
 
 export const FULL_CONFIG_BUTTON_TEXT = 'Show Full Config';
@@ -368,7 +367,7 @@ const ExperimentCreateModalComponent = ({
         {modalState.isAdvancedMode && (
           <React.Suspense fallback={<Spinner spinning tip="Loading text editor..." />}>
             <CodeEditor
-              files={[{ content: Loaded(modalState.configString), key: 'config.yaml' }]}
+              files={[{ get: () => Promise.resolve(modalState.configString), key: 'config.yaml' }]}
               height="40vh"
               onChange={handleEditorChange}
               onError={handleError}

--- a/webui/react/src/components/JupyterLabModal.tsx
+++ b/webui/react/src/components/JupyterLabModal.tsx
@@ -317,7 +317,9 @@ const JupyterLabFullConfig: React.FC<FullConfigProps> = ({
             },
           ]}>
           <CodeEditor
-            files={[{ content: config, key: 'config.yaml' }]}
+            files={[
+              { get: () => Promise.resolve(Loadable.getOrElse('', config)), key: 'config.yaml' },
+            ]}
             height="40vh"
             onError={handleError}
           />

--- a/webui/react/src/components/Markdown.tsx
+++ b/webui/react/src/components/Markdown.tsx
@@ -6,7 +6,6 @@ import Pivot from 'components/kit/Pivot';
 import Spinner from 'components/kit/Spinner';
 import useResize from 'hooks/useResize';
 import handleError from 'utils/error';
-import { Loaded } from 'utils/loadable';
 
 import css from './Markdown.module.scss';
 
@@ -64,7 +63,7 @@ const Markdown: React.FC<Props> = ({
                 </div>
               }>
               <CodeEditor
-                files={[{ content: Loaded(markdown), key: 'input.md' }]}
+                files={[{ get: () => Promise.resolve(markdown), key: 'input.md' }]}
                 height={`${resize.height - 420}px`}
                 onChange={onChange}
                 onError={handleError}

--- a/webui/react/src/components/UserSettingsModal.tsx
+++ b/webui/react/src/components/UserSettingsModal.tsx
@@ -92,7 +92,7 @@ const UserSettingsModalComponent: React.FC<Props> = ({ onSave }: Props) => {
       <CodeEditor
         files={[
           {
-            content: editedSettingsString,
+            get: () => Promise.resolve(Loadable.getOrElse('', editedSettingsString)),
             key: 'settings.json',
             title: 'settings.json',
           },

--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -15,7 +15,7 @@ import workspaceStore from 'stores/workspaces';
 import { Workspace } from 'types';
 import { DetError, ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
-import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+import { Loadable, NotLoaded } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 import { routeToReactUrl } from 'utils/routes';
 
@@ -181,7 +181,7 @@ const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }
                     },
                   ]}>
                   <CodeEditor
-                    files={[{ content: Loaded(''), key: 'config.yaml' }]}
+                    files={[{ get: () => Promise.resolve(''), key: 'config.yaml' }]}
                     height="16vh"
                     readonly={!canModifyCPS}
                     onError={handleError}

--- a/webui/react/src/components/kit/internal/types.ts
+++ b/webui/react/src/components/kit/internal/types.ts
@@ -3,7 +3,6 @@ import * as t from 'io-ts';
 
 import { isObject, isString } from 'components/kit/internal/functions';
 import rootLogger, { LoggerInterface } from 'components/kit/internal/Logger';
-import { Loadable } from 'utils/loadable';
 
 export type Primitive = boolean | number | string;
 export type RecordKey = string | number | symbol;
@@ -199,7 +198,6 @@ export interface TreeNode extends DataNode {
    * icon: custom Icon component
    */
   children?: TreeNode[];
-  content: Loadable<string>;
   download?: string;
   get?: (path: string) => Promise<string>;
   isConfig?: boolean;

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -891,7 +891,7 @@ const CodeEditorSection: React.FC = () => {
         <CodeEditor
           files={[
             {
-              content: Loaded('import math\nprint(math.pi)\n\n'),
+              get: () => Promise.resolve('import math\nprint(math.pi)\n\n'),
               key: 'test.py',
               title: 'test.py',
             },
@@ -902,9 +902,10 @@ const CodeEditorSection: React.FC = () => {
         <CodeEditor
           files={[
             {
-              content: Loaded(
-                'name: Unicode Test 日本😃\ndata:\n  url: https://example.tar.gz\nhyperparameters:\n  learning_rate: 1.0\n  global_batch_size: 64\n  n_filters1: 32\n  n_filters2: 64\n  dropout1: 0.25\n  dropout2: 0.5\nsearcher:\n  name: single\n  metric: validation_loss\n  max_length:\n      batches: 937 #60,000 training images with batch size 64\n  smaller_is_better: true\nentrypoint: model_def:MNistTrial\nresources:\n  slots_per_trial: 2',
-              ),
+              get: () =>
+                Promise.resolve(
+                  'name: Unicode Test 日本😃\ndata:\n  url: https://example.tar.gz\nhyperparameters:\n  learning_rate: 1.0\n  global_batch_size: 64\n  n_filters1: 32\n  n_filters2: 64\n  dropout1: 0.25\n  dropout2: 0.5\nsearcher:\n  name: single\n  metric: validation_loss\n  max_length:\n      batches: 937 #60,000 training images with batch size 64\n  smaller_is_better: true\nentrypoint: model_def:MNistTrial\nresources:\n  slots_per_trial: 2',
+                ),
               key: 'test1.yaml',
               title: 'test1.yaml',
             },
@@ -916,20 +917,27 @@ const CodeEditorSection: React.FC = () => {
         <CodeEditor
           files={[
             {
-              content: Loaded(
-                'hyperparameters:\n  learning_rate: 1.0\n  global_batch_size: 512\n  n_filters1: 32\n  n_filters2: 64\n  dropout1: 0.25\n  dropout2: 0.5',
-              ),
+              get: () =>
+                Promise.resolve(
+                  'hyperparameters:\n  learning_rate: 1.0\n  global_batch_size: 512\n  n_filters1: 32\n  n_filters2: 64\n  dropout1: 0.25\n  dropout2: 0.5',
+                ),
               isLeaf: true,
               key: 'one.yaml',
               title: 'one.yaml',
             },
             {
-              content: Loaded('searcher:\n  name: single\n  metric: validation_loss\n'),
+              get: () => Promise.resolve('searcher:\n  name: single\n  metric: validation_loss\n'),
               isLeaf: true,
               key: 'two.yaml',
               title: 'two.yaml',
             },
-            { content: NotLoaded, isLeaf: true, key: 'unloaded.yaml', title: 'unloaded.yaml' },
+            {
+              // eslint-disable-next-line @typescript-eslint/no-empty-function
+              get: () => new Promise(() => {}),
+              isLeaf: true,
+              key: 'unloaded.yaml',
+              title: 'unloaded.yaml',
+            },
           ]}
           readonly={true}
           onError={handleError}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.test.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.test.tsx
@@ -1,7 +1,7 @@
-import { findAllByText, screen, waitFor } from '@testing-library/dom';
+import { findAllByText, screen } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 import { SettingsProvider } from 'hooks/useSettingsProvider';
@@ -113,10 +113,15 @@ const Container: React.FC<Props> = (props) => {
     authStore.setAuthChecked();
     userStore.updateCurrentUser(CURRENT_USER);
   }, []);
+  const [selectedFilePath, onSelectFile] = useState('single-in-records.yaml');
 
   return (
     <SettingsProvider>
-      <CodeViewer experiment={props.experiment} />
+      <CodeViewer
+        experiment={props.experiment}
+        selectedFilePath={selectedFilePath}
+        onSelectFile={onSelectFile}
+      />
     </SettingsProvider>
   );
 };
@@ -157,11 +162,9 @@ describe('CodeViewer', () => {
 
     await user.click(button);
 
-    await waitFor(() =>
-      expect(vi.mocked(paths.experimentFileFromTree)).toHaveBeenCalledWith(
-        123,
-        'single-in-records.yaml',
-      ),
+    expect(vi.mocked(paths.experimentFileFromTree)).toHaveBeenCalledWith(
+      123,
+      'single-in-records.yaml',
     );
   });
 });

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
@@ -72,8 +72,8 @@ const ExperimentCodeViewer: React.FC<Props> = ({
   const fileOpts = [
     submittedConfig
       ? {
-          content: Loaded(submittedConfig),
           download: `${experiment.id}_submitted_configuration.yaml`,
+          get: () => Promise.resolve(submittedConfig),
           icon: configIcon,
           isLeaf: true,
           key: 'Submitted Configuration',
@@ -82,8 +82,8 @@ const ExperimentCodeViewer: React.FC<Props> = ({
       : null,
     runtimeConfig
       ? {
-          content: Loaded(runtimeConfig),
           download: `${experiment.id}_runtime_configuration.yaml`,
+          get: () => Promise.resolve(runtimeConfig),
           icon: configIcon,
           isLeaf: true,
           key: 'Runtime Configuration',

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -974,7 +974,13 @@ export const getExperimentFileFromTree: DetApi<
   string
 > = {
   name: 'getModelDefFile',
-  postProcess: (response) => response.file || '',
+  // file is base64 encoded
+  postProcess: ({ file = '' }) => {
+    // ts es2015 defs are wrong -- there's a pr from _2019_ that fixes this but only for the es5 defs
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const byteArray = Uint8Array.from(window.atob(file) as any, (x) => (x as any).codePointAt(0));
+    return new TextDecoder().decode(byteArray);
+  },
   request: (params) => {
     return detApi.Experiments.getModelDefFile(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
this fixes an issue where reloading the experiment code page didn't result in the selected file in the view.

## Test Plan

* [ ] go to an experiment code page
* [ ] select a file
* [ ] reload
* [ ] the same file should be selected and the code of the file be visible.

## Commentary (optional)

The fix feels large, so here's a walkthrough of what's going on:

1. codeeditor component only reads in the file path from props on mount, but the experimentcodeviewer updates the file path as settings loads in
2. codeeditor component does this because otherwise the component would have to render or load twice in order to load the files, which caused a memory leak during testing
3. codeeditor component has this problem because the selected file node state is stored along with the loading state of the content

to fix this:

1. the selected file node and file loading state are decoupled. the selected file node now is derived from the props, and the file loading state is now changed as an effect of the file node changing.
2. Because of this, the `content` prop of the file node object has been removed -- instead we always use the `get` function to get the file contents
3. Because the codeeditor accidentally assumed async content was base64 encoded ascii, that functionality was moved to the api config, while also enabling full unicode support for files on the frontend.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9717

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
