### PR TITLE
fix: Accomodate partial experiment list settings

### DIFF
--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -1,5 +1,4 @@
 import { Space } from 'antd';
-import * as t from 'io-ts';
 import React, { useCallback, useState } from 'react';
 
 import Drawer from 'components/kit/Drawer';
@@ -136,10 +135,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
   return Loadable.match(
     Loadable.all([
       useObservable(
-        userSettings.get(
-          t.partial(experimentListGlobalSettingsConfig),
-          experimentListGlobalSettingsPath,
-        ),
+        userSettings.get(experimentListGlobalSettingsConfig, experimentListGlobalSettingsPath),
       ),
       useObservable(userSettings.get(shortcutSettingsConfig, shortcutsSettingsPath)),
       useObservable(userSettings.get(FeatureSettingsConfig, FEATURE_SETTINGS_PATH)),
@@ -245,7 +241,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(rh) => rowHeightLabels[rh]}
                   onSubmit={(rh) => {
                     userSettings.set(
-                      t.type(experimentListGlobalSettingsConfig),
+                      experimentListGlobalSettingsConfig,
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,
@@ -267,7 +263,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(v) => (v === 'scroll' ? 'On' : 'Off')}
                   onSubmit={(v) => {
                     userSettings.set(
-                      t.type(experimentListGlobalSettingsConfig),
+                      experimentListGlobalSettingsConfig,
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -1,5 +1,5 @@
 import { Space } from 'antd';
-import { partial, type } from 'io-ts';
+import * as t from 'io-ts';
 import React, { useCallback, useState } from 'react';
 
 import Drawer from 'components/kit/Drawer';
@@ -137,7 +137,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
     Loadable.all([
       useObservable(
         userSettings.get(
-          partial(experimentListGlobalSettingsConfig),
+          t.partial(experimentListGlobalSettingsConfig),
           experimentListGlobalSettingsPath,
         ),
       ),
@@ -245,7 +245,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(rh) => rowHeightLabels[rh]}
                   onSubmit={(rh) => {
                     userSettings.set(
-                      type(experimentListGlobalSettingsConfig),
+                      t.type(experimentListGlobalSettingsConfig),
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,
@@ -267,7 +267,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(v) => (v === 'scroll' ? 'On' : 'Off')}
                   onSubmit={(v) => {
                     userSettings.set(
-                      type(experimentListGlobalSettingsConfig),
+                      t.type(experimentListGlobalSettingsConfig),
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -1,4 +1,5 @@
 import { Space } from 'antd';
+import { partial } from 'io-ts';
 import React, { useCallback, useState } from 'react';
 
 import Drawer from 'components/kit/Drawer';
@@ -135,7 +136,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
   return Loadable.match(
     Loadable.all([
       useObservable(
-        userSettings.get(experimentListGlobalSettingsConfig, experimentListGlobalSettingsPath),
+        userSettings.get(partial(experimentListGlobalSettingsConfig), experimentListGlobalSettingsPath),
       ),
       useObservable(userSettings.get(shortcutSettingsConfig, shortcutsSettingsPath)),
       useObservable(userSettings.get(FeatureSettingsConfig, FEATURE_SETTINGS_PATH)),

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -1,5 +1,5 @@
 import { Space } from 'antd';
-import { partial } from 'io-ts';
+import { partial, type } from 'io-ts';
 import React, { useCallback, useState } from 'react';
 
 import Drawer from 'components/kit/Drawer';
@@ -136,7 +136,10 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
   return Loadable.match(
     Loadable.all([
       useObservable(
-        userSettings.get(partial(experimentListGlobalSettingsConfig), experimentListGlobalSettingsPath),
+        userSettings.get(
+          partial(experimentListGlobalSettingsConfig),
+          experimentListGlobalSettingsPath,
+        ),
       ),
       useObservable(userSettings.get(shortcutSettingsConfig, shortcutsSettingsPath)),
       useObservable(userSettings.get(FeatureSettingsConfig, FEATURE_SETTINGS_PATH)),
@@ -242,7 +245,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(rh) => rowHeightLabels[rh]}
                   onSubmit={(rh) => {
                     userSettings.set(
-                      experimentListGlobalSettingsConfig,
+                      type(experimentListGlobalSettingsConfig),
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,
@@ -264,7 +267,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   valueFormatter={(v) => (v === 'scroll' ? 'On' : 'Off')}
                   onSubmit={(v) => {
                     userSettings.set(
-                      experimentListGlobalSettingsConfig,
+                      type(experimentListGlobalSettingsConfig),
                       experimentListGlobalSettingsPath,
                       {
                         ...experimentListGlobalSettings,

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -108,8 +108,8 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
 });
 
 export interface F_ExperimentListGlobalSettings {
-  expListView?: ExpListView;
-  rowHeight?: RowHeight;
+  expListView: ExpListView;
+  rowHeight: RowHeight;
 }
 
 const ioExpListView = union([literal('scroll'), literal('paged')]);

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -1,4 +1,4 @@
-import { array, boolean, literal, number, record, string, TypeOf, union } from 'io-ts';
+import { array, boolean, literal, number, partial, record, string, TypeOf, union } from 'io-ts';
 
 import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 import { SettingsConfig } from 'hooks/useSettings';
@@ -114,10 +114,10 @@ export interface F_ExperimentListGlobalSettings {
 
 const ioExpListView = union([literal('scroll'), literal('paged')]);
 
-export const experimentListGlobalSettingsConfig = {
+export const experimentListGlobalSettingsConfig = partial({
   expListView: ioExpListView,
   rowHeight: ioRowHeight,
-};
+});
 
 export const experimentListGlobalSettingsDefaults = {
   expListView: 'scroll',

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -1,4 +1,4 @@
-import { array, boolean, literal, number, record, string, type, TypeOf, union } from 'io-ts';
+import { array, boolean, literal, number, record, string, TypeOf, union } from 'io-ts';
 
 import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 import { SettingsConfig } from 'hooks/useSettings';
@@ -108,16 +108,16 @@ export const settingsConfigForProject = (id: number): SettingsConfig<F_Experimen
 });
 
 export interface F_ExperimentListGlobalSettings {
-  expListView: ExpListView;
-  rowHeight: RowHeight;
+  expListView?: ExpListView;
+  rowHeight?: RowHeight;
 }
 
 const ioExpListView = union([literal('scroll'), literal('paged')]);
 
-export const experimentListGlobalSettingsConfig = type({
+export const experimentListGlobalSettingsConfig = {
   expListView: ioExpListView,
   rowHeight: ioRowHeight,
-});
+};
 
 export const experimentListGlobalSettingsDefaults = {
   expListView: 'scroll',


### PR DESCRIPTION
## Description

Changes how we use `experimentListGlobalSettingsConfig` so default values will fill in for partial settings on the exp. list.

## Test Plan

Removes repeated console.error on pages such as http://latest-main.determined.ai:8080/det/projects/1/experiments
when the settings includes:

```javascript
 "f_project-details-global": {
  "expListView": "scroll"
 },
```

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.