### PR TITLE
feat: custom metric groups (formally known as types) [WEB-1469]

### DIFF
--- a/webui/react/src/components/MetricBadgeTag.test.tsx
+++ b/webui/react/src/components/MetricBadgeTag.test.tsx
@@ -18,10 +18,7 @@ const setup = (metric: Metric) => {
 };
 
 describe('MetricBadgeTag', () => {
-  const sampleMetric: Metric = {
-    name: 'accuracy',
-    type: 'validation',
-  };
+  const sampleMetric: Metric = { group: 'validation', name: 'accuracy' };
 
   it('displays metric name and first letter of type', () => {
     setup(sampleMetric);

--- a/webui/react/src/components/MetricBadgeTag.tsx
+++ b/webui/react/src/components/MetricBadgeTag.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { Metric } from 'types';
-import { getMetricName } from 'utils/metric';
 
 import BadgeTag from './BadgeTag';
 
@@ -11,8 +10,8 @@ interface Props {
 
 const MetricBadgeTag: React.FC<Props> = ({ metric }: Props) => {
   return (
-    <BadgeTag label={getMetricName(metric.name)} tooltip={metric.type}>
-      {metric.type.substring(0, 1).toUpperCase()}
+    <BadgeTag label={metric.name} tooltip={metric.group}>
+      {metric.group.substring(0, 1).toUpperCase()}
     </BadgeTag>
   );
 };

--- a/webui/react/src/components/MetricBadgeTag.tsx
+++ b/webui/react/src/components/MetricBadgeTag.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Metric } from 'types';
+import { getMetricName } from 'utils/metric';
 
 import BadgeTag from './BadgeTag';
 
@@ -10,7 +11,7 @@ interface Props {
 
 const MetricBadgeTag: React.FC<Props> = ({ metric }: Props) => {
   return (
-    <BadgeTag label={metric.name} tooltip={metric.type}>
+    <BadgeTag label={getMetricName(metric.name)} tooltip={metric.type}>
       {metric.type.substring(0, 1).toUpperCase()}
     </BadgeTag>
   );

--- a/webui/react/src/components/MetricSelect.tsx
+++ b/webui/react/src/components/MetricSelect.tsx
@@ -3,15 +3,10 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import Select, { OptGroup, Option, SelectValue } from 'components/kit/Select';
 import { Metric } from 'types';
-import {
-  getMetricName,
-  metricKeyToMetric,
-  metricSorter,
-  metricToKey,
-  metricWithTypeToKey,
-} from 'utils/metric';
+import { metricKeyToMetric, metricSorter, metricToKey } from 'utils/metric';
 
 import BadgeTag from './BadgeTag';
+import MetricBadgeTag from './MetricBadgeTag';
 
 const allOptionId = 'ALL_RESULTS';
 const resetOptionId = 'RESET_RESULTS';
@@ -163,13 +158,12 @@ const MetricSelect: React.FC<Props> = ({
       {multiple && visibleMetrics.length > 1 && allOption}
       {metricsByType.map((group) => (
         <OptGroup key={group.type} label={group.type}>
-          {group.metrics.map((metric) => {
-            const value = metricWithTypeToKey(metric, group.type);
+          {group.metrics.map((metricName) => {
+            const metric = { name: metricName, type: group.type };
+            const value = metricToKey(metric);
             return (
               <Option key={value} value={value}>
-                <BadgeTag label={getMetricName(metric)} tooltip={group.type}>
-                  {group.type.substring(0, 1).toUpperCase()}
-                </BadgeTag>
+                <MetricBadgeTag metric={metric} />
               </Option>
             );
           })}

--- a/webui/react/src/components/MetricSelect.tsx
+++ b/webui/react/src/components/MetricSelect.tsx
@@ -42,8 +42,8 @@ const MetricSelect: React.FC<Props> = ({
 
   const metricsByType = useMemo(() => {
     const groups = metrics.reduce((acc, metric) => {
-      acc[metric.type] = acc[metric.type] || [];
-      acc[metric.type].push(metric.name);
+      acc[metric.group] = acc[metric.group] || [];
+      acc[metric.group].push(metric.name);
       return acc;
     }, {} as Record<string, string[]>);
     return Object.keys(groups).map((key) => {
@@ -159,7 +159,7 @@ const MetricSelect: React.FC<Props> = ({
       {metricsByType.map((group) => (
         <OptGroup key={group.type} label={group.type}>
           {group.metrics.map((metricName) => {
-            const metric = { name: metricName, type: group.type };
+            const metric = { group: group.type, name: metricName };
             const value = metricToKey(metric);
             return (
               <Option key={value} value={value}>

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -5,7 +5,7 @@ import uPlot, { AlignedData, Plugin } from 'uplot';
 
 import { getCssVar, getTimeTickValues, glasbeyColor } from 'components/kit/internal/functions';
 import ScaleSelect from 'components/kit/internal/ScaleSelect';
-import { ErrorHandler, MetricType, Scale } from 'components/kit/internal/types';
+import { ErrorHandler, Scale } from 'components/kit/internal/types';
 import { SyncProvider } from 'components/kit/internal/UPlot/SyncProvider';
 import { UPlotPoint } from 'components/kit/internal/UPlot/types';
 import UPlotChart, { Options } from 'components/kit/internal/UPlot/UPlotChart';
@@ -38,7 +38,7 @@ export interface Serie {
   color?: string;
   data: Partial<Record<XAxisDomain, [x: number, y: number][]>>;
   key?: number;
-  metricType?: MetricType;
+  metricType?: string;
   name?: string;
 }
 

--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -108,14 +108,10 @@ export const LineChart: React.FC<LineChartProps> = ({
   );
 
   const seriesNames: string[] = useMemo(() => {
-    return series.map(
-      (s, idx) =>
-        (s.metricType === MetricType.Training
-          ? '[T] '
-          : s.metricType === MetricType.Validation
-          ? '[V] '
-          : '') + (s.name || `Series ${idx + 1}`),
-    );
+    return series.map((s, idx) => {
+      const badge = s.metricType?.substring(0, 1).toUpperCase();
+      return [badge ? `[${badge}]` : '', s.name || `Series ${idx + 1}`].join(' ');
+    });
   }, [series]);
 
   const chartData: AlignedData = useMemo(() => {
@@ -332,7 +328,7 @@ export const calculateChartProps = (
   });
   metrics.forEach((metric) => {
     const series: Serie[] = [];
-    const key = `${metric.type}|${metric.name}`;
+    const key = `${metric.group}|${metric.name}`;
     trials.forEach((t) => {
       const m = data[t?.id || 0];
       m?.[key] &&
@@ -362,7 +358,7 @@ export const calculateChartProps = (
   // then the charts have not been updated and we need to continue to show the
   // spinner.
   const chartDataIsLoaded = metrics.every((metric) => {
-    const metricKey = `${metric.type}|${metric.name}`;
+    const metricKey = `${metric.group}|${metric.name}`;
     return metricHasData?.[metricKey] ? !!chartedMetrics?.[metricKey] : true;
   });
   if (!isLoaded) {

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -5,24 +5,12 @@ import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import { V1ExpMetricNamesResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
 import { readStream } from 'services/utils';
-import { Metric, MetricType, OldMetric } from 'types';
+import { Metric } from 'types';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
-import { metricKeyToMetric, metricToKey, metricToOldMetric } from 'utils/metric';
+import { metricKeyToMetric, metricToKey } from 'utils/metric';
 import { metricSorter } from 'utils/metric';
 
 import usePrevious from './usePrevious';
-
-export const asOldMetrics = (metrics: Metric[]): OldMetric[] => {
-  return metrics
-    .filter((metric) => {
-      return ([MetricType.Training, MetricType.Validation] as string[]).includes(metric.group);
-    })
-    .map(metricToOldMetric);
-};
-
-export const asLoadableOldMetrics = (loadable: Loadable<Metric[]>): Loadable<OldMetric[]> => {
-  return Loadable.map(loadable, (metrics) => asOldMetrics(metrics));
-};
 
 const useMetricNames = (
   experimentIds: number[],

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -86,7 +86,6 @@ const useMetricNames = (
           return Loaded(
             Array.from(updatedMetricsSet)
               .map((metricKey) => metricKeyToMetric(metricKey))
-              .filter((metric): metric is Metric => !!metric)
               .sort(metricSorter),
           );
         });

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -7,15 +7,17 @@ import { detApi } from 'services/apiConfig';
 import { readStream } from 'services/utils';
 import { Metric, MetricType, OldMetric } from 'types';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
-import { metricKeyToMetric, metricToKey } from 'utils/metric';
+import { metricKeyToMetric, metricToKey, metricToOldMetric } from 'utils/metric';
 import { metricSorter } from 'utils/metric';
 
 import usePrevious from './usePrevious';
 
 export const asOldMetrics = (metrics: Metric[]): OldMetric[] => {
-  return metrics.filter((metric) => {
-    return ([MetricType.Training, MetricType.Validation] as string[]).includes(metric.type);
-  }) as OldMetric[];
+  return metrics
+    .filter((metric) => {
+      return ([MetricType.Training, MetricType.Validation] as string[]).includes(metric.group);
+    })
+    .map(metricToOldMetric);
 };
 
 export const asLoadableOldMetrics = (loadable: Loadable<Metric[]>): Loadable<OldMetric[]> => {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization.tsx
@@ -80,8 +80,8 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
   const location = useLocation();
   const storage = useStorage(`${STORAGE_PATH}/${experiment.id}`);
   const searcherMetric = useRef<Metric>({
+    group: MetricType.Validation,
     name: experiment.config.searcher.metric,
-    type: MetricType.Validation,
   });
 
   const { viz: type } = useParams<{ viz: ExperimentVisualizationType }>();
@@ -152,7 +152,7 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
     if (!hasSearcherMetric) {
       const activeMetricFound = metrics.find(
         (metric) =>
-          metric.type === searcherMetric.current.type &&
+          metric.group === searcherMetric.current.group &&
           metric.name === searcherMetric.current.name,
       );
       if (activeMetricFound) {
@@ -302,7 +302,7 @@ const ExperimentVisualization: React.FC<Props> = ({ basePath, experiment }: Prop
 
     const canceler = new AbortController();
     const metricTypeParam =
-      filters.metric.type === MetricType.Training
+      filters.metric.group === MetricType.Training
         ? 'METRIC_TYPE_TRAINING'
         : 'METRIC_TYPE_VALIDATION';
     const batchesMap: Record<number, number> = {};

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.tsx
@@ -92,7 +92,7 @@ const HpHeatMaps: React.FC<Props> = ({
   const smallerIsBetter = useMemo(() => {
     if (
       selectedMetric &&
-      selectedMetric.type === MetricType.Validation &&
+      selectedMetric.group === MetricType.Validation &&
       selectedMetric.name === experiment.config.searcher.metric
     ) {
       return experiment.config.searcher.smallerIsBetter;
@@ -226,7 +226,7 @@ const HpHeatMaps: React.FC<Props> = ({
         experiment.id,
         selectedMetric.name,
         selectedBatch,
-        metricTypeParamMap[selectedMetric.type],
+        metricTypeParamMap[selectedMetric.group],
         undefined, // custom metric group
         selectedBatchMargin,
         undefined,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -89,7 +89,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
   const smallerIsBetter = useMemo(() => {
     if (
       selectedMetric &&
-      selectedMetric.type === MetricType.Validation &&
+      selectedMetric.group === MetricType.Validation &&
       selectedMetric.name === experiment.config.searcher.metric
     ) {
       return experiment.config.searcher.smallerIsBetter;
@@ -237,7 +237,7 @@ const HpParallelCoordinates: React.FC<Props> = ({
         experiment.id,
         selectedMetric.name,
         selectedBatch,
-        metricTypeParamMap[selectedMetric.type],
+        metricTypeParamMap[selectedMetric.group],
         undefined, // custom metric group
         selectedBatchMargin,
         undefined,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -149,7 +149,7 @@ const ScatterPlots: React.FC<Props> = ({
         experiment.id,
         selectedMetric.name,
         selectedBatch,
-        metricTypeParamMap[selectedMetric.type],
+        metricTypeParamMap[selectedMetric.group],
         undefined, // custom metric group
         selectedBatchMargin,
         undefined,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -36,6 +36,7 @@ import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import { isNewTabClickEvent, openBlank, routeToReactUrl } from 'utils/routes';
 import { openCommandResponse } from 'utils/wait';
 
+import { metricToStr } from '../../../utils/metric';
 import TrialsComparisonModal from '../TrialsComparisonModal';
 
 import HpTrialTable, { TrialHParams } from './HpTrialTable';
@@ -190,7 +191,7 @@ const LearningCurve: React.FC<Props> = ({
       detApi.StreamingInternal.trialsSample(
         experiment.id,
         selectedMetric.name,
-        metricTypeParamMap[selectedMetric.type],
+        metricTypeParamMap[selectedMetric.group],
         undefined,
         selectedMaxTrial,
         MAX_DATAPOINTS,
@@ -334,7 +335,7 @@ const LearningCurve: React.FC<Props> = ({
               scale={selectedScale}
               series={chartData}
               xLabel="Batches Processed"
-              yLabel={`[${selectedMetric.type[0].toUpperCase()}] ${selectedMetric.name}`}
+              yLabel={metricToStr(selectedMetric)}
               onPointClick={handlePointClick}
               onPointFocus={handlePointFocus}
             />

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -313,7 +313,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                 </th>
               </tr>
               {selectedMetrics.map((metric) => (
-                <tr key={`${metric.type}-${metric.name}`}>
+                <tr key={`${metric.group}-${metric.name}`}>
                   <th scope="row">
                     <MetricBadgeTag metric={metric} />
                   </th>

--- a/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.settings.ts
+++ b/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.settings.ts
@@ -24,10 +24,7 @@ export const settingsConfigForExperimentHyperparameters = (
       defaultValue: undefined,
       skipUrlEncoding: true,
       storageKey: 'metric',
-      type: union([
-        undefinedType,
-        type({ name: string, type: keyof({ training: null, validation: null }) }),
-      ]),
+      type: union([undefinedType, type({ name: string, type: string })]),
     },
     scale: {
       defaultValue: Scale.Linear,

--- a/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.settings.ts
+++ b/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.settings.ts
@@ -24,7 +24,7 @@ export const settingsConfigForExperimentHyperparameters = (
       defaultValue: undefined,
       skipUrlEncoding: true,
       storageKey: 'metric',
-      type: union([undefinedType, type({ name: string, type: string })]),
+      type: union([undefinedType, type({ group: string, name: string })]),
     },
     scale: {
       defaultValue: Scale.Linear,

--- a/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareParallelCoordinates.tsx
@@ -95,7 +95,8 @@ const CompareParallelCoordinates: React.FC<Props> = ({
 
   useEffect(() => {
     const activeMetricFound = metrics.find(
-      (metric) => metric.name === settings?.metric?.name && metric.type === settings?.metric?.type,
+      (metric) =>
+        metric.name === settings?.metric?.name && metric.group === settings?.metric?.group,
     );
     updateSettings({ metric: activeMetricFound ?? metrics.first() });
   }, [selectedExperiments, metrics, settings.metric, updateSettings]);
@@ -218,7 +219,7 @@ const CompareParallelCoordinates: React.FC<Props> = ({
 
     trials?.forEach((trial) => {
       const expId = trial.experimentId;
-      const key = `${selectedMetric.type}|${selectedMetric.name}`;
+      const key = `${selectedMetric.group}|${selectedMetric.name}`;
 
       // Choose the final metric value for each trial
       const metricValue = data?.[trial.id]?.[key]?.data?.[XAxisDomain.Batches]?.at(-1)?.[1];

--- a/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.settings.ts
+++ b/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.settings.ts
@@ -47,7 +47,7 @@ export const settingsConfigForExperimentHyperparameters = (
       defaultValue: undefined,
       skipUrlEncoding: true,
       storageKey: 'metric',
-      type: union([undefinedType, type({ name: string, type: string })]),
+      type: union([undefinedType, type({ group: string, name: string })]),
     },
     scale: {
       defaultValue: Scale.Linear,

--- a/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.settings.ts
+++ b/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.settings.ts
@@ -47,10 +47,7 @@ export const settingsConfigForExperimentHyperparameters = (
       defaultValue: undefined,
       skipUrlEncoding: true,
       storageKey: 'metric',
-      type: union([
-        undefinedType,
-        type({ name: string, type: keyof({ training: null, validation: null }) }),
-      ]),
+      type: union([undefinedType, type({ name: string, type: string })]),
     },
     scale: {
       defaultValue: Scale.Linear,

--- a/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.tsx
+++ b/webui/react/src/pages/TrialDetails/MultiTrialDetailsHyperparameters.tsx
@@ -92,7 +92,7 @@ const MultiTrialDetailsHyperparameters: React.FC<Props> = ({
 
     const canceler = new AbortController();
     const metricTypeParam =
-      settings.metric.type === MetricType.Training
+      settings.metric.group === MetricType.Training
         ? 'METRIC_TYPE_TRAINING'
         : 'METRIC_TYPE_VALIDATION';
     const batchesMap: Record<number, number> = {};
@@ -152,7 +152,7 @@ const MultiTrialDetailsHyperparameters: React.FC<Props> = ({
     if (settings.metric !== undefined) return;
     const activeMetricFound = metrics.find(
       (metric) =>
-        metric.type === MetricType.Validation && metric.name === experiment.config.searcher.metric,
+        metric.group === MetricType.Validation && metric.name === experiment.config.searcher.metric,
     );
     updateSettings({ metric: activeMetricFound ?? metrics.first() });
   }, [experiment.config.searcher.metric, metrics, settings.metric, updateSettings]);

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -44,7 +44,7 @@ const TrialChart: React.FC<Props> = ({
       try {
         const summary = await timeSeries({
           maxDatapoints: screen.width > 1600 ? 1500 : 1000,
-          metricNames: metricNames,
+          metrics: metricNames,
           startBatches: 0,
           trialIds: [trialId],
         });
@@ -80,7 +80,7 @@ const TrialChart: React.FC<Props> = ({
       yValues[index] = {};
 
       const summary = Loadable.getOrElse([], trialSummary);
-      const mWrapper = summary.find((mContainer) => mContainer.type === metric.group);
+      const mWrapper = summary.find((mContainer) => mContainer.group === metric.group);
       if (!mWrapper?.data) return;
 
       mWrapper.data.forEach((avgMetrics) => {

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -16,6 +16,8 @@ import { glasbeyColor } from 'utils/color';
 import handleError, { ErrorType } from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 
+import { metricToStr } from '../../utils/metric';
+
 interface Props {
   defaultMetricNames: Metric[];
   id?: string;
@@ -25,12 +27,6 @@ interface Props {
   trialId?: number;
   trialTerminated: boolean;
 }
-
-const getChartMetricLabel = (metric: Metric): string => {
-  if (metric.type === 'training') return `[T] ${metric.name}`;
-  if (metric.type === 'validation') return `[V] ${metric.name}`;
-  return metric.name;
-};
 
 const TrialChart: React.FC<Props> = ({
   defaultMetricNames,
@@ -84,7 +80,7 @@ const TrialChart: React.FC<Props> = ({
       yValues[index] = {};
 
       const summary = Loadable.getOrElse([], trialSummary);
-      const mWrapper = summary.find((mContainer) => mContainer.type === metric.type);
+      const mWrapper = summary.find((mContainer) => mContainer.type === metric.group);
       if (!mWrapper?.data) return;
 
       mWrapper.data.forEach((avgMetrics) => {
@@ -112,7 +108,7 @@ const TrialChart: React.FC<Props> = ({
     return {
       axes: [
         { label: 'Batches' },
-        { label: metrics.length === 1 ? getChartMetricLabel(metrics[0]) : 'Metric Value' },
+        { label: metrics.length === 1 ? metricToStr(metrics[0]) : 'Metric Value' },
       ],
       height: 400,
       key: trialId,
@@ -125,7 +121,7 @@ const TrialChart: React.FC<Props> = ({
       series: [
         { label: 'Batch' },
         ...metrics.map((metric, index) => ({
-          label: getChartMetricLabel(metric),
+          label: metricToStr(metric),
           spanGaps: true,
           stroke: glasbeyColor(index),
           width: 2,

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -85,9 +85,7 @@ const TrialChart: React.FC<Props> = ({
 
       const summary = Loadable.getOrElse([], trialSummary);
       const mWrapper = summary.find((mContainer) => mContainer.type === metric.type);
-      if (!mWrapper?.data) {
-        return;
-      }
+      if (!mWrapper?.data) return;
 
       mWrapper.data.forEach((avgMetrics) => {
         if (avgMetrics.values[metric.name] || avgMetrics.values[metric.name] === 0) {

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -7,12 +7,14 @@ import { UPlotPoint } from 'components/UPlot/types';
 import { closestPointPlugin } from 'components/UPlot/UPlotChart/closestPointPlugin';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
+import useMetricNames, { asLoadableOldMetrics } from 'hooks/useMetricNames';
 import { useCheckpointFlow } from 'hooks/useModal/Checkpoint/useCheckpointFlow';
 import {
   CheckpointWorkloadExtended,
   ExperimentBase,
   Metric,
   MetricType,
+  OldMetric,
   TrialDetails,
 } from 'types';
 import handleError from 'utils/error';

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -144,7 +144,7 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
           }),
         ],
         series,
-        title: groupMetrics.length !== 0 ? groupMetrics[0].name : 'No Metric Name',
+        title: groupMetrics.length !== 0 ? stripPrefix(groupMetrics[0].name) : 'No Metric Name',
         xAxis,
         xLabel: String(xAxis),
       });

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -23,6 +23,13 @@ export interface Props {
 type XAxisVal = number;
 export type CheckpointsDict = Record<XAxisVal, CheckpointWorkloadExtended>;
 
+const TRAIN_PREFIX = /^(t_|train_|training_)/;
+const VAL_PREFIX = /^(v_|val_|validation_)/;
+
+const stripPrefix = (metricName: string): string => {
+  return metricName.replace(TRAIN_PREFIX, '').replace(VAL_PREFIX, '');
+};
+
 const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
   const [xAxis, setXAxis] = useState<XAxisDomain>(XAxisDomain.Batches);
 
@@ -80,8 +87,9 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
 
   const groupedMetrics: Metric[][] = useMemo(() => {
     const map = metrics.reduce((acc, metric) => {
-      acc[metric.name] = acc[metric.name] ?? [];
-      acc[metric.name].push(metric);
+      const metricName = stripPrefix(metric.name);
+      acc[metricName] = acc[metricName] ?? [];
+      acc[metricName].push(metric);
       return acc;
     }, {} as Record<string, Metric[]>);
     return Object.keys(map)

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -95,8 +95,8 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
   }, [data, checkpoint, xAxis]);
 
   const pairedMetrics: ([Metric] | [Metric, Metric])[] | undefined = useMemo(() => {
-    const val = metrics.filter((m) => m.type === MetricType.Validation).sort(metricSorter);
-    const train = metrics.filter((m) => m.type === MetricType.Training).sort(metricSorter);
+    const val = metrics.filter((m) => m.group === MetricType.Validation).sort(metricSorter);
+    const train = metrics.filter((m) => m.group === MetricType.Training).sort(metricSorter);
     let out: ([Metric] | [Metric, Metric])[] = [];
     while (val.length) {
       const v = val.shift();

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -7,14 +7,13 @@ import { UPlotPoint } from 'components/UPlot/types';
 import { closestPointPlugin } from 'components/UPlot/UPlotChart/closestPointPlugin';
 import { drawPointsPlugin } from 'components/UPlot/UPlotChart/drawPointsPlugin';
 import { tooltipsPlugin } from 'components/UPlot/UPlotChart/tooltipsPlugin';
-import useMetricNames, { asLoadableOldMetrics } from 'hooks/useMetricNames';
+import useMetricNames from 'hooks/useMetricNames';
 import { useCheckpointFlow } from 'hooks/useModal/Checkpoint/useCheckpointFlow';
 import {
   CheckpointWorkloadExtended,
   ExperimentBase,
   Metric,
   MetricType,
-  OldMetric,
   TrialDetails,
 } from 'types';
 import handleError from 'utils/error';

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import Spinner from 'components/kit/Spinner';
 import { terminalRunStates } from 'constants/states';
-import useMetricNames from 'hooks/useMetricNames';
+import useMetricNames, { asOldMetrics } from 'hooks/useMetricNames';
 import usePermissions from 'hooks/usePermissions';
 import { useSettings } from 'hooks/useSettings';
 import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
@@ -63,6 +63,14 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     return { defaultMetrics, metrics };
   }, [experiment?.config?.searcher, metricNames, settings.metric]);
 
+  const { oldDefaultMetrics, oldMetricNames, oldMetrics } = useMemo(() => {
+    return {
+      oldDefaultMetrics: asOldMetrics(defaultMetrics),
+      oldMetricNames: asOldMetrics(metricNames),
+      oldMetrics: asOldMetrics(metrics),
+    };
+  }, [defaultMetrics, metricNames, metrics]);
+
   const handleMetricChange = useCallback(
     (value: Metric[]) => {
       const newMetrics = value.map((metricName) => `${metricName.type}|${metricName.name}`);
@@ -86,10 +94,10 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
           />
           {settings ? (
             <TrialDetailsWorkloads
-              defaultMetrics={defaultMetrics}
+              defaultMetrics={oldDefaultMetrics}
               experiment={experiment}
-              metricNames={metricNames}
-              metrics={metrics}
+              metricNames={oldMetricNames}
+              metrics={oldMetrics}
               settings={settings}
               trial={trial}
               updateSettings={updateSettings}

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -10,6 +10,7 @@ import { ExperimentBase, Metric, MetricType, RunState, TrialDetails } from 'type
 import { ErrorType } from 'utils/error';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
+import { metricKeyToMetric, metricToKey } from 'utils/metric';
 
 import TrialChart from './TrialChart';
 import { Settings, settingsConfigForExperiment } from './TrialDetailsOverview.settings';
@@ -55,10 +56,9 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     const fallbackMetric = metricNames[0];
     const defaultMetric = defaultValidationMetric || fallbackMetric;
     const defaultMetrics = defaultMetric ? [defaultMetric] : [];
-    const settingMetrics: Metric[] = (settings.metric || []).map((metric) => {
-      const splitMetric = metric.split('|');
-      return { name: splitMetric[1], type: splitMetric[0] as MetricType };
-    });
+    const settingMetrics: Metric[] = (settings.metric || []).map((metric) =>
+      metricKeyToMetric(metric),
+    );
     const metrics = settingMetrics.length !== 0 ? settingMetrics : defaultMetrics;
     return { defaultMetrics, metrics };
   }, [experiment?.config?.searcher, metricNames, settings.metric]);
@@ -73,7 +73,7 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
 
   const handleMetricChange = useCallback(
     (value: Metric[]) => {
-      const newMetrics = value.map((metricName) => `${metricName.type}|${metricName.name}`);
+      const newMetrics = value.map((metric) => metricToKey(metric));
       updateSettings({ metric: newMetrics, tableOffset: 0 });
     },
     [updateSettings],

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -51,7 +51,7 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     const validationMetric = experiment?.config?.searcher.metric;
     const defaultValidationMetric = metricNames.find(
       (metricName) =>
-        metricName.name === validationMetric && metricName.type === MetricType.Validation,
+        metricName.name === validationMetric && metricName.group === MetricType.Validation,
     );
     const fallbackMetric = metricNames[0];
     const defaultMetric = defaultValidationMetric || fallbackMetric;

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import Spinner from 'components/kit/Spinner';
 import { terminalRunStates } from 'constants/states';
-import useMetricNames, { asOldMetrics } from 'hooks/useMetricNames';
+import useMetricNames from 'hooks/useMetricNames';
 import usePermissions from 'hooks/usePermissions';
 import { useSettings } from 'hooks/useSettings';
 import TrialInfoBox from 'pages/TrialDetails/TrialInfoBox';
@@ -63,14 +63,6 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     return { defaultMetrics, metrics };
   }, [experiment?.config?.searcher, metricNames, settings.metric]);
 
-  const { oldDefaultMetrics, oldMetricNames, oldMetrics } = useMemo(() => {
-    return {
-      oldDefaultMetrics: asOldMetrics(defaultMetrics),
-      oldMetricNames: asOldMetrics(metricNames),
-      oldMetrics: asOldMetrics(metrics),
-    };
-  }, [defaultMetrics, metricNames, metrics]);
-
   const handleMetricChange = useCallback(
     (value: Metric[]) => {
       const newMetrics = value.map((metric) => metricToKey(metric));
@@ -94,10 +86,10 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
           />
           {settings ? (
             <TrialDetailsWorkloads
-              defaultMetrics={oldDefaultMetrics}
+              defaultMetrics={defaultMetrics}
               experiment={experiment}
-              metricNames={oldMetricNames}
-              metrics={oldMetrics}
+              metricNames={metricNames}
+              metrics={metrics}
               settings={settings}
               trial={trial}
               updateSettings={updateSettings}

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -134,7 +134,6 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
           filter: settings.filter,
           id: trial.id,
           limit: settings.tableLimit,
-          // metricType: metricKeyToMetric(settings.sortKey)?.group || undefined,
           offset: settings.tableOffset,
           orderBy: settings.sortDesc ? 'ORDER_BY_DESC' : 'ORDER_BY_ASC',
           sortKey: metricKeyToMetric(settings.sortKey)?.name || undefined,

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -79,12 +79,9 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       return null;
     };
 
-    const metricRenderer = (metricName: OldMetric) => {
-      const metricCol = (_: string, record: Step) => {
-        const value = extractMetricValue(record, metricName);
-        return <HumanReadableNumber num={value} />;
-      };
-      return metricCol;
+    const metricRenderer = (metricName: OldMetric) => (_: string, record: Step) => {
+      const value = extractMetricValue(record, metricName);
+      return <HumanReadableNumber num={value} />;
     };
 
     const { metric, smallerIsBetter } = experiment?.config?.searcher || {};

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -1,4 +1,3 @@
-// import { SelectValue } from 'antd/es/select';
 import { FilterValue, SorterResult, TablePaginationConfig } from 'antd/es/table/interface';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -15,7 +14,7 @@ import usePolling from 'hooks/usePolling';
 import { getTrialWorkloads } from 'services/api';
 import {
   ExperimentBase,
-  Metric,
+  OldMetric,
   Step,
   TrialDetails,
   TrialWorkloadFilter,
@@ -26,7 +25,7 @@ import handleError from 'utils/error';
 import {
   extractMetricSortValue,
   extractMetricValue,
-  metricKeyToMetric,
+  metricKeyToOldMetric,
   metricToKey,
 } from 'utils/metric';
 import { numericSorter } from 'utils/sort';
@@ -38,10 +37,10 @@ import { Settings } from './TrialDetailsOverview.settings';
 import { columns as defaultColumns } from './TrialDetailsWorkloads.table';
 
 export interface Props {
-  defaultMetrics: Metric[];
+  defaultMetrics: OldMetric[];
   experiment: ExperimentBase;
-  metricNames: Metric[];
-  metrics: Metric[];
+  metricNames: OldMetric[];
+  metrics: OldMetric[];
   settings: Settings;
   trial?: TrialDetails;
   updateSettings: (newSettings: Partial<Settings>) => void;
@@ -80,7 +79,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       return null;
     };
 
-    const metricRenderer = (metricName: Metric) => {
+    const metricRenderer = (metricName: OldMetric) => {
       const metricCol = (_: string, record: Step) => {
         const value = extractMetricValue(record, metricName);
         return <HumanReadableNumber num={value} />;
@@ -138,10 +137,10 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
           filter: settings.filter,
           id: trial.id,
           limit: settings.tableLimit,
-          metricType: metricKeyToMetric(settings.sortKey)?.type || undefined,
+          metricType: metricKeyToOldMetric(settings.sortKey)?.type || undefined,
           offset: settings.tableOffset,
           orderBy: settings.sortDesc ? 'ORDER_BY_DESC' : 'ORDER_BY_ASC',
-          sortKey: metricKeyToMetric(settings.sortKey)?.name || undefined,
+          sortKey: metricKeyToOldMetric(settings.sortKey)?.name || undefined,
         });
         setWorkloads(Loaded(wl.workloads));
         setWorkloadCount(wl.pagination.total || 0);

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -174,9 +174,9 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
           if (settings.filter === TrialWorkloadFilter.Checkpoint) {
             return hasCheckpoint(wlStep);
           } else if (settings.filter === TrialWorkloadFilter.Validation) {
-            return !!wlStep.validation;
+            return !!wlStep.metrics.validation;
           } else if (settings.filter === TrialWorkloadFilter.CheckpointOrValidation) {
-            return !!wlStep.checkpoint || !!wlStep.validation;
+            return !!wlStep.checkpoint || !!wlStep.metrics.validation;
           }
           return false;
         });

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -14,7 +14,7 @@ import usePolling from 'hooks/usePolling';
 import { getTrialWorkloads } from 'services/api';
 import {
   ExperimentBase,
-  OldMetric,
+  Metric,
   Step,
   TrialDetails,
   TrialWorkloadFilter,
@@ -25,9 +25,8 @@ import handleError from 'utils/error';
 import {
   extractMetricSortValue,
   extractMetricValue,
-  metricKeyToOldMetric,
+  metricKeyToMetric,
   metricToKey,
-  oldMetricToMetric,
 } from 'utils/metric';
 import { numericSorter } from 'utils/sort';
 import { hasCheckpoint, hasCheckpointStep, workloadsToSteps } from 'utils/workload';
@@ -38,10 +37,10 @@ import { Settings } from './TrialDetailsOverview.settings';
 import { columns as defaultColumns } from './TrialDetailsWorkloads.table';
 
 export interface Props {
-  defaultMetrics: OldMetric[];
+  defaultMetrics: Metric[];
   experiment: ExperimentBase;
-  metricNames: OldMetric[];
-  metrics: OldMetric[];
+  metricNames: Metric[];
+  metrics: Metric[];
   settings: Settings;
   trial?: TrialDetails;
   updateSettings: (newSettings: Partial<Settings>) => void;
@@ -80,8 +79,8 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       return null;
     };
 
-    const metricRenderer = (metricName: OldMetric) => (_: string, record: Step) => {
-      const value = extractMetricValue(record, metricName);
+    const metricRenderer = (metric: Metric) => (_: string, record: Step) => {
+      const value = extractMetricValue(record, metric);
       return <HumanReadableNumber num={value} />;
     };
 
@@ -91,8 +90,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
       return column;
     });
 
-    metrics.forEach((oldMetric) => {
-      const metric = oldMetricToMetric(oldMetric);
+    metrics.forEach((metric) => {
       const stateIndex = newColumns.findIndex((column) => column.key === 'state');
       newColumns.splice(stateIndex, 0, {
         defaultSortOrder:
@@ -102,10 +100,10 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
               : 'descend'
             : undefined,
         key: metricToKey(metric),
-        render: metricRenderer(oldMetric),
+        render: metricRenderer(metric),
         sorter: (a, b) => {
-          const aVal = extractMetricSortValue(a, oldMetric),
-            bVal = extractMetricSortValue(b, oldMetric);
+          const aVal = extractMetricSortValue(a, metric),
+            bVal = extractMetricSortValue(b, metric);
           if (aVal === undefined && bVal !== undefined) {
             return settings.sortDesc ? -1 : 1;
           } else if (aVal !== undefined && bVal === undefined) {
@@ -136,10 +134,10 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
           filter: settings.filter,
           id: trial.id,
           limit: settings.tableLimit,
-          metricType: metricKeyToOldMetric(settings.sortKey)?.type || undefined,
+          // metricType: metricKeyToMetric(settings.sortKey)?.group || undefined,
           offset: settings.tableOffset,
           orderBy: settings.sortDesc ? 'ORDER_BY_DESC' : 'ORDER_BY_ASC',
-          sortKey: metricKeyToOldMetric(settings.sortKey)?.name || undefined,
+          sortKey: metricKeyToMetric(settings.sortKey)?.name || undefined,
         });
         setWorkloads(Loaded(wl.workloads));
         setWorkloadCount(wl.pagination.total || 0);

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -143,7 +143,7 @@ export const useTrialMetrics = (trials: (TrialDetails | undefined)[]): TrialMetr
         const metricsHaveData: Record<string, boolean> = {};
         const response = await timeSeries({
           maxDatapoints: screen.width > 1600 ? 1500 : 1000,
-          metricNames: metrics,
+          metrics,
           startBatches: 0,
           trialIds: trials?.map((t) => t?.id || 0).filter((i) => i > 0),
         });

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -74,9 +74,9 @@ const summarizedMetricToSeries = (
 
     const series: Serie = {
       color:
-        metric.type === MetricType.Validation ? VALIDATION_SERIES_COLOR : TRAINING_SERIES_COLOR,
+        metric.group === MetricType.Validation ? VALIDATION_SERIES_COLOR : TRAINING_SERIES_COLOR,
       data,
-      metricType: metric.type,
+      metricType: metric.group,
       name: metric.name,
     };
     trialData[metricToKey(metric)] = series;

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -945,16 +945,17 @@ export const timeSeries: DetApi<
   postProcess: (response: Api.V1CompareTrialsResponse) => {
     return response.trials.map(decoder.decodeTrialSummary);
   },
-  request: (params: Service.TimeSeriesParams) =>
-    detApi.Experiments.compareTrials(
+  request: (params: Service.TimeSeriesParams) => {
+    return detApi.Experiments.compareTrials(
       params.trialIds,
       params.maxDatapoints,
-      params.metricNames.map((m) => m.name),
+      params.metricNames.map((metric) => metric.name),
       params.startBatches,
       params.endBatches,
       params.metricType ? Type.metricTypeParamMap[params.metricType] : 'METRIC_TYPE_UNSPECIFIED',
       undefined,
-    ),
+    );
+  },
 };
 
 export const getExperimentFileTree: DetApi<

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -949,11 +949,12 @@ export const timeSeries: DetApi<
     return detApi.Experiments.compareTrials(
       params.trialIds,
       params.maxDatapoints,
-      params.metricNames.map((metric) => metric.name),
+      undefined,
       params.startBatches,
       params.endBatches,
       params.metricType ? Type.metricTypeParamMap[params.metricType] : 'METRIC_TYPE_UNSPECIFIED',
       undefined,
+      params.metrics.map((metric) => [metric.group, metric.name].join('.')),
     );
   },
 };
@@ -1024,9 +1025,9 @@ export const getTrialWorkloads: DetApi<
       WorkloadFilterParamMap[params.filter || 'FILTER_OPTION_UNSPECIFIED'] ||
         'FILTER_OPTION_UNSPECIFIED',
       undefined,
-      undefined,          // Specifically set to `undefined` to return custom group metrics.
+      undefined, // Specifically set to `undefined` to return custom group metrics.
       undefined,
-      true,   // remove deleted checkpoints
+      true, // remove deleted checkpoints
     ),
 };
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1024,13 +1024,9 @@ export const getTrialWorkloads: DetApi<
       WorkloadFilterParamMap[params.filter || 'FILTER_OPTION_UNSPECIFIED'] ||
         'FILTER_OPTION_UNSPECIFIED',
       undefined,
-      params.metricType
-        ? params.metricType === Type.MetricType.Training
-          ? 'METRIC_TYPE_TRAINING'
-          : 'METRIC_TYPE_VALIDATION'
-        : undefined,
+      undefined,          // Specifically set to `undefined` to return custom group metrics.
       undefined,
-      true, // remove deleted checkpoints
+      true,   // remove deleted checkpoints
     ),
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -640,6 +640,11 @@ const decodeMetricValues = (data: unknown): Record<string, number> => {
   if (!isObject(data)) return {};
   const dataObj = data as Record<string, unknown>;
   return Object.keys(dataObj).reduce((acc, key) => {
+    /**
+     * parseFloat is temporary until the issue of some metrics getting
+     * returned as a string is fixed:
+     * https://hpe-aiatscale.atlassian.net/browse/DET-9736
+     */
     acc[key] = isNumber(dataObj[key]) ? (dataObj[key] as number) : parseFloat(`${dataObj[key]}`);
     return acc;
   }, {} as Record<string, number>);

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -632,6 +632,19 @@ export const decodeV1TrialToTrialItem = (data: Sdk.Trialv1Trial): types.TrialIte
   };
 };
 
+/**
+ * Group metrics get returned as a string version of float values.
+ * This is needed to bridge the gap in the mean time.
+ */
+const decodeMetricValues = (data: unknown): Record<string, number> => {
+  if (!isObject(data)) return {};
+  const dataObj = data as Record<string, unknown>;
+  return Object.keys(dataObj).reduce((acc, key) => {
+    acc[key] = isNumber(dataObj[key]) ? (dataObj[key] as number) : parseFloat(`${dataObj[key]}`);
+    return acc;
+  }, {} as Record<string, number>);
+};
+
 const decodeDownsampledMetrics = (data: Sdk.V1DownsampledMetrics[]): types.MetricContainer[] => {
   return data.map((m) => {
     const metrics: types.MetricContainer = {
@@ -639,12 +652,9 @@ const decodeDownsampledMetrics = (data: Sdk.V1DownsampledMetrics[]): types.Metri
         batches: pt.batches,
         epoch: pt.epoch,
         time: pt.time,
-        values: pt.values,
+        values: decodeMetricValues(pt.values),
       })),
-      type:
-        m.type === Sdk.V1MetricType.TRAINING
-          ? types.MetricType.Training
-          : types.MetricType.Validation,
+      group: m.group,
     };
     return metrics;
   });

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -29,7 +29,7 @@ export type TrialDetailsParams = SingleEntityParams;
 export interface TrialSummaryBaseParams {
   endBatches?: number;
   maxDatapoints: number;
-  metricNames: Metric[];
+  metrics: Metric[];
   metricType?: MetricType;
   startBatches?: number;
 }

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -470,14 +470,19 @@ export const metricTypeParamMap: Record<string, MetricTypeParam> = {
   [MetricType.Validation]: 'METRIC_TYPE_VALIDATION',
 };
 
+/**
+ * `OldMetric` handles specifically training and validation metric types only.
+ * They are still supported due to how Workloads and its related types are defined.
+ * The current Metric supports generic types also know as `groups`.
+ */
 export interface OldMetric {
   name: string;
   type: MetricType;
 }
 
 export interface Metric {
+  group: string;
   name: string;
-  type: string;
 }
 
 export interface BaseWorkload extends EndTimes {

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -470,9 +470,14 @@ export const metricTypeParamMap: Record<string, MetricTypeParam> = {
   [MetricType.Validation]: 'METRIC_TYPE_VALIDATION',
 };
 
-export interface Metric {
+export interface OldMetric {
   name: string;
   type: MetricType;
+}
+
+export interface Metric {
+  name: string;
+  type: string;
 }
 
 export interface BaseWorkload extends EndTimes {

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -505,8 +505,7 @@ export interface MetricsWorkload extends BaseWorkload {
 }
 export interface WorkloadGroup {
   checkpoint?: CheckpointWorkload;
-  training?: MetricsWorkload;
-  validation?: MetricsWorkload;
+  metrics: Record<string, MetricsWorkload>;
 }
 
 export const TrialWorkloadFilter = {
@@ -523,7 +522,7 @@ export type TrialWorkloadFilter = ValueOf<typeof TrialWorkloadFilter>;
 export interface Step extends WorkloadGroup, StartEndTimes {
   batchNum: number;
   key: string;
-  training: MetricsWorkload;
+  // training: MetricsWorkload;
 }
 
 type MetricStruct = Record<string, number>;

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -625,8 +625,8 @@ export interface MetricDatapointEpoch {
 export interface MetricContainer {
   data: MetricDatapoint[];
   epochs?: MetricDatapointEpoch[];
+  group: string;
   time?: MetricDatapointTime[];
-  type: MetricType;
 }
 
 export interface TrialSummary extends TrialItem {

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -470,16 +470,6 @@ export const metricTypeParamMap: Record<string, MetricTypeParam> = {
   [MetricType.Validation]: 'METRIC_TYPE_VALIDATION',
 };
 
-/**
- * `OldMetric` handles specifically training and validation metric types only.
- * They are still supported due to how Workloads and its related types are defined.
- * The current Metric supports generic types also know as `groups`.
- */
-export interface OldMetric {
-  name: string;
-  type: MetricType;
-}
-
 export interface Metric {
   group: string;
   name: string;

--- a/webui/react/src/utils/metric.test.ts
+++ b/webui/react/src/utils/metric.test.ts
@@ -29,22 +29,22 @@ const metrics = [
   {
     metric: { group: MetricType.Training, name: 'accuracy' },
     str: '[T] accuracy',
-    value: `${MetricType.Training}|accuracy`,
+    value: '{"group":"training","name":"accuracy"}',
   },
   {
     metric: { group: MetricType.Training, name: 'loss' },
     str: '[T] loss',
-    value: `${MetricType.Training}|loss`,
+    value: '{"group":"training","name":"loss"}',
   },
   {
     metric: { group: MetricType.Validation, name: 'accuracy' },
     str: '[V] accuracy',
-    value: `${MetricType.Validation}|accuracy`,
+    value: '{"group":"validation","name":"accuracy"}',
   },
   {
     metric: { group: MetricType.Validation, name: 'loss' },
     str: '[V] loss',
-    value: `${MetricType.Validation}|loss`,
+    value: '{"group":"validation","name":"loss"}',
   },
 ];
 
@@ -52,10 +52,10 @@ describe('Metric Utilities', () => {
   describe('extractMetrics', () => {
     it('should extract metric names from workloads', () => {
       const result = [
-        { group: MetricType.Validation, name: 'accuracy' },
-        { group: MetricType.Validation, name: 'loss' },
         { group: MetricType.Training, name: 'accuracy' },
         { group: MetricType.Training, name: 'loss' },
+        { group: MetricType.Validation, name: 'accuracy' },
+        { group: MetricType.Validation, name: 'loss' },
       ];
       expect(utils.extractMetrics(workloads)).toStrictEqual(result);
     });
@@ -130,8 +130,10 @@ describe('Metric Utilities', () => {
     });
 
     it('should handle invalid metric name value', () => {
-      expect(utils.metricKeyToMetric('invalidMetricValue')).toBeUndefined();
-      expect(utils.metricKeyToMetric('fauxMetricType|loss')).toBeUndefined();
+      expect(utils.metricKeyToMetric('invalidMetricValue')).toEqual({
+        group: 'invalidMetricValue',
+        name: 'invalidMetricValue',
+      });
     });
   });
 });

--- a/webui/react/src/utils/metric.test.ts
+++ b/webui/react/src/utils/metric.test.ts
@@ -1,5 +1,6 @@
 import { MetricType, WorkloadGroup } from 'types';
 
+import { metricToOldMetric } from './metric';
 import * as utils from './metric';
 
 const workloads: WorkloadGroup[] = [
@@ -23,22 +24,26 @@ const workloads: WorkloadGroup[] = [
 
 const metrics = [
   {
-    metric: { name: 'accuracy', type: MetricType.Training },
+    metric: { group: MetricType.Training, name: 'accuracy' },
+    oldMetric: { name: 'accuracy', type: MetricType.Training },
     str: '[T] accuracy',
     value: `${MetricType.Training}|accuracy`,
   },
   {
-    metric: { name: 'loss', type: MetricType.Training },
+    metric: { group: MetricType.Training, name: 'loss' },
+    oldMetric: { name: 'loss', type: MetricType.Training },
     str: '[T] loss',
     value: `${MetricType.Training}|loss`,
   },
   {
-    metric: { name: 'accuracy', type: MetricType.Validation },
+    metric: { group: MetricType.Validation, name: 'accuracy' },
+    oldMetric: { name: 'accuracy', type: MetricType.Validation },
     str: '[V] accuracy',
     value: `${MetricType.Validation}|accuracy`,
   },
   {
-    metric: { name: 'loss', type: MetricType.Validation },
+    metric: { group: MetricType.Validation, name: 'loss' },
+    oldMetric: { name: 'loss', type: MetricType.Validation },
     str: '[V] loss',
     value: `${MetricType.Validation}|loss`,
   },
@@ -48,10 +53,10 @@ describe('Metric Utilities', () => {
   describe('extractMetrics', () => {
     it('should extract metric names from workloads', () => {
       const result = [
-        { name: 'accuracy', type: MetricType.Validation },
-        { name: 'loss', type: MetricType.Validation },
-        { name: 'accuracy', type: MetricType.Training },
-        { name: 'loss', type: MetricType.Training },
+        { group: MetricType.Validation, name: 'accuracy' },
+        { group: MetricType.Validation, name: 'loss' },
+        { group: MetricType.Training, name: 'accuracy' },
+        { group: MetricType.Training, name: 'loss' },
       ];
       expect(utils.extractMetrics(workloads)).toStrictEqual(result);
     });
@@ -62,15 +67,17 @@ describe('Metric Utilities', () => {
     const lossValidation = metrics[3].metric;
 
     it('should extract training metric', () => {
-      expect(utils.extractMetricValue(workloads[0], accuracyTraining)).toBe(0.9);
+      expect(utils.extractMetricValue(workloads[0], metricToOldMetric(accuracyTraining))).toBe(0.9);
     });
 
     it('should extract validation metric', () => {
-      expect(utils.extractMetricValue(workloads[1], lossValidation)).toBe(0.19);
+      expect(utils.extractMetricValue(workloads[1], metricToOldMetric(lossValidation))).toBe(0.19);
     });
 
     it('should handle non-existent metric extraction', () => {
-      expect(utils.extractMetricValue(workloads[0], lossValidation)).toBeUndefined();
+      expect(
+        utils.extractMetricValue(workloads[0], metricToOldMetric(lossValidation)),
+      ).toBeUndefined();
     });
   });
 
@@ -103,10 +110,26 @@ describe('Metric Utilities', () => {
 
     it('should truncate metric string to 30 characters', () => {
       const metric = {
+        group: MetricType.Training,
         name: 'very-very-very-very-very-very-long-metric-name',
-        type: MetricType.Training,
       };
       expect(utils.metricToStr(metric, 20)).toBe('[T] very-very-very-very-...');
+    });
+  });
+
+  describe('metricToOldMetric', () => {
+    it('should convert metric to old metric', () => {
+      metrics.forEach((metric) => {
+        expect(utils.metricToOldMetric(metric.metric)).toEqual(metric.oldMetric);
+      });
+    });
+  });
+
+  describe('oldMetricToMetric', () => {
+    it('should convert old metric to metric', () => {
+      metrics.forEach((metric) => {
+        expect(utils.oldMetricToMetric(metric.oldMetric)).toEqual(metric.metric);
+      });
     });
   });
 

--- a/webui/react/src/utils/metric.test.ts
+++ b/webui/react/src/utils/metric.test.ts
@@ -1,6 +1,5 @@
 import { MetricType, WorkloadGroup } from 'types';
 
-import { metricToOldMetric } from './metric';
 import * as utils from './metric';
 
 const workloads: WorkloadGroup[] = [
@@ -29,25 +28,21 @@ const workloads: WorkloadGroup[] = [
 const metrics = [
   {
     metric: { group: MetricType.Training, name: 'accuracy' },
-    oldMetric: { name: 'accuracy', type: MetricType.Training },
     str: '[T] accuracy',
     value: `${MetricType.Training}|accuracy`,
   },
   {
     metric: { group: MetricType.Training, name: 'loss' },
-    oldMetric: { name: 'loss', type: MetricType.Training },
     str: '[T] loss',
     value: `${MetricType.Training}|loss`,
   },
   {
     metric: { group: MetricType.Validation, name: 'accuracy' },
-    oldMetric: { name: 'accuracy', type: MetricType.Validation },
     str: '[V] accuracy',
     value: `${MetricType.Validation}|accuracy`,
   },
   {
     metric: { group: MetricType.Validation, name: 'loss' },
-    oldMetric: { name: 'loss', type: MetricType.Validation },
     str: '[V] loss',
     value: `${MetricType.Validation}|loss`,
   },
@@ -71,17 +66,15 @@ describe('Metric Utilities', () => {
     const lossValidation = metrics[3].metric;
 
     it('should extract training metric', () => {
-      expect(utils.extractMetricValue(workloads[0], metricToOldMetric(accuracyTraining))).toBe(0.9);
+      expect(utils.extractMetricValue(workloads[0], accuracyTraining)).toBe(0.9);
     });
 
     it('should extract validation metric', () => {
-      expect(utils.extractMetricValue(workloads[1], metricToOldMetric(lossValidation))).toBe(0.19);
+      expect(utils.extractMetricValue(workloads[1], lossValidation)).toBe(0.19);
     });
 
     it('should handle non-existent metric extraction', () => {
-      expect(
-        utils.extractMetricValue(workloads[0], metricToOldMetric(lossValidation)),
-      ).toBeUndefined();
+      expect(utils.extractMetricValue(workloads[0], lossValidation)).toBeUndefined();
     });
   });
 
@@ -118,22 +111,6 @@ describe('Metric Utilities', () => {
         name: 'very-very-very-very-very-very-long-metric-name',
       };
       expect(utils.metricToStr(metric, 20)).toBe('[T] very-very-very-very-...');
-    });
-  });
-
-  describe('metricToOldMetric', () => {
-    it('should convert metric to old metric', () => {
-      metrics.forEach((metric) => {
-        expect(utils.metricToOldMetric(metric.metric)).toEqual(metric.oldMetric);
-      });
-    });
-  });
-
-  describe('oldMetricToMetric', () => {
-    it('should convert old metric to metric', () => {
-      metrics.forEach((metric) => {
-        expect(utils.oldMetricToMetric(metric.oldMetric)).toEqual(metric.metric);
-      });
     });
   });
 

--- a/webui/react/src/utils/metric.test.ts
+++ b/webui/react/src/utils/metric.test.ts
@@ -5,19 +5,23 @@ import * as utils from './metric';
 
 const workloads: WorkloadGroup[] = [
   {
-    training: {
-      metrics: { accuracy: 0.9, loss: 0.1 },
-      totalBatches: 100,
+    metrics: {
+      training: {
+        metrics: { accuracy: 0.9, loss: 0.1 },
+        totalBatches: 100,
+      },
     },
   },
   {
-    training: {
-      metrics: { accuracy: 0.91, loss: 0.09 },
-      totalBatches: 200,
-    },
-    validation: {
-      metrics: { accuracy: 0.81, loss: 0.19 },
-      totalBatches: 200,
+    metrics: {
+      training: {
+        metrics: { accuracy: 0.91, loss: 0.09 },
+        totalBatches: 200,
+      },
+      validation: {
+        metrics: { accuracy: 0.81, loss: 0.19 },
+        totalBatches: 200,
+      },
     },
   },
 ];

--- a/webui/react/src/utils/metric.ts
+++ b/webui/react/src/utils/metric.ts
@@ -14,9 +14,9 @@ export const metricSorter = (a: Metric, b: Metric): number => {
 
 export const extractMetrics = (workloads: WorkloadGroup[]): Metric[] => {
   const trainingNames = workloads
-    .filter((workload) => workload.training?.metrics)
+    .filter((workload) => workload.metrics.training?.metrics)
     .reduce((acc, workload) => {
-      Object.keys(workload.training?.metrics as Record<string, number>).forEach((name) => {
+      Object.keys(workload.metrics.training?.metrics as Record<string, number>).forEach((name) => {
         acc.add(name);
       });
       return acc;
@@ -27,11 +27,13 @@ export const extractMetrics = (workloads: WorkloadGroup[]): Metric[] => {
   });
 
   const validationNames = workloads
-    .filter((workload) => workload.validation?.metrics)
+    .filter((workload) => workload.metrics.validation?.metrics)
     .reduce((acc, workload) => {
-      Object.keys(workload.validation?.metrics as Record<string, number>).forEach((name) => {
-        acc.add(name);
-      });
+      Object.keys(workload.metrics.validation?.metrics as Record<string, number>).forEach(
+        (name) => {
+          acc.add(name);
+        },
+      );
       return acc;
     }, new Set<string>()) as Set<string>;
 
@@ -57,7 +59,7 @@ export const extractMetricValue = (
   workload: WorkloadGroup,
   metric: OldMetric,
 ): number | undefined => {
-  const source = workload[metric.type]?.metrics ?? {};
+  const source = workload.metrics[metric.type]?.metrics ?? {};
   return source[metric.name];
 };
 

--- a/webui/react/src/utils/metric.ts
+++ b/webui/react/src/utils/metric.ts
@@ -1,7 +1,6 @@
 import { OldMetric, RecordKey } from 'types';
 import { Metric, MetricType, WorkloadGroup } from 'types';
-
-import { alphaNumericSorter } from '../utils/sort';
+import { alphaNumericSorter } from 'utils/sort';
 
 export const METRIC_KEY_DELIMITER = '||||';
 export const METRIC_API_DELIMITER = '/';
@@ -60,7 +59,7 @@ export const extractMetricValue = (
   metric: OldMetric,
 ): number | undefined => {
   const source = workload[metric.type]?.metrics ?? {};
-  return source[metricToKey(metric)];
+  return source[metric.name];
 };
 
 export const getMetricValue = (
@@ -71,9 +70,16 @@ export const getMetricValue = (
   return workload?.metrics[metric];
 };
 
-export const getMetricName = (metric: string): string => {
-  const position = metric.indexOf(METRIC_API_DELIMITER);
-  return position !== -1 ? metric.substring(position + METRIC_API_DELIMITER.length) : metric;
+/**
+ * When a metric is of custom type, the group is part of the metric name.
+ * This is a utility to parse out the group type for displaying when we show
+ * metric type separately.
+ */
+export const getMetricName = (metricName: string): string => {
+  const position = metricName.indexOf(METRIC_API_DELIMITER);
+  return position !== -1
+    ? metricName.substring(position + METRIC_API_DELIMITER.length)
+    : metricName;
 };
 
 export const isMetric = (metric?: Metric): metric is Metric => metric !== undefined;
@@ -92,10 +98,6 @@ export const metricToKey = (metric: Metric): string => {
   } catch (e) {
     return `${metric.type}${METRIC_KEY_DELIMITER}${metric.name}`;
   }
-};
-
-export const metricWithTypeToKey = (metric: string, type: string): string => {
-  return metricToKey({ name: metric, type });
 };
 
 export const metricKeyToMetric = (value: string): Metric => {

--- a/webui/react/src/utils/metric.ts
+++ b/webui/react/src/utils/metric.ts
@@ -46,20 +46,17 @@ export const extractMetrics = (workloads: WorkloadGroup[]): Metric[] => {
 
 export const extractMetricSortValue = (
   workload: WorkloadGroup,
-  metric: OldMetric,
+  metric: Metric,
 ): number | undefined => {
   return (
     extractMetricValue(workload, metric) ??
-    extractMetricValue(workload, { ...metric, type: MetricType.Validation }) ??
-    extractMetricValue(workload, { ...metric, type: MetricType.Training })
+    extractMetricValue(workload, { ...metric, group: MetricType.Validation }) ??
+    extractMetricValue(workload, { ...metric, group: MetricType.Training })
   );
 };
 
-export const extractMetricValue = (
-  workload: WorkloadGroup,
-  metric: OldMetric,
-): number | undefined => {
-  const source = workload.metrics[metric.type]?.metrics ?? {};
+export const extractMetricValue = (workload: WorkloadGroup, metric: Metric): number | undefined => {
+  const source = workload.metrics[metric.group]?.metrics ?? {};
   return source[metric.name];
 };
 
@@ -84,10 +81,6 @@ export const metricToStr = (metric: Metric, truncateLimit = 30): string => {
 export const metricToOldMetric = (metric: Metric): OldMetric => {
   const type = metric.group === MetricType.Training ? MetricType.Training : MetricType.Validation;
   return { name: metric.name, type };
-};
-
-export const oldMetricToMetric = (oldMetric: OldMetric): Metric => {
-  return { group: oldMetric.type, name: oldMetric.name };
 };
 
 export const metricToKey = (metric: Metric): string => {

--- a/webui/react/src/utils/metric.ts
+++ b/webui/react/src/utils/metric.ts
@@ -1,4 +1,4 @@
-import { OldMetric, RecordKey } from 'types';
+import { RecordKey } from 'types';
 import { Metric, MetricType, WorkloadGroup } from 'types';
 import { alphaNumericSorter } from 'utils/sort';
 
@@ -78,11 +78,6 @@ export const metricToStr = (metric: Metric, truncateLimit = 30): string => {
   return `[${group}] ${name}`;
 };
 
-export const metricToOldMetric = (metric: Metric): OldMetric => {
-  const type = metric.group === MetricType.Training ? MetricType.Training : MetricType.Validation;
-  return { name: metric.name, type };
-};
-
 export const metricToKey = (metric: Metric): string => {
   try {
     return JSON.stringify(metric);
@@ -102,17 +97,7 @@ export const metricKeyToMetric = (value: string): Metric => {
   }
 };
 
-export const metricKeyToOldMetric = (value: string): OldMetric | undefined => {
-  const parts = value.split('|');
-  if (parts.length !== 2) return;
-  if (![MetricType.Training, MetricType.Validation].includes(parts[0] as MetricType)) return;
-  return { name: parts[1], type: parts[0] as MetricType };
-};
-
 export const metricKeyToName = (key: string): string => metricKeyToMetric(key).name;
-
-export const metricKeyToType = (key: string): MetricType | undefined =>
-  metricKeyToOldMetric(key)?.type;
 
 export const metricKeyToStr = (key: string): string => {
   const metric = metricKeyToMetric(key);

--- a/webui/react/src/utils/workload.test.ts
+++ b/webui/react/src/utils/workload.test.ts
@@ -124,32 +124,38 @@ describe('Workload Utilities', () => {
       const expected = [
         {
           batchNum: 100,
-          training: {
-            metrics: { accuracy: 0.9, loss: 0.1 },
-            totalBatches: 100,
+          metrics: {
+            training: {
+              metrics: { accuracy: 0.9, loss: 0.1 },
+              totalBatches: 100,
+            },
           },
         },
         {
           batchNum: 200,
-          training: {
-            metrics: { accuracy: 0.91, loss: 0.09 },
-            totalBatches: 200,
-          },
-          validation: {
-            metrics: { accuracy: 0.81, loss: 0.19 },
-            totalBatches: 200,
+          metrics: {
+            training: {
+              metrics: { accuracy: 0.91, loss: 0.09 },
+              totalBatches: 200,
+            },
+            validation: {
+              metrics: { accuracy: 0.81, loss: 0.19 },
+              totalBatches: 200,
+            },
           },
         },
         {
           batchNum: 300,
           checkpoint: { state: 'ACTIVE', totalBatches: 300 },
-          training: {
-            metrics: { accuracy: 0.91, loss: 0.09 },
-            totalBatches: 300,
-          },
-          validation: {
-            metrics: { accuracy: 0.81, loss: 0.19 },
-            totalBatches: 300,
+          metrics: {
+            training: {
+              metrics: { accuracy: 0.91, loss: 0.09 },
+              totalBatches: 300,
+            },
+            validation: {
+              metrics: { accuracy: 0.81, loss: 0.19 },
+              totalBatches: 300,
+            },
           },
         },
       ];

--- a/webui/react/src/utils/workload.test.ts
+++ b/webui/react/src/utils/workload.test.ts
@@ -4,21 +4,27 @@ import * as utils from './workload';
 
 const WORKLOADS: WorkloadGroup[] = [
   {
-    training: {
-      metrics: { accuracy: 0.9, loss: 0.1 },
-      totalBatches: 100,
+    metrics: {
+      training: {
+        metrics: { accuracy: 0.9, loss: 0.1 },
+        totalBatches: 100,
+      },
     },
   },
   {
-    training: {
-      metrics: { accuracy: 0.91, loss: 0.09 },
-      totalBatches: 200,
+    metrics: {
+      training: {
+        metrics: { accuracy: 0.91, loss: 0.09 },
+        totalBatches: 200,
+      },
     },
   },
   {
-    validation: {
-      metrics: { accuracy: 0.81, loss: 0.19 },
-      totalBatches: 200,
+    metrics: {
+      validation: {
+        metrics: { accuracy: 0.81, loss: 0.19 },
+        totalBatches: 200,
+      },
     },
   },
   {
@@ -26,17 +32,22 @@ const WORKLOADS: WorkloadGroup[] = [
       state: CheckpointState.Active,
       totalBatches: 300,
     },
+    metrics: {},
   },
   {
-    training: {
-      metrics: { accuracy: 0.91, loss: 0.09 },
-      totalBatches: 300,
+    metrics: {
+      training: {
+        metrics: { accuracy: 0.91, loss: 0.09 },
+        totalBatches: 300,
+      },
     },
   },
   {
-    validation: {
-      metrics: { accuracy: 0.81, loss: 0.19 },
-      totalBatches: 300,
+    metrics: {
+      validation: {
+        metrics: { accuracy: 0.81, loss: 0.19 },
+        totalBatches: 300,
+      },
     },
   },
 ];
@@ -61,11 +72,11 @@ describe('Workload Utilities', () => {
 
   describe('getWorkload', () => {
     it('should extract first available training workload', () => {
-      expect(utils.getWorkload(WORKLOADS[0])).toStrictEqual(WORKLOADS[0].training);
+      expect(utils.getWorkload(WORKLOADS[0])).toStrictEqual(WORKLOADS[0].metrics.training);
     });
 
     it('should extract first available validation workload', () => {
-      expect(utils.getWorkload(WORKLOADS[2])).toStrictEqual(WORKLOADS[2].validation);
+      expect(utils.getWorkload(WORKLOADS[2])).toStrictEqual(WORKLOADS[2].metrics.validation);
     });
 
     it('should extract first available checkpoint workload', () => {
@@ -80,6 +91,7 @@ describe('Workload Utilities', () => {
           state: CheckpointState.Active,
           totalBatches: 100,
         },
+        metrics: {},
       };
       expect(utils.hasCheckpoint(workload)).toBe(true);
     });
@@ -90,6 +102,7 @@ describe('Workload Utilities', () => {
           state: CheckpointState.Deleted,
           totalBatches: 100,
         },
+        metrics: {},
       };
       expect(utils.hasCheckpoint(workload)).toBe(false);
     });
@@ -101,8 +114,8 @@ describe('Workload Utilities', () => {
         batchNum: 100,
         checkpoint: { state: CheckpointState.Active, totalBatches: 100 },
         key: 'step',
+        metrics: { training: { totalBatches: 100 } },
         startTime: '2021-11-29T00:00:00Z',
-        training: { totalBatches: 100 },
       };
       expect(utils.hasCheckpointStep(step)).toBe(true);
     });
@@ -112,8 +125,8 @@ describe('Workload Utilities', () => {
         batchNum: 100,
         checkpoint: { state: CheckpointState.Deleted, totalBatches: 100 },
         key: 'step',
+        metrics: { training: { totalBatches: 100 } },
         startTime: '2021-11-29T00:00:00Z',
-        training: { totalBatches: 100 },
       };
       expect(utils.hasCheckpointStep(step)).toBe(false);
     });

--- a/webui/react/src/utils/workload.test.ts
+++ b/webui/react/src/utils/workload.test.ts
@@ -70,20 +70,6 @@ describe('Workload Utilities', () => {
     });
   });
 
-  describe('getWorkload', () => {
-    it('should extract first available training workload', () => {
-      expect(utils.getWorkload(WORKLOADS[0])).toStrictEqual(WORKLOADS[0].metrics.training);
-    });
-
-    it('should extract first available validation workload', () => {
-      expect(utils.getWorkload(WORKLOADS[2])).toStrictEqual(WORKLOADS[2].metrics.validation);
-    });
-
-    it('should extract first available checkpoint workload', () => {
-      expect(utils.getWorkload(WORKLOADS[3])).toStrictEqual(WORKLOADS[3].checkpoint);
-    });
-  });
-
   describe('hasCheckpoint', () => {
     it('should detect checkpoint from workload', () => {
       const workload = {

--- a/webui/react/src/utils/workload.ts
+++ b/webui/react/src/utils/workload.ts
@@ -1,4 +1,4 @@
-import { RecordKey } from 'types';
+import { MetricsWorkload, RecordKey } from 'types';
 import * as Type from 'types';
 
 // Checkpoint size in bytes.
@@ -32,13 +32,15 @@ export const workloadsToSteps = (workloads: Type.WorkloadGroup[]): Type.Step[] =
     if (stepsDict[batchNum] === undefined) stepsDict[batchNum] = {};
     stepsDict[batchNum].batchNum = batchNum;
 
-    if (workload.checkpoint) {
-      stepsDict[batchNum].checkpoint = workload.checkpoint;
-    } else if (workload.validation) {
-      stepsDict[batchNum].validation = workload.validation;
-    } else if (workload.training) {
-      stepsDict[batchNum].training = workload.training;
-    }
+    Object.keys(workload).forEach((key) => {
+      if (key === 'checkpoint') {
+        stepsDict[batchNum].checkpoint = workload.checkpoint;
+      } else {
+        stepsDict[batchNum].metrics = stepsDict[batchNum].metrics ?? {};
+        (stepsDict[batchNum].metrics as Record<string, MetricsWorkload>)[key] =
+          workload.metrics[key];
+      }
+    });
   });
 
   return Object.values(stepsDict) as Type.Step[];


### PR DESCRIPTION
## Description

With the introduction of generic metric `types` (or `groups` going forward), metrics type/group is no longer restricted to just `Validation` and `Training`. It can be any user specified string value. Here are some examples to demonstrate how the metrics will change from the Web POV.

Results without custom metric groups from `/api/v1/experiments/metrics-stream/metric-names`:
```
{
    "result": {
        "searcherMetrics": [ "validation_error" ],
        "trainingMetrics": [ "loss", "train_accuracy", "train_error" ],
        "validationMetrics": [ "validation_accuracy", "validation_error" ],
        "metricNames": [
            { "group": "training", "name": "loss" },
            { "group": "training", "name": "train_accuracy" },
            { "group": "training", "name": "train_error" },
            { "group": "validation", "name": "validation_accuracy" },
            { "group": "validation", "name": "validation_error" }
        ]
    }
}
```

Results with custom metric groups from `/api/v1/experiments/metrics-stream/metric-names`:
```
{
    "result": {
        "searcherMetrics": [ "x" ],
        "trainingMetrics": [ "m0", "m1", "m2" ],
        "validationMetrics": [ "m0", "m1", "m2" ],
        "metricNames": [
            { "group": "training", "name": "m0" },
            { "group": "training", "name": "m1" },
            { "group": "training", "name": "m2" },
            { "group": "group_b", "name": "m0" },
            { "group": "group_b", "name": "m1" },
            { "group": "group_b", "name": "m2" },
            { "group": "inference", "name": "m0" },
            { "group": "inference", "name": "m1" },
            { "group": "inference", "name": "m2" },
            { "group": "validation", "name": "m0" },
            { "group": "validation", "name": "m1" },
            { "group": "validation", "name": "m2" }
        ]
    }
}
```

The current state is using the fields `searcherMetrics`, `trainingMetrics` and `validationMetrics`. Going forward, we are using `metricNames` instead. The previous fields are kept for backwards compatibility reasons.

For `time-series` API, we use the `metricIds` param instead of the `metricNames` param to allow generic group metrics to get returned. Otherwise it would only return training and validation metrics only.

### Screenshots

#### Trial Detail > Overview tab

<img width="1554" alt="Screenshot 2023-08-09 at 3 12 51 PM" src="https://github.com/determined-ai/determined/assets/220971/2e949dda-b707-4526-9b4e-114503adb630">

#### Trial Detail > Metrics Tab

<img width="1552" alt="Screenshot 2023-08-09 at 3 12 39 PM" src="https://github.com/determined-ai/determined/assets/220971/df48ea07-3215-4098-8b26-458ff154fc50">

#### New Experiment List > Column Picker

This work is entirely enabled by [this PR](https://github.com/determined-ai/determined/pull/7518)

<img width="448" alt="Screenshot 2023-08-09 at 11 34 24 AM" src="https://github.com/determined-ai/determined/assets/220971/f9bcdf14-a90e-4747-a725-d75e11898e52">


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

All the following test plans require the user to be able to create an experiment that generates custom group metrics. Use the [following experiment config and code](https://github.com/determined-ai/determined/pull/7442) to generate the necessary experiments to test.

View generic group metrics on trial detail page with `Overview` tab via Chart and Workloads.
NOTE: Though the workloads table show the generic group metrics as columns on the table, the values will not appear as no additional work will be done to expand support for Workloads. It might get sunset in the near future.
- [ ] navigate to experiment with generic group metrics, click on `Metrics` tab
- [ ] verify that the custom group metrics are available as options to choose from by the trial chart
- [ ] verify that the custom group metrics are rendering in the trial chart
- [ ] verify that the custom group metrics appear in the workloads table (just as column headers, but no values - not very useful I know)

View generic group metrics on trial detail page with `Metrics` tab.
- [ ] navigate to experiment with generic group metrics, click on `Metrics` tab
- [ ] verify that the custom group metrics are rendering in the chart grid.

**NOTE:** This test requires [this PR](https://github.com/determined-ai/determined/pull/7518) to land first!
Ability to select custom group metrics from new experiment list column picker
- [ ] navigate to new experiment list page
- [ ] click on `Columns` button to bring up columns picker, verify that the custom group metrics appear on the list under `Metrics` tab

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1469
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
