### PR TITLE
chore: summarize state of mock_client_test.go [DET-9731]

### DIFF
--- a/master/internal/rm/kubernetesrm/mock_client_test.go
+++ b/master/internal/rm/kubernetesrm/mock_client_test.go
@@ -22,7 +22,10 @@ import (
 /* As of Aug. 7, 2023, the mock interfaces found
 here & used in pod_test.go cannot be replaced easily
 by mockery-generated mocks without overcomplicating the code
-& its readability. */
+& its readability. In pod_test.go, the tests send messages
+to the Actor system, which are dealt with by a mock
+receiver struct. The mockery-generated interfaces do not
+run the necessary receiver-related code, unlike the mocks here. */
 
 type mockConfigMapInterface struct {
 	configMaps map[string]*k8sV1.ConfigMap

--- a/master/internal/rm/kubernetesrm/mock_client_test.go
+++ b/master/internal/rm/kubernetesrm/mock_client_test.go
@@ -19,6 +19,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+/* As of Aug. 7, 2023, the mock interfaces found
+here & used in pod_test.go cannot be replaced easily
+by mockery-generated mocks without overcomplicating the code
+& its readability. */
+
 type mockConfigMapInterface struct {
 	configMaps map[string]*k8sV1.ConfigMap
 	mux        sync.Mutex

--- a/master/internal/rm/kubernetesrm/mock_client_test.go
+++ b/master/internal/rm/kubernetesrm/mock_client_test.go
@@ -25,7 +25,7 @@ by mockery-generated mocks without overcomplicating the code
 & its readability. In pod_test.go, the tests send messages
 to the Actor system, which are dealt with by a mock
 receiver struct. The mockery-generated interfaces do not
-run the necessary receiver-related code, unlike the mocks here. */
+execute the necessary receiver-related code, unlike the mocks here. */
 
 type mockConfigMapInterface struct {
 	configMaps map[string]*k8sV1.ConfigMap


### PR DESCRIPTION
## Description

In DET-9675, we attempt to remove mock_client_test.go & replace the mock interfaces found there with generated mocks. Due to the complexity of the tests, it’s not possible to make this replacement without severely complicating the code. To remedy this, write a comment in mock_client_test.go detailing this.


## Test Plan

N/A


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9731
DET-9675
