### PR TITLE
chore: migrate to singularity --nvccli

### DIFF
--- a/agent/internal/options/options.go
+++ b/agent/internal/options/options.go
@@ -153,6 +153,7 @@ type ContainerRuntime string
 
 // Available container runtimes.
 const (
+	ApptainerContainerRuntime   = "apptainer"
 	SingularityContainerRuntime = "singularity"
 	DockerContainerRuntime      = "docker"
 	PodmanContainerRuntime      = "podman"

--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -310,9 +310,9 @@ func (s *SingularityClient) RunContainer(
 		}
 	}
 	if len(cudaVisibleDevices) > 0 {
-		// TODO(DET-9081): We need to move to --nvccli --nv, because --nv does not provide
-		// sufficient isolation (e.g., nvidia-smi see all GPUs on the machine, not just ours).
-		args = append(args, "--nv")
+		// Using --userns to avoid this error when using --nvccli:
+		// FATAL:   nvidia-container-cli not allowed in setuid mode
+		args = append(args, "--nv", "--nvccli", "--userns", "--contain")
 	}
 
 	args = capabilitiesToSingularityArgs(req, args)
@@ -383,15 +383,14 @@ func (s *SingularityClient) setCommandEnvironment(
 	req cproto.RunSpec, cudaVisibleDevices []string, cmd *exec.Cmd,
 ) {
 	// Per https://pkg.go.dev/os/exec#Cmd.Env, if cmd.Env is nil, the new process uses the current
-	// process's environment. If this in not the case, for example because we specify something to
+	// process's environment. If this is not the case, for example because we specify something to
 	// control Singularity operation, then we need to explicitly specify any value needed from the
 	// current environment.
 	if req.DeviceType == device.CUDA {
 		cudaVisibleDevicesVar := strings.Join(cudaVisibleDevices, ",")
-		cmd.Env = append(cmd.Env,
-			fmt.Sprintf("SINGULARITYENV_CUDA_VISIBLE_DEVICES=%s", cudaVisibleDevicesVar),
-			fmt.Sprintf("APPTAINERENV_CUDA_VISIBLE_DEVICES=%s", cudaVisibleDevicesVar),
-		)
+		visibleDevices := fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", cudaVisibleDevicesVar)
+		s.log.Trace(visibleDevices)
+		cmd.Env = append(cmd.Env, visibleDevices)
 	}
 	if req.DeviceType == device.ROCM {
 		// Avoid this problem: https://github.com/determined-ai/determined-ee/pull/922

--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -388,6 +388,9 @@ func (s *SingularityClient) setCommandEnvironment(
 	// current environment.
 	if req.DeviceType == device.CUDA {
 		cudaVisibleDevicesVar := strings.Join(cudaVisibleDevices, ",")
+
+		// NVIDIA_VISIBLE_DEVICES together with options on the singularity/apptainer run
+		// command control the visibility of the GPUs in the container.
 		visibleDevices := fmt.Sprintf("NVIDIA_VISIBLE_DEVICES=%s", cudaVisibleDevicesVar)
 		s.log.Trace(visibleDevices)
 		cmd.Env = append(cmd.Env, visibleDevices)

--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -316,7 +316,7 @@ func (s *SingularityClient) RunContainer(
 		if s.isApptainer {
 			// Using --userns to avoid this error when using --nvccli:
 			// FATAL:   nvidia-container-cli not allowed in setuid mode
-			// (casablanca, apptainer version 1.2.2-1)
+			// (e.g.: casablanca, apptainer version 1.2.2-1)
 			args = append(args, "--userns")
 		}
 	}


### PR DESCRIPTION
## Description

having installed Nvidia container CLI and updated the Singularity version on the aizn cluster, some divergence in behavior is evident in the Nvidia support offered by Singularity & Apptainer; slightly different run command qualifiers are required to get the desired result.

The approach adopted here is to allow `--container-runtime=apptainer` on the agent command line, and use this to construct the generated singularity commands appropriately.

Alternatives considered: have the singularity agent run the command `singularity --version` and parse the results; feasible of course, but more complex that the solution given here.

Additionally, I added a check to reject invalid values for the container runtime type.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

Running the agent in a resource allocation: https://rndwiki-pro.its.hpecorp.net/display/AT/Design+Note%3A++Training+on+Resource+Allocation+with+Determined+Agent

Tested on:

apptainer version 1.2.2-1 (casablanca)
singularity-ce version 3.11.4-1.el8 (aizn)

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
