### PR TITLE
fix: Filter experiments by checkpoint size [WEB-1539]

### DIFF
--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -103,7 +103,7 @@ func expColumnNameToSQL(columnName string) (string, error) {
 		"forkedFrom":      "e.parent_id",
 		"resourcePool":    "e.config->'resources'->>'resource_pool'",
 		"projectId":       "project_id",
-		"checkpointSize":  "checkpoint_size",
+		"checkpointSize":  "e.checkpoint_size",
 		"checkpointCount": "e.checkpoint_count",
 		"searcherMetricsVal": `(
 			SELECT


### PR DESCRIPTION
## Description

Currently we cannot filter by checkpoint size in the new experiment list. Error received is `ERROR: column reference "checkpoint_size" is ambiguous`

This clarifies to use the `experiments.checkpoint_size` column
This doesn't fix awkwardness of API (for example to say > 10 MB, we write checkpointSize > 1000000 )

## Test Plan

- Visit project page for Uncategorized. Filter by checkpointSize
- After server-side fix, no error emerges.
- Applying a minimum checkpointSize limits how many experiments are returned 

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.