### PR TITLE
docs: Added Profiling to the Benefits table in the intro

### DIFF
--- a/docs/architecture/introduction.rst
+++ b/docs/architecture/introduction.rst
@@ -216,6 +216,12 @@ following benefits:
 |                                                | without risking future lock-in. See                       |
 |                                                | :doc:`/model-dev-guide/apis-howto/overview`.              |
 +------------------------------------------------+-----------------------------------------------------------+
+| Profiling                                      | Out-of-the-box system metrics (measurements of hardware   |
+|                                                | usage) and timings (durations of actions taken during     |
+|                                                | training, such as data loading).                          |
+|                                                |                                                           |
+|                                                |                                                           |
++------------------------------------------------+-----------------------------------------------------------+
 | Visualization                                  | Visualize your model and training procedure by using The  |
 |                                                | built-in WebUI and by launching managed                   |
 |                                                | :doc:`/interfaces/tensorboard` instances.                 |


### PR DESCRIPTION
## Description

Added Profiling to this table: https://docs.determined.ai/latest/architecture/introduction.html#benefits

Looks like this:
<img width="855" alt="Screenshot 2023-08-07 at 5 28 43 PM" src="https://github.com/determined-ai/determined/assets/2314891/49926f3a-c6b6-4c21-9b21-ddae19212e51">
