### PR TITLE
ci:  Add pytorch2 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1869,9 +1869,9 @@ jobs:
           paths:
             - test-unit-harness-gpu-pycov
 
-  test-unit-harness-pytorch2:
+  test-unit-harness-pytorch2-gpu:
     docker:
-      - image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
+      - image: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-8b7ced7
     resource_class: determined-ai/container-runner-gpu
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -1884,13 +1884,37 @@ jobs:
       - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
       - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
       - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
-      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-pycov make -C harness test-pytorch
-      - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-pycov
+      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-gpu-pycov make -C harness test-pytorch2-gpu
+      - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - persist_to_workspace:
           root: .
           paths:
-            - test-unit-harness-pytorch2-pycov
+            - test-unit-harness-pytorch2-gpu-pycov
+
+  test-unit-harness-pytorch2-cpu:
+    docker:
+      - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-8b7ced7
+    resource_class: determined-ai/container-runner-gpu
+    steps:
+      - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - checkout
+      - skip-if-docs-only
+      - skip-if-github-only
+      - skip-if-webui-only
+      - run: pip install mypy pytest coverage
+      - install-codecov
+      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
+      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
+      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-cpu-pycov make -C harness test-pytorch2-cpu
+      - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-cpu-pycov
+      - run: codecov -v -t $CODECOV_TOKEN -F harness
+      - persist_to_workspace:
+          root: .
+          paths:
+            - test-unit-harness-pytorch2-cpu-pycov
+
 
   test-unit-harness-gpu-parallel:
     docker:
@@ -2623,7 +2647,8 @@ workflows:
           filters: *any-upstream
       - test-unit-harness-cpu
       - test-unit-harness-tf2
-      - test-unit-harness-pytorch2
+      - test-unit-harness-pytorch2-cpu
+      - test-unit-harness-pytorch2-gpu
 
       - test-unit-harness-cpu-tf1:
           filters: *any-upstream
@@ -2667,7 +2692,8 @@ workflows:
             - test-unit-harness-gpu
             - test-unit-harness-gpu-parallel
             - test-unit-harness-tf2
-            - test-unit-harness-pytorch2
+            - test-unit-harness-pytorch2-cpu
+            - test-unit-harness-pytorch2-gpu
             - test-unit-model-hub
             - test-unit-storage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1895,7 +1895,6 @@ jobs:
   test-unit-harness-pytorch2-cpu:
     docker:
       - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-8b7ced7
-    resource_class: determined-ai/container-runner-gpu
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,7 +504,7 @@ commands:
               docker exec <<parameters.image-name>> tools/scripts/retry.sh pip install --progress-bar off <<parameters.extras-requires>>
             fi
 
-  setup-library-paths:
+  setup-paths:
     steps:
       - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
       - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
@@ -1840,7 +1840,7 @@ jobs:
       - skip-if-github-only
       - skip-if-webui-only
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-cpu-tf1-pycov make -C harness test-cpu-tf1
       - run: coverage xml -i --data-file=./test-unit-harness-cpu-tf1-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1862,7 +1862,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-pycov make -C harness test-gpu
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1883,7 +1883,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-gpu-pycov make -C harness test-pytorch-gpu
       - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1925,7 +1925,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-parallel-pycov make -C harness test-gpu-parallel
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-parallel-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1946,7 +1946,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install pytorch_lightning==1.5.10 torchmetrics==0.5.1 torchvision==0.10.0 mypy pytest coverage
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-lightning-pycov make -C harness test-gpu-lightning
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-lightning-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1967,9 +1967,10 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - setup-library-paths
+      - setup-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-deepspeed-pycov make -C harness test-gpu-deepspeed
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-deepspeed-pycov
+      - run: codecov -v -t $CODECOV_TOKEN -F harness
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,12 @@ commands:
               docker exec <<parameters.image-name>> tools/scripts/retry.sh pip install --progress-bar off <<parameters.extras-requires>>
             fi
 
+  setup-library-paths:
+    steps:
+      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
+      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
+      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+
   run-e2e-tests:
     parameters:
       mark:
@@ -1834,9 +1840,7 @@ jobs:
       - skip-if-github-only
       - skip-if-webui-only
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-cpu-tf1-pycov make -C harness test-cpu-tf1
       - run: coverage xml -i --data-file=./test-unit-harness-cpu-tf1-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1858,9 +1862,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-pycov make -C harness test-gpu
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1881,9 +1883,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-gpu-pycov make -C harness test-pytorch-gpu
       - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1904,8 +1904,6 @@ jobs:
       - run: pip install mypy pytest coverage
       - install-codecov
       - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
       - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-cpu-pycov make -C harness test-pytorch-cpu
       - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-cpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1926,10 +1924,8 @@ jobs:
       - skip-if-github-only
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
-      - run: echo 'export PATH=${PATH}:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-parallel-pycov make -C harness test-gpu-parallel
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-parallel-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1950,9 +1946,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install pytorch_lightning==1.5.10 torchmetrics==0.5.1 torchvision==0.10.0 mypy pytest coverage
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-lightning-pycov make -C harness test-gpu-lightning
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-lightning-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
@@ -1973,9 +1967,7 @@ jobs:
       - skip-if-webui-only
       - run: pip install mypy pytest coverage
       - install-codecov
-      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
-      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
-      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - setup-library-paths
       - run: COVERAGE_FILE=/root/project/test-unit-harness-gpu-deepspeed-pycov make -C harness test-gpu-deepspeed
       - run: coverage xml -i --data-file=./test-unit-harness-gpu-deepspeed-pycov
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1884,7 +1884,7 @@ jobs:
       - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
       - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
       - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
-      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-gpu-pycov make -C harness test-pytorch2-gpu
+      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-gpu-pycov make -C harness test-pytorch-gpu
       - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-gpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - persist_to_workspace:
@@ -1907,7 +1907,7 @@ jobs:
       - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
       - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
       - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
-      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-cpu-pycov make -C harness test-pytorch2-cpu
+      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-cpu-pycov make -C harness test-pytorch-cpu
       - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-cpu-pycov
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1869,6 +1869,29 @@ jobs:
           paths:
             - test-unit-harness-gpu-pycov
 
+  test-unit-harness-pytorch2:
+    docker:
+      - image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
+    resource_class: determined-ai/container-runner-gpu
+    steps:
+      - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - checkout
+      - skip-if-docs-only
+      - skip-if-github-only
+      - skip-if-webui-only
+      - run: pip install mypy pytest coverage
+      - install-codecov
+      - run: echo 'export PATH=$PATH:$HOME/.local/bin' >> $BASH_ENV
+      - run: echo 'export PATH=$PATH:/usr/local/nvidia/bin' >> $BASH_ENV
+      - run: echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64' >> $BASH_ENV
+      - run: COVERAGE_FILE=/root/project/test-unit-harness-pytorch2-pycov make -C harness test-pytorch
+      - run: coverage xml -i --data-file=./test-unit-harness-pytorch2-pycov
+      - run: codecov -v -t $CODECOV_TOKEN -F harness
+      - persist_to_workspace:
+          root: .
+          paths:
+            - test-unit-harness-pytorch2-pycov
+
   test-unit-harness-gpu-parallel:
     docker:
       - image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.21.2
@@ -2600,6 +2623,7 @@ workflows:
           filters: *any-upstream
       - test-unit-harness-cpu
       - test-unit-harness-tf2
+      - test-unit-harness-pytorch2
 
       - test-unit-harness-cpu-tf1:
           filters: *any-upstream
@@ -2643,6 +2667,7 @@ workflows:
             - test-unit-harness-gpu
             - test-unit-harness-gpu-parallel
             - test-unit-harness-tf2
+            - test-unit-harness-pytorch2
             - test-unit-model-hub
             - test-unit-storage
 

--- a/docs/release-notes/pytorch2.rst
+++ b/docs/release-notes/pytorch2.rst
@@ -2,8 +2,5 @@
 
 **New Features**
 
--  Environments: Add experimental PyTorch 2.0 images.
-
-   -  We are providing a set of images with ``pytorch==2.0.1``, ``python==3.10.12``, and
-      ``CUDA==11.8``. These images have not been fully tested against certain integrations, and are
-      experimental.
+-  Environments: Add the following PyTorch2.0 images (experimental): ``pytorch==2.0.1``,
+   ``python==3.10.12``, and ``CUDA==11.8``.

--- a/docs/release-notes/pytorch2.rst
+++ b/docs/release-notes/pytorch2.rst
@@ -2,7 +2,8 @@
 
 **New Features**
 
--  Environments: Add experimental PyTorch2.0 images.
+-  Environments: Add experimental PyTorch 2.0 images.
 
-   -  We are providing a set of images with `pytorch==2.0.1`, `python==3.10.12`, and `CUDA==11.8`.
-      These images have not been fully tested against certain integrations, and are experimental.
+   -  We are providing a set of images with ``pytorch==2.0.1``, ``python==3.10.12``, and
+      ``CUDA==11.8``. These images have not been fully tested against certain integrations, and are
+      experimental.

--- a/docs/release-notes/pytorch2.rst
+++ b/docs/release-notes/pytorch2.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+**New Features**
+
+-  Environments: Add PyTorch2.0 Beta images.
+
+   -  We are providing a set of images with `pytorch==2.0.1`, `python==3.10.12`, and `CUDA==11.8`.
+      These images have not been fully tested against certain integrations, and are still in beta.

--- a/docs/release-notes/pytorch2.rst
+++ b/docs/release-notes/pytorch2.rst
@@ -2,7 +2,7 @@
 
 **New Features**
 
--  Environments: Add PyTorch2.0 Beta images.
+-  Environments: Add experimental PyTorch2.0 images.
 
    -  We are providing a set of images with `pytorch==2.0.1`, `python==3.10.12`, and `CUDA==11.8`.
-      These images have not been fully tested against certain integrations, and are still in beta.
+      These images have not been fully tested against certain integrations, and are experimental.

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -179,6 +179,7 @@ def set_tf2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
 def set_pt_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, PT_CPU_IMAGE, PT_GPU_IMAGE)
 
+
 def set_pt2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, PT2_CPU_IMAGE, PT2_GPU_IMAGE)
 

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -19,7 +19,7 @@ DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15
 DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca"
 DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-6eceaca"
 DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-6eceaca"
-DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-base-cpu-8b7ced7"
+DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-pytorch-2.0-cpu-8b7ced7"
 DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-8b7ced7"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -19,6 +19,8 @@ DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15
 DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-6eceaca"
 DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-6eceaca"
 DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-6eceaca"
+DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-base-cpu-8b7ced7"
+DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-8b7ced7"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE
@@ -26,6 +28,8 @@ TF1_GPU_IMAGE = os.environ.get("TF1_GPU_IMAGE") or DEFAULT_TF1_GPU_IMAGE
 TF2_GPU_IMAGE = os.environ.get("TF2_GPU_IMAGE") or DEFAULT_TF2_GPU_IMAGE
 PT_CPU_IMAGE = os.environ.get("PT_CPU_IMAGE") or DEFAULT_PT_CPU_IMAGE
 PT_GPU_IMAGE = os.environ.get("PT_GPU_IMAGE") or DEFAULT_PT_GPU_IMAGE
+PT2_CPU_IMAGE = os.environ.get("PT2_CPU_IMAGE") or DEFAULT_PT2_CPU_IMAGE
+PT2_GPU_IMAGE = os.environ.get("PT2_GPU_IMAGE") or DEFAULT_PT2_GPU_IMAGE
 GPU_ENABLED = os.environ.get("DET_TEST_GPU_ENABLED", "1") not in ("0", "false")
 
 PROJECT_ROOT_PATH = Path(__file__).resolve().parents[2]
@@ -174,6 +178,9 @@ def set_tf2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
 
 def set_pt_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
     return set_image(config, PT_CPU_IMAGE, PT_GPU_IMAGE)
+
+def set_pt2_image(config: Dict[Any, Any]) -> Dict[Any, Any]:
+    return set_image(config, PT2_CPU_IMAGE, PT2_GPU_IMAGE)
 
 
 def set_random_seed(config: Dict[Any, Any], seed: int) -> Dict[Any, Any]:

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -11,7 +11,7 @@ from tests import experiment as exp
 
 
 @pytest.mark.distributed
-@pytest.mark.parametrize("image_type", ["PT", "TF2"])
+@pytest.mark.parametrize("image_type", ["PT", "TF2", "PT2"])
 def test_mnist_pytorch_distributed(image_type: str) -> None:
     config = conf.load_config(conf.tutorials_path("mnist_pytorch/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -18,6 +18,8 @@ def test_mnist_pytorch_distributed(image_type: str) -> None:
 
     if image_type == "PT":
         config = conf.set_pt_image(config)
+    elif image_type == "PT2":
+        config = conf.set_pt2_image(config)
     elif image_type == "TF2":
         config = conf.set_tf2_image(config)
     else:

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -52,11 +52,11 @@ test-gpu-parallel:
 	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "gpu_parallel" tests/experiment --ignore=tests/experiment/integrations
 
 .PHONY: test-pytorch-cpu
-test-pytorch:
+test-pytorch-cpu:
 	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "not gpu or cpu" tests/experiment/pytorch
 
 .PHONY: test-pytorch-gpu
-test-pytorch:
+test-pytorch-gpu:
 	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "gpu" tests/experiment/pytorch
 
 .PHONY: test

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -51,6 +51,10 @@ test-gpu-deepspeed:
 test-gpu-parallel:
 	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "gpu_parallel" tests/experiment --ignore=tests/experiment/integrations
 
+.PHONY: test-pytorch
+test-pytorch:
+	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "not gpu_parallel" tests/experiment/pytorch
+
 .PHONY: test
 test:
 	coverage run -m pytest -v --runslow --durations=0 tests

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -51,9 +51,13 @@ test-gpu-deepspeed:
 test-gpu-parallel:
 	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "gpu_parallel" tests/experiment --ignore=tests/experiment/integrations
 
-.PHONY: test-pytorch
+.PHONY: test-pytorch-cpu
 test-pytorch:
-	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "not gpu_parallel" tests/experiment/pytorch
+	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "not gpu or cpu" tests/experiment/pytorch
+
+.PHONY: test-pytorch-gpu
+test-pytorch:
+	coverage run -m pytest -v --runslow --durations=0 -m tests/experiment -m "gpu" tests/experiment/pytorch
 
 .PHONY: test
 test:

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -48,6 +48,14 @@ pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-
   old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-a8b9c02}
 pt_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.2,
   old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.21.1}
+pt2_cpu_0_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-8b7ced7}
+pt2_cpu_0_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-0.24.0}
+pt2_cpu_1_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-8b7ced7}
+pt2_cpu_1_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-0.24.0}
+pt2_gpu_0_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-8b7ced7}
+pt2_gpu_0_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-0.24.0}
+pt2_gpu_1_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-8b7ced7}
+pt2_gpu_1_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-0.24.0}
 pytorch10_tf27_rocm50_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-6eceaca,
   old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-a8b9c02}
 pytorch10_tf27_rocm50_0_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.21.2,

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -40,7 +40,7 @@ JOB_SUFFIXES = [
     "tf2-cpu",
     "tf28-cpu",
     "pt-cpu",
-    "pt2-cpu"
+    "pt2-cpu",
     "tf2-gpu",
     "tf28-gpu",
     "pt-gpu",

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -40,9 +40,11 @@ JOB_SUFFIXES = [
     "tf2-cpu",
     "tf28-cpu",
     "pt-cpu",
+    "pt2-cpu"
     "tf2-gpu",
     "tf28-gpu",
     "pt-gpu",
+    "pt2-gpu"
 ]
 
 JOB_SUFFIXES_WITHOUT_MPI = [

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -44,7 +44,7 @@ JOB_SUFFIXES = [
     "tf2-gpu",
     "tf28-gpu",
     "pt-gpu",
-    "pt2-gpu"
+    "pt2-gpu",
 ]
 
 JOB_SUFFIXES_WITHOUT_MPI = [


### PR DESCRIPTION
## Description

Putting our pytorch single-gpu and cpu tests on the shiny new `pytorch==2.0.1` images. Also throwing one nightly test in for good measure.



## Test Plan

`test-unit-harness-pytorch2-cpu`
`test-unit-harness-pytorch2-gpu`


## Commentary (optional)

Hopefully we will not need this in the future when we upgrade our default task environments. We'll treat these as separate for now, until we have a better way to verify that they work with every integration we support.


## Checklist

- [ ] Changes have been manually QA'd
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.


## Ticket
MLG-510
