### PR TITLE
fix: Single-point tooltip closes when mouse exits chart [WEB-1541]

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -154,6 +154,7 @@ export const LineChart: React.FC<LineChartProps> = ({
   const chartOptions: Options = useMemo(() => {
     const plugins: Plugin[] = propPlugins ?? [
       tooltipsPlugin({
+        closeOnMouseExit: true,
         isShownEmptyVal: false,
         // use specified color on Serie, or glasbeyColor
         seriesColors,

--- a/webui/react/src/components/kit/internal/UPlot/UPlotChart/tooltipsPlugin.ts
+++ b/webui/react/src/components/kit/internal/UPlot/UPlotChart/tooltipsPlugin.ts
@@ -192,7 +192,7 @@ export const tooltipsPlugin = (
         const { left, idx, top } = uPlot.cursor;
 
         if (!left || left < 0 || !top || top < 0 || idx == null) {
-          if (displayedIdx) hide();
+          hide();
           return;
         }
 


### PR DESCRIPTION
## Description

Turns on the `closeOnMouseExit` option on chart tooltip. This is especially helpful for single-point charts where the tooltip never closed.

## Test Plan

Using latest-main backend,
- Go to `/det/projects/1/experiments` , with the new glide table
- Filter name to include `trees`, this includes experiments which end by reporting a validation metric one time
- Select one of the tree experiments

<img width="1114" alt="Screen Shot 2023-08-08 at 3 54 50 PM" src="https://github.com/determined-ai/determined/assets/643918/ceb1291d-9886-4b79-b090-424d7a791368">

- Confirm there is a single validation metric point
- Confirm tooltip appears when mouse enters, and disappears when mouse exits the chart

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.