### PR TITLE
chore: add agent --image-root

### DIFF
--- a/agent/cmd/determined-agent/run.go
+++ b/agent/cmd/determined-agent/run.go
@@ -126,6 +126,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Debug, "debug", false, "Enable verbose script output")
 	cmd.Flags().IntVar(&opts.ArtificialSlots, "artificial-slots", 0, "")
 	cmd.Flags().Lookup("artificial-slots").Hidden = true
+	cmd.Flags().StringVar(&opts.ImageRoot, "image-root", "", "Path to local container image cache")
 
 	// Endpoint TLS flags.
 	cmd.Flags().BoolVar(&opts.TLS, "tls", false, "Use TLS for the API server")

--- a/agent/internal/options/options.go
+++ b/agent/internal/options/options.go
@@ -54,6 +54,7 @@ type Options struct {
 	Hooks HooksOptions `json:"hooks"`
 
 	ContainerRuntime   string             `json:"container_runtime"`
+	ImageRoot          string             `json:"image_root"`
 	SingularityOptions SingularityOptions `json:"singularity_options"`
 	PodmanOptions      PodmanOptions      `json:"podman_options"`
 

--- a/docs/reference/deploy/config/agent-config-reference.rst
+++ b/docs/reference/deploy/config/agent-config-reference.rst
@@ -198,3 +198,11 @@ Deprecated. This field has been deprecated and will be ignored. Use ``resource_p
 
 If ``true``, enables a more verbose form of logging that may be helpful in diagnosing issues.
 Defaults to ``false``.
+
+****************
+ ``image_root``
+****************
+
+If set then specifies the path to a shared directory of previously downloaded Determined environment
+images. If not defined, then Determined environments will be downloaded automatically. For more
+information on setting up an image cache see :ref:`singularity-image-cache`. Defaults to undefined.


### PR DESCRIPTION
## Description
add singularity image cache capability.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

Start the agent with a reference to an image cache:

`srun -N1 --gpus-per-node=4 /mnt/lustre/foundation_engineering/gaisford/determined-agent --master-host=casablanca-login  --master-port=8086 --resource-pool=default --container-runtime=apptainer --image-root=.launcher/images
`

If the requested image is in the cache then it is used on the generated singularity command line:

```
TRAC[2023-08-09T08:51:36-05:00] Requested image: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809  component=singularity
TRAC[2023-08-09T08:51:36-05:00] singularity run \
	--writable-tmpfs \
	--pwd /run/determined/workdir \
	--env-file /tmp/determined-gaisford-node002/2625739182-9da62980-a155-4eb7-a511-eb49f6bfdc1f/envfile \
	--bind /tmp/determined-gaisford-node002/2625739182-9da62980-a155-4eb7-a511-eb49f6bfdc1f/archives/opt/determined:/opt/determined \
	--bind /tmp/determined-gaisford-node002/2625739182-9da62980-a155-4eb7-a511-eb49f6bfdc1f/archives/run/determined:/run/determined \
	--bind /etc/hosts:/etc/hosts \
	--nv \
	--nvccli \
	--contain \
	--userns .launcher/images/determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809 /run/determined/singularity-entrypoint-wrapper.sh /run/determined/command-entrypoint.sh nvidia-smi -L  component=singularity
```


<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

If the image is not in the cache, or if no cache is defined, then we fallback to downloading, perhaps using a previously cached SIF result:

`[gaisford@casablanca-login ~]$ srun -N1 --gpus-per-node=4 /mnt/lustre/foundation_engineering/gaisford/determined-agent --master-host=casablanca-login  --master-port=8086 --resource-pool=default --container-runtime=apptainer --image-root=./empty`

```
TRAC[2023-08-09T08:50:41-05:00] Failed to locate image in cache: stat ./empty/determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809: no such file or directory  component=singularity
TRAC[2023-08-09T08:50:41-05:00] singularity run \
	--writable-tmpfs \
	--pwd /run/determined/workdir \
	--env-file /tmp/determined-gaisford-node002/4044637353-95410333-2362-4ecf-a94c-6a226960ee5a/envfile \
	--bind /tmp/determined-gaisford-node002/4044637353-95410333-2362-4ecf-a94c-6a226960ee5a/archives/opt/determined:/opt/determined \
	--bind /tmp/determined-gaisford-node002/4044637353-95410333-2362-4ecf-a94c-6a226960ee5a/archives/run/determined:/run/determined \
	--bind /etc/hosts:/etc/hosts \
	--nv \
	--nvccli \
	--contain \
	--userns docker://determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.8-gpu-9d07809 /run/determined/singularity-entrypoint-wrapper.sh /run/determined/command-entrypoint.sh nvidia-smi -L  component=singularity

```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
