### PR TITLE
test: increase timeouts for tensorboard test in test_task_logs

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -59,14 +59,18 @@ def test_trial_logs() -> None:
 @pytest.mark.e2e_cpu_elastic
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu  # Note, e2e_gpu and not gpu_required hits k8s cpu tests.
-@pytest.mark.timeout(5 * 60)
+@pytest.mark.timeout(15 * 60)
 @pytest.mark.parametrize(
     "task_type,task_config,log_regex",
     [
         (command.TaskTypeCommand, {"entrypoint": ["echo", "hello"]}, re.compile("^.*hello.*$")),
         (command.TaskTypeNotebook, {}, re.compile("^.*Jupyter Server .* is running.*$")),
         (command.TaskTypeShell, {}, re.compile("^.*Server listening on.*$")),
-        (command.TaskTypeTensorBoard, {}, re.compile("^.*TensorBoard .* at .*$")),
+        (
+            command.TaskTypeTensorBoard,
+            {"idle_timeout": "600s"},
+            re.compile("^.*TensorBoard .* at .*$"),
+        ),
     ],
 )
 def test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: Any) -> None:


### PR DESCRIPTION
## Description

This test has been very flaky:

tests/cluster/test_logging.py::test_task_logs[tensorboard-task_config3-^.*TensorBoard .* at .*$] - Failed: Timeout >300.0s

The default tensorboard idle time-out value is 5 minutes. If the tensorboard job has to download and build an image, it will hit the service idle timeout value before the expected log entry can appear in the logs. Increase the tensorboard idle timeout to 10 minutes should help.

The timeout value for test_task_logs should be greater than the tensorboard timeout value because it has to run an experiment to complete before starting tensorboard. The time to run the experiment is about 2-3 minutes.  

This happened in test-e2e-slurm-agent-singularity-znode on determined-ee main branch after increased test timeout to 10 minutes without increasing tensorboard idle_timeout.

```
tests/cluster/test_logging.py:119: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

log_regex = re.compile('^.*TensorBoard .* at .*$')
log_fn = functools.partial(<function task_logs at 0x7fc18d9b5dc0>, <determined.common.api._session.Session object at 0x7fc150492df0>, 'e194dd68-4346-4680-bbbc-60c18eccd22c')
log_fields_fn = functools.partial(<function get_TaskLogsFields at 0x7fc18d9ab3a0>, <determined.common.api._session.Session object at 0x7fc150492df0>, taskId='e194dd68-4346-4680-bbbc-60c18eccd22c')

    def check_logs(
        log_regex: Any,
        log_fn: Callable[..., Iterable[Log]],
        log_fields_fn: Callable[..., Iterable[LogFields]],
    ) -> None:
        # This is also testing that follow terminates. If we timeout here, that's it.
        for log in log_fn(follow=True):
            if log_regex.match(log.message):
                break
        else:
            for log in log_fn(follow=True):
                print(log.message)
>           pytest.fail("ran out of logs without a match")
E           Failed: ran out of logs without a match

tests/cluster/test_logging.py:143: Failed
---------------------------- Captured stdout setup -----------------------------
starting at 2023-08-07 16:26:33
----------------------------- Captured stdout call -----------------------------
[2023-08-07T21:26:49.899485Z]          || INFO: Scheduling TensorBoard (remarkably-rare-hound) (id: e194dd68-4346-4680-bbbc-60c18eccd22c.1)

[2023-08-07T21:26:49.976656Z]          || INFO: TensorBoard (remarkably-rare-hound) was assigned to an agent

[2023-08-07T21:26:49.976395Z] 94a42c23 || DEBUG: container requested network virtualization, but network creation isn't allowed; overriding to host networking

[2023-08-07T21:26:49.977121Z] 94a42c23 || WARNING: archive file /run/determined/etc/passwd has user 0:0 but agent can only write as 1002:10300, writing anyway

[2023-08-07T21:26:49.977171Z] 94a42c23 || WARNING: archive file /run/determined/etc/shadow has user 0:0 but agent can only write as 1002:10300, writing anyway

[2023-08-07T21:26:49.977187Z] 94a42c23 || WARNING: archive file /run/determined/etc/group has user 0:0 but agent can only write as 1002:10300, writing anyway

[2023-08-07T21:26:49.977410Z] 94a42c23 || DEBUG: singularity run \
	--writable-tmpfs \
	--pwd /run/determined/workdir \
	--env-file /tmp/determined-launcher-znode51/1890160161-94a42c23-e594-453b-a8b8-727468838036/envfile \
	--bind /tmp/determined-launcher-znode51/1890160161-94a42c23-e594-453b-a8b8-727468838036/archives/opt/determined:/opt/determined \
	--bind /tmp/determined-launcher-znode51/1890160161-94a42c23-e594-453b-a8b8-727468838036/archives/run/determined:/run/determined \
	--bind /tmp:/determined_shared_fs docker://determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-6eceaca /run/determined/singularity-entrypoint-wrapper.sh /run/determined/tensorboard/tensorboard-entrypoint.sh /run/determined/tensorboard/storage_config.json /determined_shared_fs/determined-integration-checkpoints/8553db5d-4f89-42e2-bafd-c1d75b57f994/tensorboard/experiment/2/

[2023-08-07T21:26:49.978511Z] 94a42c23 || INFO: Resources for TensorBoard (remarkably-rare-hound) have started

[2023-08-07T21:26:50.493330Z] 94a42c23 || INFO: Converting OCI blobs to SIF format

[2023-08-07T21:26:50.539626Z] 94a42c23 || INFO: Starting build...

[2023-08-07T21:26:57.125387Z] 94a42c23 || INFO: 2023/08/07 16:26:57  info unpack layer: sha256:ca1778b6935686ad781c27472c4668fc61ec3aeb85494f72deb1921892b9d39e

[2023-08-07T21:26:57.967104Z] 94a42c23 || INFO: 2023/08/07 16:26:57  info unpack layer: sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1

[2023-08-07T21:26:57.969638Z] 94a42c23 || INFO: 2023/08/07 16:26:57  info unpack layer: sha256:db77652ffcca281bdaa9532302e6c10817e02593bc308eb964687e54716c34cc

[2023-08-07T21:26:57.970008Z] 94a42c23 || INFO: 2023/08/07 16:26:57  info unpack layer: sha256:692fd6a4452047970a6e0e98af70c736b8398c947a48b60cf7754dc734093834

[2023-08-07T21:27:02.270156Z] 94a42c23 || INFO: 2023/08/07 16:27:02  info unpack layer: sha256:18886ba58f6cc5768178af31973b351f829c6aca107cc11538efa47c5e827e8d

[2023-08-07T21:27:02.275155Z] 94a42c23 || INFO: 2023/08/07 16:27:02  info unpack layer: sha256:4708d7c4c7bdc352bc37db3b86acc7c4f3a38e93f6923ed466b2535739ce598d

[2023-08-07T21:27:04.540982Z] 94a42c23 || INFO: 2023/08/07 16:27:04  info unpack layer: sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1

[2023-08-07T21:27:04.543106Z] 94a42c23 || INFO: 2023/08/07 16:27:04  info unpack layer: sha256:10c64726101c6c510124196fe6f91411fde8a31356858ceab0bcee64d18c3dd8

[2023-08-07T21:27:07.262037Z] 94a42c23 || INFO: 2023/08/07 16:27:07  info unpack layer: sha256:c815ecc44925594c6df8284cd9b5a2d94d4df86971e9b9974d1949613ec7ab76

[2023-08-07T21:27:09.265468Z] 94a42c23 || INFO: 2023/08/07 16:27:09  info unpack layer: sha256:d88f8532744301388da9b6ff1642776d046875cfcedda2ad04b7c65302aae54c

[2023-08-07T21:27:09.334691Z] 94a42c23 || INFO: 2023/08/07 16:27:09  info unpack layer: sha256:eb4e4099396eb73120484a648f37b626fe7d5a88835c005a8e76f98175d0d802

[2023-08-07T21:27:09.336180Z] 94a42c23 || INFO: 2023/08/07 16:27:09  info unpack layer: sha256:0535c0f0db99406acffc57fff0607f2d710feee5bda3f7fd60a421aa526cd312

[2023-08-07T21:27:09.339369Z] 94a42c23 || INFO: 2023/08/07 16:27:09  info unpack layer: sha256:2fbe3f6ffbd8a3a322405bd35b8b8cc7dd078bb24292a4ea5fcc02dfdcd62d75

[2023-08-07T21:27:09.345021Z] 94a42c23 || INFO: 2023/08/07 16:27:09  info unpack layer: sha256:861b927e5834b35602973dff5748b630848097edc756d2dc1d645b01a19f4dd1

[2023-08-07T21:27:19.342236Z] 94a42c23 || INFO: 2023/08/07 16:27:19  info unpack layer: sha256:9927354308d51e2f489e80da2602d5cad1318b71d4d084b21a24d38f4171489e

[2023-08-07T21:27:27.732291Z] 94a42c23 || INFO: 2023/08/07 16:27:27  info unpack layer: sha256:405bd058c5163f60f080aea4cddcdc140e40c6e5b3db806bce0281a17615e1f7

[2023-08-07T21:27:34.082351Z] 94a42c23 || INFO: 2023/08/07 16:27:34  info unpack layer: sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1

[2023-08-07T21:27:34.085595Z] 94a42c23 || INFO: 2023/08/07 16:27:34  info unpack layer: sha256:87e3d73178175b143833e728ecc746ab3d2eb93d4223b22f5bd7d5bc2c83e722

[2023-08-07T21:27:34.846346Z] 94a42c23 || INFO: 2023/08/07 16:27:34  info unpack layer: sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1

[2023-08-07T21:27:34.847867Z] 94a42c23 || INFO: 2023/08/07 16:27:34  info unpack layer: sha256:0000e585f2138264bd7cbc4908f2d6986388568a9c462422d8fe900b1e82467e

[2023-08-07T21:27:35.643555Z] 94a42c23 || INFO: 2023/08/07 16:27:35  info unpack layer: sha256:2ae20846eba7150a52ec23cb0182633516b1fad617a1b5555aad9a4dabe8e6ce

[2023-08-07T21:27:36.709439Z] 94a42c23 || INFO: 2023/08/07 16:27:36  info unpack layer: sha256:83ce7e5dbb97692cc78c41a6caf104f0c4a90a1dba9e5552ebe8476b1a09b8d6

[2023-08-07T21:27:38.040550Z] 94a42c23 || INFO: 2023/08/07 16:27:38  info unpack layer: sha256:5553b558f399f9f32a2d6b88d413ee9dbb0a8adbdbec50e508f40a7aa20eb6b4

[2023-08-07T21:27:38.078307Z] 94a42c23 || INFO: Creating SIF file...

[2023-08-07T21:31:54.964696Z]          || INFO: forcibly killing allocation's remaining resources (reason: idle for more than 5m0s: service is inactive)

[2023-08-07T21:31:54.966121Z] 94a42c23 || INFO: killed: resources failed with non-zero exit code: request for action on unknown container: container is gone on reattachment

[2023-08-07T21:31:54.967404Z]          || INFO: TensorBoard (remarkably-rare-hound) was terminated: allocation killed after all resources exited: resources were killed
```

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
