### PR TITLE
ci: fix remote name in PR tracking script

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -38,7 +38,7 @@ TEST = os.environ.get("RELEASE_TEST") == "1"
 
 
 ORG = "determined-ai"
-CLONED_REMOTE = "0"
+CLONED_REMOTE = "origin"
 ISSUES_REPO = "release-party-issues-test" if TEST else "release-party-issues"
 
 CHERRY_PICK_LABEL = "to-cherry-pick"


### PR DESCRIPTION
Undoing an accidental local development change that came in as part of #7502.