### PR TITLE
feat: Don't show charts where all series are Loaded(no data) [WEB-1524]

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -393,9 +393,19 @@ export const ChartGrid: React.FC<GroupProps> = React.memo(
     const chartGridRef = useRef<HTMLDivElement | null>(null);
     const { width, height } = useResize(chartGridRef);
     const columnCount = Math.max(1, Math.floor(width / 540));
-    const chartsProps = Loadable.isLoadable(propChartsProps)
-      ? Loadable.getOrElse([], propChartsProps)
-      : propChartsProps;
+    const chartsProps = (
+      Loadable.isLoadable(propChartsProps)
+        ? Loadable.getOrElse([], propChartsProps)
+        : propChartsProps
+    ).filter(
+      (c) =>
+        // filter out Loadable series which are Loaded yet have no serie with more than 0 points.
+        !Loadable.isLoadable(c.series) ||
+        !Loadable.isLoaded(c.series) ||
+        Loadable.getOrElse([], c.series).find((serie) =>
+          Object.entries(serie.data).find(([, points]) => points.length > 0),
+        ),
+    );
     const isLoading = Loadable.isLoadable(propChartsProps) && Loadable.isLoading(propChartsProps);
     // X-Axis control
 

--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -55,25 +55,30 @@ class SyncService {
   updateDataBounds(data: AlignedData) {
     const xValues = data[0];
     const lastIdx = xValues.length - 1;
-    const dataMin = xValues[0];
-    const dataMax = xValues[lastIdx];
+    let dataMin = xValues[0];
+    let dataMax = xValues[lastIdx];
 
     if (dataMin === undefined || dataMax === undefined) return;
 
     this.bounds.update((b) => {
-      let max = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
-      let min = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
+      dataMax = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
+      dataMin = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
+      let max = dataMax;
+      let min = dataMin;
       if (min === max) {
+        // for one point; start min at 0; unless all x-vals are negative (then set max to 0)
         if (max < 0) {
-          min = max;
           max = 0;
         } else {
           min = 0;
         }
       }
+      const margin = 0.02 * (max - min);
+      max += margin;
+      min -= margin;
       return {
         ...b,
-        dataBounds: { max, min },
+        dataBounds: { max: dataMax, min: dataMin },
         unzoomedBounds: { max, min },
       };
     });

--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -58,22 +58,22 @@ class SyncService {
     const dataMin = xValues[0];
     const dataMax = xValues[lastIdx];
 
+    if (dataMin === undefined || dataMax === undefined) return;
+
     this.bounds.update((b) => {
       let max = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
       let min = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
-      const width = max - min;
-      if (width <= 0) {
-        // default handling of min = max is not great
-        min = Math.min(max, 0);
-        max = 2 * max;
-      } else {
-        const margin = 0.02 * width;
-        max = max + margin;
-        min = min - margin;
+      if (min === max) {
+        if (max < 0) {
+          min = max;
+          max = 0;
+        } else {
+          min = 0;
+        }
       }
       return {
         ...b,
-        dataBounds: { max: dataMax, min: dataMin },
+        dataBounds: { max, min },
         unzoomedBounds: { max, min },
       };
     });

--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -55,31 +55,35 @@ class SyncService {
   updateDataBounds(data: AlignedData) {
     const xValues = data[0];
     const lastIdx = xValues.length - 1;
-    let dataMin = xValues[0];
-    let dataMax = xValues[lastIdx];
+    const chartMin = xValues[0];
+    const chartMax = xValues[lastIdx];
 
-    if (dataMin === undefined || dataMax === undefined) return;
+    if (chartMin === undefined || chartMax === undefined) return;
 
     this.bounds.update((b) => {
-      dataMax = Math.max(b.dataBounds?.max ?? dataMax, dataMax);
-      dataMin = Math.min(b.dataBounds?.min ?? dataMin, dataMin);
-      let max = dataMax;
-      let min = dataMin;
-      if (min === max) {
-        // for one point; start min at 0; unless all x-vals are negative (then set max to 0)
-        if (max < 0) {
-          max = 0;
-        } else {
-          min = 0;
-        }
-      }
-      const margin = 0.02 * (max - min);
-      max += margin;
-      min -= margin;
+      const previousMin =
+        b.dataBounds?.min !== undefined && isFinite(b.dataBounds?.min)
+          ? b.dataBounds?.min
+          : chartMin;
+
+      const previousMax =
+        b.dataBounds?.max !== undefined && isFinite(b.dataBounds?.max)
+          ? b.dataBounds?.max
+          : chartMax;
+
+      const dataMin = Math.min(previousMin, chartMin);
+      const dataMax = Math.max(previousMax, chartMax);
+
+      const width = dataMax - dataMin;
+      const margin = 0.02 * width;
+
+      const unzoomedMin = width > 0 ? dataMin - margin : Math.min(dataMin, 0);
+      const unzoomedMax = width > 0 ? dataMax + margin : 2 * dataMax;
+
       return {
         ...b,
         dataBounds: { max: dataMax, min: dataMin },
-        unzoomedBounds: { max, min },
+        unzoomedBounds: { max: unzoomedMax, min: unzoomedMin },
       };
     });
   }


### PR DESCRIPTION
## Description

This contains two ChartGrid fixes:
1. When a ChartGrid contains two series with different x-min-max ranges, the scale should expand to cover both ranges
2. ChartGrid charts represent a NotLoaded series as spinner.  Once the series are all Loaded, if none contain points, then the chart should not be shown in the grid.

Visual of Problem 1: chart appears blank, x-axis range too small

<img width="884" alt="Screen Shot 2023-08-09 at 1 58 36 PM" src="https://github.com/determined-ai/determined/assets/643918/26f9f354-7cd4-4638-97e1-77931df754f0">

Visual of Problem 2: chartgrid with 'no data' messages

<img width="804" alt="Screen Shot 2023-08-09 at 4 44 31 PM" src="https://github.com/determined-ai/determined/assets/643918/07bf3556-d5d4-40dc-a8b3-258b38a86bbb">

Details:
- bounds were previously combined into the `unzoomedBounds` with some adjustments to prevent NaN/undefined values during loading, this should function the same
- if there is only one point on the chart, the dataMin and dataMax are the same. We set the bounds to [0, max], unless the point is negative, in this case the range is [min, 0]

## Test Plan

**Scale fix**
- In `/det/projects/1/experiments`, activate compare mode. Select two experiments with different names and different x-ranges. The metrics should have the same x-min and x-max. This view is after some `Ctrl -` to fit multiple charts on screen.  
<img width="1221" alt="Screen Shot 2023-08-09 at 2 27 07 PM" src="https://github.com/determined-ai/determined/assets/643918/14ee5312-d535-48c2-a0df-15ee12cfe715">
- Hover over a point in one chart, and tooltip should appear for closest point on all charts.
- Click and drag on one of the charts to zoom to new x-bounds.  This should update all charts bounds
- View an experiment named mnist_pytorch_const for an example of metrics with 1 point


**Loadable fix**

- Clear selection
- In compare mode, sort by ID ascending. Select experiment 1229, which as an incomplete multi-trial experiment gives us a testable combination of NotLoaded / Loaded and populated / Loaded and empty series.

<img width="845" alt="Screen Shot 2023-08-09 at 4 45 14 PM" src="https://github.com/determined-ai/determined/assets/643918/093f9d2f-4a53-4d4f-a098-9fd2265ac68a">

- Select other experiments to confirm they can be shown together with 1229 in compare mode

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.