### PR TITLE
docs: Add css to turn off scrolling when clicking on section links

### DIFF
--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -1,5 +1,10 @@
 /*! determined.css */
 
+/* Jump to sections instead of scrolling to them */
+html {
+  scroll-behavior: auto !important;
+}
+
 html {
   --pst-font-family-base-system: "Open Sans", "Metric HPE", Arial, sans-serif;
   --docsearch-modal-max-width: 1000px;


### PR DESCRIPTION
## Description

When clicking on a link to a specific section, the new page loads at the top and then scrolls down to the section. This can get annoying because it sometimes doesn't start scrolling for half a second, and then you have to wait for it scroll too.

So this PR turns off that behavior. 

Example: This link should load immediately at "Slurm Options": https://determined-ai-docs.s3.us-west-2.amazonaws.com/previews/6a8c454897b93e6f53e0f3508fabcdd6/reference/training/experiment-config-reference.html#slurm-options

- [x] tested to ensure this change won't break the docs build


