### PR TITLE
fix: treat searcher metrics value as a number in the ui

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -154,7 +154,7 @@ func (a *apiServer) getProjectColumnsByID(
 			Column:      "searcherMetricsVal",
 			DisplayName: "Searcher Metric Value",
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
-			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+			Type:        projectv1.ColumnType_COLUMN_TYPE_NUMBER,
 		},
 	}
 


### PR DESCRIPTION


## Description

This fixes an issue where the searcher metrics value was labeled as a string in the columns api. String filters (like "contains") would throw errors when set as filters.


## Test Plan

users on the new experiment list ui should be able to filter results by searcher metric value



## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
