### PR TITLE
docs: Add docs dropdown component

### DIFF
--- a/docs/_templates/article-header-buttons.html
+++ b/docs/_templates/article-header-buttons.html
@@ -5,6 +5,35 @@
   <a href="https://determined.ai/blog/">Blog</a>
 </div>
 
+   
+<div class="container">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+  <div class="dropdown">
+    <button class="btn btn-default dropdown-toggle" type="button" id="menu1" data-toggle="dropdown">Tutorials
+    <span class="caret"></span></button>
+    <ul class="dropdown-menu" role="menu" aria-labelledby="menu1">
+      <li role="presentation"><a role="menuitem" tabindex="-1" href="#">HTML</a></li>
+      <li role="presentation"><a role="menuitem" tabindex="-1" href="#">CSS</a></li>
+      <li role="presentation"><a role="menuitem" tabindex="-1" href="#">JavaScript</a></li>
+      <li role="presentation" class="divider"></li>
+      <li role="presentation"><a role="menuitem" tabindex="-1" href="#">About Us</a></li>
+    </ul>
+  </div>
+</div>
+
+
+<div class="dropdown">
+  <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+    <p style="color:#ee6600;">Docs</p>
+  </button>
+  <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="dropdownMenuButton2">
+    <li><a class="dropdown-item" href="https://docs.determined.ai/latest/"><p style="color:#ee6600;">Determined AI Docs</p></a></li>
+    <li><a class="dropdown-item" href="https://docs.pachyderm.com/"><p style="color:#ee6600;">Pachyderm Docs</p></a></li>
+    <li><hr class="dropdown-divider"></li>
+    <li><a class="dropdown-item" href="http://internal.det-cloud.net/docs/cloud-provider.html"><p style="color:#ee6600;">Bring Your Own Cloud Docs</p></a></li>
+  </ul>
+</div>
+
 <div class="article-header-buttons">
   <a
     href="https://determined-community.slack.com/join/shared_invite/zt-cnj7802v-KcVbaUrIzQOwmkmY7gP0Ew#/shared-invite/email"


### PR DESCRIPTION
Status: Closed. We decided to allow the user to find the pachyderm docs from the Integrations section.

Add an html docs dropdown component to article-header-buttons html file.

To Do

- [ ] [styling](https://getbootstrap.com/docs/5.0/components/dropdowns/)
- [ ] content consistent with Pachyderm docs dropdown 
