### PR TITLE
feat: OptionsMenu moved to left group [WEB-1519]

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
@@ -384,6 +384,12 @@ const TableActionBar: React.FC<Props> = ({
             projectId={project.id}
             setVisibleColumns={setVisibleColumns}
           />
+          <OptionsMenu
+            expListView={expListView}
+            rowHeight={rowHeight}
+            setExpListView={setExpListView}
+            onRowHeightChange={onRowHeightChange}
+          />
           {(selectAll || selectedExperimentIds.length > 0) && (
             <Dropdown menu={editMenuItems} onClick={handleAction}>
               <Button hideChildren={isMobile}>Actions</Button>
@@ -403,12 +409,6 @@ const TableActionBar: React.FC<Props> = ({
               />
             </Tooltip>
           )}
-          <OptionsMenu
-            expListView={expListView}
-            rowHeight={rowHeight}
-            setExpListView={setExpListView}
-            onRowHeightChange={onRowHeightChange}
-          />
           {!!toggleComparisonView && (
             <Button
               hideChildren={isMobile}


### PR DESCRIPTION
## Description

Moves options menu to left group of buttons in glide table view

<img width="901" alt="Screen Shot 2023-08-14 at 11 47 48 AM" src="https://github.com/determined-ai/determined/assets/643918/4685e337-d4f3-4be9-94bb-f58454bb63fa">

## Test Plan

On experiment list, Options button:
- is in new location
- has tooltip on hover
- can change row height setting

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.