### PR TITLE
ci: fix release branch selection when cherry-picking EE PRs

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -172,6 +172,9 @@ def cherry_pick_pr(pr_id: str) -> None:
 
     try:
         # Find and fetch the PR commit and both release branches.
+        branch_pat = re.compile(
+            r"/release-(\d+)\.(\d+)\.(\d+){}$".format("-ee" if is_ee_pr else "")
+        )
         release_branch = max(
             (
                 line.split()[1]
@@ -179,9 +182,7 @@ def cherry_pick_pr(pr_id: str) -> None:
                     "git", "ls-remote", CLONED_REMOTE, "refs/heads/release-*"
                 ).stdout.splitlines()
             ),
-            key=lambda branch: [
-                int(part) for part in re.search(r"/release-(\d+)\.(\d+)\.(\d+)$", branch).groups()
-            ],
+            key=lambda branch: [int(part) for part in branch_pat.search(branch).groups()],
         )[len("refs/heads/") :]
         print(f"Found release branch {release_branch}")
 


### PR DESCRIPTION
## Description

The pattern for finding release branches didn't take into account the `-ee` suffix used for EE branches.

We could just remove the `$` and it would probably be fine, but in this case I feel that the extra complexity is worth the precision.

## Test Plan

- [x] test the regex code locally with `is_ee_pr` set to both true and false
