### PR TITLE
fix: Handle metric names finish loading, but still empty

### DIFF
--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -60,11 +60,7 @@ const useMetricNames = (
         ];
         setMetrics((prevMetrics) => {
           if (newMetrics.length === 0) {
-            if (!Loadable.isLoaded(prevMetrics)) {
-              return Loaded([]);
-            } else {
-              return prevMetrics;
-            }
+            return Loadable.isLoaded(prevMetrics) ? prevMetrics :  Loaded([]); 
           }
 
           /*

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -60,7 +60,7 @@ const useMetricNames = (
         ];
         setMetrics((prevMetrics) => {
           if (newMetrics.length === 0) {
-            return Loadable.isLoaded(prevMetrics) ? prevMetrics :  Loaded([]); 
+            return Loadable.isLoaded(prevMetrics) ? prevMetrics : Loaded([]);
           }
 
           /*

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -58,35 +58,41 @@ const useMetricNames = (
           ...newValidationMetrics.map((name) => ({ name, type: MetricType.Validation })),
           ...newTrainingMetrics.map((name) => ({ name, type: MetricType.Training })),
         ];
-        if (newMetrics.length > 0) {
-          setMetrics((prevMetrics) => {
-            /*
-             * Since we may intermittently receive a subset of all available
-             * metrics or an empty list of metrics we must merge the new and
-             * previous metrics to accurately determine if any new metrics have
-             * not been seen before.
-             */
-            const previousMetrics = Loadable.getOrElse([], prevMetrics);
+        setMetrics((prevMetrics) => {
+          if (newMetrics.length === 0) {
+            if (!Loadable.isLoaded(prevMetrics)) {
+              return Loaded([]);
+            } else {
+              return prevMetrics;
+            }
+          }
 
-            const previousMetricsSet = Loadable.getOrElse([], prevMetrics).reduce(
-              (acc, cur) => acc.add(metricToKey(cur)),
-              new Set<string>(),
-            );
-            const updatedMetricsSet = [...newMetrics, ...previousMetrics].reduce(
-              (acc, cur) => acc.add(metricToKey(cur)),
-              new Set<string>(),
-            );
+          /*
+           * Since we may intermittently receive a subset of all available
+           * metrics or an empty list of metrics we must merge the new and
+           * previous metrics to accurately determine if any new metrics have
+           * not been seen before.
+           */
+          const previousMetrics = Loadable.getOrElse([], prevMetrics);
 
-            if (_.isEqual(previousMetricsSet, updatedMetricsSet)) return prevMetrics;
+          const previousMetricsSet = Loadable.getOrElse([], prevMetrics).reduce(
+            (acc, cur) => acc.add(metricToKey(cur)),
+            new Set<string>(),
+          );
+          const updatedMetricsSet = [...newMetrics, ...previousMetrics].reduce(
+            (acc, cur) => acc.add(metricToKey(cur)),
+            new Set<string>(),
+          );
 
-            return Loaded(
-              Array.from(updatedMetricsSet)
-                .map((metricKey) => metricKeyToMetric(metricKey))
-                .filter((metric): metric is Metric => !!metric)
-                .sort(metricSorter),
-            );
-          });
-        }
+          if (_.isEqual(previousMetricsSet, updatedMetricsSet)) return prevMetrics;
+
+          return Loaded(
+            Array.from(updatedMetricsSet)
+              .map((metricKey) => metricKeyToMetric(metricKey))
+              .filter((metric): metric is Metric => !!metric)
+              .sort(metricSorter),
+          );
+        });
       },
       errorHandler,
     );


### PR DESCRIPTION
## Description

To cherry-pick into release? https://github.com/determined-ai/release-party-issues/issues/464

On experiments such as http://latest-main.determined.ai:8080/det/experiments/2118/trials/9397/metrics which failed without generating metrics, the Metrics and Hyperparameters tab show a loading spinner instead of a No Data message.

`useTrialMetrics` is returning `isLoaded: false` due to `metricNamesLoaded` returning false
After review, the issue is that we require `V1ExpMetricNamesResponse` to have new metric names before calling `setMetrics(Loaded( ... ))`. This experiment failed before generating any metrics.
This branch changes our setup for `V1ExpMetricNamesResponse` to update `NotLoaded` to `Loaded([])`.

## Test Plan

- Using latest-main as a backend, `/det/experiments/2118/trials/9397/metrics` should show a No Data message instead of a spinner.
- Other single-trial experiments have a metrics tab with charts
- Other multi-trial experiments have a metrics tab with charts

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.