### PR TITLE
ci: indicate GHA run URL when reporting a cherry-pick conflict

### DIFF
--- a/.github/workflows/track-prs-for-release.yml
+++ b/.github/workflows/track-prs-for-release.yml
@@ -13,6 +13,9 @@ on:  # yamllint disable-line rule:truthy
 concurrency:
   group: track-prs-for-release
 
+env:
+  LOGS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
 # All jobs require a specifically generated token to run, since we want to
 # access org-level projects and the normal GITHUB_TOKEN only has access to this
 # repository.

--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -241,7 +241,7 @@ def cherry_pick_pr(pr_id: str) -> None:
         requests.post(
             "https://casper.internal.infra.determined.ai/hubot/conflict",
             headers={"X-Casper-Token": CASPER_TOKEN},
-            json={"url": pr["url"]},
+            json={"url": pr["url"], "logs_url": os.environ.get("LOGS_URL")},
         )
 
 


### PR DESCRIPTION
## Description

For visibility's sake, this includes the URL for viewing the GitHub Actions logs in the Slack notification for a cherry-pick conflict.

## Test Plan

- [x] use a dummy repo to ensure that the definition of `LOGS_URL` works
