### PR TITLE
chore: use eslint rule to avoid relative imports through parent [WEB-1496]

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -106,7 +106,7 @@ module.exports = {
     'no-empty': ['error', { allowEmptyCatch: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],
     'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
-    'no-relative-import-paths/no-relative-import-paths': ['error', { 'allowSameFolder': true, 'rootDir': 'src' }],
+    'no-restricted-imports': ['error', {'patterns': ['..*']}],
     'no-throw-literal': 'error',
     'no-trailing-spaces': ['error', {}],
     'no-unused-vars': 'off',

--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['import', 'jsdoc', 'react', 'react-hooks', 'sort-keys-fix'],
+  plugins: ['import', 'jsdoc', 'no-relative-import-paths', 'react', 'react-hooks', 'sort-keys-fix'],
   root: true,
   rules: {
     // Can disagree with @typescript-eslint/member-ordering.
@@ -106,6 +106,7 @@ module.exports = {
     'no-empty': ['error', { allowEmptyCatch: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],
     'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
+    'no-relative-import-paths/no-relative-import-paths': ['error', { 'allowSameFolder': true, 'rootDir': 'src' }],
     'no-throw-literal': 'error',
     'no-trailing-spaces': ['error', {}],
     'no-unused-vars': 'off',

--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['import', 'jsdoc', 'no-relative-import-paths', 'react', 'react-hooks', 'sort-keys-fix'],
+  plugins: ['import', 'jsdoc', 'react', 'react-hooks', 'sort-keys-fix'],
   root: true,
   rules: {
     // Can disagree with @typescript-eslint/member-ordering.

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -88,7 +88,6 @@
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^44.2.5",
-        "eslint-plugin-no-relative-import-paths": "^1.5.2",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
@@ -4735,12 +4734,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/eslint-plugin-no-relative-import-paths": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.2.tgz",
-      "integrity": "sha512-wMlL+TVuDhKk1plP+w3L4Hc7+u89vUkrOYq6/0ARjcYqwc9/YaS9uEXNzaqAk+WLoEgakzNL5JgJJw6m4qd5zw==",
-      "dev": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -88,6 +88,7 @@
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^44.2.5",
+        "eslint-plugin-no-relative-import-paths": "^1.5.2",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-sort-keys-fix": "^1.1.2",
@@ -4734,6 +4735,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.2.tgz",
+      "integrity": "sha512-wMlL+TVuDhKk1plP+w3L4Hc7+u89vUkrOYq6/0ARjcYqwc9/YaS9uEXNzaqAk+WLoEgakzNL5JgJJw6m4qd5zw==",
+      "dev": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.32.2",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -123,7 +123,6 @@
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^44.2.5",
-    "eslint-plugin-no-relative-import-paths": "^1.5.2",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -123,6 +123,7 @@
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^44.2.5",
+    "eslint-plugin-no-relative-import-paths": "^1.5.2",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sort-keys-fix": "^1.1.2",

--- a/webui/react/src/components/ActionDropdown/ActionDropdown.tsx
+++ b/webui/react/src/components/ActionDropdown/ActionDropdown.tsx
@@ -4,11 +4,10 @@ import Button from 'components/kit/Button';
 import Dropdown, { MenuItem } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import useConfirm, { ConfirmModalProps } from 'components/kit/useConfirm';
+import { Eventually } from 'types';
 import { DetError, ErrorLevel, ErrorType, wrapPublicMessage } from 'utils/error';
 import handleError from 'utils/error';
 import { capitalize } from 'utils/string';
-
-import { Eventually } from '../../types';
 
 import css from './ActionDropdown.module.scss';
 

--- a/webui/react/src/components/AvatarCard/AvatarCard.tsx
+++ b/webui/react/src/components/AvatarCard/AvatarCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Avatar, { Props as AvatarProps } from '../Avatar';
+import Avatar, { Props as AvatarProps } from 'components/Avatar';
 
 import css from './AvatarCard.module.scss';
 

--- a/webui/react/src/components/BatchActionConfirmModal.test.tsx
+++ b/webui/react/src/components/BatchActionConfirmModal.test.tsx
@@ -4,8 +4,7 @@ import React from 'react';
 
 import Button from 'components/kit/Button';
 import { DEFAULT_CANCEL_LABEL, useModal } from 'components/kit/Modal';
-
-import { ExperimentAction as Action, ExperimentAction } from '../types';
+import { ExperimentAction as Action, ExperimentAction } from 'types';
 
 import BatchActionConfirmModalComponent from './BatchActionConfirmModal';
 

--- a/webui/react/src/components/BatchActionConfirmModal.tsx
+++ b/webui/react/src/components/BatchActionConfirmModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import { ExperimentAction } from 'types';
 import handleError from 'utils/error';
-
-import { ExperimentAction } from '../types';
 
 import { Modal } from './kit/Modal';
 

--- a/webui/react/src/components/PageHeader/PageHeader.tsx
+++ b/webui/react/src/components/PageHeader/PageHeader.tsx
@@ -3,10 +3,9 @@ import React, { useMemo } from 'react';
 import Breadcrumb from 'components/kit/Breadcrumb';
 import { MenuItem } from 'components/kit/Dropdown';
 import Tooltip from 'components/kit/Tooltip';
+import Link from 'components/Link';
 import { BreadCrumbRoute } from 'components/Page';
 import { CommonProps } from 'types';
-
-import Link from '../Link';
 
 import css from './PageHeader.module.scss';
 

--- a/webui/react/src/components/ScaleSelect.tsx
+++ b/webui/react/src/components/ScaleSelect.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
 import Select, { Option, SelectValue } from 'components/kit/Select';
+import { Scale } from 'types';
 import { capitalize } from 'utils/string';
-
-import { Scale } from '../types';
 
 interface Props {
   onChange: (value: Scale) => void;

--- a/webui/react/src/components/Table/SkeletonTable.tsx
+++ b/webui/react/src/components/Table/SkeletonTable.tsx
@@ -1,9 +1,8 @@
 import { Skeleton } from 'antd';
 import React, { useMemo } from 'react';
 
+import SkeletonSection, { Props as SkeletonSectionProps } from 'components/SkeletonSection';
 import { isNumber } from 'utils/data';
-
-import SkeletonSection, { Props as SkeletonSectionProps } from '../SkeletonSection';
 
 import css from './SkeletonTable.module.scss';
 

--- a/webui/react/src/components/UPlot/UPlotScatter.tsx
+++ b/webui/react/src/components/UPlot/UPlotScatter.tsx
@@ -4,8 +4,7 @@ import uPlot from 'uplot';
 import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
 import QuadTree, { pointWithin } from 'components/UPlot/UPlotScatter/quadtree';
 import { Range } from 'types';
-
-import { Scale } from '../../types';
+import { Scale } from 'types';
 
 import { FacetedData, UPlotData } from './types';
 import {

--- a/webui/react/src/components/UPlot/UPlotScatter.tsx
+++ b/webui/react/src/components/UPlot/UPlotScatter.tsx
@@ -3,8 +3,7 @@ import uPlot from 'uplot';
 
 import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
 import QuadTree, { pointWithin } from 'components/UPlot/UPlotScatter/quadtree';
-import { Range } from 'types';
-import { Scale } from 'types';
+import { Range, Scale } from 'types';
 
 import { FacetedData, UPlotData } from './types';
 import {

--- a/webui/react/src/components/UPlot/UPlotScatter/UPlotScatter.utils.ts
+++ b/webui/react/src/components/UPlot/UPlotScatter/UPlotScatter.utils.ts
@@ -1,8 +1,7 @@
 import uPlot from 'uplot';
 
 import { UPlotAxisSplits, UPlotData } from 'components/UPlot/types';
-import { Range } from 'types';
-import { Scale } from 'types';
+import { Range, Scale } from 'types';
 import { rgba2str, rgbaFromGradient, str2rgba } from 'utils/color';
 
 export const X_INDEX = 0;

--- a/webui/react/src/components/UPlot/UPlotScatter/UPlotScatter.utils.ts
+++ b/webui/react/src/components/UPlot/UPlotScatter/UPlotScatter.utils.ts
@@ -1,10 +1,9 @@
 import uPlot from 'uplot';
 
+import { UPlotAxisSplits, UPlotData } from 'components/UPlot/types';
 import { Range } from 'types';
+import { Scale } from 'types';
 import { rgba2str, rgbaFromGradient, str2rgba } from 'utils/color';
-
-import { Scale } from '../../../types';
-import { UPlotAxisSplits, UPlotData } from '../types';
 
 export const X_INDEX = 0;
 export const Y_INDEX = 1;

--- a/webui/react/src/components/UPlot/UPlotScatter/useScatterPointTooltipPlugin.ts
+++ b/webui/react/src/components/UPlot/UPlotScatter/useScatterPointTooltipPlugin.ts
@@ -1,10 +1,9 @@
 import { useCallback, useMemo, useRef } from 'react';
 import uPlot, { Plugin } from 'uplot';
 
+import { UPlotData } from 'components/UPlot/types';
 import { humanReadableNumber } from 'utils/number';
 import { generateAlphaNumeric } from 'utils/string';
-
-import { UPlotData } from '../types';
 
 import { X_INDEX, Y_INDEX } from './UPlotScatter.utils';
 import css from './useScatterPointTooltipPlugin.module.scss';

--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -12,6 +12,7 @@ import { sprintf } from 'sprintf-js';
 import { throttle } from 'throttle-debounce';
 
 import Button from 'components/kit/Button';
+import ClipboardButton from 'components/kit/ClipboardButton';
 import Icon from 'components/kit/Icon';
 import {
   clone,
@@ -28,8 +29,6 @@ import { Log, LogLevel } from 'components/kit/internal/types';
 import useGetCharMeasureInContainer from 'components/kit/internal/useGetCharMeasureInContainer';
 import useResize from 'components/kit/internal/useResize';
 import Spinner from 'components/kit/Spinner';
-
-import ClipboardButton from '../ClipboardButton';
 
 import css from './LogViewer.module.scss';
 import LogViewerEntry, { DATETIME_FORMAT, ICON_WIDTH, MAX_DATETIME_LENGTH } from './LogViewerEntry';

--- a/webui/react/src/hooks/useModal/useModal.tsx
+++ b/webui/react/src/hooks/useModal/useModal.tsx
@@ -4,10 +4,9 @@ import { ModalFunc } from 'antd/es/modal/confirm';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import usePrevious from 'hooks/usePrevious';
 import { RecordUnknown, ValueOf } from 'types';
 import { isAsyncFunction } from 'utils/data';
-
-import usePrevious from '../../hooks/usePrevious';
 
 export const ModalCloseReason = {
   Cancel: 'Cancel',

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -7,13 +7,12 @@ import ResourcePoolDetails from 'components/ResourcePoolDetails';
 import Section from 'components/Section';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
+import { ClusterOverallBar } from 'pages/Cluster/ClusterOverallBar';
+import { ClusterOverallStats } from 'pages/Cluster/ClusterOverallStats';
 import clusterStore from 'stores/cluster';
 import { ResourcePool } from 'types';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
-
-import { ClusterOverallBar } from '../Cluster/ClusterOverallBar';
-import { ClusterOverallStats } from '../Cluster/ClusterOverallStats';
 
 const ClusterOverview: React.FC = () => {
   const resourcePools = useObservable(clusterStore.resourcePools);

--- a/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
+++ b/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
@@ -2,10 +2,9 @@ import { Radio } from 'antd';
 import React, { useMemo, useState } from 'react';
 
 import Section from 'components/Section';
+import ClusterHistoricalUsageChart from 'pages/Cluster/ClusterHistoricalUsageChart';
 import { V1RPQueueStat } from 'services/api-ts-sdk';
 import { DURATION_DAY, durationInEnglish } from 'utils/datetime';
-
-import ClusterHistoricalUsageChart from '../Cluster/ClusterHistoricalUsageChart';
 
 import css from './ClustersQueuedChart.module.scss';
 

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -40,6 +40,7 @@ import Toggle from 'components/kit/Toggle';
 import Tooltip from 'components/kit/Tooltip';
 import Header from 'components/kit/Typography/Header';
 import Paragraph from 'components/kit/Typography/Paragraph';
+import useConfirm, { voidPromiseFn } from 'components/kit/useConfirm';
 import UserAvatar from 'components/kit/UserAvatar';
 import { useTags } from 'components/kit/useTags';
 import Label from 'components/Label';
@@ -73,8 +74,6 @@ import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import loremIpsum, { loremIpsumSentence } from 'utils/loremIpsum';
 import { noOp } from 'utils/service';
 import { KeyboardShortcut } from 'utils/shortcut';
-
-import useConfirm, { voidPromiseFn } from '../components/kit/useConfirm';
 
 import css from './DesignKit.module.scss';
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -15,18 +15,17 @@ import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import usePrevious from 'hooks/usePrevious';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
+import TrialDetailsHyperparameters from 'pages/TrialDetails/TrialDetailsHyperparameters';
+import TrialDetailsLogs from 'pages/TrialDetails/TrialDetailsLogs';
 import TrialDetailsMetrics from 'pages/TrialDetails/TrialDetailsMetrics';
+import TrialDetailsOverview from 'pages/TrialDetails/TrialDetailsOverview';
+import TrialDetailsProfiles from 'pages/TrialDetails/TrialDetailsProfiles';
 import { paths } from 'routes/utils';
 import { getExpTrials, getTrialDetails, patchExperiment } from 'services/api';
 import { ValueOf } from 'types';
 import { ExperimentBase, Note, TrialDetails, TrialItem } from 'types';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
-
-import TrialDetailsHyperparameters from '../TrialDetails/TrialDetailsHyperparameters';
-import TrialDetailsLogs from '../TrialDetails/TrialDetailsLogs';
-import TrialDetailsOverview from '../TrialDetails/TrialDetailsOverview';
-import TrialDetailsProfiles from '../TrialDetails/TrialDetailsProfiles';
 
 import ExperimentCheckpoints from './ExperimentCheckpoints';
 import ExperimentCodeViewer from './ExperimentCodeViewer';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
@@ -9,8 +9,7 @@ import MetricSelect from 'components/MetricSelect';
 import RadioGroup from 'components/RadioGroup';
 import ScaleSelect from 'components/ScaleSelect';
 import { ExperimentVisualizationType } from 'pages/ExperimentDetails/ExperimentVisualization';
-import { ValueOf } from 'types';
-import { Metric, Scale } from 'types';
+import { Metric, Scale, ValueOf } from 'types';
 
 import css from './ExperimentVisualizationFilters.module.scss';
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/ExperimentVisualizationFilters.tsx
@@ -8,10 +8,9 @@ import Select, { Option, SelectValue } from 'components/kit/Select';
 import MetricSelect from 'components/MetricSelect';
 import RadioGroup from 'components/RadioGroup';
 import ScaleSelect from 'components/ScaleSelect';
+import { ExperimentVisualizationType } from 'pages/ExperimentDetails/ExperimentVisualization';
 import { ValueOf } from 'types';
 import { Metric, Scale } from 'types';
-
-import { ExperimentVisualizationType } from '../ExperimentVisualization';
 
 import css from './ExperimentVisualizationFilters.module.scss';
 

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpParallelCoordinates.tsx
@@ -8,6 +8,7 @@ import ParallelCoordinates from 'components/ParallelCoordinates';
 import Section from 'components/Section';
 import TableBatch from 'components/Table/TableBatch';
 import { terminalRunStates } from 'constants/states';
+import TrialsComparisonModal from 'pages/ExperimentDetails/TrialsComparisonModal';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSnapshotResponse } from 'services/api-ts-sdk';
 import { detApi } from 'services/apiConfig';
@@ -35,8 +36,6 @@ import handleError from 'utils/error';
 import { metricToStr } from 'utils/metric';
 import { numericSorter } from 'utils/sort';
 import { openCommandResponse } from 'utils/wait';
-
-import TrialsComparisonModal from '../TrialsComparisonModal';
 
 import css from './HpParallelCoordinates.module.scss';
 import HpTrialTable, { TrialHParams } from './HpTrialTable';

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -10,6 +10,7 @@ import Section from 'components/Section';
 import TableBatch from 'components/Table/TableBatch';
 import { UPlotPoint } from 'components/UPlot/types';
 import { terminalRunStates } from 'constants/states';
+import TrialsComparisonModal from 'pages/ExperimentDetails/TrialsComparisonModal';
 import { paths } from 'routes/utils';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1TrialsSampleResponse } from 'services/api-ts-sdk';
@@ -33,11 +34,9 @@ import { flattenObject, isPrimitive } from 'utils/data';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
+import { metricToStr } from 'utils/metric';
 import { isNewTabClickEvent, openBlank, routeToReactUrl } from 'utils/routes';
 import { openCommandResponse } from 'utils/wait';
-
-import { metricToStr } from '../../../utils/metric';
-import TrialsComparisonModal from '../TrialsComparisonModal';
 
 import HpTrialTable, { TrialHParams } from './HpTrialTable';
 import css from './LearningCurve.module.scss';

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -3,6 +3,7 @@ import { FilterDropdownProps } from 'antd/lib/table/interface';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import Badge, { BadgeType } from 'components/Badge';
+import BatchActionConfirmModalComponent from 'components/BatchActionConfirmModal';
 import ColumnsCustomizeModalComponent from 'components/ColumnsCustomizeModal';
 import { useSetDynamicTabBar } from 'components/DynamicTabs';
 import ExperimentActionDropdown from 'components/ExperimentActionDropdown';
@@ -84,8 +85,6 @@ import { alphaNumericSorter } from 'utils/sort';
 import { humanReadableBytes } from 'utils/string';
 import { getDisplayName } from 'utils/user';
 import { openCommandResponse } from 'utils/wait';
-
-import BatchActionConfirmModalComponent from '../components/BatchActionConfirmModal';
 
 import {
   DEFAULT_COLUMN_WIDTHS,

--- a/webui/react/src/pages/F_ExpList/glide-table/ColumnPickerMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/ColumnPickerMenu.tsx
@@ -11,12 +11,14 @@ import Input from 'components/kit/Input';
 import Pivot from 'components/kit/Pivot';
 import Spinner from 'components/kit/Spinner';
 import { useSettings } from 'hooks/useSettings';
+import {
+  F_ExperimentListSettings,
+  settingsConfigForProject,
+} from 'pages/F_ExpList/F_ExperimentList.settings';
 import { V1LocationType } from 'services/api-ts-sdk';
 import { ProjectColumn } from 'types';
 import { ensureArray } from 'utils/data';
 import { Loadable } from 'utils/loadable';
-
-import { F_ExperimentListSettings, settingsConfigForProject } from '../F_ExperimentList.settings';
 
 import css from './ColumnPickerMenu.module.scss';
 import { defaultExperimentColumns } from './columns';

--- a/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/GlideTable.tsx
@@ -37,6 +37,8 @@ import { MenuItem } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import { MapOfIdsToColors } from 'hooks/useGlasbey';
 import useMobile from 'hooks/useMobile';
+import { PAGE_SIZE } from 'pages/F_ExpList/F_ExperimentList';
+import { RowHeight } from 'pages/F_ExpList/F_ExperimentList.settings';
 import { handlePath } from 'routes/utils';
 import { V1ColumnType, V1LocationType } from 'services/api-ts-sdk';
 import useUI from 'stores/contexts/UI';
@@ -48,9 +50,6 @@ import { Loadable } from 'utils/loadable';
 import { observable, useObservable, WritableObservable } from 'utils/observable';
 import { AnyMouseEvent } from 'utils/routes';
 import { getCssVar } from 'utils/themes';
-
-import { PAGE_SIZE } from '../F_ExperimentList';
-import { RowHeight } from '../F_ExperimentList.settings';
 
 import {
   ColumnDef,

--- a/webui/react/src/pages/F_ExpList/glide-table/OptionsMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/OptionsMenu.tsx
@@ -4,8 +4,7 @@ import Button from 'components/kit/Button';
 import Dropdown, { MenuItem } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import Toggle from 'components/kit/Toggle';
-
-import { ExpListView, RowHeight } from '../F_ExperimentList.settings';
+import { ExpListView, RowHeight } from 'pages/F_ExpList/F_ExperimentList.settings';
 
 import css from './OptionsMenu.module.scss';
 

--- a/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
@@ -13,6 +13,7 @@ import { useModal } from 'components/kit/Modal';
 import Tooltip from 'components/kit/Tooltip';
 import useMobile from 'hooks/useMobile';
 import usePermissions from 'hooks/usePermissions';
+import { ExpListView, RowHeight } from 'pages/F_ExpList/F_ExperimentList.settings';
 import {
   activateExperiments,
   archiveExperiments,
@@ -42,10 +43,8 @@ import {
   getProjectExperimentForExperimentItem,
 } from 'utils/experiment';
 import { Loadable } from 'utils/loadable';
+import { pluralizer } from 'utils/string';
 import { openCommandResponse } from 'utils/wait';
-
-import { pluralizer } from '../../../utils/string';
-import { ExpListView, RowHeight } from '../F_ExperimentList.settings';
 
 import ColumnPickerMenu from './ColumnPickerMenu';
 import MultiSortMenu, { Sort } from './MultiSortMenu';

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/checkboxCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/checkboxCell.tsx
@@ -4,7 +4,7 @@ import {
   CustomRenderer,
 } from '@hpe.com/glide-data-grid/dist/ts/data-grid/cells/cell-types';
 
-import { roundedRect } from '../utils';
+import { roundedRect } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
 
 function drawCheckbox(
   ctx: CanvasRenderingContext2D,

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/experimentStateCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/experimentStateCell.tsx
@@ -1,9 +1,8 @@
 import { CustomCell, CustomRenderer, GridCellKind } from '@hpe.com/glide-data-grid';
 
+import { roundedRect } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
 import { CompoundRunState, JobState, RunState } from 'types';
 import { Theme } from 'utils/themes';
-
-import { roundedRect } from '../utils';
 
 interface ExperimentStateCellProps {
   readonly appTheme: Theme;

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/loadingCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/loadingCell.tsx
@@ -1,9 +1,8 @@
 import { CustomCell, CustomRenderer, GridCellKind } from '@hpe.com/glide-data-grid';
 
+import { roundedRect } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
 import { rgba2str, rgbaFromGradient, str2rgba } from 'utils/color';
 import { Theme } from 'utils/themes';
-
-import { roundedRect } from '../utils';
 
 interface LoadingCellProps {
   readonly appTheme: Theme;

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/progressCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/progressCell.tsx
@@ -1,6 +1,6 @@
 import { CustomCell, CustomRenderer, GridCellKind } from '@hpe.com/glide-data-grid';
 
-import { roundedRect } from '../utils';
+import { roundedRect } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
 
 interface RangeCellProps {
   readonly kind: 'range-cell';

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/tagsCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/tagsCell.tsx
@@ -7,7 +7,7 @@ import {
   Rectangle,
 } from '@hpe.com/glide-data-grid';
 
-import { roundedRect } from '../utils';
+import { roundedRect } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
 
 interface TagsCellProps {
   readonly kind: 'tags-cell';

--- a/webui/react/src/pages/InteractiveTask.test.tsx
+++ b/webui/react/src/pages/InteractiveTask.test.tsx
@@ -4,10 +4,9 @@ import React, { useEffect } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
 
+import { ConfirmationProvider } from 'components/kit/useConfirm';
 import authStore from 'stores/auth';
 import { StoreProvider as UIProvider } from 'stores/contexts/UI';
-
-import { ConfirmationProvider } from '../components/kit/useConfirm';
 
 import InteractiveTask from './InteractiveTask';
 

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -5,13 +5,15 @@ import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
+import { ChartProps } from 'pages/TrialDetails/Profiles/types';
+import { MetricType } from 'pages/TrialDetails/Profiles/types';
+import { useFetchProfilerMetrics } from 'pages/TrialDetails/Profiles/useFetchProfilerMetrics';
+import { useFetchProfilerSeries } from 'pages/TrialDetails/Profiles/useFetchProfilerSeries';
+import {
+  getScientificNotationTickValues,
+  getUnitForMetricName,
+} from 'pages/TrialDetails/Profiles/utils';
 import handleError from 'utils/error';
-
-import { ChartProps } from '../types';
-import { MetricType } from '../types';
-import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
-import { useFetchProfilerSeries } from '../useFetchProfilerSeries';
-import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 import SystemMetricFilter from './SystemMetricChartFilters';
 

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChartFilters.tsx
@@ -2,8 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import Select, { Option, SelectValue } from 'components/kit/Select';
 import { UpdateSettings } from 'hooks/useSettings';
-
-import { AvailableSeriesType } from '../types';
+import { AvailableSeriesType } from 'pages/TrialDetails/Profiles/types';
 
 import { Settings } from './SystemMetricChart';
 

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/ThroughputMetricChart.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
+import { ChartProps } from 'pages/TrialDetails/Profiles/types';
+import { MetricType } from 'pages/TrialDetails/Profiles/types';
+import { useFetchProfilerMetrics } from 'pages/TrialDetails/Profiles/useFetchProfilerMetrics';
+import {
+  getScientificNotationTickValues,
+  getUnitForMetricName,
+} from 'pages/TrialDetails/Profiles/utils';
 import handleError from 'utils/error';
-
-import { ChartProps } from '../types';
-import { MetricType } from '../types';
-import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
-import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 const ThroughputMetricChart: React.FC<ChartProps> = ({ trial }) => {
   const throughputMetrics = useFetchProfilerMetrics(

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/TimingMetricChart.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import { LineChart } from 'components/kit/LineChart';
 import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Section from 'components/Section';
+import { ChartProps } from 'pages/TrialDetails/Profiles/types';
+import { MetricType } from 'pages/TrialDetails/Profiles/types';
+import { useFetchProfilerMetrics } from 'pages/TrialDetails/Profiles/useFetchProfilerMetrics';
+import {
+  getScientificNotationTickValues,
+  getUnitForMetricName,
+} from 'pages/TrialDetails/Profiles/utils';
 import handleError from 'utils/error';
-
-import { ChartProps } from '../types';
-import { MetricType } from '../types';
-import { useFetchProfilerMetrics } from '../useFetchProfilerMetrics';
-import { getScientificNotationTickValues, getUnitForMetricName } from '../utils';
 
 export const TimingMetricChart: React.FC<ChartProps> = ({ trial }) => {
   const timingMetrics = useFetchProfilerMetrics(trial.id, trial.state, MetricType.Timing);

--- a/webui/react/src/pages/TrialDetails/TrialChart.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialChart.tsx
@@ -15,8 +15,7 @@ import { Metric, MetricContainer, Scale } from 'types';
 import { glasbeyColor } from 'utils/color';
 import handleError, { ErrorType } from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
-
-import { metricToStr } from '../../utils/metric';
+import { metricToStr } from 'utils/metric';
 
 interface Props {
   defaultMetricNames: Metric[];

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import ClipboardButton from 'components/kit/ClipboardButton';
 import LogViewer, {
   FetchConfig,
   FetchDirection,
@@ -22,8 +23,6 @@ import { ExperimentBase, TrialDetails } from 'types';
 import { downloadTrialLogs } from 'utils/browser';
 import { ErrorType } from 'utils/error';
 import handleError from 'utils/error';
-
-import ClipboardButton from '../../components/kit/ClipboardButton';
 
 import css from './TrialDetailsLogs.module.scss';
 

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -22,6 +22,7 @@ import {
 } from 'types';
 import { ErrorType } from 'utils/error';
 import handleError from 'utils/error';
+import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import {
   extractMetricSortValue,
   extractMetricValue,
@@ -30,8 +31,6 @@ import {
 } from 'utils/metric';
 import { numericSorter } from 'utils/sort';
 import { hasCheckpoint, hasCheckpointStep, workloadsToSteps } from 'utils/workload';
-
-import { Loadable, Loaded, NotLoaded } from '../../utils/loadable';
 
 import { Settings } from './TrialDetailsOverview.settings';
 import { columns as defaultColumns } from './TrialDetailsWorkloads.table';

--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import Pivot from 'components/kit/Pivot';
 import Spinner from 'components/kit/Spinner';
 import Message from 'components/Message';
+import ModelRegistry from 'components/ModelRegistry';
 import Page from 'components/Page';
 import PageNotFound from 'components/PageNotFound';
 import TaskList from 'components/TaskList';
@@ -23,8 +24,6 @@ import { User } from 'types';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
-
-import ModelRegistry from '../components/ModelRegistry';
 
 import ResourcePoolsBound from './WorkspaceDetails/ResourcePoolsBound';
 import WorkspaceMembers from './WorkspaceDetails/WorkspaceMembers';

--- a/webui/react/src/stores/contexts/UI.tsx
+++ b/webui/react/src/stores/contexts/UI.tsx
@@ -2,10 +2,9 @@ import React, { Dispatch, useContext, useMemo, useReducer } from 'react';
 
 import rootLogger from 'utils/Logger';
 import { checkDeepEquality } from 'utils/store';
+import { DarkLight, Mode, Theme } from 'utils/themes';
 
 const logger = rootLogger.extend('stores/ui');
-
-import { DarkLight, Mode, Theme } from '../../utils/themes';
 
 interface StateUI {
   chromeCollapsed: boolean;


### PR DESCRIPTION
## Description

Adds an eslint plugin and rule, which on `make fmt` updates our existing relative imports to absolute paths
Example `../Avatar` to `components/Avatar`

## Test Plan

- Codebase passes `make fmt` and `npm run build`
- Satisfactory updates to imports

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.