### PR TITLE
docs: Update resource pool to workspace mapping

### DIFF
--- a/docs/interfaces/tensorboard.rst
+++ b/docs/interfaces/tensorboard.rst
@@ -76,8 +76,8 @@ Example job configuration file:
        read_only: true
    tensorboard_args: ['--samples_per_plugin=images=100']
 
-The tensorboard_args field allows you to provide optional Tensorboard arguments. In the example
-above, we set the maximum number of image to display to 100, overriding Tensorboard's default value.
+The tensorboard_args field allows you to provide optional TensorBoard arguments. In the example
+above, we set the maximum number of image to display to 100, overriding TensorBoard's default value.
 
 For detailed configuration settings, refer to the :ref:`command-notebook-configuration`.
 

--- a/docs/setup-cluster/workspaces-rpools.rst
+++ b/docs/setup-cluster/workspaces-rpools.rst
@@ -7,8 +7,8 @@
 .. meta::
    :description: Discover how to associate resource pools to specific workspaces in the same way you associate certain artifacts, like experiments, to workspaces.
 
-You can associate resource pools to specific workspaces in the same way you associate certain
-artifacts, like experiments, to workspaces.
+You can associate :ref:`resource pools <resource-pools>` to specific workspaces similar to how you
+associate certain artifacts, like experiments, to workspaces.
 
 .. attention::
 
@@ -22,7 +22,7 @@ Binding and unbinding resource pools allows administrators to control resource p
 within the cluster.
 
 Resource pools can be either unbound, meaning they are shared across the entire cluster, or bound to
-specific workspaces. Experiments, notebooks, Tensorboards, shells, or commands associated with a
+specific workspaces. Experiments, notebooks, TensorBoards, shells, or commands associated with a
 particular workspace can only use resource pools that are either unbound or bound to a particular
 workspace.
 
@@ -38,8 +38,12 @@ related artifacts.
  Binding or Unbinding a Resource Pool
 **************************************
 
-You can bind or unbind a resource pool. By default, all resource pools are unbound, making them
-globally available to all workspaces in the cluster.
+You can bind or unbind a resource pool to a workspace. By default, all resource pools are unbound,
+making them globally available to all workspaces in the cluster.
+
+.. note::
+
+   Default resource pools cannot be bound to a workspace.
 
 WebUI
 =====


### PR DESCRIPTION
Update the instructions to let users know they cannot bind a **default** resource pool to a workspace.