### PR TITLE
chore: Show Tooltip instead of actions for Default Resource Pools [WEB-1554]

### DIFF
--- a/webui/react/src/components/ResourcePoolCard.module.scss
+++ b/webui/react/src/components/ResourcePoolCard.module.scss
@@ -56,6 +56,12 @@ $font-size-content: 12px;
         font-weight: bold;
       }
     }
+    .defaultPoolTooltip {
+      color: var(--theme-surface-on);
+      font-size: $font-size-content;
+      position: absolute;
+      right: var(--outside-padding);
+    }
   }
   .empty {
     color: var(--theme-surface-on-weak);

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -10,6 +10,7 @@ import { MenuItem } from 'components/kit/Dropdown';
 import Icon from 'components/kit/Icon';
 import { useModal } from 'components/kit/Modal';
 import Spinner from 'components/kit/Spinner';
+import Tooltip from 'components/kit/Tooltip';
 import SlotAllocationBar from 'components/SlotAllocationBar';
 import { V1ResourcePoolTypeToLabel, V1SchedulerTypeToLabel } from 'constants/states';
 import useFeature from 'hooks/useFeature';
@@ -97,7 +98,7 @@ const ResourcePoolCard: React.FC<Props> = ({
 }: Props) => {
   const rpBindingFlagOn = useFeature().isOn('rp_binding');
   const ResourcePoolBindingModal = useModal(ResourcePoolBindingModalComponent);
-
+  const isDefaultPool = pool.defaultAuxPool || pool.defaultComputePool;
   const descriptionClasses = [css.description];
 
   const resourcePoolBindingMap = useObservable(clusterStore.resourcePoolBindings);
@@ -168,9 +169,16 @@ const ResourcePoolCard: React.FC<Props> = ({
               <div className={css.name}>{pool.name}</div>
             </div>
             <div className={css.default}>
-              <span>{descriptiveLabel}</span>
+              {!isDefaultPool && <span>{descriptiveLabel}</span>}
               {pool.description && <Icon name="info" showTooltip title={pool.description} />}
             </div>
+            {rpBindingFlagOn && isDefaultPool && (
+              <div className={css.defaultPoolTooltip}>
+                <Tooltip content="You cannot bind your default resource pool to a workspace">
+                  <span>Default</span>
+                </Tooltip>
+              </div>
+            )}
           </div>
           <Suspense fallback={<Spinner center spinning />}>
             <div className={css.body}>

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -174,7 +174,7 @@ const ResourcePoolCard: React.FC<Props> = ({
             </div>
             {rpBindingFlagOn && isDefaultPool && (
               <div className={css.defaultPoolTooltip}>
-                <Tooltip content="You cannot bind your default resource pool to a workspace">
+                <Tooltip content="You cannot bind your default resource pool to a workspace.">
                   <span>Default</span>
                 </Tooltip>
               </div>

--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -14,6 +14,7 @@ import Tooltip from 'components/kit/Tooltip';
 import SlotAllocationBar from 'components/SlotAllocationBar';
 import { V1ResourcePoolTypeToLabel, V1SchedulerTypeToLabel } from 'constants/states';
 import useFeature from 'hooks/useFeature';
+import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
 import { V1ResourcePoolType, V1RPQueueStat, V1SchedulerType } from 'services/api-ts-sdk';
 import { maxPoolSlotCapacity } from 'stores/cluster';
@@ -97,10 +98,11 @@ const ResourcePoolCard: React.FC<Props> = ({
   descriptiveLabel,
 }: Props) => {
   const rpBindingFlagOn = useFeature().isOn('rp_binding');
+  const { canManageResourcePoolBindings } = usePermissions();
   const ResourcePoolBindingModal = useModal(ResourcePoolBindingModalComponent);
   const isDefaultPool = pool.defaultAuxPool || pool.defaultComputePool;
   const descriptionClasses = [css.description];
-
+  const showDescriptiveLabel = !(canManageResourcePoolBindings && rpBindingFlagOn) ?? isDefaultPool;
   const resourcePoolBindingMap = useObservable(clusterStore.resourcePoolBindings);
   const resourcePoolBindings: number[] = resourcePoolBindingMap.get(pool.name, []);
   const workspaces = Loadable.getOrElse([], useObservable(workspaceStore.workspaces));
@@ -169,10 +171,10 @@ const ResourcePoolCard: React.FC<Props> = ({
               <div className={css.name}>{pool.name}</div>
             </div>
             <div className={css.default}>
-              {!isDefaultPool && <span>{descriptiveLabel}</span>}
+              {showDescriptiveLabel && <span>{descriptiveLabel}</span>}
               {pool.description && <Icon name="info" showTooltip title={pool.description} />}
             </div>
-            {rpBindingFlagOn && isDefaultPool && (
+            {!showDescriptiveLabel && (
               <div className={css.defaultPoolTooltip}>
                 <Tooltip content="You cannot bind your default resource pool to a workspace.">
                   <span>Default</span>

--- a/webui/react/src/pages/Clusters/ClustersOverview.tsx
+++ b/webui/react/src/pages/Clusters/ClustersOverview.tsx
@@ -26,10 +26,11 @@ const ClusterOverview: React.FC = () => {
 
   const actionMenu = useCallback(
     (pool: ResourcePool) =>
-      rpBindingFlagOn && canManageResourcePoolBindings
+      rpBindingFlagOn &&
+      canManageResourcePoolBindings &&
+      !(pool.defaultAuxPool || pool.defaultComputePool)
         ? [
             {
-              disabled: pool.defaultAuxPool || pool.defaultComputePool,
               icon: <Icon name="four-squares" title="manage-bindings" />,
               key: 'bindings',
               label: 'Manage bindings',


### PR DESCRIPTION
## Description

This PR replaces the action menu on resource pool cards with a tooltip for default resource pools. The message to the user informs them that a default resource pool's bindings cannot be changed. 


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

1. Navigate to the Cluster overview page as an admin.
2. With the `Resource Pool Binding` feature flag off, ensure that no action menu nor tooltip is shown for the resource pool cards under "Resource Pool". 
3. Ensure that the descriptive label i.e "Default Compute" is shown for the default resource pools.
4. With the `Resource Pool Binding` feature flag on, ensure that for the default resource pools an action item menu (3 dots) is not shown. Ensure that the text "Default" is shown with a tooltip message that is visible when hovering over the "Default" text. 
5. Navigate to the Cluster overview page as a non-admin.
6. With the `Resource Pool Binding` feature flag off, ensure that no action menu nor tooltip is shown for the resource pool cards under "Resource Pool". Ensure that the descriptive label i.e "Default Compute" is shown for the default resource pools.
7. With the `Resource Pool Binding` feature flag on, ensure that no action menu nor tooltip is shown for the resource pool cards under "Resource Pool". Ensure that the descriptive label i.e "Default Compute" is shown for the default resource pools.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->
## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1554
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
