### PR TITLE
fix: Project delete/move triggers update of workspace projects list [WEB-1497] [WEB-1377]

### DIFF
--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -59,10 +59,7 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
             <ProjectDeleteModal.Component
               project={project}
               onClose={onComplete}
-              onDelete={() => {
-                onDelete?.();
-                onComplete?.();
-              }}
+              onDelete={onDelete}
             />
             <ProjectEditModal.Component project={project} onClose={onComplete} />
           </>

--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -59,7 +59,10 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
             <ProjectDeleteModal.Component
               project={project}
               onClose={onComplete}
-              onDelete={onDelete}
+              onDelete={() => {
+                onDelete?.();
+                onComplete?.();
+              }}
             />
             <ProjectEditModal.Component project={project} onClose={onComplete} />
           </>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -28,6 +28,7 @@ const ProjectCard: React.FC<Props> = ({
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
     onComplete: fetchProjects,
+    onDelete: fetchProjects,
     project,
     workspaceArchived,
   });

--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -52,6 +52,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
         ),
         message: 'Move Success',
       });
+      onClose?.();
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,
@@ -61,7 +62,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
         type: ErrorType.Server,
       });
     }
-  }, [destinationWorkspaceId, project.id, project.name, workspaces]);
+  }, [destinationWorkspaceId, onClose, project.id, project.name, workspaces]);
 
   const handleWorkspaceSelect = useCallback(
     (selectedWorkspaceId: SelectValue) => {


### PR DESCRIPTION
## Description

Deleting an empty project takes time to be reflected on the WorkspaceDetails page.
On review, `ProjectDeleteModal` calls `onClose` if the modal is exited or `onDelete` if the modal is submitted; and our use of `ProjectActionDropdown` assumed both would execute and use (`onComplete`) to trigger updating project list.

The logic might be due to a delay if the project contains experiments. Web UI currently shows the Delete option only for empty projects, so it's a non-issue.

## Test Plan

- Create a project. In the WorkspaceDetails cards view, delete the project and see it quickly disappear
- Create a project. In the WorkspaceDetails list/table view, delete the project and see it quickly disappear
- Move a project to another workspace. The project should quickly disappear from this workspace view

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.