### PR TITLE
fix: default pools editable and submittable

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -423,13 +423,19 @@ func (a *apiServer) PatchWorkspace(
 		insertColumns = append(insertColumns, "uid", "user_", "gid", "group_")
 	}
 
-	if req.Workspace.DefaultComputePool != "" {
-		updatedWorkspace.DefaultComputePool = req.Workspace.DefaultComputePool
-		insertColumns = append(insertColumns, "default_compute_pool")
-	}
-	if req.Workspace.DefaultAuxPool != "" {
-		updatedWorkspace.DefaultAuxPool = req.Workspace.DefaultAuxPool
-		insertColumns = append(insertColumns, "default_aux_pool")
+	if req.Workspace.DefaultAuxPool != "" || req.Workspace.DefaultComputePool != "" {
+		if err = workspace.AuthZProvider.Get().
+			CanSetWorkspacesDefaultPools(ctx, currUser, currWorkspace); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+		if req.Workspace.DefaultComputePool != "" {
+			updatedWorkspace.DefaultComputePool = req.Workspace.DefaultComputePool
+			insertColumns = append(insertColumns, "default_compute_pool")
+		}
+		if req.Workspace.DefaultAuxPool != "" {
+			updatedWorkspace.DefaultAuxPool = req.Workspace.DefaultAuxPool
+			insertColumns = append(insertColumns, "default_aux_pool")
+		}
 	}
 
 	if req.Workspace.CheckpointStorageConfig != nil {

--- a/master/internal/mocks/workspace_authz_iface.go
+++ b/master/internal/mocks/workspace_authz_iface.go
@@ -173,6 +173,20 @@ func (_m *WorkspaceAuthZ) CanSetWorkspacesCheckpointStorageConfig(ctx context.Co
 	return r0
 }
 
+// CanSetWorkspacesDefaultPools provides a mock function with given fields: ctx, curUser, _a2
+func (_m *WorkspaceAuthZ) CanSetWorkspacesDefaultPools(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) error {
+	ret := _m.Called(ctx, curUser, _a2)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *workspacev1.Workspace) error); ok {
+		r0 = rf(ctx, curUser, _a2)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CanSetWorkspacesName provides a mock function with given fields: ctx, curUser, _a2
 func (_m *WorkspaceAuthZ) CanSetWorkspacesName(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) error {
 	ret := _m.Called(ctx, curUser, _a2)

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -119,10 +119,7 @@ func (a ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := a.ValidateResourcePool(actorCtx, defaultAuxPool); err != nil {
-			return "", fmt.Errorf("validating default aux pool: %w", err)
-		}
-		return defaultAuxPool, nil
+		name = defaultAuxPool
 	}
 
 	if name == "" && slots >= 0 {
@@ -134,10 +131,7 @@ func (a ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := a.ValidateResourcePool(actorCtx, defaultComputePool); err != nil {
-			return "", fmt.Errorf("validating default compute pool: %w", err)
-		}
-		return defaultComputePool, nil
+		name = defaultComputePool
 	}
 
 	resp, err := a.GetResourcePools(actorCtx, &apiv1.GetResourcePoolsRequest{})

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -104,10 +104,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := k.ValidateResourcePool(actorCtx, defaultAuxPool); err != nil {
-			return "", fmt.Errorf("validating default aux pool: %w", err)
-		}
-		return defaultAuxPool, nil
+		name = defaultAuxPool
 	}
 
 	if name == "" && slots >= 0 {
@@ -119,10 +116,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := k.ValidateResourcePool(actorCtx, defaultComputePool); err != nil {
-			return "", fmt.Errorf("validating default compute pool: %w", err)
-		}
-		return defaultComputePool, nil
+		name = defaultComputePool
 	}
 
 	resp, err := k.GetResourcePools(actorCtx, &apiv1.GetResourcePoolsRequest{})

--- a/master/internal/workspace/authz_basic_impl.go
+++ b/master/internal/workspace/authz_basic_impl.go
@@ -158,6 +158,13 @@ func (a *WorkspaceAuthZBasic) CanCreateWorkspaceWithCheckpointStorageConfig(
 	return nil
 }
 
+// CanSetWorkspacesDefaultPools returns a nil error.
+func (a *WorkspaceAuthZBasic) CanSetWorkspacesDefaultPools(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	return nil
+}
+
 func init() {
 	AuthZProvider.Register("basic", &WorkspaceAuthZBasic{})
 }

--- a/master/internal/workspace/authz_iface.go
+++ b/master/internal/workspace/authz_iface.go
@@ -58,6 +58,7 @@ type WorkspaceAuthZ interface {
 	CanSetWorkspacesDefaultPools(
 		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 	) error
+	// TODO: we should consider userID as an arg instead of model.User
 
 	// DELETE /api/v1/workspaces/:workspace_id
 	CanDeleteWorkspace(

--- a/master/internal/workspace/authz_iface.go
+++ b/master/internal/workspace/authz_iface.go
@@ -55,6 +55,9 @@ type WorkspaceAuthZ interface {
 	CanSetWorkspacesCheckpointStorageConfig(
 		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 	) error
+	CanSetWorkspacesDefaultPools(
+		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	) error
 
 	// DELETE /api/v1/workspaces/:workspace_id
 	CanDeleteWorkspace(


### PR DESCRIPTION
## Description
There was an issue where a workspace viewer had permissions to edit workspace default pools and submit experiments to them, even if they were bound to another workspace. This change tightens the security around editing the workspace and experiment submission by:

- making the resolve resource pool function check for accessible resource pools even for default workspace pools
- adding a workspace RBAC authorization function that only allows cluster admins to be able to modify the default pool
- add logic so that a pool that is inaccessible to the workspace cannot be used as its default pool 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
