### PR TITLE
docs: Point to pytorch distributed launcher

### DIFF
--- a/docs/model-dev-guide/apis-howto/api-pytorch-ug.rst
+++ b/docs/model-dev-guide/apis-howto/api-pytorch-ug.rst
@@ -19,9 +19,9 @@ In this guide, you'll learn how to use :ref:`pytorch_trial_ug` and :ref:`pytorch
  PyTorch Trial
 ***************
 
-This section guides you through training a PyTorch model in Determined. You need to implement a
-trial class that inherits from :class:`~determined.pytorch.PyTorchTrial` and specify it as the
-entrypoint in the :ref:`experiment configuration <experiment-config-reference>`.
+To train a PyTorch model in Determined, you need to implement a trial class that inherits from
+:class:`~determined.pytorch.PyTorchTrial` and specify it as the entrypoint in the :ref:`experiment
+configuration <experiment-config-reference>`.
 
 To implement a :class:`~determined.pytorch.PyTorchTrial`, you need to override specific functions
 that represent the components that are used in the training procedure. It is helpful to work off of
@@ -60,6 +60,13 @@ following examples:
 For tips on debugging, see :ref:`model-debug`.
 
 .. _pytorch-downloading-data:
+
+Distributed Backend
+===================
+
+By default, PyTorch Trial uses Horovod as the backend. You can choose to use ``torch.distributed``
+and ``DistributedDataParallel`` as your distributed backend, by following :ref:`PyTorch Distributed
+Launcher <pytorch-dist-launcher>`.
 
 Download Data
 =============
@@ -169,8 +176,8 @@ the following formats:
        "label": (torch.Tensor([0, 0]), torch.Tensor([[0, 0], [0, 0]])),
    }
 
-Initializing Objects
-====================
+Initialize Objects
+==================
 
 You need to initialize the objects that will be used in training in the constructor
 :meth:`~determined.pytorch.PyTorchTrial.__init__` of :class:`determined.pytorch.PyTorchTrial` using

--- a/docs/model-dev-guide/submit-experiment.rst
+++ b/docs/model-dev-guide/submit-experiment.rst
@@ -123,6 +123,8 @@ Example:
 
    python3 -m determined.launch.horovod --fusion-threshold-mb 1 --cycle-time-ms 2 -- --trial model_def:MyTrial
 
+.. _pytorch-dist-launcher:
+
 PyTorch Distributed Launcher
 ============================
 


### PR DESCRIPTION
Edit the PyTorch Trial docs to add a pointer to the pytorch distributed launcher information.

## Description

Jira ticket [TECHWR-79]. 

## Test Plan

Test that the solution solves the problem of having a user encounter the PyTorch Trial docs without any information about the predefined PyTorch Distributed Launcher.


[TECHWR-79]: https://hpe-aiatscale.atlassian.net/browse/TECHWR-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ