### PR TITLE
feat: Allow deleting a workspace or project with 1+ experiments [WEB-750]

### DIFF
--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -59,10 +59,7 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
             <ProjectDeleteModal.Component
               project={project}
               onClose={onComplete}
-              onDelete={() => {
-                onDelete?.();
-                onComplete?.();
-              }}
+              onDelete={onDelete}
             />
             <ProjectEditModal.Component project={project} onClose={onComplete} />
           </>

--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -117,8 +117,7 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
     }
     if (
       canDeleteProjects({ project, workspace: { id: project.workspaceId } }) &&
-      !project.archived &&
-      project.numExperiments === 0
+      !project.archived
     ) {
       items.push({ danger: true, key: MenuKey.Delete, label: 'Delete...' });
     }

--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -59,7 +59,10 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
             <ProjectDeleteModal.Component
               project={project}
               onClose={onComplete}
-              onDelete={onDelete}
+              onDelete={() => {
+                onDelete?.();
+                onComplete?.();
+              }}
             />
             <ProjectEditModal.Component project={project} onClose={onComplete} />
           </>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -4,9 +4,10 @@ import React from 'react';
 import Card from 'components/kit/Card';
 import Icon from 'components/kit/Icon';
 import Tooltip from 'components/kit/Tooltip';
+import { stateRenderer } from 'components/Table/Table';
 import TimeAgo from 'components/TimeAgo';
 import { paths } from 'routes/utils';
-import { Project } from 'types';
+import { Project, WorkspaceState } from 'types';
 import { nearestCardinalNumber } from 'utils/number';
 
 import DynamicIcon from './DynamicIcon';
@@ -57,6 +58,9 @@ const ProjectCard: React.FC<Props> = ({
               </Tooltip>
             )}
           </div>
+          {project.state !== WorkspaceState.Unspecified && (
+            <div>{stateRenderer(project.state, project, 1)}</div>
+          )}
           <div className={css.footerContainer}>
             <div className={css.experiments}>
               <Tooltip

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -57,10 +57,10 @@ const ProjectCard: React.FC<Props> = ({
                 </div>
               </Tooltip>
             )}
+            {project.state !== WorkspaceState.Unspecified && (
+              <div>{stateRenderer(project.state, project, 1)}</div>
+            )}
           </div>
-          {project.state !== WorkspaceState.Unspecified && (
-            <div>{stateRenderer(project.state, project, 1)}</div>
-          )}
           <div className={css.footerContainer}>
             <div className={css.experiments}>
               <Tooltip

--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -9,7 +9,7 @@ import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
 import { moveProject } from 'services/api';
 import workspaceStore from 'stores/workspaces';
-import { Project, Workspace } from 'types';
+import { Project, Workspace, WorkspaceState } from 'types';
 import { notification } from 'utils/dialogApi';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
@@ -30,7 +30,12 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
   const { canMoveProjectsTo } = usePermissions();
   const workspaces = Loadable.match(useObservable(workspaceStore.unarchived), {
     Loaded: (workspaces: Workspace[]) =>
-      workspaces.filter((w) => !w.immutable && canMoveProjectsTo({ destination: { id: w.id } })),
+      workspaces.filter(
+        (w) =>
+          !w.immutable &&
+          canMoveProjectsTo({ destination: { id: w.id } }) &&
+          (w.state === WorkspaceState.Unspecified || w.state === WorkspaceState.DeleteFailed),
+      ),
     NotLoaded: () => [],
   });
 

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.settings.ts
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.settings.ts
@@ -20,6 +20,7 @@ export const DEFAULT_COLUMNS: ProjectColumnName[] = [
   'name',
   'description',
   'numExperiments',
+  'state',
   'lastUpdated',
   'userId',
 ];

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -2,7 +2,6 @@ import { Space } from 'antd';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import ExperimentIcons from 'components/ExperimentIcons';
 import GridListRadioGroup, { GridListView } from 'components/GridListRadioGroup';
 import Button from 'components/kit/Button';
 import Card from 'components/kit/Card';
@@ -36,7 +35,7 @@ import { paths } from 'routes/utils';
 import { getWorkspaceProjects, patchProject } from 'services/api';
 import { V1GetWorkspaceProjectsRequestSortBy } from 'services/api-ts-sdk';
 import userStore from 'stores/users';
-import { Project, RunState, Workspace, WorkspaceState } from 'types';
+import { Project, Workspace, WorkspaceState } from 'types';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
@@ -254,7 +253,8 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         dataIndex: 'state',
         defaultWidth: DEFAULT_COLUMN_WIDTHS['state'],
         key: 'state',
-        render: (value: WorkspaceState, ...args) => value !== WorkspaceState.Unspecified && stateRenderer(value, ...args),
+        render: (value: WorkspaceState, ...args) =>
+          value !== WorkspaceState.Unspecified && stateRenderer(value, ...args),
         title: 'State',
       },
       {

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -2,6 +2,7 @@ import { Space } from 'antd';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import ExperimentIcons from 'components/ExperimentIcons';
 import GridListRadioGroup, { GridListView } from 'components/GridListRadioGroup';
 import Button from 'components/kit/Button';
 import Card from 'components/kit/Card';
@@ -35,7 +36,7 @@ import { paths } from 'routes/utils';
 import { getWorkspaceProjects, patchProject } from 'services/api';
 import { V1GetWorkspaceProjectsRequestSortBy } from 'services/api-ts-sdk';
 import userStore from 'stores/users';
-import { Project, Workspace } from 'types';
+import { Project, RunState, Workspace, WorkspaceState } from 'types';
 import { ErrorLevel, ErrorType } from 'utils/error';
 import handleError from 'utils/error';
 import { Loadable } from 'utils/loadable';
@@ -182,6 +183,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         project={record}
         workspaceArchived={workspace?.archived}
         onComplete={fetchProjects}
+        onDelete={fetchProjects}
       />
     );
 
@@ -252,7 +254,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         dataIndex: 'state',
         defaultWidth: DEFAULT_COLUMN_WIDTHS['state'],
         key: 'state',
-        render: stateRenderer,
+        render: (value: WorkspaceState, ...args) => value !== WorkspaceState.Unspecified && stateRenderer(value, ...args),
         title: 'State',
       },
       {

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -250,6 +250,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         title: 'Archived',
       },
       {
+        align: 'center',
         dataIndex: 'state',
         defaultWidth: DEFAULT_COLUMN_WIDTHS['state'],
         key: 'state',

--- a/webui/react/src/pages/WorkspaceList.settings.ts
+++ b/webui/react/src/pages/WorkspaceList.settings.ts
@@ -14,7 +14,7 @@ export type WorkspaceColumnName =
   | 'state'
   | 'userId';
 
-export const DEFAULT_COLUMNS: WorkspaceColumnName[] = ['name', 'numProjects', 'userId'];
+export const DEFAULT_COLUMNS: WorkspaceColumnName[] = ['name', 'numProjects', 'state', 'userId'];
 
 export const WhoseWorkspaces = {
   All: 'ALL_WORKSPACES',

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -34,7 +34,7 @@ import { paths } from 'routes/utils';
 import { getWorkspaces } from 'services/api';
 import { V1GetWorkspacesRequestSortBy } from 'services/api-ts-sdk';
 import userStore from 'stores/users';
-import { Workspace } from 'types';
+import { Workspace, WorkspaceState } from 'types';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 import { validateDetApiEnum } from 'utils/service';
@@ -196,7 +196,8 @@ const WorkspaceList: React.FC = () => {
         dataIndex: 'state',
         defaultWidth: DEFAULT_COLUMN_WIDTHS['state'],
         key: 'state',
-        render: stateRenderer,
+        render: (value: WorkspaceState, ...args) =>
+          value !== WorkspaceState.Unspecified && stateRenderer(value, ...args),
         title: 'State',
       },
       {

--- a/webui/react/src/pages/WorkspaceList/WorkspaceActionDropdown.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceActionDropdown.tsx
@@ -133,7 +133,7 @@ export const useWorkspaceActionMenu: (props: WorkspaceMenuPropsIn) => WorkspaceM
         label: workspace.archived ? 'Unarchive' : 'Archive',
       });
     }
-    if (canDeleteWorkspace({ workspace }) && workspace.numExperiments === 0) {
+    if (canDeleteWorkspace({ workspace })) {
       menuItems.push({ type: 'divider' });
       menuItems.push({ danger: true, key: MenuKey.Delete, label: 'Delete...' });
     }

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -7,9 +7,10 @@ import Card from 'components/kit/Card';
 import { Columns } from 'components/kit/Columns';
 import Spinner from 'components/kit/Spinner';
 import Avatar from 'components/kit/UserAvatar';
+import { stateRenderer } from 'components/Table/Table';
 import { paths } from 'routes/utils';
 import userStore from 'stores/users';
-import { Workspace } from 'types';
+import { Workspace, WorkspaceState } from 'types';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 import { pluralizer } from 'utils/string';
@@ -55,6 +56,9 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
               <p className={css.projects}>
                 {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
               </p>
+              {workspace.state !== WorkspaceState.Unspecified && (
+                <div>{stateRenderer(workspace.state, workspace, 1)}</div>
+              )}
               <div className={css.avatarRow}>
                 <div className={css.avatar}>
                   <Spinner conditionalRender spinning={Loadable.isLoading(loadableUser)}>


### PR DESCRIPTION
## Description

**Draft PR** pending design

- Allow user to delete their workspaces and projects (starts backend async process)
- Label a workspace or project that is being deleted
- Don't allow experiments/projects to be moved into a workspace while it's being deleted

## Test Plan

- Create and delete a test workspace
- Create a workspace and add a project. Delete the empty project
- Add a project. Create experiments using the CLI with `--project_id 101` (id of the destination project)
- There is a Delete option in the workspace menus in the Workspaces Cards view, Workspaces List view, and the WorkspaceDetails page header
- There is a Delete option in the project menus in the Project Cards view, Project List view, and the ProjectDetails page header
- When you delete a project from the ProjectDetails page header, you are redirected to the WorkspaceDetails page. The project should be marked "Deleting" in both cards and list views
- Create a new project and create or move experiments into it with `--project_id 101`
- Delete the workspace; the should be marked "Deleting" in cards and lists views



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.