### PR TITLE
fix: make -C master clean build [DET-9333]

### DIFF
--- a/master/Makefile
+++ b/master/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build
 SHELL := bash
 GENERATED := packaging/LICENSE
-GENERATION_INPUTS = ../schemas/gen.py $(shell find ./pkg/schemas/ -name '*.go') $(shell find ../schemas/expconf -name '*.json')
+GENERATION_INPUTS = ../schemas/gen.py $(shell find ../schemas/expconf -name '*.go') $(shell find ../schemas/expconf -name '*.json') # TODO CAROLINA
 MOCK_GENERATION_INPUTS = ./internal/sproto/task.go ./internal/db/database.go ./internal/command/authz_iface.go ./go.mod ./go.sum ./internal/rm/resource_manager_iface.go ./internal/task/allocation_service_iface.go
 GORELEASER = goreleaser
 


### PR DESCRIPTION
## Description
Change master Makefile variables such that `make -C master clean build` succeeds on each try.


## Test Plan
Check out this branch and run `make -C master clean build`. Instead of seeing
```
% make -C master clean build
rm -f packaging/LICENSE
rm -f `find ./pkg/schemas/ -name 'zgen_*.go'` build/schema_gen.stamp
rm -f `find ./internal/mocks -name '*.go'` build/mock_gen.stamp
rm -rf dist
rm -rf build
../tools/scripts/gen-attributions.py master packaging/LICENSE
make: *** No rule to make target `pkg/schemas/expconf/zgen_s3_config_v0.go', needed by `build/schema_gen.stamp'.  Stop.
```
You should see:
% make -C master clean build
```
rm -f packaging/LICENSE
rm -f `find ./pkg/schemas/ -name 'zgen_*.go'` build/schema_gen.stamp
rm -f `find ./internal/mocks -name '*.go'` build/mock_gen.stamp
rm -rf dist
rm -rf build
../tools/scripts/gen-attributions.py master packaging/LICENSE
go generate ./pkg/schemas/...
mkdir -p build
touch build/schema_gen.stamp
go build \
		-ldflags "-X github.com/determined-ai/determined/master/version.Version=0.24.0-dev0 \
		          -X github.com/determined-ai/determined/master/internal/config.DefaultSegmentMasterKey= \
		          -X github.com/determined-ai/determined/master/internal/config.DefaultSegmentWebUIKey=" \
		-o build/determined-master \
		./cmd/determined-master
```

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-93333