### PR TITLE
docs: Introduce users to pachyderm w det

### DIFF
--- a/docs/architecture/introduction.rst
+++ b/docs/architecture/introduction.rst
@@ -153,6 +153,8 @@ experiment or to compare multiple experiments.
 TensorBoard instances can be launched via the WebUI or the CLI. To launch TensorBoard instances from
 the CLI, first :ref:`install the CLI <install-cli>` on your development machine.
 
+.. _benefits:
+
 **********
  Benefits
 **********

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,7 @@
 
    Works with Determined <integrations/ecosystem/ecosystem-integration>
    IDE Integration <interfaces/ide-integration>
+   Pachyderm <integrations/pachyderm/pachyderm>
    Prometheus and Grafana <integrations/prometheus/prometheus>
    attributions
 

--- a/docs/integrations/ecosystem/ecosystem-integration.rst
+++ b/docs/integrations/ecosystem/ecosystem-integration.rst
@@ -1,11 +1,11 @@
 #######################
- Ecosystem Integration
+ Works with Determined
 #######################
 
 Determined is designed to easily integrate with other popular ML ecosystem tools for tasks that are
 related to model training, such as ETL, ML pipelines, and model serving. It is recommended to use
 the Python SDK to interact with Determined.
 
-The `Works with Determined <https://github.com/determined-ai/works-with-determined>`__ repository
+Our `Works with Determined <https://github.com/determined-ai/works-with-determined>`__ repository
 includes examples of how to use Determined with a variety of ML ecosystem tools, including
 Pachyderm, DVC, Delta Lake, Seldon, Spark, Argo, Airflow, and Kubeflow.

--- a/docs/integrations/pachyderm/pachyderm.rst
+++ b/docs/integrations/pachyderm/pachyderm.rst
@@ -1,0 +1,12 @@
+##########
+ Pachyderm
+##########
+
+`Pachyderm <https://www.pachyderm.com/>`_ provides data-driven pipelines with version control and autoscaling that can be used alongside Determined. Pachyderm runs across all major cloud providers and on-premise installations. 
+
+- Use Pachyderm to store and version your data via repositories and pipelines
+- Use Determined to train your models on Pachyderm data
+
+.. tip::
+    
+    To get started with Pachyderm, visit the `Pachyderm documentation <https://docs.pachyderm.com/>`_.


### PR DESCRIPTION
Problem domain: Determined users cannot find the Pachyderm documentation when visiting the Determined docs.

Solution: Introduce users to the concept of using pachyderm alongside determined, ensuring users can find "pachyderm" when using the Algolia search by and can access the Pachyderm documentation.

