### PR TITLE
chore: update determined cli to handle timestamp format for external jobs

### DIFF
--- a/harness/determined/cli/job.py
+++ b/harness/determined/cli/job.py
@@ -77,9 +77,10 @@ def ls(args: Namespace) -> None:
             j.type.value,
             computed_job_name(j) if isinstance(j, bindings.v1Job) else render.OMITTED_VALUE,
             j.priority if is_priority else j.weight,
-            pytz.utc.localize(
-                datetime.strptime(j.submissionTime.split(".")[0], "%Y-%m-%dT%H:%M:%S")
-            )
+            # submissionTime is of the format 2022-12-31T23:59:59.999999Z for DeterminedAI jobs and
+            # 2022-12-31T23:59:59Z for External jobs. We only need first 19 characters to
+            # process the timestamp in both the cases.
+            pytz.utc.localize(datetime.strptime(j.submissionTime[:19], "%Y-%m-%dT%H:%M:%S"))
             if isinstance(j, bindings.v1Job)
             else render.OMITTED_VALUE,
             f"{j.allocatedSlots}/{j.requestedSlots}",

--- a/harness/determined/cli/job.py
+++ b/harness/determined/cli/job.py
@@ -1,5 +1,4 @@
 from argparse import ONE_OR_MORE, Namespace
-from datetime import datetime
 from typing import Any, List, Union
 
 import pytz
@@ -9,6 +8,7 @@ from determined.cli import render
 from determined.common import api, yaml
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd, Group
+from determined.common.util import parse_protobuf_timestamp
 
 
 def parse_jobv2_resp(
@@ -77,10 +77,7 @@ def ls(args: Namespace) -> None:
             j.type.value,
             computed_job_name(j) if isinstance(j, bindings.v1Job) else render.OMITTED_VALUE,
             j.priority if is_priority else j.weight,
-            # submissionTime is of the format 2022-12-31T23:59:59.999999Z for DeterminedAI jobs and
-            # 2022-12-31T23:59:59Z for External jobs. We only need first 19 characters to
-            # process the timestamp in both the cases.
-            pytz.utc.localize(datetime.strptime(j.submissionTime[:19], "%Y-%m-%dT%H:%M:%S"))
+            pytz.utc.localize(parse_protobuf_timestamp(j.submissionTime))
             if isinstance(j, bindings.v1Job)
             else render.OMITTED_VALUE,
             f"{j.allocatedSlots}/{j.requestedSlots}",

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -210,7 +210,7 @@ def parse_protobuf_timestamp(ts: str) -> datetime.datetime:
         ts = ts[:-1] + "+00:00"
     # Remove the [milli,micro,nano]seconds portion from the timestamp because
     # fromisoformat cannot process nanoseconds and we do not other values either.
-    re.sub("\\..*?\\+", "", ts)
+    re.sub("\\.[0-9]*\\+", "+", ts)
     return datetime.datetime.fromisoformat(ts)
 
 

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import platform
 import random
+import re
 import sys
 import time
 import warnings
@@ -207,6 +208,9 @@ def parse_protobuf_timestamp(ts: str) -> datetime.datetime:
     # [2] https://bugs.python.org/issue35829
     if ts.endswith("Z"):
         ts = ts[:-1] + "+00:00"
+    # Remove the [milli,micro,nano]seconds portion from the timestamp because
+    # fromisoformat cannot process nanoseconds and we do not other values either.
+    re.sub("\\..*?\\+", "", ts)
     return datetime.datetime.fromisoformat(ts)
 
 

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -220,22 +220,22 @@ def parse_protobuf_timestamp(ts: str) -> datetime.datetime:
     # [4] https://bugs.python.org/issue35829
     # [5] https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220/27
     #
-    # Workaround for restriction 1 - replace UTC timezone indicator "Z" with "+00:00"
+    # Workaround for restriction 1 - replace UTC timezone indicator "Z" with "+00:00".
     if ts.endswith("Z"):
         ts = ts[:-1] + "+00:00"
-    # Workaround for restriction 2 - remove any sub-second portion in the timestamp string
+    # Workaround for restriction 2 - remove any sub-second portion in the timestamp string.
     # Below are the list of examples demonstrating that the regex implementation is safe:
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45.242391275+00:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45.242391275+00:00")
     # '2023-08-22T22:06:45+00:00'
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45.242391275+06:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45.242391275+06:00")
     # '2023-08-22T22:06:45+06:00'
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45.242391275-06:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45.242391275-06:00")
     # '2023-08-22T22:06:45-06:00'
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45.242391+00:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45.242391+00:00")
     # '2023-08-22T22:06:45+00:00'
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45.242+00:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45.242+00:00")
     # '2023-08-22T22:06:45+00:00'
-    # >>> re.sub(r'\.[0-9]*', "", "2023-08-22T22:06:45+00:00")
+    # >>> re.sub(r"\.[0-9]*", "", "2023-08-22T22:06:45+00:00")
     # '2023-08-22T22:06:45+00:00'
     re.sub(r"\.[0-9]*", "", ts)
     return datetime.datetime.fromisoformat(ts)

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -209,7 +209,7 @@ def parse_protobuf_timestamp(ts: str) -> datetime.datetime:
     if ts.endswith("Z"):
         ts = ts[:-1] + "+00:00"
     # Remove the [milli,micro,nano]seconds portion from the timestamp because
-    # fromisoformat cannot process nanoseconds and we do not other values either.
+    # fromisoformat cannot process nanoseconds and we do not use other values either.
     re.sub("\\.[0-9]*\\+", "+", ts)
     return datetime.datetime.fromisoformat(ts)
 


### PR DESCRIPTION
## Description

When displaying the list of jobs, DeterminedAI CLI splits the provided job submission timestamp on a dot(`.`). This works fine for DeterminedAI-provided timestamps which are of the format `2022-12-31T23:59:59.999999Z`. But, this code crashes when the timestamp is in another format like in the case of external jobs the timestamp format is `2022-12-31T23:59:59Z`. In either case, we only need the first 19 characters to create the timestamp. So, updated the code to use only the first 19 characters.

## Test Plan
Tested manually using EE repo.
```
jagadeesh.madagundi@C02FJ10GMD6Q cifar10_pytorch % det job list
   # | ID                                   | Type            | Job Name                    |   Weight | Submitted                 | Slots (acquired/needed)   | State           | User
-----+--------------------------------------+-----------------+-----------------------------+----------+---------------------------+---------------------------+-----------------+------------
   0 | af85b655-3c0e-4e04-8a21-751322d66e0e | TYPE_EXPERIMENT | cifar10_pytorch_const (742) |        1 | 2023-08-15 22:20:32+00:00 | 1/1                       | STATE_SCHEDULED | determined
   1 | 3ee09ccb-d2fb-4536-87f8-7b0603cfd6d1 | TYPE_EXPERIMENT | cifar10_pytorch_const (743) |        1 | 2023-08-15 22:20:42+00:00 | 1/1                       | STATE_SCHEDULED | determined
   0 | 840                                  | TYPE_EXTERNAL   | hello_world_sleep           |        0 | 2023-08-15 22:20:36+00:00 | 1/1                       | STATE_SCHEDULED | madagund
   0 | 842                                  | TYPE_EXTERNAL   | hello_world_sleep           |        0 | 2023-08-15 22:20:45+00:00 | 0/1                       | STATE_QUEUED    | madagund
jagadeesh.madagundi@C02FJ10GMD6Q cifar10_pytorch % 
```


## Checklist
- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
FE-23