### PR TITLE
fix: default pools editable and submittable (#7647)

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/set"
 
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -430,6 +431,44 @@ func (a *apiServer) PatchWorkspace(
 	if req.Workspace.DefaultAuxResourcePool != nil {
 		updatedWorkspace.DefaultAuxPool = *req.Workspace.DefaultAuxResourcePool
 		insertColumns = append(insertColumns, "default_aux_pool")
+	}
+
+	if req.Workspace.DefaultComputeResourcePool != nil ||
+		req.Workspace.DefaultAuxResourcePool != nil {
+		if err = workspace.AuthZProvider.Get().
+			CanSetWorkspacesDefaultPools(ctx, currUser, currWorkspace); err != nil {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+
+		rpConfigs, err := a.resourcePoolsAsConfigs()
+		if err != nil {
+			return nil, err
+		}
+		rpNamesSlice, _, err := db.ReadRPsAvailableToWorkspace(
+			ctx, currWorkspace.Id, 0, -1, rpConfigs,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		rpNames := set.FromSlice(append(rpNamesSlice, ""))
+
+		if req.Workspace.DefaultComputeResourcePool != nil {
+			if !rpNames.Contains(*req.Workspace.DefaultComputeResourcePool) {
+				return nil, status.Error(codes.FailedPrecondition, "unable to bind a resource "+
+					"pool that does not exist or is not available to the workspace")
+			}
+			updatedWorkspace.DefaultComputePool = *req.Workspace.DefaultComputeResourcePool
+			insertColumns = append(insertColumns, "default_compute_pool")
+		}
+		if req.Workspace.DefaultAuxResourcePool != nil {
+			if !rpNames.Contains(*req.Workspace.DefaultAuxResourcePool) {
+				return nil, status.Error(codes.FailedPrecondition, "unable to bind a resource "+
+					"pool that does not exist or is not available to the workspace")
+			}
+			updatedWorkspace.DefaultAuxPool = *req.Workspace.DefaultAuxResourcePool
+			insertColumns = append(insertColumns, "default_aux_pool")
+		}
 	}
 
 	if req.Workspace.CheckpointStorageConfig != nil {

--- a/master/internal/mocks/workspace_authz_iface.go
+++ b/master/internal/mocks/workspace_authz_iface.go
@@ -173,6 +173,20 @@ func (_m *WorkspaceAuthZ) CanSetWorkspacesCheckpointStorageConfig(ctx context.Co
 	return r0
 }
 
+// CanSetWorkspacesDefaultPools provides a mock function with given fields: ctx, curUser, _a2
+func (_m *WorkspaceAuthZ) CanSetWorkspacesDefaultPools(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) error {
+	ret := _m.Called(ctx, curUser, _a2)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, model.User, *workspacev1.Workspace) error); ok {
+		r0 = rf(ctx, curUser, _a2)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CanSetWorkspacesName provides a mock function with given fields: ctx, curUser, _a2
 func (_m *WorkspaceAuthZ) CanSetWorkspacesName(ctx context.Context, curUser model.User, _a2 *workspacev1.Workspace) error {
 	ret := _m.Called(ctx, curUser, _a2)

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -119,10 +119,7 @@ func (a ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := a.ValidateResourcePool(actorCtx, defaultAuxPool); err != nil {
-			return "", fmt.Errorf("validating default aux pool: %w", err)
-		}
-		return defaultAuxPool, nil
+		name = defaultAuxPool
 	}
 
 	if name == "" && slots >= 0 {
@@ -134,10 +131,7 @@ func (a ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := a.ValidateResourcePool(actorCtx, defaultComputePool); err != nil {
-			return "", fmt.Errorf("validating default compute pool: %w", err)
-		}
-		return defaultComputePool, nil
+		name = defaultComputePool
 	}
 
 	resp, err := a.GetResourcePools(actorCtx, &apiv1.GetResourcePoolsRequest{})

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -104,10 +104,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := k.ValidateResourcePool(actorCtx, defaultAuxPool); err != nil {
-			return "", fmt.Errorf("validating default aux pool: %w", err)
-		}
-		return defaultAuxPool, nil
+		name = defaultAuxPool
 	}
 
 	if name == "" && slots >= 0 {
@@ -119,10 +116,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp.PoolName, nil
 		}
-		if err := k.ValidateResourcePool(actorCtx, defaultComputePool); err != nil {
-			return "", fmt.Errorf("validating default compute pool: %w", err)
-		}
-		return defaultComputePool, nil
+		name = defaultComputePool
 	}
 
 	resp, err := k.GetResourcePools(actorCtx, &apiv1.GetResourcePoolsRequest{})

--- a/master/internal/workspace/authz_basic_impl.go
+++ b/master/internal/workspace/authz_basic_impl.go
@@ -158,6 +158,13 @@ func (a *WorkspaceAuthZBasic) CanCreateWorkspaceWithCheckpointStorageConfig(
 	return nil
 }
 
+// CanSetWorkspacesDefaultPools returns a nil error.
+func (a *WorkspaceAuthZBasic) CanSetWorkspacesDefaultPools(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	return nil
+}
+
 func init() {
 	AuthZProvider.Register("basic", &WorkspaceAuthZBasic{})
 }

--- a/master/internal/workspace/authz_iface.go
+++ b/master/internal/workspace/authz_iface.go
@@ -55,6 +55,10 @@ type WorkspaceAuthZ interface {
 	CanSetWorkspacesCheckpointStorageConfig(
 		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 	) error
+	CanSetWorkspacesDefaultPools(
+		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	) error
+	// TODO: we should consider userID as an arg instead of model.User
 
 	// DELETE /api/v1/workspaces/:workspace_id
 	CanDeleteWorkspace(


### PR DESCRIPTION
## Description
Pulls the same changes as #7647 but applies to main instead of release branch. The main difference between the this PR and 7647 is the `req.Workspace.DefaultComputeResourcePool` and `req.Workspace.DefaultAuxResourcePool` fields, which are new and of type *string instead of string. The logic has been changed slightly to account for the nil case. 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
This PR included multiple fixes, but most have been tested in the previous release party. The only part that requires testing is setting default resource pools for a workspace.

Using a privileged user (clusterAdmin or workspaceAdmin permissions), verify that you can set a default compute and aux pool for a workspace using both the CLI and WebUI. 

CLI command: `det w edit <name> --default-compute-pool <name> --default-aux-pool <name>`. 

WebUI: navigate to the desired workspace and click on the `resource pools` tab. Find the resource pool you want to set as the default, click on the meatball menu ( ". . . " ), and select set as default compute or default aux pool.

For both cases, verify that the pool has become the default pool by submitting an experiment or task to it.

Lastly, verify that an unprivileged user (workspace editor/viewer) does not have the ability to make those changes.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
