### PR TITLE
chore: limit ROCM device discovery

### DIFF
--- a/agent/internal/detect/rocm.go
+++ b/agent/internal/detect/rocm.go
@@ -97,6 +97,8 @@ func parseRocmSmi(jsonData []byte) ([]RocmDevice, error) {
 	return result, nil
 }
 
+// deviceAllocated returns true if the specified device is within the set of resources
+// allocated to the process.
 func deviceAllocated(deviceIndex int, allocatedDevices []string) bool {
 	if allocatedDevices == nil {
 		return true
@@ -109,6 +111,7 @@ func deviceAllocated(deviceIndex int, allocatedDevices []string) bool {
 	return false
 }
 
+// parseVisibleDevices returns as a slice the content of ROCR_VISIBLE_DEVICES.
 func parseVisibleDevices() []string {
 	devices, found := os.LookupEnv("ROCR_VISIBLE_DEVICES")
 	if !found {

--- a/agent/internal/detect/rocm_test.go
+++ b/agent/internal/detect/rocm_test.go
@@ -49,3 +49,47 @@ func TestRocmSmiParser(t *testing.T) {
 	assert.Equal(t, len(result), 4)
 	assert.Equal(t, result[1].UUID, "0x6be2ee3b2b314cfc")
 }
+
+func Test_deviceAllocated(t *testing.T) {
+	type args struct {
+		deviceIndex      int
+		allocatedDevices []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "VISIBLE_DEVICES not defined",
+			args: args{
+				deviceIndex:      0,
+				allocatedDevices: nil,
+			},
+			want: true,
+		},
+		{
+			name: "Device allocated",
+			args: args{
+				deviceIndex:      0,
+				allocatedDevices: []string{"0", "1"},
+			},
+			want: true,
+		},
+		{
+			name: "Device not allocated",
+			args: args{
+				deviceIndex:      2,
+				allocatedDevices: []string{"0", "1"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deviceAllocated(tt.args.deviceIndex, tt.args.allocatedDevices); got != tt.want {
+				t.Errorf("deviceAllocated() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
[FE-173]
In an HPC environment, certain GPU resources allocated to a job will be described by the environment variable `ROCR_VISIBLE_DEVICES`. Depending on how the WLM is configured, GPUs outside of this set may still be visible to the job however, so we are making a small change to agent device discovery to limit the GPU slots reported to the master to those described by ROCR_VISIBLE_DEVICES (if defined).

This change affects only ROCM device discovery; a similar issue in CUDA device discovery was recently addressed in FE-172.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
The following srun command requests five GPUs. This causes three nodes to be allocated. Although the agents discover all twelve of the GPUs hosted by these nodes, only those allocated to the respective agent processes are reported to the master.

`gaisford@o184i054:~$ srun --gpus=5 -p mlde_rocm /home/gaisford/determined-agent --master-host=o184i054.gre.smktg.hpecorp.net  --master-port=8086 --resource-pool=default --container-runtime=singularity --slot-type=rocm`

Agent log excerpts follow:

```
INFO[2023-08-17T22:46:03+02:00] connecting to master at: ws://o184i054.gre.smktg.hpecorp.net:8086/agents?id=o186i122&version=0.24.0-dev0&resource_pool=default&reconnect=false  component=agent
…
INFO[2023-08-17T22:46:03+02:00] Rocm driver version: 6.0.5                   
TRAC[2023-08-17T22:46:04+02:00] ROCR_VISIBLE_DEVICES: '0'                    
TRAC[2023-08-17T22:46:04+02:00] Device not allocated: 1                      
INFO[2023-08-17T22:46:04+02:00] detected compute devices:                    
INFO[2023-08-17T22:46:04+02:00] 	rocm0 (Advanced Micro Devices, Inc. [AMD/ATI]) 
TRAC[2023-08-17T22:46:04+02:00] setting up singularity runtime                component=agent

INFO[2023-08-17T22:46:03+02:00] connecting to master at: ws://o184i054.gre.smktg.hpecorp.net:8086/agents?id=o186i123&version=0.24.0-dev0&resource_pool=default&reconnect=false  component=agent
…
TRAC[2023-08-17T22:46:08+02:00] detecting devices                             component=agent
INFO[2023-08-17T22:46:08+02:00] Rocm driver version: 6.0.5                   
TRAC[2023-08-17T22:46:08+02:00] ROCR_VISIBLE_DEVICES: '0'                    
TRAC[2023-08-17T22:46:08+02:00] Device not allocated: 1                      
INFO[2023-08-17T22:46:08+02:00] detected compute devices:                    
INFO[2023-08-17T22:46:08+02:00] 	rocm0 (Advanced Micro Devices, Inc. [AMD/ATI]) 
TRAC[2023-08-17T22:46:08+02:00] setting up singularity runtime                component=agent
…
INFO[2023-08-17T22:46:06+02:00] connecting to master at: ws://o184i054.gre.smktg.hpecorp.net:8086/agents?id=o184i082&version=0.24.0-dev0&resource_pool=default&reconnect=false  component=agent
…
TRAC[2023-08-17T22:46:11+02:00] ROCR_VISIBLE_DEVICES: '0,1,2'                
TRAC[2023-08-17T22:46:11+02:00] Device not allocated: 5                      
TRAC[2023-08-17T22:46:11+02:00] Device not allocated: 6                      
TRAC[2023-08-17T22:46:11+02:00] Device not allocated: 7                      
TRAC[2023-08-17T22:46:11+02:00] Device not allocated: 3                      
TRAC[2023-08-17T22:46:11+02:00] Device not allocated: 4                      
INFO[2023-08-17T22:46:11+02:00] detected compute devices:                    
INFO[2023-08-17T22:46:11+02:00] 	rocm0 (Advanced Micro Devices, Inc. [AMD/ATI]) 
INFO[2023-08-17T22:46:11+02:00] 	rocm1 (Advanced Micro Devices, Inc. [AMD/ATI]) 
INFO[2023-08-17T22:46:11+02:00] 	rocm2 (Advanced Micro Devices, Inc. [AMD/ATI]) 
TRAC[2023-08-17T22:46:11+02:00] setting up singularity runtime                component=agent

```
And Determined sees only the slots allocated by Slurm:

```
(dai-ee) % det s list  
 Agent ID   | Resource Pool   |   Slot ID | Enabled   | Draining   | Allocation ID   | Task Name   | Type   | Device
------------+-----------------+-----------+-----------+------------+-----------------+-------------+--------+----------------------------------------
 o184i082   | default         |         0 | True      | False      | FREE            | FREE        | rocm   | Advanced Micro Devices, Inc. [AMD/ATI]
 o184i082   | default         |         1 | True      | False      | FREE            | FREE        | rocm   | Advanced Micro Devices, Inc. [AMD/ATI]
 o184i082   | default         |         2 | True      | False      | FREE            | FREE        | rocm   | Advanced Micro Devices, Inc. [AMD/ATI]
 o186i122   | default         |         0 | True      | False      | FREE            | FREE        | rocm   | Advanced Micro Devices, Inc. [AMD/ATI]
 o186i123   | default         |         0 | True      | False      | FREE            | FREE        | rocm   | Advanced Micro Devices, Inc. [AMD/ATI]
(dai-ee) %
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
FE-173
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[FE-173]: https://hpe-aiatscale.atlassian.net/browse/FE-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ