### PR TITLE
fix: tensorflow version for macos

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,6 +27,7 @@ algoliasearch>=2.0,<3.0
 boto3>=1.24.4<2.0
 
 # build requirements
-tensorflow==2.12.0
+tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torch==1.11.0
 torchvision==0.12.0

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -9,7 +9,8 @@ deepspeed==0.8.3
 transformers>=4.8.2,<4.29.0
 torch==1.11.0
 torchvision==0.12.0
-tensorflow==2.12.0
+tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 attrdict3
 moto
 # Pydantic V2 has changes that break existing tests


### PR DESCRIPTION
## Description

When I moved some requirements out of `.circleci` and into our `requirements.txt` files, I didn't copy the architecture clause that was present in `e2e_tests/tests/requirements.txt`. This PR replaces all `tensorflow==2.12` with that clause instead.


## Test Plan

Requires 2 systems.

`pip install -r requirements.txt` for `docs/requirements.txt` and `harness/tests/requirements/requirements-harness.txt`

This should install `tensorflow==2.11` on MacOS, and `tensorflow==2.12` on other systems.

## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

