### PR TITLE
chore: unpin click version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 build
 black==23.3.0 # Note: this should be kept in sync with the version in `.pre-commit-config.yaml`.
-click<=8.0.4  # Unpin click after tensorflow update.
+click
 flake8==3.9.2 # Note: this should be kept in sync with the version in `.pre-commit-config.yaml`.
 flake8-bugbear>=19.8.0
 flake8-builtins>=1.5.3


### PR DESCRIPTION
## Description

Unpinning `click` package version as both our versions of `tensorflow` and `black` have been updated, which addresses the core reason for the version pin.


## Test Plan

ci passes linting tests



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-445