### PR TITLE
docs: work around bug causing version dropdown to fail

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ def env_get_outdated(app, env, added, changed, removed):
 
 def setup(app):
     app.connect("env-get-outdated", env_get_outdated)
+    app.set_html_assets_policy("always")
 
 
 exclude_patterns = [


### PR DESCRIPTION
## Description

Due to a rather unfortunate interaction between `sphinx-tabs` and the internals of Sphinx itself, simply including the former as an extension causes `pydata-sphinx-theme`'s version dropdown to break. This change deactivates the code that causes that to happen, at the cost of unnecessarily including the tabs-related CSS and JS files even on pages that don't need them.

The issue is that `sphinx-tabs` replaces one of Sphinx's internal data structures with a copy of itself in a callback [1] (well, two, but only one is relevant here). This seems like it probably ought to be fine, but Sphinx's HTML builder depends on two different places referencing the same object, which the copy breaks.

Inside Sphinx, `StandaloneHTMLBuilder` creates a `globalcontext` member variable, a `dict` whose value for the `"script_files"` key is the _same_ list object as the builder's own `script_files` member variable [2]. A shallow copy (still referencing the same list object) of this context object is created [3] and passed to the `"html-page-context"` callback of registered extensions [4], and the value of the context is used to construct the HTML output afterward [5].

`StandaloneHTMLBuilder.add_js_file` is the other place that references the same list object, via the original `script_files` member variable [6]; `pydata-sphinx-theme` calls it [7] to insert JavaScript code that sets the version switcher JSON URL that other JavaScript code [8] uses to fetch the list of versions for the dropdown. _Normally_, calling it also modifies the context object, because they are both looking at the same list object, so that the added JavaScript code appears in the final output. However, since `sphinx-tabs` has swapped out that list for a different object, that modification actually has no effect on the output, causing the version dropdown to break.

Calling `app.set_html_assets_policy("always")` tells `sphinx-tabs` not to modify the context object at all [9]; the intended effect is only about the tabs-related files, but, since it skips that entire chunk of code, it also avoids the replacement-with-a-copy that caused this issue.

This should perhaps be reported as a bug in Sphinx and/or `sphinx-tabs`, but since there is a workaround, I wanted to get it in and not have to wait on either of those projects.

In conclusion, aliasing is terrible.

[1] https://github.com/executablebooks/sphinx-tabs/blob/v3.4.1/sphinx_tabs/tabs.py#L333
[2] https://github.com/sphinx-doc/sphinx/blob/v4.2.0/sphinx/builders/html/__init__.py#L518
[3] https://github.com/sphinx-doc/sphinx/blob/v4.2.0/sphinx/builders/html/__init__.py#L987
[4] https://github.com/sphinx-doc/sphinx/blob/v4.2.0/sphinx/builders/html/__init__.py#L1033
[5] https://github.com/sphinx-doc/sphinx/blob/v4.2.0/sphinx/builders/html/__init__.py#L1055
[6] https://github.com/sphinx-doc/sphinx/blob/v4.2.0/sphinx/builders/html/__init__.py#L336
[7] https://github.com/pydata/pydata-sphinx-theme/blob/v0.13.3/src/pydata_sphinx_theme/__init__.py#L277
[8] https://github.com/pydata/pydata-sphinx-theme/blob/v0.13.3/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js#L310
[9] https://github.com/executablebooks/sphinx-tabs/blob/v3.4.1/sphinx_tabs/tabs.py#L323

## Test Plan

- test the dropdown locally with and without this change (note that this requires (1) removing the code in `_templates/sidebar-version.html` that wipes out the version switcher except on `docs.determined.ai/latest` and (2) changing the switcher JSON URL in `conf.py` to a relative one (since `docs.determined.ai` evidently does not have CORS set up) and testing on a page that is not under any subdirectories, e.g., `/release-notes.html`)

## Commentary

Do we really want to wipe out the version switcher except on `docs.determined.ai/latest`? Seems useful to have even on older versions.

## Alternatives

One alternative to [sphinx tabs](https://sphinx-tabs.readthedocs.io/en/latest/) is the [sphinx design plugin](https://pypi.org/project/sphinx_design/). We attempted to install this and ended up reversing it (see [DET-9607](https://hpe-aiatscale.atlassian.net/browse/DET-9607)). However, we've since realized there may have been a resolution that we did not try. 

[DET-9607]: https://hpe-aiatscale.atlassian.net/browse/DET-9607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ