### PR TITLE
feat: check if default resource pools are bound

### DIFF
--- a/master/internal/db/postgres_rp_workspace_bindings.go
+++ b/master/internal/db/postgres_rp_workspace_bindings.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/determined-ai/determined/master/pkg/set"
 
@@ -322,4 +323,18 @@ func GetDefaultPoolsForWorkspace(ctx context.Context, workspaceID int,
 	}
 
 	return target.DefaultComputePool, target.DefaultAuxPool, nil
+}
+
+// CheckIfRPUnbound checks to make sure the specified resource pools is not bound to any workspace
+// and returns an error if it is.
+func CheckIfRPUnbound(poolName string) error {
+	exists, err := Bun().NewSelect().Table("rp_workspace_bindings").
+		Where("pool_name = ?", poolName).
+		Exists(context.TODO())
+	if err != nil {
+		return err
+	} else if exists {
+		return fmt.Errorf("default resource pool %s can not be bound to any workspaces", poolName)
+	}
+	return nil
 }


### PR DESCRIPTION
## Description
Prevents a cluster from starting up if the specified default resource pools have bindings to workspaces.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Start a cluster, create a workspace, and bind one of your resource pools to the workspace. Go into the config and set:
```
...
  resource_manager:
      ...
      default_compute_resource_pool: <name of the bound pool>
...
```

Attempt to start the cluster up again and see that it fails. Repeat the same with `default_aux_resource_pool`.
Try this with a different resource pool (and with no default resource pools specified) and make sure it succeeds.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
