### PR TITLE
fix: Continue Trial modal does not reset mode [WEB-1566]

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -340,7 +340,7 @@ const ExperimentCreateModalComponent = ({
         config: publicConfig,
         configString: yaml.dump(publicConfig),
         experiment,
-        isAdvancedMode: false,
+        isAdvancedMode: prev.isAdvancedMode,
         open: true,
         trial,
         type,

--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -340,7 +340,6 @@ const ExperimentCreateModalComponent = ({
         ...prev,
         config: publicConfig,
         experiment,
-        isAdvancedMode: prev.isAdvancedMode,
         open: true,
         trial,
         type,

--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -337,8 +337,8 @@ const ExperimentCreateModalComponent = ({
     };
     setModalState((prev) => {
       const newModalState = {
+        ...prev,
         config: publicConfig,
-        configString: yaml.dump(publicConfig),
         experiment,
         isAdvancedMode: prev.isAdvancedMode,
         open: true,


### PR DESCRIPTION
## Description

Keeps Continue Trial modal's state, by reducing changes from a `useEffect` based on experiment / trial update.

Confirmed @hkang1 's comment about polling during incomplete experiment was resetting the modal

## Test Plan

Go to `/det/experiments/3698/overview` to see a paused experiment which continues polling
Click "Continue Trial" and select "Show Full Config" to open the custom YAML modal
Enter custom text into the custom YAML textbox (such as making another version for image / cpu, doesn't need to be accurate)
Confirm after 20-30 seconds that the modal and its textbox are unchanged
Click Continue Trial and confirm the new experiment has your custom config

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.