### PR TITLE
fix: add type check to pod spec merge

### DIFF
--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -126,7 +126,7 @@ func mergeCustomSpecs(
 	config map[string]interface{},
 	cp map[string]interface{},
 ) map[string]interface{} {
-	if conf, ok := cp["task_container_defaults"]; ok {
+	if conf, ok := cp["task_container_defaults"].(interface{}); ok {
 		if cpu, ok := conf.(map[string]interface{})["cpu_pod_spec"]; ok {
 			config["task_container_defaults"].(map[string]interface{})["cpu_pod_spec"] = cpu
 		}

--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -126,11 +126,11 @@ func mergeCustomSpecs(
 	config map[string]interface{},
 	cp map[string]interface{},
 ) map[string]interface{} {
-	if conf, ok := cp["task_container_defaults"].(interface{}); ok {
-		if cpu, ok := conf.(map[string]interface{})["cpu_pod_spec"]; ok {
+	if conf, ok := cp["task_container_defaults"].(map[string]interface{}); ok {
+		if cpu, ok := conf["cpu_pod_spec"]; ok {
 			config["task_container_defaults"].(map[string]interface{})["cpu_pod_spec"] = cpu
 		}
-		if gpu, ok := conf.(map[string]interface{})["gpu_pod_spec"]; ok {
+		if gpu, ok := conf["gpu_pod_spec"]; ok {
 			config["task_container_defaults"].(map[string]interface{})["gpu_pod_spec"] = gpu
 		}
 	}


### PR DESCRIPTION
## Description
This fixes a crash when 'task_container_defaults' isn't fully specified in config.


## Test Plan
Run these changes in a test branch & spin up a devcluster _with_ `task_container_defaults` & `cpuSpec` defined, with _only_ `task_container_defaults` defined, and without `task_container_defaults`.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
FE-176