### PR TITLE
fix: patch workspace has duplicate update statements

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -424,15 +424,6 @@ func (a *apiServer) PatchWorkspace(
 		insertColumns = append(insertColumns, "uid", "user_", "gid", "group_")
 	}
 
-	if req.Workspace.DefaultComputeResourcePool != nil {
-		updatedWorkspace.DefaultComputePool = *req.Workspace.DefaultComputeResourcePool
-		insertColumns = append(insertColumns, "default_compute_pool")
-	}
-	if req.Workspace.DefaultAuxResourcePool != nil {
-		updatedWorkspace.DefaultAuxPool = *req.Workspace.DefaultAuxResourcePool
-		insertColumns = append(insertColumns, "default_aux_pool")
-	}
-
 	if req.Workspace.DefaultComputeResourcePool != nil ||
 		req.Workspace.DefaultAuxResourcePool != nil {
 		if err = workspace.AuthZProvider.Get().


### PR DESCRIPTION
## Description
Previous updates to workspace update had inadvertently left a double update when setting default resource pools. As a result, the db update was failing due to "multiple assignments to same column". This fixes it.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Use the webui (workspaces -> select a workspace -> resource pools -> set as a default) and make sure it succeeds. Or use the cli: `det w edit <workspace name> --default-compute-pool <pool name> --default-aux-pool <pool name>`. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
