### PR TITLE
fix: add unit test cases for mapx methods Values and Clear

### DIFF
--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -14,7 +14,7 @@ func FuzzMap(f *testing.F) {
 
 	f.Add(uint8(0), uint8(0), "hello")
 	f.Fuzz(func(t *testing.T, op, k uint8, v string) {
-		switch op % 5 {
+		switch op % 7 {
 		case 0:
 			m.Len()
 		case 1:
@@ -28,6 +28,10 @@ func FuzzMap(f *testing.F) {
 			m.WithLock(func(m map[uint8]string) {
 				_ = maps.Keys(m)
 			})
+		case 5:
+			_ = m.Values()
+		case 6:
+			m.Clear()
 		}
 	})
 }

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -3,6 +3,7 @@ package mapx
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/maps"
 )
 
@@ -34,4 +35,33 @@ func FuzzMap(f *testing.F) {
 			m.Clear()
 		}
 	})
+}
+
+func TestMapx(t *testing.T) {
+	tests := []struct {
+		k string
+		v string
+	}{
+		{"1234", "hi"},
+		{"1235", "hello"},
+		{"1236", "world"},
+	}
+	testMap := New[string, string]()
+	for _, tt := range tests {
+		t.Run(tt.k, func(t *testing.T) {
+			testMap.Store(tt.k, tt.v)
+		})
+	}
+	assert.Equal(t, len(tests), testMap.Len())
+	value, _ := testMap.Load("1235")
+	assert.Equal(t, "hello", value)
+	testMap.Delete("1235")
+	expectedValueList := [...]string{"hi", "world"}
+	valueList := testMap.Values()
+	assert.Equal(t, 2, testMap.Len())
+	for i, v := range valueList {
+		assert.Equal(t, expectedValueList[i], v)
+	}
+	testMap.Clear()
+	assert.Equal(t, 0, testMap.Len())
 }

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -1,6 +1,7 @@
 package mapx
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,7 @@ func TestMapx(t *testing.T) {
 	expectedValueList := [...]string{"hi", "world"}
 	valueList := testMap.Values()
 	assert.Equal(t, 2, testMap.Len())
+	sort.Strings(valueList)
 	for i, v := range valueList {
 		assert.Equal(t, expectedValueList[i], v)
 	}

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -49,9 +49,7 @@ func TestMapx(t *testing.T) {
 	}
 	testMap := New[string, string]()
 	for _, tt := range tests {
-		t.Run(tt.k, func(t *testing.T) {
-			testMap.Store(tt.k, tt.v)
-		})
+		testMap.Store(tt.k, tt.v)
 	}
 	assert.Equal(t, len(tests), testMap.Len())
 	value, _ := testMap.Load("1235")


### PR DESCRIPTION
## Description

fix: add unit test cases for `mapx` methods `Values()` and `Clear()`


## Test Plan

Added unit test `TestMapx` to test all methods of `mapx`.

Test results for `FuzzMap` test before the fix in #7698 
```
jagadeesh.madagundi@C02FJ10GMD6Q mapx % go test -fuzz FuzzMap --parallel 64 .     
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
failure while testing seed corpus entry: FuzzMap/2fa92b628ed3b99b
fuzz: elapsed: 0s, gathering baseline coverage: 2/6 completed
--- FAIL: FuzzMap (0.20s)
    fuzzing process hung or terminated unexpectedly: exit status 2
FAIL
exit status 1
FAIL    github.com/determined-ai/determined/master/pkg/syncx/mapx       0.452s
jagadeesh.madagundi@C02FJ10GMD6Q mapx % go test -fuzz FuzzMap --parallel 64 .
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
failure while testing seed corpus entry: FuzzMap/2fa92b628ed3b99b
fuzz: elapsed: 0s, gathering baseline coverage: 2/6 completed
--- FAIL: FuzzMap (0.20s)
    fuzzing process hung or terminated unexpectedly: exit status 2
FAIL
exit status 1
FAIL    github.com/determined-ai/determined/master/pkg/syncx/mapx       0.359s
jagadeesh.madagundi@C02FJ10GMD6Q mapx % go test -fuzz FuzzMap --parallel 64 .
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
failure while testing seed corpus entry: FuzzMap/2fa92b628ed3b99b
fuzz: elapsed: 0s, gathering baseline coverage: 1/6 completed
--- FAIL: FuzzMap (0.19s)
    fuzzing process hung or terminated unexpectedly: exit status 2
FAIL
exit status 1
FAIL    github.com/determined-ai/determined/master/pkg/syncx/mapx       0.350s
jagadeesh.madagundi@C02FJ10GMD6Q mapx % go test -fuzz FuzzMap --parallel 64 .
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
failure while testing seed corpus entry: FuzzMap/2fa92b628ed3b99b
fuzz: elapsed: 0s, gathering baseline coverage: 5/6 completed
--- FAIL: FuzzMap (0.20s)
    fuzzing process hung or terminated unexpectedly: exit status 2
FAIL
exit status 1
FAIL    github.com/determined-ai/determined/master/pkg/syncx/mapx       0.361s
```
Test result for `FuzzMap` after the fix in #7698 
```
jagadeesh.madagundi@C02FJ10GMD6Q mapx % go test -fuzz FuzzMap --parallel 64 .
fuzz: elapsed: 0s, gathering baseline coverage: 0/6 completed
fuzz: elapsed: 0s, gathering baseline coverage: 6/6 completed, now fuzzing with 64 workers
fuzz: elapsed: 3s, execs: 634793 (211564/sec), new interesting: 10 (total: 16)
fuzz: elapsed: 6s, execs: 1373924 (246412/sec), new interesting: 11 (total: 17)
fuzz: elapsed: 9s, execs: 2034932 (220325/sec), new interesting: 11 (total: 17)
fuzz: elapsed: 12s, execs: 2765836 (243640/sec), new interesting: 11 (total: 17)
fuzz: elapsed: 15s, execs: 3486807 (240285/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 18s, execs: 4227645 (246992/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 21s, execs: 4932707 (234976/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 24s, execs: 5636448 (234625/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 27s, execs: 6355728 (239763/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 30s, execs: 7056443 (233565/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 33s, execs: 7767889 (237145/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 36s, execs: 8462556 (231559/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 39s, execs: 9155857 (231101/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 42s, execs: 9860776 (234943/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 45s, execs: 10540511 (226586/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 48s, execs: 11212534 (223992/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 51s, execs: 11894719 (227433/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 54s, execs: 12543624 (216303/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 57s, execs: 13143762 (200038/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 1m0s, execs: 13762971 (206411/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 1m3s, execs: 14428161 (221731/sec), new interesting: 12 (total: 18)
...
fuzz: elapsed: 6m57s, execs: 85434309 (189358/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 7m0s, execs: 86001824 (189174/sec), new interesting: 12 (total: 18)
fuzz: elapsed: 7m3s, execs: 86546703 (181626/sec), new interesting: 12 (total: 18)
^Cfuzz: elapsed: 7m4s, execs: 86701407 (156272/sec), new interesting: 12 (total: 18)
PASS
ok      github.com/determined-ai/determined/master/pkg/syncx/mapx       424.533s
```


## Commentary (optional)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[FE-23](https://hpe-aiatscale.atlassian.net/browse/FE-23)



[FE-23]: https://hpe-aiatscale.atlassian.net/browse/FE-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ