### PR TITLE
fix: allow NodeInformer to fail with permission error [DET-9772]

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -273,7 +273,6 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		}
 
 		k.podsActor = Initialize(
-			ctx,
 			ctx.Self().System(),
 			k.echoRef,
 			ctx.Self(),

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -273,6 +273,7 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		}
 
 		k.podsActor = Initialize(
+			ctx,
 			ctx.Self().System(),
 			k.echoRef,
 			ctx.Self(),

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -204,7 +204,7 @@ func Initialize(
 	err = p.startNodeInformer()
 	switch {
 	case err != nil && k8error.IsForbidden(err):
-		p.syslog.Warnf("unable to start node informer due to permission error: %s", err)
+		p.syslog.Warnf("unable to start node informer due to permission error, some features will be degraded: %s", err)
 	case err != nil:
 		panic(err)
 	}

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -133,6 +134,7 @@ type reattachPodResponse struct {
 
 // Initialize creates a new global pods actor.
 func Initialize(
+	ctx *actor.Context,
 	s *actor.System,
 	e *echo.Echo,
 	c *actor.Ref,
@@ -202,7 +204,11 @@ func Initialize(
 
 	err = p.startNodeInformer()
 	if err != nil {
-		panic(err)
+		if strings.Contains(err.Error(), "nodes is forbidden") {
+			ctx.Log().Warnf("unable to start node informer due to permission error: %s", err)
+		} else {
+			panic(err)
+		}
 	}
 
 	err = p.startEventListeners(s)

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -204,7 +204,9 @@ func Initialize(
 	err = p.startNodeInformer()
 	switch {
 	case err != nil && k8error.IsForbidden(err):
-		p.syslog.Warnf("unable to start node informer due to permission error, some features will be degraded: %s", err)
+		p.syslog.Warnf("unable to start node informer due to permission error,"+
+			"some features will be degraded: %s", err,
+		)
 	case err != nil:
 		panic(err)
 	}

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -202,10 +202,11 @@ func Initialize(
 	}
 
 	err = p.startNodeInformer()
-	if err != nil && !k8error.IsForbidden(err) {
-		panic(err)
-	} else if err != nil {
+	switch {
+	case err != nil && k8error.IsForbidden(err):
 		p.syslog.Warnf("unable to start node informer due to permission error: %s", err)
+	case err != nil:
+		panic(err)
 	}
 
 	err = p.startEventListeners(s)


### PR DESCRIPTION
## Description
When a k8's NodeInformer fails to list nodes on initialization due to a permission error, instead of panic'ing the expected behavior is to allow the failure and log a warning that the the node informer failed due to a permission error. 

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Change the following snippit from `helm/charts/determined/templates/master-permissions.yaml`:
Current:
```
  - apiGroups: [""]
    resources: ["nodes", "events"]
    verbs: ["list", "watch"]
```
Change to:
```
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["list", "watch"]
```
- Spin up a GKE environment (using the [Runbook](https://hpe-aiatscale.atlassian.net/wiki/spaces/ENGINEERIN/pages/1339359245/Runbook+Developing+Determined+with+Kubernetes))
    - determined may not properly be installed in the cluster since the permissions will fail, if so you'll need to clone the determined repo into the cluster & run `make get-deps`
- Run `devcluster --no-guess-host`
- Confirm there is a warning stating that NodeInformer failed due to a permission warning:
```
"unable to start node informer due to permission error, some features will be degraded: ..."
```
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9772
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
