### PR TITLE
chore: reset paging when paging hits an offset error [WEB-1531]

### DIFF
--- a/webui/react/src/pages/Admin/GroupManagement.tsx
+++ b/webui/react/src/pages/Admin/GroupManagement.tsx
@@ -22,7 +22,7 @@ import determinedStore from 'stores/determinedInfo';
 import roleStore from 'stores/roles';
 import { DetailedUser } from 'types';
 import { message } from 'utils/dialogApi';
-import handleError, { ErrorType } from 'utils/error';
+import handleError, { ErrorType, isOffsetError } from 'utils/error';
 import { useObservable } from 'utils/observable';
 
 import css from './GroupManagement.module.scss';
@@ -117,11 +117,15 @@ const GroupManagement: React.FC = () => {
         return response.groups || [];
       });
     } catch (e) {
+      if (isOffsetError(e) && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+        return;
+      }
       handleError(e, { publicSubject: 'Unable to fetch groups.' });
     } finally {
       setIsLoading(false);
     }
-  }, [settings]);
+  }, [settings, updateSettings]);
 
   const fetchGroup = useCallback(
     async (groupId: number): Promise<void> => {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentTrials.tsx
@@ -290,6 +290,9 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
       setTotal(responsePagination?.total || 0);
       setTrials(experimentTrials);
       setIsLoading(false);
+      if (experimentTrials.length === 0 && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+      }
     } catch (e) {
       handleError(e, {
         publicSubject: `Unable to fetch experiments ${experiment.id} trials.`,
@@ -298,7 +301,7 @@ const ExperimentTrials: React.FC<Props> = ({ experiment, pageRef }: Props) => {
       });
       setIsLoading(false);
     }
-  }, [experiment.id, canceler, settings, stateString]);
+  }, [experiment.id, canceler, settings, updateSettings, stateString]);
 
   const sendBatchActions = useCallback(
     async (action: Action) => {

--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import ActionDropdown, { Triggers } from 'components/ActionDropdown/ActionDropdown';
 import Icon from 'components/kit/Icon';
-import { DetError } from 'components/kit/internal/types';
 import Section from 'components/Section';
 import InteractiveTable, { ColumnDef } from 'components/Table/InteractiveTable';
 import SkeletonTable from 'components/Table/SkeletonTable';
@@ -24,7 +23,7 @@ import * as Api from 'services/api-ts-sdk';
 import clusterStore from 'stores/cluster';
 import userStore from 'stores/users';
 import { FullJob, Job, JobAction, JobState, JobType, ResourcePool, RPStats } from 'types';
-import handleError, { ErrorLevel, ErrorType } from 'utils/error';
+import handleError, { ErrorLevel, ErrorType, isOffsetError } from 'utils/error';
 import {
   canManageJob,
   jobTypeToCommandType,
@@ -113,7 +112,7 @@ const JobQueue: React.FC<Props> = ({ selectedRp, jobState }) => {
       // Process job stats response.
       setRpStats(stats.results.sort((a, b) => a.resourcePool.localeCompare(b.resourcePool)));
     } catch (e) {
-      if ((e as DetError)?.publicMessage === 'offset out of bounds' && settings.tableOffset !== 0) {
+      if (isOffsetError(e) && settings.tableOffset > 0) {
         updateSettings({ tableOffset: 0 });
         return;
       }

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -39,7 +39,7 @@ import { V1GetModelVersionsRequestSortBy } from 'services/api-ts-sdk';
 import userStore from 'stores/users';
 import workspaceStore from 'stores/workspaces';
 import { Metadata, ModelVersion, ModelVersions, Note } from 'types';
-import handleError, { ErrorType } from 'utils/error';
+import handleError, { ErrorType, isOffsetError } from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 import { isAborted, isNotFound, validateDetApiEnum } from 'utils/service';
@@ -95,11 +95,15 @@ const ModelDetails: React.FC = () => {
       setTotal(modelData?.pagination.total || 0);
       setModel((prev) => (!_.isEqual(modelData, prev) ? modelData : prev));
     } catch (e) {
+      if (isOffsetError(e) && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+        return;
+      }
       if (!pageError && !isAborted(e)) setPageError(e as Error);
     } finally {
       setIsLoading(false);
     }
-  }, [modelId, pageError, settings]);
+  }, [modelId, pageError, settings, updateSettings]);
 
   const modelDownloadModal = useModal(ModelDownloadModal);
   const modelVersionDeleteModal = useModal(ModelVersionDeleteModal);

--- a/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsWorkloads.tsx
@@ -20,7 +20,7 @@ import {
   TrialWorkloadFilter,
   WorkloadGroup,
 } from 'types';
-import handleError, { ErrorType } from 'utils/error';
+import handleError, { ErrorType, isOffsetError } from 'utils/error';
 import { Loadable, Loaded, NotLoaded } from 'utils/loadable';
 import {
   extractMetricSortValue,
@@ -143,6 +143,10 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
         setWorkloadCount(0);
       }
     } catch (e) {
+      if (isOffsetError(e) && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+        return;
+      }
       handleError(e, {
         publicMessage: 'Failed to load recent trial workloads.',
         publicSubject: 'Unable to fetch Trial Workloads.',
@@ -157,6 +161,7 @@ const TrialDetailsWorkloads: React.FC<Props> = ({
     settings.tableLimit,
     settings.tableOffset,
     settings.filter,
+    updateSettings,
   ]);
 
   const { stopPolling } = usePolling(fetchWorkloads, { rerunOnNewFn: true });

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -91,12 +91,16 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         if (_.isEqual(prev, response.projects)) return prev;
         return response.projects;
       });
+      if (response.projects.length === 0 && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+        return;
+      }
     } catch (e) {
       handleError(e, { publicSubject: 'Unable to fetch projects.' });
     } finally {
       setIsLoading(false);
     }
-  }, [canceler.signal, id, workspace, settings]);
+  }, [canceler.signal, id, workspace, settings, updateSettings]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -35,6 +35,7 @@ import { getWorkspaces } from 'services/api';
 import { V1GetWorkspacesRequestSortBy } from 'services/api-ts-sdk';
 import userStore from 'stores/users';
 import { Workspace } from 'types';
+import { isOffsetError } from 'utils/error';
 import { Loadable } from 'utils/loadable';
 import { useObservable } from 'utils/observable';
 import { validateDetApiEnum } from 'utils/service';
@@ -88,11 +89,15 @@ const WorkspaceList: React.FC = () => {
         return withoutDefault;
       });
     } catch (e) {
+      if (isOffsetError(e) && settings.tableOffset > 0) {
+        updateSettings({ tableOffset: 0 });
+        return;
+      }
       if (!pageError) setPageError(e as Error);
     } finally {
       setIsLoading(false);
     }
-  }, [canceler.signal, pageError, settings]);
+  }, [canceler.signal, pageError, settings, updateSettings]);
 
   usePolling(fetchWorkspaces);
 

--- a/webui/react/src/utils/error.ts
+++ b/webui/react/src/utils/error.ts
@@ -71,6 +71,10 @@ export const isDetError = (error: unknown): error is DetError => {
   return error instanceof DetError;
 };
 
+export const isOffsetError = (error: unknown): boolean => {
+  return isDetError(error) && error.publicMessage === 'offset out of bounds';
+};
+
 /**
  * used to preserve the public message potentially provided by lower levels where the error
  * was generated or rethrowed.


### PR DESCRIPTION
## Description

Draft PR

This creates a check `isOffsetError(error)` to reset offset to 0 instead of printing an error and getting stuck.
- Groups
- Experiment Checkpoints
- Jobs
- Model Versions within a Model
- Trial Workloads

For some endpoints, the offset error hits at an unexpected point (for example if there are 50 models, at offset=50 you would get a "no models" message)
- Models table
- Workspaces List
- Workspace Projects Table

For one endpoint, there is no offset error:
- ExperimentTrials

## Test Plan

Draft PR

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.