### PR TITLE
fix: code cleanup for mapx unit test

### DIFF
--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -48,9 +48,6 @@ func TestMapx(t *testing.T) {
 		{"1236", "world"},
 	}
 	testMap := New[string, string]()
-	for _, tt := range tests {
-		testMap.Store(tt.k, tt.v)
-	}
 	assert.Equal(t, len(tests), testMap.Len())
 	value, _ := testMap.Load("1235")
 	assert.Equal(t, "hello", value)

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -48,6 +48,9 @@ func TestMapx(t *testing.T) {
 		{"1236", "world"},
 	}
 	testMap := New[string, string]()
+	for _, tt := range tests {
+		testMap.Store(tt.k, tt.v)
+	}
 	assert.Equal(t, len(tests), testMap.Len())
 	value, _ := testMap.Load("1235")
 	assert.Equal(t, "hello", value)

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -39,29 +39,26 @@ func FuzzMap(f *testing.F) {
 }
 
 func TestMapx(t *testing.T) {
-	tests := []struct {
-		k string
-		v string
-	}{
-		{"1234", "hi"},
-		{"1235", "hello"},
-		{"1236", "world"},
-	}
 	testMap := New[string, string]()
-	for _, tt := range tests {
-		testMap.Store(tt.k, tt.v)
-	}
-	assert.Equal(t, len(tests), testMap.Len())
+	testMap.Store("1234", "hi")
+	testMap.Store("1235", "hello")
+	testMap.Store("1236", "world")
+
+	assert.Equal(t, 3, testMap.Len())
+
 	value, _ := testMap.Load("1235")
 	assert.Equal(t, "hello", value)
-	testMap.Delete("1235")
+
 	expectedValueList := [...]string{"hi", "world"}
+	testMap.Delete("1235")
 	valueList := testMap.Values()
 	assert.Equal(t, 2, testMap.Len())
+
 	sort.Strings(valueList)
 	for i, v := range valueList {
 		assert.Equal(t, expectedValueList[i], v)
 	}
+
 	testMap.Clear()
 	assert.Equal(t, 0, testMap.Len())
 }


### PR DESCRIPTION
## Description
Code cleanup for the `mapx` unit test.
Addressing outstanding comments on #7699 


## Test Plan
The unit test ran successfully


## Commentary (optional)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
FE-23
