### PR TITLE
fix: remove nanoseconds when parsing protobuf timestamp

### DIFF
--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import platform
 import random
+import re
 import sys
 import time
 import warnings
@@ -207,6 +208,9 @@ def parse_protobuf_timestamp(ts: str) -> datetime.datetime:
     # [2] https://bugs.python.org/issue35829
     if ts.endswith("Z"):
         ts = ts[:-1] + "+00:00"
+    # Remove the [milli,micro,nano]seconds portion from the timestamp because
+    # fromisoformat cannot process nanoseconds and we do not use other values either.
+    re.sub("\\.[0-9]*\\+", "+", ts)
     return datetime.datetime.fromisoformat(ts)
 
 


### PR DESCRIPTION
## Description
Remove nanoseconds when parsing a protobuf timestamp. Python's `fromisoformat()` cannot parse a timestamp with nanoseconds. So remove the nanoseconds part before parsing the protobuf timestamp.

## Test Plan
Tested manually.
`fromisoformat()` examples
```
jagadeesh.madagundi@C02FJ10GMD6Q determined % python
Python 3.8.12 (default, Jul 28 2022, 12:48:34) 
[Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> print(datetime.datetime.fromisoformat("2023-08-22T22:06:45+00:00"))
2023-08-22 22:06:45+00:00
>>> print(datetime.datetime.fromisoformat("2023-08-22T22:06:45.242+00:00"))
2023-08-22 22:06:45.242000+00:00
>>> print(datetime.datetime.fromisoformat("2023-08-22T22:06:45.242391+00:00"))
2023-08-22 22:06:45.242391+00:00
>>> print(datetime.datetime.fromisoformat("2023-08-22T22:06:45.242391275+00:00"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid isoformat string: '2023-08-22T22:06:45.242391275+00:00'
```
`re.sub()` testing
```
jagadeesh.madagundi@C02FJ10GMD6Q determined % python
Python 3.8.12 (default, Jul 28 2022, 12:48:34) 
[Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> re.sub("\\.[0-9]*\\+", "+", "2023-08-22T22:06:45.242391275+00:00")
'2023-08-22T22:06:45+00:00'
```


## Commentary (optional)
Blocks #7668 

## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[FE-23](https://hpe-aiatscale.atlassian.net/browse/FE-23)


[FE-23]: https://hpe-aiatscale.atlassian.net/browse/FE-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ