### PR TITLE
fix: Reset chart min/max when changing XAxisDomain

### DIFF
--- a/webui/react/src/components/kit/LineChart.tsx
+++ b/webui/react/src/components/kit/LineChart.tsx
@@ -243,6 +243,7 @@ export const LineChart: React.FC<LineChartProps> = ({
         handleError={handleError}
         isLoading={isLoading}
         options={chartOptions}
+        xAxis={xAxis}
       />
       {showLegend && (
         <div className={css.legendContainer}>

--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useMemo } from 'react';
 import uPlot, { AlignedData } from 'uplot';
 
 import { generateUUID } from 'components/kit/internal/functions';
+import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 
 type Bounds = {
   dataBounds: {
@@ -20,6 +21,7 @@ type Bounds = {
 };
 
 class SyncService {
+  axis: XAxisDomain | undefined;
   bounds = observable<Bounds>({ dataBounds: null, unzoomedBounds: null, zoomBounds: null });
 
   pubSub: uPlot.SyncPubSub;
@@ -52,7 +54,7 @@ class SyncService {
     this.bounds.update((b) => ({ ...b, zoomBounds: { max, min } }));
   }
 
-  updateDataBounds(data: AlignedData) {
+  updateDataBounds(data: AlignedData, axis?: XAxisDomain) {
     const xValues = data[0];
     const lastIdx = xValues.length - 1;
     const chartMin = xValues[0];
@@ -61,13 +63,16 @@ class SyncService {
     if (chartMin === undefined || chartMax === undefined) return;
 
     this.bounds.update((b) => {
+      const resetAxis = axis !== this.axis;
+      this.axis = axis;
+
       const previousMin =
-        b.dataBounds?.min !== undefined && isFinite(b.dataBounds?.min)
+        b.dataBounds?.min !== undefined && isFinite(b.dataBounds?.min) && !resetAxis
           ? b.dataBounds?.min
           : chartMin;
 
       const previousMax =
-        b.dataBounds?.max !== undefined && isFinite(b.dataBounds?.max)
+        b.dataBounds?.max !== undefined && isFinite(b.dataBounds?.max) && !resetAxis
           ? b.dataBounds?.max
           : chartMax;
 

--- a/webui/react/src/components/kit/internal/UPlot/UPlotChart.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/UPlotChart.tsx
@@ -7,6 +7,7 @@ import uPlot, { AlignedData } from 'uplot';
 import { DarkLight, ErrorHandler, ErrorLevel, ErrorType } from 'components/kit/internal/types';
 import usePrevious from 'components/kit/internal/usePrevious';
 import useResize from 'components/kit/internal/useResize';
+import { XAxisDomain } from 'components/kit/LineChart/XAxisFilter';
 import Spinner from 'components/kit/Spinner';
 import useUI from 'stores/contexts/UI';
 
@@ -27,6 +28,7 @@ interface Props {
   options?: Partial<Options>;
   style?: React.CSSProperties;
   handleError?: ErrorHandler;
+  xAxis?: XAxisDomain;
 }
 
 const SCROLL_THROTTLE_TIME = 500;
@@ -87,6 +89,7 @@ const UPlotChart: React.FC<Props> = ({
   style,
   handleError,
   experimentId,
+  xAxis,
 }: Props) => {
   const chartRef = useRef<uPlot>();
   const [divHeight, setDivHeight] = useState((options?.height ?? 300) + 20);
@@ -105,8 +108,8 @@ const UPlotChart: React.FC<Props> = ({
 
   useEffect(() => {
     if (data !== undefined && chartType === 'Line')
-      syncService.updateDataBounds(data as AlignedData);
-  }, [syncService, chartType, data]);
+      syncService.updateDataBounds(data as AlignedData, xAxis);
+  }, [syncService, chartType, data, xAxis]);
 
   const extendedOptions = useMemo(() => {
     const extended: Partial<uPlot.Options> = uPlot.assign(


### PR DESCRIPTION
## Description

Fixes an issue with ChartGrid component - after #7609 the x-axis min and max accumulate across charts
This x-axis sync needs to reset when we switch the x-axis domain (such as batches -> time), to avoid expanding min-max across incompatible units

## Test Plan

Can toggle between batches and time x-axis on an experiment metrics tab (`/det/experiments/1651/metrics`) 
Can toggle between batches and time on an experiment list comparison sidebar (`/det/projects/107/experiments?compare=true`)

Neither builds up a huge x-axis bounds from

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.