### PR TITLE
docs: Add user guides to the Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ For installation details, visit the the cluster deployment guide for your enviro
 * Tutorials:
   * [PyTorch MNIST Tutorial](https://docs.determined.ai/latest/tutorials/pytorch-mnist-tutorial.html)
   * [TensorFlow Keras MNIST Tutorial](https://docs.determined.ai/latest/tutorials/tf-mnist-tutorial.html)
+* User Guides:
+  * [Core API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-core-ug.html)
+  * [PyTorch API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-pytorch-ug.html)
+  * [Keras API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-keras-ug.html)
+  * [DeepSpeed API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/deepspeed/overview.html)
 
 
 # Community


### PR DESCRIPTION
## Description

Adds links to user guides to the Documentation section of the GitHub Readme.

View it here: https://github.com/determined-ai/determined/tree/KevinMusgrave/readme3#documentation