### PR TITLE
ci: quarantine some flaky nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3395,14 +3395,6 @@ workflows:
           requires:
             - check-if-nightly-tests-should-run
       - test-e2e-aws:
-          name: test-e2e-gpu-nightly-quarantine
-          context: aws
-          matrix:
-            parameters:
-              parallelism: [2]
-              cluster-id-prefix: ["nightly-quarantine"]
-              mark: ["nightly_quarantine"]
-      - test-e2e-aws:
           name: test-e2e-gpu-distributed
           context: aws
           matrix:
@@ -3414,16 +3406,6 @@ workflows:
               max-dynamic-agents: [2]
           requires:
             - check-if-nightly-tests-should-run
-      - test-e2e-aws:
-          name: test-e2e-gpu-distributed-quarantine
-          context: aws
-          matrix:
-            parameters:
-              cluster-id-prefix: ["distributed-quarantine"]
-              mark: ["distributed_quarantine"]
-              compute-agent-instance-type: ["g4dn.metal"]
-              aux-agent-instance-type: ["m5.large"]
-              max-dynamic-agents: [2]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers
           context: aws
@@ -3513,6 +3495,39 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
+          requires:
+            - check-if-nightly-tests-should-run
+
+  # ATTENTION: When adding jobs to the "nightly-quarantine" workflow, make sure you have a
+  # "requires" that lists "check-if-nightly-tests-should-run", so that the job
+  # only runs if "check-if-nightly-tests-should-run" allows it to.
+  nightly-quarantine:
+    jobs:
+      - check-if-nightly-tests-should-run:
+          context:
+            # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
+            # that's required by the "gh" command for authentication.
+            - github-write
+      - test-e2e-aws:
+          name: test-e2e-gpu-nightly-quarantine
+          context: aws
+          matrix:
+            parameters:
+              parallelism: [2]
+              cluster-id-prefix: ["nightly-quarantine"]
+              mark: ["nightly_quarantine"]
+          requires:
+            - check-if-nightly-tests-should-run
+      - test-e2e-aws:
+          name: test-e2e-gpu-distributed-quarantine
+          context: aws
+          matrix:
+            parameters:
+              cluster-id-prefix: ["distributed-quarantine"]
+              mark: ["distributed_quarantine"]
+              compute-agent-instance-type: ["g4dn.metal"]
+              aux-agent-instance-type: ["m5.large"]
+              max-dynamic-agents: [2]
           requires:
             - check-if-nightly-tests-should-run
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3513,7 +3513,7 @@ workflows:
           context: aws
           matrix:
             parameters:
-              parallelism: [2]
+              parallelism: [1]
               cluster-id-prefix: ["nightly-quarantine"]
               mark: ["nightly_quarantine"]
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3395,6 +3395,14 @@ workflows:
           requires:
             - check-if-nightly-tests-should-run
       - test-e2e-aws:
+          name: test-e2e-gpu-nightly-quarantine
+          context: aws
+          matrix:
+            parameters:
+              parallelism: [2]
+              cluster-id-prefix: ["nightly-quarantine"]
+              mark: ["nightly_quarantine"]
+      - test-e2e-aws:
           name: test-e2e-gpu-distributed
           context: aws
           matrix:
@@ -3406,6 +3414,16 @@ workflows:
               max-dynamic-agents: [2]
           requires:
             - check-if-nightly-tests-should-run
+      - test-e2e-aws:
+          name: test-e2e-gpu-distributed-quarantine
+          context: aws
+          matrix:
+            parameters:
+              cluster-id-prefix: ["distributed-quarantine"]
+              mark: ["distributed_quarantine"]
+              compute-agent-instance-type: ["g4dn.metal"]
+              aux-agent-instance-type: ["m5.large"]
+              max-dynamic-agents: [2]
       - test-e2e-aws:
           name: test-e2e-gpu-transformers
           context: aws

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -29,6 +29,8 @@ markers =
     port_registry: tests for port registry and unique port offset
 
     model_hub_mmdetection_quarantine: model_hub_mmdetection tests (quarantine)
+    nightly_quarantine: nightly tests (quarantine)
+    distributed_quarantine: distributed training tests (quarantine)
     det_deploy_local_quarantine: test det deploy local (quarantine)
 
 junit_logging = all

--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -41,6 +41,8 @@ _INTEG_MARKERS = {
     "managed_devcluster",
     "port_registry",
     "model_hub_mmdetection_quarantine",
+    "nightly_quarantine",
+    "distributed_quarantine",
     "det_deploy_local_quarantine",
 }
 

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -164,7 +164,7 @@ def test_cifar10_byol_pytorch_accuracy(client: _client.Determined) -> None:
     )
 
 
-@pytest.mark.nightly_quarantine
+@pytest.mark.nightly
 def test_hf_trainer_api_accuracy(client: _client.Determined) -> None:
     test_dir = "hf_image_classification"
     config = conf.load_config(conf.hf_trainer_examples_path(f"{test_dir}/const.yaml"))

--- a/e2e_tests/tests/nightly/test_convergence.py
+++ b/e2e_tests/tests/nightly/test_convergence.py
@@ -164,7 +164,7 @@ def test_cifar10_byol_pytorch_accuracy(client: _client.Determined) -> None:
     )
 
 
-@pytest.mark.nightly
+@pytest.mark.nightly_quarantine
 def test_hf_trainer_api_accuracy(client: _client.Determined) -> None:
     test_dir = "hf_image_classification"
     config = conf.load_config(conf.hf_trainer_examples_path(f"{test_dir}/const.yaml"))

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -66,7 +66,7 @@ def test_cifar10_pytorch_distributed(image_type: str) -> None:
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("cifar10_pytorch"), 1)
 
 
-@pytest.mark.distributed
+@pytest.mark.distributed_quarantine
 def test_cifar10_tf_keras_distributed() -> None:
     config = conf.load_config(conf.cv_examples_path("cifar10_tf_keras/distributed.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
@@ -198,7 +198,7 @@ def test_byol_pytorch_distributed() -> None:
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("byol_pytorch"), 1)
 
 
-@pytest.mark.distributed_quarantine
+@pytest.mark.distributed
 @pytest.mark.gpu_required
 def test_hf_trainer_api_integration() -> None:
     test_dir = "hf_image_classification"
@@ -350,7 +350,7 @@ def test_textual_inversion_stable_diffusion_generate() -> None:
             raise k
 
 
-@pytest.mark.distributed_quarantine
+@pytest.mark.distributed
 @pytest.mark.gpu_required
 @pytest.mark.deepspeed
 def test_hf_trainer_image_classification_deepspeed_autotuning() -> None:
@@ -368,7 +368,7 @@ def test_hf_trainer_image_classification_deepspeed_autotuning() -> None:
         )
 
 
-@pytest.mark.distributed_quarantine
+@pytest.mark.distributed
 @pytest.mark.gpu_required
 @pytest.mark.deepspeed
 def test_hf_trainer_language_modeling_deepspeed_autotuning() -> None:

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -198,7 +198,7 @@ def test_byol_pytorch_distributed() -> None:
     exp.run_basic_test_with_temp_config(config, conf.cv_examples_path("byol_pytorch"), 1)
 
 
-@pytest.mark.distributed
+@pytest.mark.distributed_quarantine
 @pytest.mark.gpu_required
 def test_hf_trainer_api_integration() -> None:
     test_dir = "hf_image_classification"
@@ -350,7 +350,7 @@ def test_textual_inversion_stable_diffusion_generate() -> None:
             raise k
 
 
-@pytest.mark.distributed
+@pytest.mark.distributed_quarantine
 @pytest.mark.gpu_required
 @pytest.mark.deepspeed
 def test_hf_trainer_image_classification_deepspeed_autotuning() -> None:
@@ -368,7 +368,7 @@ def test_hf_trainer_image_classification_deepspeed_autotuning() -> None:
         )
 
 
-@pytest.mark.distributed
+@pytest.mark.distributed_quarantine
 @pytest.mark.gpu_required
 @pytest.mark.deepspeed
 def test_hf_trainer_language_modeling_deepspeed_autotuning() -> None:


### PR DESCRIPTION
## Description

Per [this Slack thread](https://hpe-aiatscale.slack.com/archives/C04C9JXB1C2/p1692209150919889?thread_ts=1692208341.014209&cid=C04C9JXB1C2), I did some digging into what's flaky using the CI Dashboard and [the CircleCI Insights tool](https://app.circleci.com/insights/github/determined-ai/determined/workflows/nightly/tests?branch=main&reporting-window=last-7-days) to find what's seeming flakiest.

This is based on @wes-turner's #7520, which quarantined two flaky nightly tests. There's some more work and/or thought that needs to go into coming up with the proper approach for quarantining those (especially `test_cifar10_tf_keras_accuracy`), so in the meantime I hope this helps the nightlies be more useful.

## Test Plan

This should be a CI-only change.