### PR TITLE
fix: Changing x axis type should reset any current custom zoom

### DIFF
--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -89,6 +89,7 @@ class SyncService {
         ...b,
         dataBounds: { max: dataMax, min: dataMin },
         unzoomedBounds: { max: unzoomedMax, min: unzoomedMin },
+        zoomBounds: resetAxis ? null : b.zoomBounds,
       };
     });
   }


### PR DESCRIPTION
## Description

Discovered in testing #7719 - 
In a chart grid component,  you can zoom into a chart by clicking and dragging left or right
When we switch the x-axis such as Batches -> [Unix] Time, the units are incompatible. Any custom zoom should be reset

## Test Plan

In an experiment metrics tab such as `/det/experiments/1651/metrics`, 
- Zoom into one chart by clicking and dragging left or right
- All charts should sync to the new x-min-max bounds
- Change X Axis between batches -> time
- Chart zoom should reset to the bounds in time units

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.