### PR TITLE
fix: backfilled tasks weren't seen as trial tasks

### DIFF
--- a/docs/release-notes/trial-logs-failing.rst
+++ b/docs/release-notes/trial-logs-failing.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Trials: Fix an issue where trial logs could fail for trials created prior to Determined version
+   0.17.0.

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -813,6 +813,28 @@ func TestTrialProtoTaskIDs(t *testing.T) {
 	}
 }
 
+func TestExperimentIDFromTrialTaskID(t *testing.T) {
+	api, curUser, _ := setupAPITest(t, nil)
+
+	trial, task := createTestTrial(t, api, curUser)
+	actual, err := experimentIDFromTrialTaskID(task.TaskID)
+	require.NoError(t, err)
+	require.Equal(t, trial.ExperimentID, actual)
+
+	notTrialTask := &model.Task{
+		TaskType:   model.TaskTypeTrial,
+		LogVersion: model.TaskLogVersion1,
+		StartTime:  time.Now(),
+		TaskID:     model.TaskID(uuid.New().String()),
+	}
+	require.NoError(t, api.m.db.AddTask(task))
+	_, err = experimentIDFromTrialTaskID(notTrialTask.TaskID)
+	require.ErrorIs(t, err, errIsNotTrialTaskID)
+
+	_, err = experimentIDFromTrialTaskID(model.TaskID(uuid.New().String()))
+	require.ErrorIs(t, err, errIsNotTrialTaskID)
+}
+
 func TestTrialLogsBackported(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
 

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -759,9 +759,12 @@ var errIsNotTrialTaskID = fmt.Errorf("taskID is not a trial task ID")
 // Currently unable to go through the database since trials are not necessarily persisted when
 // we return allocation information.
 func experimentIDFromTrialTaskID(taskID model.TaskID) (int, error) {
-	expID, _, found := strings.Cut(string(taskID), ".")
+	expID, found := strings.CutPrefix(string(taskID), "backported.")
 	if !found {
-		return 0, errors.Wrapf(errIsNotTrialTaskID, "error on task ID %s", taskID)
+		expID, _, found = strings.Cut(string(taskID), ".")
+		if !found {
+			return 0, errors.Wrapf(errIsNotTrialTaskID, "error on task ID %s", taskID)
+		}
 	}
 
 	id, err := strconv.Atoi(expID)

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
 
@@ -755,23 +753,21 @@ func trialTaskID(eID int, rID model.RequestID) model.TaskID {
 
 var errIsNotTrialTaskID = fmt.Errorf("taskID is not a trial task ID")
 
-// Hack to associate allocations to experiments for RBAC.
-// Currently unable to go through the database since trials are not necessarily persisted when
-// we return allocation information.
 func experimentIDFromTrialTaskID(taskID model.TaskID) (int, error) {
-	expID, found := strings.CutPrefix(string(taskID), "backported.")
-	if !found {
-		expID, _, found = strings.Cut(string(taskID), ".")
-		if !found {
-			return 0, errors.Wrapf(errIsNotTrialTaskID, "error on task ID %s", taskID)
-		}
+	var experimentID int
+	err := db.Bun().NewSelect().
+		Table("trial_id_task_id").
+		Column("experiment_id").
+		Join("LEFT JOIN trials ON trials.id = trial_id_task_id.trial_id").
+		Where("task_id = ?", taskID).
+		Scan(context.TODO(), &experimentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, errIsNotTrialTaskID
+	} else if err != nil {
+		return 0, fmt.Errorf("getting experiment ID from trial task ID: %w", err)
 	}
 
-	id, err := strconv.Atoi(expID)
-	if err != nil {
-		return 0, errors.Wrapf(err, "error parsing experiment ID for task ID %s", taskID)
-	}
-	return id, nil
+	return experimentID, nil
 }
 
 func (e *experiment) checkpointForCreate(op searcher.Create) (*model.Checkpoint, error) {


### PR DESCRIPTION
## Description

Fixes `experimentIDFromTrialTaskID` to account for the `backfilled` taskIDs.


## Test Plan

Integration test

manual get trial logs for trial ID 2020 on gcloud with ```det t logs 2020````

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
