### PR TITLE
chore: add a new assertion method to check command exit status and report any errors

### DIFF
--- a/e2e_tests/tests/cluster/test_agent_disable.py
+++ b/e2e_tests/tests/cluster/test_agent_disable.py
@@ -12,7 +12,7 @@ from tests import config as conf
 from tests import experiment as exp
 
 from .test_users import ADMIN_CREDENTIALS, logged_in_user
-from .utils import get_command_info, run_zero_slot_command, wait_for_command_state
+from .utils import assert_command_succeeded, run_zero_slot_command, wait_for_command_state
 
 
 @pytest.mark.e2e_cpu
@@ -306,8 +306,8 @@ def test_drain_agent_sched_zeroslot() -> None:
         with _disable_agent(agent_id2, drain=True):
             for command_id in [command_id1, command_id2]:
                 wait_for_command_state(command_id, "TERMINATED", 60)
-                assert "success" in get_command_info(command_id)["exitStatus"]
+                assert_command_succeeded(command_id)
 
     command_id3 = run_zero_slot_command(1)
     wait_for_command_state(command_id3, "TERMINATED", 60)
-    assert "success" in get_command_info(command_id3)["exitStatus"]
+    assert_command_succeeded(command_id3)

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -19,8 +19,7 @@ from .managed_cluster import ManagedCluster, get_agent_data
 from .managed_cluster_k8s import ManagedK8sCluster
 from .test_groups import det_cmd_json
 from .utils import (
-    command_succeeded,
-    get_command_info,
+    assert_command_succeeded,
     run_command,
     wait_for_command_state,
     wait_for_task_state,
@@ -52,7 +51,7 @@ def _test_master_restart_ok(managed_cluster: Cluster) -> None:
 
             for cmd_id in cmd_ids:
                 wait_for_command_state(cmd_id, "TERMINATED", 300)
-                assert command_succeeded(cmd_id)
+                assert_command_succeeded(cmd_id)
 
             managed_cluster.kill_master()
             managed_cluster.restart_master()
@@ -235,8 +234,7 @@ def _test_master_restart_cmd(managed_cluster: Cluster, slots: int, downtime: int
         managed_cluster.restart_master()
 
     wait_for_command_state(command_id, "TERMINATED", 30)
-    succeeded = "success" in get_command_info(command_id)["exitStatus"]
-    assert succeeded
+    assert_command_succeeded(command_id)
 
 
 @pytest.mark.managed_devcluster
@@ -433,4 +431,4 @@ def test_master_restart_with_queued(k8s_managed_cluster: ManagedK8sCluster) -> N
 
     for cmd_id in [running_command_id, queued_command_id]:
         wait_for_command_state(cmd_id, "TERMINATED", 60)
-        assert "success" in get_command_info(cmd_id)["exitStatus"]
+        assert_command_succeeded(cmd_id)

--- a/e2e_tests/tests/cluster/test_priority_scheduler.py
+++ b/e2e_tests/tests/cluster/test_priority_scheduler.py
@@ -6,7 +6,12 @@ from tests import config as conf
 from tests import experiment as exp
 
 from .managed_cluster import ManagedCluster
-from .utils import command_succeeded, run_command, run_command_set_priority, wait_for_command_state
+from .utils import (
+    assert_command_succeeded,
+    run_command,
+    run_command_set_priority,
+    wait_for_command_state,
+)
 
 
 @pytest.mark.managed_devcluster
@@ -32,15 +37,15 @@ def test_priortity_scheduler_noop_command(
     # without slots (and default priority)
     command_id = run_command(slots=0)
     wait_for_command_state(command_id, "TERMINATED", 40)
-    assert command_succeeded(command_id)
+    assert_command_succeeded(command_id)
     # with slots (and default priority)
     command_id = run_command(slots=1)
     wait_for_command_state(command_id, "TERMINATED", 60)
-    assert command_succeeded(command_id)
+    assert_command_succeeded(command_id)
     # explicity priority
     command_id = run_command_set_priority(slots=0, priority=60)
     wait_for_command_state(command_id, "TERMINATED", 60)
-    assert command_succeeded(command_id)
+    assert_command_succeeded(command_id)
 
 
 @pytest.mark.managed_devcluster

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -11,6 +11,7 @@ from typing_extensions import Literal
 from determined.common import api
 from determined.common.api import authentication, certs
 from tests import config as conf
+from tests.command import print_command_logs
 
 
 def cluster_slots() -> Dict[str, Any]:
@@ -100,13 +101,12 @@ def get_command_info(command_id: str) -> Dict[str, Any]:
     return get_task_info("command", command_id)
 
 
-# assert_command_succeded checks if a command succeeded or not. It prints the command info in case
-# of a failure.
+# assert_command_succeded checks if a command succeeded or not. It prints the command logs if the
+# command failed.
 def assert_command_succeeded(command_id: str) -> None:
     command_info = get_command_info(command_id)
-    command_info_json = json.dumps(command_info, indent=2, separators=(",", ":"))
     succeeded = "success" in command_info["exitStatus"]
-    assert succeeded, f"Command failed. Command Info:\n {command_info_json}"
+    assert succeeded, print_command_logs(command_id)
 
 
 def wait_for_task_state(task_type: TaskType, task_id: str, state: str, ticks: int = 60) -> None:

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -100,10 +100,12 @@ def get_command_info(command_id: str) -> Dict[str, Any]:
     return get_task_info("command", command_id)
 
 
-def command_succeeded(command_id: str) -> bool:
-    print(get_command_info(command_id))
-
-    return "success" in get_command_info(command_id)["exitStatus"]
+def assert_command_succeeded(command_id: str) -> None:
+    command_info = get_command_info(command_id)
+    command_info_json = json.dumps(command_info, indent=2, separators=(",", ":"))
+    exit_status = command_info["exitStatus"]
+    succeeded = "success" in exit_status
+    assert succeeded, f"Command failed. Command Info:\n {command_info_json}"
 
 
 def wait_for_task_state(task_type: TaskType, task_id: str, state: str, ticks: int = 60) -> None:

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -100,11 +100,12 @@ def get_command_info(command_id: str) -> Dict[str, Any]:
     return get_task_info("command", command_id)
 
 
+# assert_command_succeded checks if a command succeeded or not. It prints the command info in case
+# of a failure.
 def assert_command_succeeded(command_id: str) -> None:
     command_info = get_command_info(command_id)
     command_info_json = json.dumps(command_info, indent=2, separators=(",", ":"))
-    exit_status = command_info["exitStatus"]
-    succeeded = "success" in exit_status
+    succeeded = "success" in command_info["exitStatus"]
     assert succeeded, f"Command failed. Command Info:\n {command_info_json}"
 
 

--- a/e2e_tests/tests/command/__init__.py
+++ b/e2e_tests/tests/command/__init__.py
@@ -1,1 +1,7 @@
-from .command import get_command, get_command_config, get_num_running_commands, interactive_command
+from .command import (
+    get_command,
+    get_command_config,
+    get_num_running_commands,
+    interactive_command,
+    print_command_logs,
+)

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -7,7 +7,8 @@ from typing import IO, Any, Iterator, Optional
 import requests
 
 from determined.common import api
-from determined.common.api import authentication, certs
+from determined.common.api import authentication, certs, task_logs
+from tests import api_utils
 from tests import config as conf
 
 
@@ -120,3 +121,8 @@ def get_command_config(command_type: str, task_id: str) -> str:
         completed_process.stdout, completed_process.stderr
     )
     return str(completed_process.stdout)
+
+
+def print_command_logs(task_id: str) -> None:
+    for tl in task_logs(api_utils.determined_test_session(), task_id):
+        print(tl.message)

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -123,6 +123,7 @@ def get_command_config(command_type: str, task_id: str) -> str:
     return str(completed_process.stdout)
 
 
-def print_command_logs(task_id: str) -> None:
+def print_command_logs(task_id: str) -> bool:
     for tl in task_logs(api_utils.determined_test_session(), task_id):
         print(tl.message)
+    return True


### PR DESCRIPTION
## Description
chore: add a new assertion method to check command exit status and report any errors
One of the e2e slurm tests, part of determined-ee nightly tests, is failing on and off. The current test setup does provide any info on such failures (please refer [here](https://app.circleci.com/pipelines/github/determined-ai/determined-ee/9014/workflows/b1b11f41-e452-446e-aece-6e26124754b8/jobs/405428)). Added a new method that evaluates the command info and asserts if the command was successful. In case of a failure, it will print the command logs to help the developers debug the issue further. 
### Sample output
#### Failure scenario:
```
e2e_tests % pytest tests/cluster/test_master_restart.py -k test_master_restart_cmd
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.8.12, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jagadeesh.madagundi/github/determined/e2e_tests, configfile: pytest.ini
plugins: timeout-2.1.0, requests-mock-1.10.0
collected 21 items / 20 deselected / 1 selected                                                                                                                                

tests/cluster/test_master_restart.py F                                                                                                                                   [100%]

=================================================================================== FAILURES ===================================================================================
________________________________________________________________________ test_master_restart_cmd[20-0] _________________________________________________________________________

restartable_managed_cluster = <tests.cluster.managed_cluster.ManagedCluster object at 0x108fafdf0>, slots = 0, downtime = 20

    @pytest.mark.managed_devcluster
    # @pytest.mark.parametrize("slots", [0, 1])
    # @pytest.mark.parametrize("downtime", [0, 20, 60])
    @pytest.mark.parametrize("slots", [0])#, 1])
    @pytest.mark.parametrize("downtime", [20])#[0, 20, 60])
    def test_master_restart_cmd(
        restartable_managed_cluster: ManagedCluster, slots: int, downtime: int
    ) -> None:
>       _test_master_restart_cmd(restartable_managed_cluster, slots, downtime)

/Users/jagadeesh.madagundi/github/determined/e2e_tests/tests/cluster/test_master_restart.py:217: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/Users/jagadeesh.madagundi/github/determined/e2e_tests/tests/cluster/test_master_restart.py:239: in _test_master_restart_cmd
    assert_command_succeeded(command_id)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

command_id = 'dda039f6-dce0-461d-9b62-0cb5cf618491'

    def assert_command_succeeded(command_id: str) -> None:
        command_info = get_command_info(command_id)
        command_info_json = json.dumps(command_info, indent=2, separators=(",", ":"))
        succeeded = "asdf" in command_info["exitStatus"]
>       assert succeeded, get_command_logs(command_id)
E       AssertionError: None

/Users/jagadeesh.madagundi/github/determined/e2e_tests/tests/cluster/utils.py:110: AssertionError
----------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------
[2023-08-25T16:45:31.359978Z]          || INFO: Scheduling Command (eagerly-immense-satyr) (id: dda039f6-dce0-461d-9b62-0cb5cf618491.1)

[2023-08-25T16:45:31.749408Z]          || INFO: Command (eagerly-immense-satyr) was assigned to an agent

[2023-08-25T16:45:31.753010Z] aa7c2452 || INFO: image already found, skipping pull phase: docker.io/determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-2b7e2a1

[2023-08-25T16:45:31.791475Z] aa7c2452 || INFO: copying files to container: /

[2023-08-25T16:45:31.801984Z] aa7c2452 || INFO: copying files to container: /run/determined

[2023-08-25T16:45:31.820352Z] aa7c2452 || INFO: copying files to container: /

[2023-08-25T16:45:31.841999Z] aa7c2452 || INFO: copying files to container: /

[2023-08-25T16:45:31.850504Z] aa7c2452 || INFO: copying files to container: /

[2023-08-25T16:45:32.161469Z] aa7c2452 || INFO: Resources for Command (eagerly-immense-satyr) have started

[2023-08-25T16:45:54.389575Z]          || INFO: Scheduling Command (eagerly-immense-satyr) (id: dda039f6-dce0-461d-9b62-0cb5cf618491.1)

[2023-08-25T16:46:05.925274Z] aa7c2452 || INFO: resources exited successfully with a zero exit code

[2023-08-25T16:46:05.931941Z]          || INFO: Command (eagerly-immense-satyr) was terminated: allocation stopped early after all resources exited: resources exited successfully with a zero exit code

--------------------------------------------------------------------------- Captured stdout teardown ---------------------------------------------------------------------------
Skip compare stats because error at fetch master
--------------------------------------------------------------------------- Captured stderr teardown ---------------------------------------------------------------------------
Master not found at http://localhost:8080/. Hint: Remember to set the DET_MASTER environment variable to the correct Determined master IP and port or use the '-m' flag.
Failed to fetch master logs: HTTPConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /api/v1/me (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10db8afd0>: Failed to establish a new connection: [Errno 61] Connection refused'))
Traceback (most recent call last):
  File "/Users/jagadeesh.madagundi/github/determined/e2e_tests/tests/nightly/compute_stats.py", line 86, in fetch_master_log
    output = subprocess.check_output(command)
  File "/Users/jagadeesh.madagundi/.pyenv/versions/3.8.12/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/Users/jagadeesh.madagundi/.pyenv/versions/3.8.12/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['det', '-m', 'http://localhost:8080/', 'master', 'logs']' returned non-zero exit status 1.
=========================================================================== short test summary info ============================================================================
FAILED tests/cluster/test_master_restart.py::test_master_restart_cmd[20-0] - AssertionError: None
====================================================================== 1 failed, 20 deselected in 42.78s =======================================================================
```

#### Successful scenario:
```
e2e_tests % pytest tests/cluster/test_master_restart.py -k test_master_restart_cmd
============================================================================= test session starts ==============================================================================
platform darwin -- Python 3.8.12, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jagadeesh.madagundi/github/determined/e2e_tests, configfile: pytest.ini
plugins: timeout-2.1.0, requests-mock-1.10.0
collected 21 items / 20 deselected / 1 selected                                                                                                                                

tests/cluster/test_master_restart.py .                                                                                                                                   [100%]

====================================================================== 1 passed, 20 deselected in 42.12s =======================================================================
```

## Test Plan
Circle CI tests were completed successfully.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[FE-159](https://hpe-aiatscale.atlassian.net/browse/FE-159)

[FE-159]: https://hpe-aiatscale.atlassian.net/browse/FE-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ