### PR TITLE
fix: Faster polling for first experiment metrics [WEB-1576]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1619,12 +1619,12 @@ func (a *apiServer) ExpMetricNames(req *apiv1.ExpMetricNamesRequest,
 			return err
 		}
 
-		numNonTermialExperiments, err := db.GetNonTerminalExperimentCount(resp.Context(), req.Ids)
+		numNonTerminalExperiments, err := db.GetNonTerminalExperimentCount(resp.Context(), req.Ids)
 		if err != nil {
 			return errors.Wrap(err, "error looking up state of experiments")
 		}
 
-		if numNonTermialExperiments == 0 {
+		if numNonTerminalExperiments == 0 {
 			return nil
 		}
 

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -14,7 +14,7 @@ import usePrevious from './usePrevious';
 const useMetricNames = (
   experimentIds: number[],
   errorHandler?: (e: unknown) => void,
-  initialRun?: boolean,
+  quickPoll?: boolean,
 ): Loadable<Metric[]> => {
   const [metrics, setMetrics] = useState<Loadable<Metric[]>>(NotLoaded);
   const [actualExpIds, setActualExpIds] = useState<number[]>([]);
@@ -36,7 +36,7 @@ const useMetricNames = (
     const xAxisMetrics = Object.values(XAxisDomain).map((v) => v.toLowerCase());
 
     readStream<V1ExpMetricNamesResponse>(
-      detApi.StreamingInternal.expMetricNames(actualExpIds, initialRun ? 5 : undefined, {
+      detApi.StreamingInternal.expMetricNames(actualExpIds, quickPoll ? 5 : undefined, {
         signal: canceler.signal,
       }),
       (event: V1ExpMetricNamesResponse) => {
@@ -83,7 +83,7 @@ const useMetricNames = (
       errorHandler,
     );
     return () => canceler.abort();
-  }, [actualExpIds, previousExpIds, errorHandler, initialRun]);
+  }, [actualExpIds, previousExpIds, errorHandler, quickPoll]);
 
   return metrics;
 };

--- a/webui/react/src/hooks/useMetricNames.ts
+++ b/webui/react/src/hooks/useMetricNames.ts
@@ -14,6 +14,7 @@ import usePrevious from './usePrevious';
 const useMetricNames = (
   experimentIds: number[],
   errorHandler?: (e: unknown) => void,
+  initialRun?: boolean,
 ): Loadable<Metric[]> => {
   const [metrics, setMetrics] = useState<Loadable<Metric[]>>(NotLoaded);
   const [actualExpIds, setActualExpIds] = useState<number[]>([]);
@@ -35,7 +36,7 @@ const useMetricNames = (
     const xAxisMetrics = Object.values(XAxisDomain).map((v) => v.toLowerCase());
 
     readStream<V1ExpMetricNamesResponse>(
-      detApi.StreamingInternal.expMetricNames(actualExpIds, undefined, {
+      detApi.StreamingInternal.expMetricNames(actualExpIds, initialRun ? 5 : undefined, {
         signal: canceler.signal,
       }),
       (event: V1ExpMetricNamesResponse) => {
@@ -82,7 +83,7 @@ const useMetricNames = (
       errorHandler,
     );
     return () => canceler.abort();
-  }, [actualExpIds, previousExpIds, errorHandler]);
+  }, [actualExpIds, previousExpIds, errorHandler, initialRun]);
 
   return metrics;
 };

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -42,7 +42,13 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
     [experiment.id],
   );
 
-  const loadableMetricNames = useMetricNames([experiment.id], handleMetricNamesError);
+  const trialNonTerminal = !terminalRunStates.has(experiment.state ?? RunState.Error);
+
+  const loadableMetricNames = useMetricNames(
+    [experiment.id],
+    handleMetricNamesError,
+    trialNonTerminal,
+  );
   const defaultMetricNames = useMemo(() => [], []);
   const metricNames = Loadable.getOrElse(defaultMetricNames, loadableMetricNames);
 


### PR DESCRIPTION
## Description

TrialOverview and TrialMetrics stream metric names until the experiments/trials on the page have all terminated.
On the server we check for new metric names every 30 seconds unless requested, and this delays when we can start showing values for the first metrics
After discussion of this ticket, we'd like the metric names endpoint to query faster (every 5 seconds).

## Test Plan

Locally fork an experiment from `/det/projects/107/experiments`, or use the const.yaml in WEB-1576 to make your own quick-running experiment

The first metric names should appear in the dropdown, and on the chart, before the experiment finishes running

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.