### PR TITLE
chore: disable interactive matching for dev bindings

### DIFF
--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -274,9 +274,10 @@ def auto_complete_binding(available_calls: List[str], fn_name: str) -> str:
     indexed_matches = [f"{idx}: {match}" for idx, match in list(enumerate(matches))]
     user_idx = (
         input(
-            f"{len(matches)} calls matched '{fn_name}'."
+            f"{len(matches)} call(s) matched '{fn_name}'."
             + " Pick one by index.\n"
             + "\n".join(indexed_matches)
+            + "\n"
         )
         or "0"
     )

--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -272,7 +272,7 @@ def auto_complete_binding(available_calls: List[str], fn_name: str) -> str:
             f"no exact matches for '{fn_name}'. Did you mean:" + "\n{}".format("\n".join(matches))
         )
     indexed_matches = [f"{idx}: {match}" for idx, match in list(enumerate(matches))]
-    user_idx = (
+    selected_idx = (
         input(
             f"{len(matches)} call(s) matched '{fn_name}'."
             + " Pick one by index.\n"
@@ -281,7 +281,7 @@ def auto_complete_binding(available_calls: List[str], fn_name: str) -> str:
         )
         or "0"
     )
-    fn_name = matches[int(user_idx.strip())]
+    fn_name = matches[int(selected_idx.strip())]
     return fn_name
 
 


### PR DESCRIPTION
when piped into another program

## Description

when using det dev bindings the cli will try to match user query to a specific call via a single interactive prompt. We should disable this and error out if the call is being piped to another program

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

no testing is needed (internal dev tool).

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
