### PR TITLE
chore: Create/document a mechanism to run the nightly tests on a PR [FE-146]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ orbs:
   gcloud: circleci/gcp-cli@2.1.0
   queue: eddiewebb/queue@volatile
   codecov: codecov/codecov@3.0.0
+  gh: circleci/github-cli@2.0
 
 executors:
   python-37:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1113,6 +1113,77 @@ commands:
           background: true
 
 jobs:
+  # Allows jobs in the "nightly" workflow to run if either of the following
+  # conditions are true:
+  #
+  # 1. A scheduled pipeline is run with the "nightly_tests" trigger name.
+  #
+  #    See "https://circleci.com/docs/schedule-pipelines-with-multiple-workflows/".
+  #
+  #    The CircleCI Admin will set up a trigger for when the nightly scheduled
+  #    pipeline is to be run. Typically, the nightly scheduled pipeline will
+  #    only be configured to run on the "main" branch or a release branch.
+  #
+  #    See "https://circleci.com/docs/set-a-nightly-scheduled-pipeline/".
+  #
+  #    The "pipeline.trigger_source" and "pipeline.schedule.name" are built-in
+  #    pipeline values and, therefore, do not need to be declared in the
+  #    "parameters:" section.
+  #
+  #    See "https://circleci.com/docs/variables/#pipeline-values".
+  #
+  # 2. The developer requests that the nightly tests be run on demand at the
+  #    gate by adding the 'ci-run-nightly' label to their pull request.
+  #    pull request.
+  #
+  # If neither condition is true, the "nightly" workflow is cancelled.
+  #
+  # For this mechanism to work, all jobs in the "nightly" workflow must have
+  # a "requires" statement listing "check-if-nightly-tests-should-run".
+  check-if-nightly-tests-should-run:
+    docker:
+      - image: <<pipeline.parameters.docker-image>>
+    steps:
+      # Install the GitHub CLI. Requires the 'gh' orb.
+      - gh/install
+      - checkout
+      - run:
+          name: Check if nightly tests should run
+          command: |
+            # Check if the nightly workflow was triggered by the scheduled
+            # pipeline.
+            if [ "scheduled_pipeline" == "<<pipeline.trigger_source>>" ] &&
+               [ "nightly_tests" == "<<pipeline.schedule.name>>" ]
+            then
+                echo "Nightly workflow triggered from scheduled pipeline"
+                circleci-agent step halt
+                exit 0
+            fi
+
+            # Check if the 'ci-run-nightly' label was set on the pull request,
+            # which indicates that we want the nightly tests to run on demand.
+            if gh pr view | grep "^labels:" | grep -w ci-run-nightly
+            then
+                echo "Nightly workflow triggered from 'ci-run-nightly' label on pull request"
+                circleci-agent step halt
+                exit 0
+            fi
+
+            echo "Canceling the nightly workflow, as it was not requested from either a scheduled pipeline or 'ci-run-nightly' label."
+
+            # Cancel the workflow.
+            OUTPUT=$(curl -s -w "\nHTTP_CODE=%{http_code}" -X POST "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLECI_API_KEY}")
+
+            echo "CircleCI API response: ${OUTPUT}"
+
+            # An HTTP code other than one of the "2XX" success codes in indicates
+            # that an error occured and we were not able to cancel the workflow.
+            if [[ ! "${OUTPUT}" =~ "HTTP_CODE=2" ]]
+            then
+                echo "Unable to cancel the nightly workflow"
+                exit 1
+            fi
+
   build-helm:
     docker:
       - image: <<pipeline.parameters.docker-image>>
@@ -3302,16 +3373,16 @@ workflows:
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
 
+  # ATTENTION: When adding jobs to the "nightly" workflow, make sure you have a
+  # "requires" that lists "check-if-nightly-tests-should-run", so that the job
+  # only runs if "check-if-nightly-tests-should-run" allows it to.
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only:
-                - main
-                - /release-(\d)+(\.(\d)+)+(-ee)?/
     jobs:
+      - check-if-nightly-tests-should-run:
+          context:
+            # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
+            # that's required by the "gh" command for authentication.
+            - github-write
       - test-e2e-aws:
           name: test-e2e-gpu-nightly
           context: aws
@@ -3320,6 +3391,8 @@ workflows:
               parallelism: [2]
               cluster-id-prefix: ["nightly"]
               mark: ["nightly"]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-gpu-distributed
           context: aws
@@ -3330,6 +3403,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-gpu-transformers
           context: aws
@@ -3340,6 +3415,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-gpu-transformers-amp
           context: aws
@@ -3350,6 +3427,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-gpu-mmdetection
           context: aws
@@ -3360,6 +3439,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-gpu-mmdetection-quarantine
           context: aws
@@ -3370,6 +3451,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.metal"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
         # DeepSpeed tests do not work on K80s, so we need V100 instances.
       - test-e2e-aws:
           name: test-e2e-gpu-deepspeed
@@ -3381,6 +3464,8 @@ workflows:
               compute-agent-instance-type: ["g4dn.12xlarge"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [2]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-e2e-aws:
           name: test-e2e-cpu-distributed
           context: aws
@@ -3392,12 +3477,16 @@ workflows:
               environment-gpu-enabled: ["0"]
               aux-agent-instance-type: ["m5.large"]
               max-dynamic-agents: [16]
+          requires:
+            - check-if-nightly-tests-should-run
       - test-aws-fs:
           name: test-aws-fs-fsx
           context: aws
           cluster-id-prefix: aws-fs-fsx
           deployment-type: fsx
           slack-mentions: "${SLACK_USER_ID}"
+          requires:
+            - check-if-nightly-tests-should-run
 
       - test-aws-fs:
           name: test-aws-fs-efs
@@ -3405,6 +3494,8 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
+          requires:
+            - check-if-nightly-tests-should-run
 
   release:
     jobs:


### PR DESCRIPTION
## Description

The `nightly` tests workflow currently runs on the `main` branch using the CircleCI `triggers:` mechanism in `.circleci/config.yml`.

```
  nightly:
    triggers:
      - schedule:
          cron: "0 5 * * *"
          filters:
            branches:
              only:
                - main
```

However, this does not allow the developer to run the `nightly` tests workflow on demand at the gate, in case they wish to see how their code changes impact the nightly tests.

The changes being made in this pull request allow the `nightly` tests workflow to continue to run on the `main` branch once per night, according to a schedule that the CircleCI administrator sets up (see https://circleci.com/docs/set-a-nightly-scheduled-pipeline/).  It also allows the developer to request that the `nightly` tests workflow be run on demand at the gate if the developer adds the `ci-run-nightly` label to their pull request on `github.com`.

**Note:** The CircleCI Admin (Danny Sauer) will need to create a scheduled pipeline for the `main` branch to trigger the `nightly` workflow, since we will no longer be scheduling the `nightly` workflow using `cron` as shown above.  The CircleCI Admin will need to do this for any release branches on which we want to run the `nightly` workflow.



## Test Plan

The tests cases below were performed on the EE repository.

**Test Case #1:  Trigger `nightly` workflow from scheduled pipeline.**

Created the following trigger in https://app.circleci.com/settings/project/github/determined-ai/determined-ee/triggers/991fe8b0-fde8-4816-8b7c-0173e420f4f1, which runs the `nightly` workflow on my `FE-146` branch at 14:00 UTC.

![image](https://github.com/determined-ai/determined-ee/assets/90728398/35ab86fb-fc51-4609-951d-ffee72749c70)


We can see that the scheduled `nightly` workflow was triggered at 10:50am EDT, although it was scheduled for 14:00 UTC (2pm UTC), which is 10:00am EDT my time.  Not sure why it wasn't triggered at exactly 10:00am EDT.

![image](https://github.com/determined-ai/determined-ee/assets/90728398/5aad8075-8639-4989-ac2f-4d459cab83c2)


https://app.circleci.com/pipelines/github/determined-ai/determined-ee/8950/workflows/38ce62de-2709-4300-8b39-2250667152ac/jobs/400924

![image](https://github.com/determined-ai/determined-ee/assets/90728398/611e76fc-cb5e-458c-bb94-27bc3c8776ea)

![image](https://github.com/determined-ai/determined-ee/assets/90728398/5b20fe8e-d412-4e79-8248-d9146a62d5fb)


**Test Case #2:  Verify that the `nightly` workflow runs when the `ci-run-nightly` label is present in the pull request.**

Added the `ci-run-nightly` label to this pull request.

![image](https://github.com/determined-ai/determined-ee/assets/90728398/866bac0c-660f-4ac3-bbfe-07196f3a83f6)

Rebased with `main`.

```
(base) rcorujo@C02FJ0T8MD6Q determined-ee % git pull --rebase origin main
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
remote: Enumerating objects: 1574, done.
remote: Counting objects: 100% (1574/1574), done.
remote: Compressing objects: 100% (529/529), done.
remote: Total 1574 (delta 1053), reused 1393 (delta 1045), pack-reused 0
Receiving objects: 100% (1574/1574), 263.63 KiB | 5.27 MiB/s, done.
Resolving deltas: 100% (1053/1053), completed with 21 local objects.
From github.com:determined-ai/determined-ee
 * branch                  main       -> FETCH_HEAD
 + 641fab5ae4...c63505f1e3 main       -> origin/main  (forced update)
Successfully rebased and updated refs/heads/FE-146.
```

Then pushed my changes.

```
(base) rcorujo@C02FJ0T8MD6Q determined-ee % git push -f origin FE-146
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
Enumerating objects: 252, done.
Counting objects: 100% (252/252), done.
Delta compression using up to 16 threads
Compressing objects: 100% (249/249), done.
Writing objects: 100% (249/249), 102.71 KiB | 3.67 MiB/s, done.
Total 249 (delta 181), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (181/181), completed with 3 local objects.
To github.com:determined-ai/determined-ee.git
 + 28b9afb40d...b13974fa77 FE-146 -> FE-146 (forced update)
```

We can see that the workflows are running.

https://app.circleci.com/pipelines/github/determined-ai/determined-ee?branch=FE-146

![image](https://github.com/determined-ai/determined-ee/assets/90728398/3ef2aed5-2e79-49cc-830f-537cda265eed)

Specifically, the `nightly` workflow is running.

https://app.circleci.com/pipelines/github/determined-ai/determined-ee/8953/workflows/c319e6ad-a102-408b-9364-6e4f2d796738

![image](https://github.com/determined-ai/determined-ee/assets/90728398/60661972-8fca-4464-9fa9-afc90756b4e3)

![image](https://github.com/determined-ai/determined-ee/assets/90728398/7f3b32cb-ce04-4de8-a3b2-2a579152fb2b)


**Test Case #3: Verify that the `nightly` workflow does not run when the `ci-run-nightly` label is not present in the pull request.**

I removed the `ci-run-nightly` label from the pull request.

![image](https://github.com/determined-ai/determined-ee/assets/90728398/7dd382ee-bc6e-40cc-aca9-d8b58f673ac8)

Rebased with `main`.

```
(base) rcorujo@C02FJ0T8MD6Q determined-ee % git pull --rebase origin main
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
remote: Enumerating objects: 2026, done.
remote: Counting objects: 100% (2026/2026), done.
remote: Compressing objects: 100% (628/628), done.
remote: Total 2026 (delta 1397), reused 2022 (delta 1394), pack-reused 0
Receiving objects: 100% (2026/2026), 531.21 KiB | 9.49 MiB/s, done.
Resolving deltas: 100% (1397/1397), completed with 1 local object.
From github.com:determined-ai/determined-ee
 * branch                  main       -> FETCH_HEAD
 + c63505f1e3...e6e6093041 main       -> origin/main  (forced update)
Successfully rebased and updated refs/heads/FE-146.
```

Then pushed my changes.

```
(base) rcorujo@C02FJ0T8MD6Q determined-ee % git push -f origin FE-146
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
Enumerating objects: 252, done.
Counting objects: 100% (252/252), done.
Delta compression using up to 16 threads
Compressing objects: 100% (249/249), done.
Writing objects: 100% (249/249), 77.71 KiB | 3.24 MiB/s, done.
Total 249 (delta 182), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (182/182), completed with 3 local objects.
To github.com:determined-ai/determined-ee.git
```

We can see that the `nightly` workflow did not run.

![image](https://github.com/determined-ai/determined-ee/assets/90728398/2c1f8357-1038-46d5-b487-ac36d144c2d7)


![image](https://github.com/determined-ai/determined-ee/assets/90728398/7f1df4cd-1789-4b14-958b-b2046beefc71)


![image](https://github.com/determined-ai/determined-ee/assets/90728398/a288f084-17df-43c4-bfef-d5a1977f0bae)




## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
