### PR TITLE
fix: correct date range for avg queued time charts [WEB-1621]

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -11,26 +11,28 @@ import css from './ClusterHistoricalUsageChart.module.scss';
 
 interface ClusterHistoricalUsageChartProps {
   chartKey?: number;
+  dateRange?: [number, number];
+  formatValues?: (self: uPlot, splits: number[]) => string[];
   groupBy?: GroupBy;
   height?: number;
   hoursByLabel: Record<string, number[]>;
   hoursTotal?: number[];
   label?: string;
   time: string[];
-  formatValues?: (self: uPlot, splits: number[]) => string[];
 }
 
 const CHART_HEIGHT = 350;
 
 const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = ({
+  chartKey,
+  dateRange,
+  formatValues,
   groupBy,
   height = CHART_HEIGHT,
-  label,
   hoursByLabel,
   hoursTotal,
+  label,
   time,
-  chartKey,
-  formatValues,
 }: ClusterHistoricalUsageChartProps) => {
   const chartData: AlignedData = useMemo(() => {
     const timeUnix: number[] = time.map((item) => Date.parse(item) / 1000);
@@ -109,18 +111,30 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
       scales: {
         x: {
           auto: !singlePoint,
-          range: singlePoint
-            ? [
-                new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
-                new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
-              ]
-            : undefined,
+          range:
+            dateRange ??
+            (singlePoint
+              ? [
+                  new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
+                  new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
+                ]
+              : undefined),
         },
       },
       series,
       tzDate: (ts) => uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'),
     };
-  }, [groupBy, height, hoursByLabel, hoursTotal, label, chartKey, singlePoint, formatValues]);
+  }, [
+    chartKey,
+    dateRange,
+    formatValues,
+    groupBy,
+    height,
+    hoursByLabel,
+    hoursTotal,
+    label,
+    singlePoint,
+  ]);
 
   if (!hasData) {
     return <Message title="No data to plot." type={MessageType.Empty} />;

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -11,7 +11,7 @@ import css from './ClusterHistoricalUsageChart.module.scss';
 
 interface ClusterHistoricalUsageChartProps {
   chartKey?: number;
-  dateRange?: [number, number];
+  dateRange?: [start: number, end: number];
   formatValues?: (self: uPlot, splits: number[]) => string[];
   groupBy?: GroupBy;
   height?: number;

--- a/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
+++ b/webui/react/src/pages/Clusters/ClustersQueuedChart.tsx
@@ -27,6 +27,11 @@ const ClustersQueuedChart: React.FC<Props> = ({ poolStats }: Props) => {
     };
   }, [poolStats, viewDays]);
 
+  const dateRange: [number, number] = useMemo(() => {
+    const now = Date.now() / 1000;
+    return [now - viewDays * 86400, now];
+  }, [viewDays]);
+
   if (!queuedStats) return <div />;
   return (
     <>
@@ -44,6 +49,7 @@ const ClustersQueuedChart: React.FC<Props> = ({ poolStats }: Props) => {
         title="Avg Queue Time">
         <ClusterHistoricalUsageChart
           chartKey={viewDays}
+          dateRange={dateRange}
           formatValues={(_: uPlot, splits: number[]) =>
             splits.map((n) => durationInEnglish(n * 1000))
           }


### PR DESCRIPTION
## Description

On the `Avg Queued Time` charts (under each resource pool) when there is only a single data point, the date range is incorrect. Fix the date range to render a proper chart.

BEFORE:
<img width="1347" alt="Screenshot 2023-08-29 at 3 03 08 PM" src="https://github.com/determined-ai/determined/assets/220971/b31ebec8-8b22-4712-9e72-9e29375df273">
<img width="1347" alt="Screenshot 2023-08-29 at 3 03 12 PM" src="https://github.com/determined-ai/determined/assets/220971/4cf40389-88bd-4e9d-b18c-2931e49eee59">

AFTER:
<img width="1340" alt="Screenshot 2023-08-29 at 3 02 21 PM" src="https://github.com/determined-ai/determined/assets/220971/76a42aaa-7360-4b0c-8c17-505b4d7daf06">
<img width="1342" alt="Screenshot 2023-08-29 at 3 02 15 PM" src="https://github.com/determined-ai/determined/assets/220971/f878335c-5a27-4d95-aed2-6e7aad0cd2b2">


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

The hard part is going to replicate the state of the resource pool stats to ensure there is only one data point... This can be mocked but not easy to do...

- [ ] navigate to `Stats` tab under a resource pool
- [ ] click on 7 days (also test 30 days)
- [ ] ensure there is only one data point (if not possible ok to ignore and just check the date ranges)
- [ ] verify that the chart has the correct date ranges

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1621
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
