### PR TITLE
fix: Handle chart x-axis with all points at x=0 [WEB-1622]

### DIFF
--- a/webui/react/src/components/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/UPlot/SyncProvider.tsx
@@ -71,6 +71,10 @@ class SyncService {
         max = max + margin;
         min = min - margin;
       }
+      if (min === max) {
+        max = 1;
+      }
+
       return {
         ...b,
         dataBounds: { max: dataMax, min: dataMin },

--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -83,7 +83,11 @@ class SyncService {
       const margin = 0.02 * width;
 
       const unzoomedMin = width > 0 ? dataMin - margin : Math.min(dataMin, 0);
-      const unzoomedMax = width > 0 ? dataMax + margin : 2 * dataMax;
+      let unzoomedMax = width > 0 ? dataMax + margin : 2 * dataMax;
+      if (unzoomedMin === unzoomedMax) {
+        // for single point at x=0
+        unzoomedMax = 1;
+      }
 
       return {
         ...b,

--- a/webui/react/src/pages/DesignKit.tsx
+++ b/webui/react/src/pages/DesignKit.tsx
@@ -619,6 +619,16 @@ const ChartsSection: React.FC = () => {
     name: 'Alt-Line',
   };
 
+  const zeroline: Serie = {
+    color: '#009BDE',
+    data: {
+      [XAxisDomain.Batches]: [[0, 1]],
+      [XAxisDomain.Time]: [],
+    },
+    metricType: MetricType.Training,
+    name: 'Line',
+  };
+
   const checkpointsDict: CheckpointsDict = {
     2: {
       endTime: '2023-02-02T04:54:41.095204Z',
@@ -669,6 +679,15 @@ const ChartsSection: React.FC = () => {
           height={250}
           series={[line1, line2]}
           title="Sample"
+        />
+      </AntDCard>
+      <AntDCard title="Series with all x=0">
+        <p>When all points have x=0, the x-axis bounds should go from 0 to 1.</p>
+        <LineChart
+          handleError={handleError}
+          height={250}
+          series={[zeroline]}
+          title="Series with all x=0"
         />
       </AntDCard>
       <AntDCard title="States without data">


### PR DESCRIPTION
## Description

For charts with a single x-value, we typically set the x-axis to include the point and 0. This is breaking on charts where all points are at x=0

In this case, we should set the x-axis to be xmin=0, xmax=1. The chart datapoint will then be rendered:

<img width="438" alt="Screen Shot 2023-08-30 at 11 59 19 AM" src="https://github.com/determined-ai/determined/assets/643918/485f3b35-9053-40fa-8bac-ffce5e92cd50">
<img width="516" alt="Screen Shot 2023-08-30 at 11 59 13 AM" src="https://github.com/determined-ai/determined/assets/643918/d201beda-5b9d-4451-850a-9a5e8436b03a">


## Test Plan

Visit `/det/experiments/4194/overview` and confirm a visible and hoverable point in the top left
Visit `/det/experiments/4194/metrics` and confirm a visible hoverable point on the left edge of both charts
Visit another completed experiment and confirm chart bounds look normal on Overview and Metrics tabs 

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.