### PR TITLE
chore: add db migrations for permission CAN_VIEW_EXTERNAL_JOBS

### DIFF
--- a/master/static/migrations/20230830120745_add-rbac-external-jobs.tx.down.sql
+++ b/master/static/migrations/20230830120745_add-rbac-external-jobs.tx.down.sql
@@ -1,0 +1,3 @@
+DELETE FROM permission_assignments WHERE permission_id = 8007;
+
+DELETE FROM permissions WHERE id = 8007;

--- a/master/static/migrations/20230830120745_add-rbac-external-jobs.tx.up.sql
+++ b/master/static/migrations/20230830120745_add-rbac-external-jobs.tx.up.sql
@@ -1,0 +1,24 @@
+--  // Ability to view external jobs
+--  PERMISSION_TYPE_VIEW_EXTERNAL_JOBS = 8007;
+
+INSERT into permissions(id, name, global_only) VALUES
+    (8007, 'view external jobs', true);
+
+
+-- determined> select * from roles;
+-- +----+---------------------+----------------------------+
+-- | id | role_name           | created_at                 |
+-- |----+---------------------+----------------------------|
+-- | 1  | ClusterAdmin        | 2023-05-30 16:20:54.825443 |
+-- | 2  | WorkspaceAdmin      | 2023-05-30 16:20:54.825443 |
+-- | 3  | WorkspaceCreator    | 2023-05-30 16:20:54.825443 |
+-- | 4  | Viewer              | 2023-05-30 16:20:54.825443 |
+-- | 5  | Editor              | 2023-05-30 16:20:54.825443 |
+-- | 6  | ModelRegistryViewer | 2023-05-30 16:20:55.136146 |
+-- +----+---------------------+----------------------------+
+-- SELECT 6
+
+INSERT INTO permission_assignments (permission_id, role_id)
+SELECT 8007, roles.id
+FROM roles
+WHERE roles.role_name IN ('ClusterAdmin');


### PR DESCRIPTION
## Description
Add db migrations for permission CAN_VIEW_EXTERNAL_JOBS. This permission will be added to the built-in role `ClusterAdmin`.

## Test Plan
NA

## Commentary (optional)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[FE-23](https://hpe-aiatscale.atlassian.net/browse/FE-23)

[FE-23]: https://hpe-aiatscale.atlassian.net/browse/FE-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ