### PR TITLE
fix: glitchy width in code editor

### DIFF
--- a/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
+++ b/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
@@ -1,7 +1,7 @@
 .codeEditorBase {
   display: grid;
   grid-template:
-    'tree title' min-content
+    'tree title' minmax(38px, min-content)
     'tree editor' auto / clamp(300px, 25vw, 400px) minmax(0, auto);
   max-width: 100vw;
   min-height: 250px;

--- a/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
+++ b/webui/react/src/components/kit/CodeEditor/CodeEditor.module.scss
@@ -2,7 +2,7 @@
   display: grid;
   grid-template:
     'tree title' min-content
-    'tree editor' auto / minmax(15%, auto) minmax(52%, auto);
+    'tree editor' auto / clamp(300px, 25vw, 400px) minmax(0, auto);
   max-width: 100vw;
   min-height: 250px;
 


### PR DESCRIPTION
## Description
[WEB-1612], [WEB-1431], [DET-9683]

### Before


https://github.com/determined-ai/determined/assets/109113616/735f9036-d1cd-48f8-9e1c-663e1c1a07d4

### After

https://github.com/determined-ai/determined/assets/109113616/716053be-efb1-49f5-8977-2f57fed97ae6



<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Check if width in code editor is consistent during scrolling and after switching files
  - tips: find a file with long lines (ideally at least 110 lines)
- Check if mobile view behavior is the same as before this PR
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1612]: https://hpe-aiatscale.atlassian.net/browse/WEB-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-1431]: https://hpe-aiatscale.atlassian.net/browse/WEB-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-9683]: https://hpe-aiatscale.atlassian.net/browse/DET-9683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ