### PR TITLE
chore: make pre-commit dev setup opt-in.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 all:
 	$(MAKE) get-deps
 	$(MAKE) build
-	$(MAKE) set-config-dev
 
 .PHONY: get-deps
 get-deps: get-deps-pip get-deps-go get-deps-webui


### PR DESCRIPTION
## Description

Since a significant group of people on the team are not using pre-commit, let's not automatically set it up on `make all` and make it an "opt-in" feature instead.

pre-commit users can run `make set-config-dev` or `pre-commit install` directly.

## Test Plan

N/A

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
