### PR TITLE
fix: Get distributed jobs working with devcluster [FE-181]

### DIFF
--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -259,11 +259,17 @@ func (a *Agent) connect(ctx context.Context, reconnect bool) (*MasterWebsocket, 
 		TLSClientConfig:  tlsConfig,
 	}
 
-	masterAddr := fmt.Sprintf(
-		"%s://%s:%d/agents?id=%s&version=%s&resource_pool=%s&reconnect=%v",
-		masterProto, a.opts.MasterHost, a.opts.MasterPort, a.opts.AgentID, a.version,
-		a.opts.ResourcePool, reconnect,
-	)
+        hostname, err := os.Hostname()
+
+        if err != nil {
+                a.log.Warnf("Unable to get hostname : %v", err)
+        }
+
+        masterAddr := fmt.Sprintf(
+                "%s://%s:%d/agents?id=%s&version=%s&resource_pool=%s&reconnect=%v&hostname=%s",
+                masterProto, a.opts.MasterHost, a.opts.MasterPort, a.opts.AgentID, a.version,
+                a.opts.ResourcePool, reconnect, hostname,
+        )
 	a.log.Infof("connecting to master at: %s", masterAddr)
 	conn, resp, err := dialer.DialContext(ctx, masterAddr, nil)
 	if resp != nil {

--- a/agent/internal/agent.go
+++ b/agent/internal/agent.go
@@ -259,17 +259,16 @@ func (a *Agent) connect(ctx context.Context, reconnect bool) (*MasterWebsocket, 
 		TLSClientConfig:  tlsConfig,
 	}
 
-        hostname, err := os.Hostname()
+	hostname, err := os.Hostname()
+	if err != nil {
+		a.log.Warnf("Unable to get hostname : %v", err)
+	}
 
-        if err != nil {
-                a.log.Warnf("Unable to get hostname : %v", err)
-        }
-
-        masterAddr := fmt.Sprintf(
-                "%s://%s:%d/agents?id=%s&version=%s&resource_pool=%s&reconnect=%v&hostname=%s",
-                masterProto, a.opts.MasterHost, a.opts.MasterPort, a.opts.AgentID, a.version,
-                a.opts.ResourcePool, reconnect, hostname,
-        )
+	masterAddr := fmt.Sprintf(
+		"%s://%s:%d/agents?id=%s&version=%s&resource_pool=%s&reconnect=%v&hostname=%s",
+		masterProto, a.opts.MasterHost, a.opts.MasterPort, a.opts.AgentID, a.version,
+		a.opts.ResourcePool, reconnect, hostname,
+	)
 	a.log.Infof("connecting to master at: %s", masterAddr)
 	conn, resp, err := dialer.DialContext(ctx, masterAddr, nil)
 	if resp != nil {

--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -447,13 +447,13 @@ func (a *agent) receive(ctx *actor.Context, msg interface{}) error {
 // mechanism, this will work.
 func (a *agent) adjustAgentIPAddrIfRunningDevClusterOnHpcUsingAnSSHTunnel(
 	ctx *actor.Context,
-	msg ws.WebSocketConnected) {
+	msg ws.WebSocketConnected,
+) {
 	// Check if the address is a loopback address.
 	if addr := net.ParseIP(strings.Trim(a.address, "[]")); addr != nil && addr.IsLoopback() {
 		agentHostname := strings.TrimSpace(msg.Ctx.QueryParam("hostname"))
 
 		masterHostname, err := os.Hostname()
-
 		if err != nil {
 			ctx.Log().Warnf("Unable to get hostname : %v", err)
 		}
@@ -465,7 +465,7 @@ func (a *agent) adjustAgentIPAddrIfRunningDevClusterOnHpcUsingAnSSHTunnel(
 		// Use the "hostname" parameter that the agent sent us as the address.
 		if agentHostname != masterHostname {
 			ctx.Log().Infof(
-				"Received loopback address '%s' from agent. Using agent hostname '%s' as address.",
+				"remote address for agent is loopback ('%s'), using provided hostname '%s' instead",
 				a.address, agentHostname)
 			a.address = agentHostname
 		}


### PR DESCRIPTION
## Description
        
On the Determined Enterprise Edition, when the dev cluster is started with `tools/slurmcluster.sh`, an SSH tunnel is created between the local host and the HPC cluster. Due to the way the reverse tunnel is created, all the nodes will report a loopback address of `[::1]`. This will cause distributed experiments to fail. To work around this, use the newly added agent's `hostname` parameter, which will be the node name that the agent is running on, as the IP address. As long as the cluster has been configured to resolve the node names to their respective IP addresses via `/etc/hosts`, DNS, or some other mechanism, this will work.

Note that if the master and the agent are both running locally on the same machine, the agent will also report an address of `[::1]`.  In this case, where the master and the agent's hostname is the same, we do not modify the agent's IP address and leave it as `[::1]`.

## Test Plan

Tested with `determined-ee` repo.

**Test Case #1:  Start the agent on the `casablanca-login` HPC cluster. This verifies that when we receive the agent's address as `[::1]`, we use the `hostname` parameter provided by the agent instead.**

Started the dev cluster on my MAC laptop, specifying the `-A` option to indicate that we want to use the agent resource manager, instead of the dispatcher resource manager.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q determined-ee % tools/slurmcluster.sh -A casablanca
```

On `casablanca-login`, I started the agent on 2 nodes, requesting 4 GPUs per node, using `srun -N2 --gpus-per-node=4...`.

```
[corujor@casablanca-login ~]$ srun -N2 --gpus-per-node=4 ~/determined-agent --master-host=casablanca-login  --master-port=8085 --resource-pool=default --container-runtime=apptainer --slot-type=cuda --debug=true
```

We can immediately see our info level log statement.

```
master: INFO[2023-09-05T13:37:08-04:00] remote address for agent is loopback ('[::1]'), using provided hostname 'node002' instead  actor-local-addr=node002 actor-system=master go-type=agent
master: INFO[2023-09-05T13:37:08-04:00] remote address for agent is loopback ('[::1]'), using provided hostname 'node010' instead  actor-local-addr=node010 actor-system=master go-type=agent
```

Used the following configuration file for the experiment, which requests `8 slots` (i.e., `8 GPUs`).

```
(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % cat distributed.yaml
debug: true
name: cifar10_pytorch_distributed
hyperparameters:
  learning_rate: 1.0e-4
  learning_rate_decay: 1.0e-6
  layer1_dropout: 0.25
  layer2_dropout: 0.25
  layer3_dropout: 0.5
  global_batch_size: 512 # Per-GPU batch size of 32
max_restarts: 0
resources:
  slots_per_trial: 8
records_per_epoch: 50000
searcher:
  name: single
  metric: validation_error
  max_length:
    epochs: 1
entrypoint: model_def:CIFARTrial
min_validation_period:
  epochs: 1
```

Ran the experiment.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % det experiment create distributed.yaml .
CLI version 0.24.0-dev0 is less than master version 0.25.0-dev0. Consider upgrading the CLI.
Preparing files to send to master... 14.2KB and 8 files 
Created experiment 57
```

The experiment completed successfully.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % det experiment list | egrep " ID |---| 57 "
CLI version 0.24.0-dev0 is less than master version 0.25.0-dev0. Consider upgrading the CLI.
   ID | Owner              | Name                        | Parent ID   | State     | Progress   | Started                  | Ended                    | Resource Pool
------+--------------------+-----------------------------+-------------+-----------+------------+--------------------------+--------------------------+-----------------
   57 | corujor-casablanca | cifar10_pytorch_distributed |             | COMPLETED | 100.0%     | 2023-09-05 15:52:32+0000 | 2023-09-05 15:54:19+0000 | default
```

**Test Case #2:  Start the agent locally on the MAC laptop where the Determined master is running. This verifies that when we receive the agent's address as `[::1]`, we DO NOT use the `hostname` parameter provided by the agent because both the master and the agent are running locally on the same machine.**

Started the dev cluster on my MAC laptop, specifying the `-A` option to indicate that we want to use the agent resource manager, instead of the dispatcher resource manager.  This will not be the way that customers will start the master locally when not using HPC, but this provides an easy way for me to start the master with the `agent resource manager`, instead of the `dispatcher resource manager`.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q determined-ee % tools/slurmcluster.sh -A casablanca
```

Start the agent locally.

```
(base) rcorujo@C02FJ0T8MD6Q determined-ee % ./agent/build/determined-agent  --master-host=localhost  --master-port=8081 --resource-pool=default --container-runtime=apptainer --slot-type=cuda --debug=true
WARN[2023-09-05T12:00:36-04:00] no configuration file at /etc/determined/agent.yaml, skipping 
INFO[2023-09-05T12:00:36-04:00] agent configuration: {"config_file":"","master_host":"localhost","master_port":8081,"agent_id":"C02FJ0T8MD6Q","artificial_slots":0,"slot_type":"cuda","container_master_host":"","container_master_port":0,"label":"","resource_pool":"default","api_enabled":false,"bind_ip":"0.0.0.0","bind_port":9090,"visible_gpus":"","tls":false,"cert_file":"","key_file":"","http_proxy":"","https_proxy":"","ftp_proxy":"","no_proxy":"","security":{"tls":{"enabled":false,"skip_verify":false,"master_cert":"","master_cert_name":"","client_cert":"","client_key":""}},"fluent":{"image":"fluent/fluent-bit:1.6","port":24224,"container_name":"determined-fluent"},"container_auto_remove_disabled":false,"agent_reconnect_attempts":5,"agent_reconnect_backoff":5,"hooks":{"on_connection_lost":null},"container_runtime":"apptainer","image_root":"","singularity_options":{"allow_network_creation":false},"podman_options":{"allow_network_creation":false},"debug":true} 
TRAC[2023-09-05T12:00:36-04:00] starting main agent process                  
TRAC[2023-09-05T12:00:36-04:00] connecting to master                          component=agent
INFO[2023-09-05T12:00:36-04:00] connecting to master at: ws://localhost:8081/agents?id=C02FJ0T8MD6Q&version=0.25.0-dev0&resource_pool=default&reconnect=false&hostname=C02FJ0T8MD6Q  component=agent
TRAC[2023-09-05T12:00:36-04:00] reading master set agent options message      component=agent
TRAC[2023-09-05T12:00:36-04:00] running socket write loop                     component=websocket name=C02FJ0T8MD6Q remote-addr="[::1]:8081"
TRAC[2023-09-05T12:00:36-04:00] running socket read loop                      component=websocket name=C02FJ0T8MD6Q remote-addr="[::1]:8081"
TRAC[2023-09-05T12:00:36-04:00] detecting devices                             component=agent
INFO[2023-09-05T12:00:36-04:00] detected compute devices:                    
TRAC[2023-09-05T12:00:36-04:00] setting up apptainer runtime                  component=agent
TRAC[2023-09-05T12:00:36-04:00] setting up container manager                  component=agent
TRAC[2023-09-05T12:00:36-04:00] reattaching containers                        component=agent
DEBU[2023-09-05T12:00:36-04:00] reattachContainers: expected survivors: []    component=container-manager
DEBU[2023-09-05T12:00:36-04:00] reattachContainers: running containers: []    component=container-manager
TRAC[2023-09-05T12:00:36-04:00] iterating expected survivors and seeing if they were found  component=container-manager
TRAC[2023-09-05T12:00:36-04:00] sending SIGKILL to running containers that were not reattached  component=container-manager
TRAC[2023-09-05T12:00:36-04:00] writing agent started message                 component=agent
TRAC[2023-09-05T12:00:36-04:00] watching for ws requests and system events    component=agent
```

Notice that we do not see the message `Received loopback address '[::1]' from agent. Using agent hostname 'node010' as address.  actor-local-addr=node010` because, even though the agent sent us an address of `[::1]`, we detected that the master and the agent are running on the same host and did not need to modify the agent's address to use the `hostname` parameter provided by the agent.

```
master: INFO[2023-09-05T12:00:26-04:00] accepting incoming connections on port 8081  
devcluster is up
master: DEBU[2023-09-05T12:00:26-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:00:27-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: INFO[2023-09-05T12:00:36-04:00] agent connected ip: [::1] resource pool: default slots: 0  actor-local-addr=C02FJ0T8MD6Q actor-system=master go-type=agent
master: DEBU[2023-09-05T12:00:36-04:00] agent ContainersRestored ip: [::1] , reattached: [], allocations: []  actor-local-addr=C02FJ0T8MD6Q actor-system=master go-type=agent
master: INFO[2023-09-05T12:00:36-04:00] adding agent: C02FJ0T8MD6Q                    actor-local-addr=default actor-system=master agent-id=C02FJ0T8MD6Q go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:00:36-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:00:38-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:00:49-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: ERRO[2023-09-05T12:00:51-04:00] error while actor was running                 actor-local-addr=node010 actor-system=master error="agent failed to reconnect by deadline" go-type=agent
master: DEBU[2023-09-05T12:00:51-04:00] restored containers: 0                        agent-id=node010
master: ERRO[2023-09-05T12:00:51-04:00] error while actor was running                 actor-local-addr=node002 actor-system=master error="agent failed to reconnect by deadline" go-type=agent
master: DEBU[2023-09-05T12:00:51-04:00] restored containers: 0                        agent-id=node002
master: INFO[2023-09-05T12:00:51-04:00] removing agent: node010                       actor-local-addr=default actor-system=master agent-id=node010 go-type=resourcePool resource-pool=default
master: INFO[2023-09-05T12:00:51-04:00] removing agent: node002                       actor-local-addr=default actor-system=master agent-id=node002 go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:00:51-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:01:00-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
master: DEBU[2023-09-05T12:01:11-04:00] scheduling                                    actor-local-addr=default actor-system=master go-type=resourcePool resource-pool=default
```
## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
