### PR TITLE
fix: Make models list editing work via ModelActionDropdown [WEB-1603]

### DIFF
--- a/webui/react/src/components/ModelActionDropdown.tsx
+++ b/webui/react/src/components/ModelActionDropdown.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from 'react';
+
+import DeleteModelModal from 'components/DeleteModelModal';
+import Dropdown, { MenuItem } from 'components/kit/Dropdown';
+import { useModal } from 'components/kit/Modal';
+import ModelMoveModal from 'components/ModelMoveModal';
+import usePermissions from 'hooks/usePermissions';
+import { archiveModel, unarchiveModel } from 'services/api';
+import { ModelItem } from 'types';
+
+export const ModelActionMenuKey = {
+  DeleteModel: 'delete-model',
+  MoveModel: 'move-model',
+  SwitchArchived: 'switch-archived',
+} as const;
+
+interface Props {
+  children: React.ReactNode;
+  record: ModelItem;
+}
+
+export const ModelActionDropdown: React.FC<Props> = ({ children, record: model }: Props) => {
+  const deleteModelModal = useModal(DeleteModelModal);
+  const modelMoveModal = useModal(ModelMoveModal);
+
+  const { canDeleteModel, canModifyModel } = usePermissions();
+  const canDelete = canDeleteModel({ model });
+  const canModify = canModifyModel({ model });
+
+  const switchArchived = useCallback(async () => {
+    if (model.archived) {
+      await unarchiveModel({ modelName: model.name });
+    } else {
+      await archiveModel({ modelName: model.name });
+    }
+  }, [model.archived, model.name]);
+
+  const handleDropdown = (key: string) => {
+    switch (key) {
+      case ModelActionMenuKey.DeleteModel:
+        deleteModelModal.open();
+        break;
+      case ModelActionMenuKey.MoveModel:
+        modelMoveModal.open();
+        break;
+      case ModelActionMenuKey.SwitchArchived:
+        switchArchived();
+        break;
+    }
+  };
+
+  const ModelActionMenu = useCallback(
+    (record: ModelItem) => {
+      const menuItems: MenuItem[] = [];
+      if (canModify) {
+        menuItems.push({
+          key: ModelActionMenuKey.SwitchArchived,
+          label: record.archived ? 'Unarchive' : 'Archive',
+        });
+        if (!record.archived) {
+          menuItems.push({ key: ModelActionMenuKey.MoveModel, label: 'Move' });
+        }
+      }
+      if (canDelete) {
+        menuItems.push({
+          danger: true,
+          key: ModelActionMenuKey.DeleteModel,
+          label: 'Delete Model',
+        });
+      }
+
+      return menuItems;
+    },
+    [canModify, canDelete],
+  );
+
+  return (
+    <>
+      <Dropdown
+        isContextMenu
+        menu={ModelActionMenu(model)}
+        onClick={(key: string) => handleDropdown(key)}>
+        {children}
+      </Dropdown>
+      {model && <deleteModelModal.Component model={model} />}
+      {model && <modelMoveModal.Component model={model} />}
+    </>
+  );
+};

--- a/webui/react/src/components/ModelActionDropdown.tsx
+++ b/webui/react/src/components/ModelActionDropdown.tsx
@@ -16,10 +16,15 @@ export const ModelActionMenuKey = {
 
 interface Props {
   children: React.ReactNode;
+  onVisibleChange: (visible: boolean) => void;
   record: ModelItem;
 }
 
-export const ModelActionDropdown: React.FC<Props> = ({ children, record: model }: Props) => {
+export const ModelActionDropdown: React.FC<Props> = ({
+  children,
+  onVisibleChange,
+  record: model,
+}: Props) => {
   const deleteModelModal = useModal(DeleteModelModal);
   const modelMoveModal = useModal(ModelMoveModal);
 
@@ -33,7 +38,8 @@ export const ModelActionDropdown: React.FC<Props> = ({ children, record: model }
     } else {
       await archiveModel({ modelName: model.name });
     }
-  }, [model.archived, model.name]);
+    onVisibleChange(true);
+  }, [model.archived, model.name, onVisibleChange]);
 
   const handleDropdown = (key: string) => {
     switch (key) {

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -96,6 +96,20 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     resetSettings,
   } = useSettings<Settings>(settingConfig);
 
+  const [permissionsByModel, setPermissionsByModel] = useState<
+    Record<number, { canDelete: boolean; canModify: boolean }>
+  >({});
+  useEffect(() => {
+    const allPerm: Record<number, { canDelete: boolean; canModify: boolean }> = {};
+    models.forEach((model) => {
+      allPerm[model.id] = {
+        canDelete: canDeleteModel({ model }),
+        canModify: canModifyModel({ model }),
+      };
+    });
+    setPermissionsByModel((prev) => (_.isEqual(prev, allPerm) ? prev : allPerm));
+  }, [models, canDeleteModel, canModifyModel]);
+
   const filterCount = useMemo(() => activeSettings(filterKeys).length, [activeSettings]);
   const isTableLoading = useMemo(
     () => isLoading || isLoadingSettings,
@@ -137,20 +151,6 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       setIsLoading(false);
     }
   }, [settings, workspace?.id]);
-
-  const [permissionsByModel, setPermissionsByModel] = useState<
-    Record<number, { canDelete: boolean; canModify: boolean }>
-  >({});
-  useEffect(() => {
-    const allPerm: Record<number, { canDelete: boolean; canModify: boolean }> = {};
-    models.forEach((model) => {
-      allPerm[model.id] = {
-        canDelete: canDeleteModel({ model }),
-        canModify: canModifyModel({ model }),
-      };
-    });
-    setPermissionsByModel((prev) => (_.isEqual(prev, allPerm) ? prev : allPerm));
-  }, [models, canDeleteModel, canModifyModel]);
 
   const fetchTags = useCallback(async () => {
     try {

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -404,7 +404,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
 
       return menuItems;
     },
-    [canDeleteModel, canModifyModel],
+    [], // canDeleteModel, canModifyModel
   );
 
   const handleDropdown = useCallback(
@@ -587,11 +587,11 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     labelFilterDropdown,
     tags,
     userFilterDropdown,
-    canModifyModel,
+    // canModifyModel,
     setModelTags,
-    canDeleteModel,
+    // canDeleteModel,
     ModelActionMenu,
-    handleDropdown,
+    // handleDropdown,
     saveModelDescription,
     workspaceRenderer,
   ]);
@@ -674,7 +674,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
         </Dropdown>
       );
     },
-    [ModelActionMenu, handleDropdown],
+    [ModelActionMenu], // handleDropdown
   );
 
   return (

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -21,6 +21,7 @@ import Tags, { tagsActionHelper } from 'components/kit/Tags';
 import Toggle from 'components/kit/Toggle';
 import Tooltip from 'components/kit/Tooltip';
 import Link from 'components/Link';
+import { ModelActionMenuKey as MenuKey, ModelActionDropdown } from 'components/ModelActionDropdown';
 import ModelCreateModal from 'components/ModelCreateModal';
 import ModelMoveModal from 'components/ModelMoveModal';
 import InteractiveTable, {
@@ -67,12 +68,6 @@ const filterKeys: Array<keyof Settings> = ['tags', 'name', 'users', 'description
 interface Props {
   workspace?: Workspace;
 }
-
-const MenuKey = {
-  DeleteModel: 'delete-model',
-  MoveModel: 'move-model',
-  SwitchArchived: 'switch-archived',
-} as const;
 
 const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const canceler = useRef(new AbortController());
@@ -673,36 +668,6 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       });
     },
     [settings, updateSettings],
-  );
-
-  const ModelActionDropdown = useCallback(
-    ({ record, children }: { children: React.ReactNode; record: ModelItem }) => {
-      const handleDropdown = (key: string, record: ModelItem) => {
-        switch (key) {
-          case MenuKey.DeleteModel:
-            setModel(record);
-            deleteModelModal.open();
-            break;
-          case MenuKey.MoveModel:
-            setModel(record);
-            modelMoveModal.open();
-            break;
-          case MenuKey.SwitchArchived:
-            switchArchived(record);
-            break;
-        }
-      };
-
-      return (
-        <Dropdown
-          isContextMenu
-          menu={ModelActionMenu(record)}
-          onClick={(key) => handleDropdown(key, record)}>
-          {children}
-        </Dropdown>
-      );
-    },
-    [ModelActionMenu, deleteModelModal, modelMoveModal, switchArchived],
   );
 
   return (

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -128,6 +128,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
       );
       setTotal(response.pagination.total || 0);
       setModels((prev) => {
+        response.models.map((m) => m.labels?.sort?.());
         if (_.isEqual(prev, response.models)) return prev;
         return response.models;
       });


### PR DESCRIPTION
## Description

We allow users to edit rows of the ModelRegistry table, similar to ExperimentList.  When we refresh model data through polling, it overwrites an edit in progress.

ExperimentList does not have this issue because it uses ExperimentActionDropdown. I've transferred that logic here for a new ModelActionDropdown component.

This also fixes an issue where state was updated every time, because existing model tags were sorted differently in the API response and in the rendered state.

## Test Plan

- On `/det/models`, start editing the description field. Pause and wait several seconds. The description should not be changed back to the original or empty value
- Add a model tag
- Right-click a row and Archive the model; soon it should appear Archived (i.e. editing disabled)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.