### PR TITLE
fix: Avoid dropdown repeating in ExpList fields dropdown [WEB-1598]

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -219,13 +219,17 @@ func (a *apiServer) getProjectColumnsByID(
 		}
 	}
 
-	for _, stats := range summaryMetrics {
-		// If there are multiple metrics with the same group and name, report the type as unspecified.
+	for idx, stats := range summaryMetrics {
+		// If there are multiple metrics with the same group and name, report one unspecified column.
 		if stats.Count > 1 {
-			columns[len(columns)-1].Type = projectv1.ColumnType_COLUMN_TYPE_UNSPECIFIED
+			continue
 		}
 
 		columnType := parseMetricsType(stats.MetricType)
+		if len(summaryMetrics) > idx+1 && summaryMetrics[idx+1].Count > 1 {
+			columnType = projectv1.ColumnType_COLUMN_TYPE_UNSPECIFIED
+		}
+
 		columnPrefix := stats.JSONPath
 		columnLocation := projectv1.LocationType_LOCATION_TYPE_CUSTOM_METRIC
 		if stats.JSONPath == metricGroupTraining {

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -188,7 +188,8 @@ const FilterField = ({
         <Select
           autoFocus
           dropdownMatchSelectWidth={300}
-          options={columns.map((col) => ({
+          options={columns.map((col, idx) => ({
+            key: `${col.column} ${idx}`,
             label: col.displayName || col.column,
             value: col.column,
           }))}


### PR DESCRIPTION
## Description

We've seen this issue on gcloud - likely there are metric names which we consider to be different, but when turned into the React key attribute are the same string, or clash with our use of .min/.max/.last

With this index fix, the keys in the dropdown options are unique

**Updated with backend fix**
On https://gcloud.determined.ai/api/v1/projects/1/columns we return `training.accurarcy.last` three times, with Unspecified, Number, and Text types.
We should return one Unspecified column, and skip repeats of the column name 

## Test Plan

Use the omnibar to set the backend to https://gcloud.determined.ai
On `/det/projects/1/experiments`, click "Filter" at top-left of the table
Open up the field Name dropdown, and you should see ID, Name, State
Use the mouse to grab the dropdown scroll cursor and rapidly go to the middle or end of the list. In the current gcloud version, you will get stuck with the same visible options. In the fixed version, you can smoothly jump to the middle and bottom of the dropdown, without repeating values.

`/api/v1/projects/1/columns` returns successfully

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.