### PR TITLE
fix: Metadata deleting last row, cancelling delete [WEB-1655]

### DIFF
--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -71,7 +71,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
                     }
                     key={field.key}
                     name={field.name}
-                    onDelete={fields.length > 1 ? () => remove(field.name) : undefined}
+                    onDelete={() => remove(field.name)}
                   />
                 ))}
                 <Link onClick={() => add({ key: '', value: '' })}>{ADD_ROW_TEXT}</Link>

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 
 import InfoBox, { InfoRow } from 'components/InfoBox';
 import Form from 'components/kit/Form';
@@ -51,8 +51,13 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
     [updateMetadata],
   );
 
+  const [form] = Form.useForm();
+  useEffect(() => {
+    form.resetFields();
+  }, [form, editing]);
+
   return (
-    <Form initialValues={{ metadata: metadataList }} onValuesChange={onValuesChange}>
+    <Form form={form} initialValues={{ metadata: metadataList }} onValuesChange={onValuesChange}>
       {editing ? (
         <>
           <div className={css.titleRow}>

--- a/webui/react/src/components/Metadata/MetadataCard.tsx
+++ b/webui/react/src/components/Metadata/MetadataCard.tsx
@@ -48,8 +48,9 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
   }, [editedMetadata, onSave]);
 
   const cancelEditMetadata = useCallback(() => {
+    setEditedMetadata(metadata);
     setIsEditing(false);
-  }, []);
+  }, [setEditedMetadata, metadata]);
 
   const showPlaceholder = useMemo(() => {
     return metadataArray.length === 0 && !isEditing;


### PR DESCRIPTION
## Description

Support metadata editor, allowing the value to be fully cleared, and recovering rows when cancelled

## Test Plan

- On `/det/models`, select a model
- In the Metadata section at the end of the page, click the pencil icon to open the editor
- Add one key and value, then click Save. Metadata now is available
- Click the pencil icon, and use the menu to remove that row. Click Save and the Metadata is now empty. Refresh the page to confirm Metadata was removed.
- Click the pencil icon, add one key, and save. Click the pencil again, remove that row, then click Cancel. The metadata should still be present.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.