### PR TITLE
feat: helm ca.cert injection, cluster-wide non-namespaced res creation flag, password change and minor-fix

### DIFF
--- a/helm/charts/determined/scripts/k8s-password-change.py
+++ b/helm/charts/determined/scripts/k8s-password-change.py
@@ -22,7 +22,7 @@ def pwChange(user: str, password: str, entrypoint: str) -> None:
                 headers={"Authorization": f"Bearer {data['token']}"},
                 verify=False,
             )
-            print(f"Sucessfully changed {user}'s password", flush=True)
+            print(f"Successfully changed {user}'s password", flush=True)
             return
         except Exception as e:
             print(f"Encountered exception: {e}", flush=True)
@@ -68,7 +68,7 @@ def getMasterAddress(
                     status = svc["status"]["loadBalancer"]
                     if "ingress" not in svc["status"]["loadBalancer"] or status["ingress"] is None:
                         n = n - 1
-                        time.sleep(1) # 1 second
+                        time.sleep(1) # 1 second and loop
                         break
                     if status["ingress"][0].get("hostname"):
                         # use hostname over ip address, if available

--- a/helm/charts/determined/scripts/k8s-password-change.py
+++ b/helm/charts/determined/scripts/k8s-password-change.py
@@ -55,8 +55,7 @@ def getMasterAddress(
     target_service = f"determined-master-service-{service_name}"
 
     if node_port != "true":
-        n=300 # 5 minutes
-        while n > 0: 
+        for i in range(300): # 5 minutes
             services = requests.get(
                 url=f"https://{service_host}:{service_port}/api/v1/namespaces/{namespace}/services",
                 headers={"Authorization": f"Bearer {token}"},
@@ -67,7 +66,6 @@ def getMasterAddress(
                 if target_service in svc["metadata"]["name"]:
                     status = svc["status"]["loadBalancer"]
                     if "ingress" not in svc["status"]["loadBalancer"] or status["ingress"] is None:
-                        n = n - 1
                         time.sleep(1) # 1 second and loop
                         break
                     if status["ingress"][0].get("hostname"):

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -40,7 +40,5 @@ spec:
             $KUBERNETES_PORT_443_TCP_PORT \
             $KUBE_TOKEN \
             {{ .Values.defaultPassword | default "" | quote }}
-            
-          #!## {{ .Values.defaultPassword | default ""}}
   
 {{- end }}

--- a/helm/charts/determined/templates/change-password.yaml
+++ b/helm/charts/determined/templates/change-password.yaml
@@ -39,5 +39,8 @@ spec:
             $KUBERNETES_SERVICE_HOST \
             $KUBERNETES_PORT_443_TCP_PORT \
             $KUBE_TOKEN \
-            {{ .Values.defaultPassword | default ""}}
+            {{ .Values.defaultPassword | default "" | quote }}
+            
+          #!## {{ .Values.defaultPassword | default ""}}
+  
 {{- end }}

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -49,6 +49,8 @@ spec:
             value: {{ .Values.db.user | quote }}
           - name: POSTGRES_PASSWORD
             value: {{ .Values.db.password | quote }}
+          - name: PGPORT
+            value: {{ .Values.db.port | quote }}
           - name: PGDATA
             value: /var/lib/postgresql/data/pgdata
         args: ["--max_connections=96", "--shared_buffers=512MB"]

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -39,7 +39,6 @@ spec:
         {{- if .Values.enterpriseEdition }}
         {{- if .Values.oidc }}
         env:
-          ## OLD - name: DETERMINED_OIDC_CLIENT_SECRET
           - name: DETERMINED_OIDC_CLIENT_SECRET
             valueFrom:
               secretKeyRef:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -60,7 +60,14 @@ spec:
           - name: database-cert
             mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
-          {{ end }}
+          {{- end }}
+          ## ISP CUSTOM - additional volume mount for ca.crt or boundle to perform the ca cert injection
+          {{- if .Values.externalCaCertSecretName }}
+          - name: etc-ssl-certs
+            mountPath: /etc/ssl/certs
+            readOnly: true
+          {{- end }}
+          ## ISP CUSTOM -END
         resources:
           requests:
             {{- if .Values.masterCpuRequest }}
@@ -79,6 +86,25 @@ spec:
             memory: {{ .Values.masterMemLimit  | quote }}
             {{- end}}
           {{- end}}
+      ## ISP CUSTOM - init container to update ca.crt or ca bundle into the master image
+      {{- if .Values.externalCaCertSecretName }}
+      initContainers:
+      - name: update-ca-certificates
+        command:
+          - sh
+          - -c
+          - update-ca-certificates --fresh
+        image: {{ .Values.imageRegistry }}/{{ $image }}:{{ $tag }}
+        imagePullPolicy: "Always"
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /usr/local/share/ca-certificates/
+            name: usr-local-share-ca-certificates
+          - mountPath: /etc/ssl/certs
+            name: etc-ssl-certs
+      {{- end }}
+      ## ISP CUSTOM - END
       {{- if .Values.imagePullSecretName}}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecretName }}
@@ -91,7 +117,7 @@ spec:
         - name: tls-secret
           secret:
             secretName: {{ .Values.tlsSecret }}
-        {{ end }}
+        {{- end }}
         {{- if .Values.db.sslMode }}
         - name: database-cert
           {{- $resourceType := (required "A valid .Values.db.resourceType entry required!" .Values.db.resourceType | trim)}}
@@ -102,4 +128,15 @@ spec:
           secret:
             secretName: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.db.certResourceName }}
           {{- end }}
-        {{ end }}
+        {{- end }}
+        ## ISP CUSTOM - additional volumes to manage ca.crt or ca boundle injection
+        {{- if .Values.externalCaCertSecretName }}
+        - name: usr-local-share-ca-certificates
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.externalCaCertSecretName }}
+        - name: etc-ssl-certs
+          emptyDir: {}
+        {{- end }}
+        ## ISP CUSTOM - END
+

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- if .Values.oidc }}
         env:
           ## OLD - name: DETERMINED_OIDC_CLIENT_SECRET
-          - name: DET_OIDC_CLIENT_SECRET
+          - name: DETERMINED_OIDC_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ required "A valid client secret name is required!" .Values.oidc.clientSecretName }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -39,7 +39,8 @@ spec:
         {{- if .Values.enterpriseEdition }}
         {{- if .Values.oidc }}
         env:
-          - name: DETERMINED_OIDC_CLIENT_SECRET
+          ## OLD - name: DETERMINED_OIDC_CLIENT_SECRET
+          - name: DET_OIDC_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ required "A valid client secret name is required!" .Values.oidc.clientSecretName }}
@@ -67,7 +68,7 @@ spec:
             mountPath: /etc/ssl/certs
             readOnly: true
           {{- end }}
-          ## ISP CUSTOM -END
+          ## ISP CUSTOM - END
         resources:
           requests:
             {{- if .Values.masterCpuRequest }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -61,13 +61,13 @@ spec:
             mountPath: {{ include "determined.secretPath" . }}
             readOnly: true
           {{- end }}
-          ## ISP CUSTOM - additional volume mount for ca.crt or boundle to perform the ca cert injection
+          # Additional volume mount for ca.crt or boundle to perform the ca cert injection
           {{- if .Values.externalCaCertSecretName }}
           - name: etc-ssl-certs
             mountPath: /etc/ssl/certs
             readOnly: true
           {{- end }}
-          ## ISP CUSTOM - END
+          # end - Additional volume mount
         resources:
           requests:
             {{- if .Values.masterCpuRequest }}
@@ -86,7 +86,7 @@ spec:
             memory: {{ .Values.masterMemLimit  | quote }}
             {{- end}}
           {{- end}}
-      ## ISP CUSTOM - init container to update ca.crt or ca bundle into the master image
+      # Init container to update ca.crt or ca bundle into the master image
       {{- if .Values.externalCaCertSecretName }}
       initContainers:
       - name: update-ca-certificates
@@ -104,7 +104,7 @@ spec:
           - mountPath: /etc/ssl/certs
             name: etc-ssl-certs
       {{- end }}
-      ## ISP CUSTOM - END
+      # end - Init container
       {{- if .Values.imagePullSecretName}}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecretName }}
@@ -129,7 +129,7 @@ spec:
             secretName: {{ required  "A valid Values.db.certResourceName entry is required!" .Values.db.certResourceName }}
           {{- end }}
         {{- end }}
-        ## ISP CUSTOM - additional volumes to manage ca.crt or ca boundle injection
+        # Additional volumes for ca.crt or ca boundle injection
         {{- if .Values.externalCaCertSecretName }}
         - name: usr-local-share-ca-certificates
           secret:
@@ -138,5 +138,5 @@ spec:
         - name: etc-ssl-certs
           emptyDir: {}
         {{- end }}
-        ## ISP CUSTOM - END
+        # end - Additional volumes 
 

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createNonNamespacesResources }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -15,3 +16,4 @@ value: 50
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for medium priority Determined jobs."
+{{ end }}

--- a/helm/charts/determined/templates/priority-classes.yaml
+++ b/helm/charts/determined/templates/priority-classes.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.createNonNamespacesResources }}
+{{- if .Values.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -7,7 +7,9 @@ value: 1000000
 preemptionPolicy: Never
 globalDefault: false
 description: "This priority class should be used for Determined system pods only."
+{{ end }}
 ---
+{{- if .Values.createNonNamespacedObjects }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -49,6 +49,13 @@ logColor: true
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080
 
+# Enables the creation of non-namespaces resources - Default: true
+# Non-namespaces resources are cluster-wide resources such as the priorityClasses.
+# Usage: In multiple installation on a single cluster (using different namespaces), 
+# this flag set to false avoids to recreate cluster-wide resources. 
+# Is some cases, creating existing cluster-wide resources could stop the automatic deployments.
+createNonNamespacesResources: true
+
 # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed to make
 # the Determined master reachable from outside the cluster. When useNodePortForMaster is set to
 # true, the master will instead be exposed behind a NodePort service. When using a NodePort service

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -54,6 +54,10 @@ masterPort: 8080
 # In multiple installation on a single cluster (using different namespaces), 
 # this flag set to false avoids to recreate non-namespaced objects. In some cases (e.g., GitOps w/ArgoCD) 
 # creating existing cluster-wide resources could stop/hang automatic deployments.
+#
+# WARNING 
+# The first installation must run with the createNonNamespacedObjects flag set to true to ensure 
+# the non-namespaced objects are created.
 createNonNamespacedObjects: true
 
 # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed to make

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -60,6 +60,12 @@ masterPort: 8080
 # the non-namespaced objects are created.
 createNonNamespacedObjects: true
 
+# External ca.crt injection certificate/s secret name
+# Command to create the ca cert secret: 
+#     kubectl create secret generic <external ca cert secret name, e.g., ext-ca-cert> --from-file=<ca.crt or ca bundle filename> -n <namespace>
+#
+# externalCaCertSecretName: <external ca cert secret name, e.g., ext-ca-cert>
+
 # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed to make
 # the Determined master reachable from outside the cluster. When useNodePortForMaster is set to
 # true, the master will instead be exposed behind a NodePort service. When using a NodePort service

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -49,12 +49,12 @@ logColor: true
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080
 
-# Enables the creation of non-namespaces resources - Default: true
-# Non-namespaces resources are cluster-wide resources such as the priorityClasses.
-# Usage: In multiple installation on a single cluster (using different namespaces), 
-# this flag set to false avoids to recreate cluster-wide resources. 
-# Is some cases, creating existing cluster-wide resources could stop the automatic deployments.
-createNonNamespacesResources: true
+# Enables the creation of non-namespaced objects - Default: true
+# Non-namespaced object are cluster-wide resources, such as the PriorityClasses.
+# In multiple installation on a single cluster (using different namespaces), 
+# this flag set to false avoids to recreate non-namespaced objects. In some cases (e.g., GitOps w/ArgoCD) 
+# creating existing cluster-wide resources could stop/hang automatic deployments.
+createNonNamespacedObjects: true
 
 # When useNodePortForMaster is set to false (default), a LoadBalancer service is deployed to make
 # the Determined master reachable from outside the cluster. When useNodePortForMaster is set to


### PR DESCRIPTION
## Description

Changes regarding: Helm chart

### Features
* Management of cluster wide object **non-namespeced** objects creation scheduler priority creation can be disable permitting to deploy two masters on the same K8s cluster without errors
* External Ca Cert injection using initcontainer - Installer could create a secret with the certificate 
  e.g., `kubectl create secret generic ext-ca-cert --from-file="ca.crt" -n mlde`
  and point it inside the `values.yaml` to insert into the Master container in the certificate dir

### Bug fix
* K8s change passwords script 
   * not working in Node port mode when Cluster IP is specified
   * escape password parameter added `| quote` (missed by mistake I guess)
* PostgreSQL port setup now works
