### PR TITLE
fix: Learning curve will send falsey metricType

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/LearningCurve.tsx
@@ -242,6 +242,7 @@ const LearningCurve: React.FC<Props> = ({
             color: glasbeyColor(trialId),
             data: { [XAxisDomain.Batches]: metricsMap[trialId] },
             key: trialId,
+            metricType: '',
             name: `trial ${trialId}`,
           }));
         setChartData(Loaded(newChartData));


### PR DESCRIPTION
## Description

We recently added support for metric groups other than the original training and validation types (see: #7727)
LearningCurve is defaulting to "unknown" group, because we didn't update its tooltip. We should send `metricType: ''` so it's not replaced, and not rendering an empty/blank group name.

<img width="282" alt="Screen Shot 2023-09-06 at 4 27 20 PM" src="https://github.com/determined-ai/determined/assets/643918/7072d85c-f207-4351-a699-f04541374c89">


## Test Plan

Visit a multi-trial experiment, and hover over points
Confirm "unknown." does not appear in multitrial chart tooltip

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.