### PR TITLE
chore: Split out partial updates into setPartial

### DIFF
--- a/webui/react/src/stores/userSettings.test.tsx
+++ b/webui/react/src/stores/userSettings.test.tsx
@@ -67,13 +67,41 @@ describe('userSettings', () => {
       const newSettings = store.get(t.string, configPath).get();
       expect(newSettings).toStrictEqual(Loaded(expectedValue));
     });
+  });
 
+  describe('setPartial', () => {
     it('should accept partial updates', async () => {
       const store = await setup({ [configPath]: expectedSettings });
 
-      store.set(Config, configPath, { string: expectedValue });
+      store.setPartial(Config, configPath, { string: expectedValue });
       const result = store.get(Config, configPath).get();
       expect(Loadable.map(result, (r) => r?.string)).toStrictEqual(Loaded(expectedValue));
+    });
+    it('should work on semipartial types', async () => {
+      const Semi = t.intersection([
+        t.type({
+          bar: t.string,
+          foo: t.number,
+        }),
+        t.partial({
+          baz: t.boolean,
+          qux: t.array(t.number),
+        }),
+      ]);
+      const path = 'semi';
+      const init = { bar: 'one', baz: true, foo: 1 };
+      const expected = 'two';
+      const expected2 = [1];
+
+      const store = await setup({ [path]: init });
+
+      store.setPartial(Semi, path, { bar: expected });
+      const result = store.get(Semi, path).get();
+      expect(Loadable.map(result, (r) => r?.bar)).toStrictEqual(Loaded(expected));
+
+      store.setPartial(Semi, path, { qux: expected2 });
+      const result2 = store.get(Semi, path).get();
+      expect(Loadable.map(result2, (r) => r?.qux)).toStrictEqual(Loaded(expected2));
     });
   });
 


### PR DESCRIPTION
## Description
This PR does two things:
1. splits out the overload case for partial updates from the `userSettings.set` case into its own function called `setPartial`. This reduces the magic a bit and makes each piece easier to reason about.
2. Adds a special-case to `setPartial` for the type `T & Partial<U>`.

The second case _could_ be generalized to work on any intersections of object types but the typing was _a lot_ and I didn't really want to get into it.

## Test Plan
1. Check that the tests pass
2. Check that the user settings drawer works properly


## Checklist

- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No Ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
