### PR TITLE
chore: handle case where steps completed is more than max length

### DIFF
--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -387,13 +387,6 @@ class WorkloadSequencer(workload.Source):
                 yield from self.validate(None)
 
             for op in self.core_context.searcher.operations(core.SearcherMode.ChiefOnly):
-                # This can occur when we have already trained more than our trial
-                # will train for. For example, if we are provided a steps_completed
-                # larger than our searcher max length.
-                if self.batches_until_op_complete(op) <= 0:
-                    logging.info("trial has already completed training")
-                    raise ShouldExit(skip_exit_checkpoint=True)
-
                 while self.batches_until_op_complete(op) > 0:
                     # Do some training.
                     yield from self.train(

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -431,7 +431,11 @@ class WorkloadSequencer(workload.Source):
                 if not self.validation_is_current():
                     yield from self.validate(op)
 
-                assert op._completed, "logic error; op was never completed"
+                if not op._completed:
+                    # The only case where op isn't reported as completed is if we restarted but
+                    # op.length was already trained for and validated on; in that case just break
+                    # out of the operations loop; we have nothing to do.
+                    break
 
         except ShouldExit as e:
             # Checkpoint unsaved work and exit.

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -6,11 +6,10 @@ import determined as det
 from determined import core, util, workload
 from determined.common import check
 
-import os
-
 WorkloadStreamElem = Tuple[workload.Workload, workload.ResponseFunc]
 
 WorkloadGenerator = Generator[WorkloadStreamElem, None, None]
+
 
 def yield_and_await_response(
     wkld: workload.Workload,
@@ -154,7 +153,6 @@ class WorkloadSequencer(workload.Source):
         if state.get("trial_id") != self._trial_id:
             return
 
-        print("STATE!?!?", state)
         self.state = self.SavableState(**state)
 
         # Detect the case where the final validation we made was against this exact checkpoint.  In
@@ -392,7 +390,6 @@ class WorkloadSequencer(workload.Source):
                 # This can occur when we have already trained more than our trial
                 # will train for. For example, if we are provided a steps_completed
                 # larger than our searcher max length.
-                print("BATCHES until op complete?", self.batches_until_op_complete(op), self.state.steps_completed, os.environ)
                 if self.batches_until_op_complete(op) <= 0:
                     logging.info("trial has already completed training")
                     raise ShouldExit(skip_exit_checkpoint=True)

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -701,6 +701,22 @@ class _PyTorchTrialController:
         for batch_idx, batch in training_enumerator:
             epoch_idx, batch_in_epoch_idx = divmod(batch_idx, epoch_len)
 
+            # This can occur when we have already trained more than our trial
+            # will train for. For example, if we are provided a steps_completed
+            # larger than our searcher max length.
+            #
+            # TODO this is really ugly, I think this is the earliest this can be
+            # since we need the dataloader to be initialized to tell us what batch we are on?
+            # It also seems we should do the check before we actually train any batches? So the
+            # natural place where we check `should_stop` feels too late?
+            for step in train_boundaries:
+                if step.step_type == _TrainBoundaryType.TRAIN and (
+                    (isinstance(step.unit, Batch) and batch_idx >= step.unit.value)
+                    or (isinstance(step.unit, Epoch) and epoch_idx >= step.unit.value)
+                ):
+                    logging.info("trial has already completed training")
+                    raise ShouldExit(skip_exit_checkpoint=True)
+
             # Set the batch index on the trial context used by step_optimizer.
             self.context._current_batch_idx = batch_idx
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -739,6 +739,7 @@ class _PyTorchTrialController:
     def _train_for_op(
         self, op: core.SearcherOperation, train_boundaries: List[_TrainBoundary]
     ) -> None:
+        searcher_complete = op._completed
         if self.local_training:
             searcher_length = self.max_length
         else:
@@ -768,6 +769,7 @@ class _PyTorchTrialController:
                 if train_boundary.step_type == _TrainBoundaryType.TRAIN:
                     if not op._completed and self.is_chief:
                         self._report_searcher_progress(op, self.searcher_unit)
+                    searcher_complete = train_boundary.limit_reached
                 elif train_boundary.step_type == _TrainBoundaryType.VALIDATE:
                     if not self._validation_is_current():
                         self._validate(op)
@@ -782,6 +784,14 @@ class _PyTorchTrialController:
                 if self.context.get_enable_tensorboard_logging():
                     self._upload_tb_files()
                 self._stop_requested()
+
+                # Test mode will break after one batch despite not completing op.
+                if self.is_chief and not self.test_mode:
+                    if not op._completed:
+                        # The only case where op isn't reported as completed is if we restarted but
+                        # op.length was already trained for and validated on; in that case just break
+                        # out of the operations loop; we have nothing to do.
+                        break
 
         # Finished training for op. Perform final checkpoint/validation if necessary.
         if not self._validation_is_current():

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1074,7 +1074,7 @@ class TestPyTorchTrial:
         trial_controller_A.run()
 
         checkpoint_callback = trial_A.checkpoint_callback
-        assert len(checkpoint_callback.uuids) == 1  # , "trial did not return a checkpoint UUID"
+        assert len(checkpoint_callback.uuids) == 1, "trial did not return a checkpoint UUID"
 
         trial_B, trial_controller_B = pytorch_utils.create_trial_and_trial_controller(
             trial_class=pytorch_onevar_model.OneVarTrial,

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1050,6 +1050,29 @@ class TestPyTorchTrial:
 
         utils.assert_patterns_in_logs(log_output, patterns)
 
+    @pytest.mark.parametrize(
+        "max_batches,steps_completed",
+        [
+            (5, 5),
+            (5, 10),
+            (6, 10),
+        ],
+    )
+    def test_max_batches_leq_steps_completed(self, max_batches: int, steps_completed: int):
+        trial, trial_controller = pytorch_utils.create_trial_and_trial_controller(
+            trial_class=pytorch_onevar_model.OneVarTrial,
+            hparams=self.hparams,
+            trial_seed=self.trial_seed,
+            max_batches=max_batches,
+            min_validation_batches=1,
+            min_checkpoint_batches=1,
+            steps_completed=steps_completed,
+        )
+        trial_controller.run()
+
+        assert len(trial.metrics_callback.validation_metrics) == 0
+        assert len(trial.metrics_callback.training_metrics) == 0
+
     def checkpoint_and_check_metrics(
         self,
         trial_class: pytorch_onevar_model.OneVarTrial,


### PR DESCRIPTION
## Description

In an upcoming feature https://github.com/determined-ai/determined/pull/7764, we have the ability to change experiment config then try rerunning an experiment.

The import aspect for this is we can resume from a checkpoint with a steps_completed larger or equal to our searcher's max length. Current trial code does not handle this case well. Pytorch trial trains for another max length, and other trials seem to error.

## Test Plan

Pytorch trial changes covered by unit test

I don't see an obvious way to test `_workload_sequencer` changes. I manually tested using the in progress single experiment continue on running `fashion_mnist_tf_keras_const` and running where steps_completed would be equal to searcher's max length. You might be able to do this with some db surgery and pause and activating the experiment. The individual trials that use _workload_sequencer test's don't seem to use the sequencer and just take lists of workloads.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
