### PR TITLE
feat: allow metrics with duplicate keys and the same value [MLG-890].

### DIFF
--- a/docs/release-notes/metrics-overwrites.rst
+++ b/docs/release-notes/metrics-overwrites.rst
@@ -2,5 +2,5 @@
 
 **Improvements**
 
--  API: It is now allowed to report duplicate metrics across multiple ``report_metrics`` with the
-   same ``steps_completed`` if their value is the same.
+-  API: Allow the reporting of duplicate metrics across multiple ``report_metrics`` with the same
+   ``steps_completed``, provided they have identical values.

--- a/docs/release-notes/metrics-overwrites.rst
+++ b/docs/release-notes/metrics-overwrites.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  API: It is now allowed to report duplicate metrics across multiple ``report_metrics`` with the
+   same ``steps_completed`` if their value is the same.

--- a/master/go.mod
+++ b/master/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/go-pg/pg/v10 v10.10.6
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0


### PR DESCRIPTION
## Description

Allow reporting metrics at the same step with duplicate keys as long as the duplicate keys have the same value, e.g.

```
{'step': 1718, 'valid_loss_epoch': 0.592993438243866, 'epoch': 0}
{'step': 1718, 'train_loss_epoch': 0.9345674514770508, 'epoch': 0}
```

## Test Plan

Automated tests have been added.

To test manually, implement a core API script which reports metrics in this fashion, e.g.
```
epoch = i // 10
core_v2.train.report_training_metrics(steps_completed=i, metrics={"loss": random.random(), "epoch": epoch})
core_v2.train.report_training_metrics(steps_completed=i, metrics={"loss2": random.random(), "epoch": epoch})
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
