### PR TITLE
fix: dupe checkpoints

### DIFF
--- a/docs/release-notes/dupeCheckpoints.rst
+++ b/docs/release-notes/dupeCheckpoints.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Checkpoints: Fix an issue where in certain situations duplicate checkpoints with the same UUID would be returned by the webui and the CLI.
+
+
+

--- a/docs/release-notes/dupeCheckpoints.rst
+++ b/docs/release-notes/dupeCheckpoints.rst
@@ -3,4 +3,4 @@
 **Bug Fixes**
 
 -  Checkpoints: Fix an issue where in certain situations duplicate checkpoints with the same UUID
-   would be returned by the webui and the CLI.
+   would be returned by the WebUI and the CLI.

--- a/docs/release-notes/dupeCheckpoints.rst
+++ b/docs/release-notes/dupeCheckpoints.rst
@@ -2,7 +2,5 @@
 
 **Bug Fixes**
 
--  Checkpoints: Fix an issue where in certain situations duplicate checkpoints with the same UUID would be returned by the webui and the CLI.
-
-
-
+-  Checkpoints: Fix an issue where in certain situations duplicate checkpoints with the same UUID
+   would be returned by the webui and the CLI.

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -173,13 +173,14 @@ func TestCheckpointsOnArchivedSteps(t *testing.T) {
 			State:        checkpointv1.State_STATE_COMPLETED,
 		},
 	})
+	require.NoError(t, err)
 
 	// We should only have one checkpoint.
 	checkpoints, err := api.GetExperimentCheckpoints(ctx, &apiv1.GetExperimentCheckpointsRequest{
 		Id: int32(trial.ExperimentID),
 	})
 	require.NoError(t, err)
-	require.Len(t, checkpoints.Checkpoints, 2)
+	require.Len(t, checkpoints.Checkpoints, 1)
 
 	actual := checkpoints.Checkpoints[0]
 	require.Equal(t, map[string]any{"expected": expected},

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/uptrace/bun"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiPkg "github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
@@ -23,6 +25,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
+	"github.com/determined-ai/determined/proto/pkg/commonv1"
+	"github.com/determined-ai/determined/proto/pkg/trialv1"
 )
 
 func createVersionTwoCheckpoint(
@@ -107,6 +111,81 @@ func getExperimentSizeFromUUID(ctx context.Context, t *testing.T, uuid string) i
 	require.NoError(t, err)
 
 	return out.CheckpointSize
+}
+
+func TestCheckpointsOnArchivedSteps(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+
+	// Create steps and validation so that we have steps / validations on 0 and 1
+	// archived and unarchived.
+	trialRunID := 0
+	trial, task := createTestTrial(t, api, curUser)
+	for _, shouldArchive := range []bool{false, true} {
+		if shouldArchive {
+			_, err := db.Bun().NewUpdate().Table("trials").
+				Set("run_id = 1").
+				Where("id = ?", trial.ID).
+				Exec(ctx)
+			require.NoError(t, err)
+			trialRunID++
+		}
+
+		for i := 0; i < 3; i++ {
+			expectedMetrics, err := structpb.NewStruct(map[string]any{
+				"expected": fmt.Sprintf("%t-%d", shouldArchive, i),
+			})
+			require.NoError(t, err)
+
+			for _, group := range []string{
+				model.ValidationMetricGroup.ToString(),
+				model.TrainingMetricGroup.ToString(),
+			} {
+				_, err = api.ReportTrialMetrics(ctx, &apiv1.ReportTrialMetricsRequest{
+					Metrics: &trialv1.TrialMetrics{
+						TrialId:        int32(trial.ID),
+						TrialRunId:     int32(trialRunID),
+						StepsCompleted: int32(i),
+						Metrics: &commonv1.Metrics{
+							AvgMetrics: expectedMetrics,
+						},
+					},
+					Group: group,
+				})
+				require.NoError(t, err)
+			}
+		}
+	}
+	expected := "true-1"
+
+	// Checkpoint on the 1.
+	checkpointMeta, err := structpb.NewStruct(map[string]any{
+		"steps_completed": 1,
+	})
+	require.NoError(t, err)
+	_, err = api.ReportCheckpoint(ctx, &apiv1.ReportCheckpointRequest{
+		Checkpoint: &checkpointv1.Checkpoint{
+			TaskId:       string(task.TaskID),
+			AllocationId: nil,
+			Uuid:         uuid.New().String(),
+			ReportTime:   timestamppb.New(time.Now()),
+			Resources:    nil,
+			Metadata:     checkpointMeta,
+			State:        checkpointv1.State_STATE_COMPLETED,
+		},
+	})
+
+	// We should only have one checkpoint.
+	checkpoints, err := api.GetExperimentCheckpoints(ctx, &apiv1.GetExperimentCheckpointsRequest{
+		Id: int32(trial.ExperimentID),
+	})
+	require.NoError(t, err)
+	require.Len(t, checkpoints.Checkpoints, 2)
+
+	actual := checkpoints.Checkpoints[0]
+	require.Equal(t, map[string]any{"expected": expected},
+		actual.Training.TrainingMetrics.AvgMetrics.AsMap())
+	require.Equal(t, map[string]any{"expected": expected},
+		actual.Training.ValidationMetrics.AvgMetrics.AsMap())
 }
 
 func TestCheckpointRemoveFilesPrefixAndEmpty(t *testing.T) {

--- a/master/static/migrations/20230908100300_fix-dupe-checkpoints.tx.down.sql
+++ b/master/static/migrations/20230908100300_fix-dupe-checkpoints.tx.down.sql
@@ -1,0 +1,57 @@
+DROP VIEW proto_checkpoints_view;
+DROP VIEW checkpoints_view;
+
+CREATE OR REPLACE VIEW checkpoints_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        t.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        t.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        CAST(c.metadata->>'steps_completed' AS int) as steps_completed,
+        c.size
+    FROM checkpoints_v2 AS c
+    LEFT JOIN trial_id_task_id AS task ON c.task_id = task.task_id
+    LEFT JOIN trials AS t on t.id = task.trial_id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN raw_validations AS v on CAST(c.metadata->>'steps_completed' AS int) = v.total_batches and t.id = v.trial_id
+    LEFT JOIN raw_steps AS s on CAST(c.metadata->>'steps_completed' AS int) = s.total_batches and t.id = s.trial_id
+    -- avoiding the steps view causes Postgres to not "Materialize" in this join.
+    WHERE s.archived IS NULL OR s.archived = false
+      AND v.archived IS NULL OR v.archived = false;
+
+CREATE OR REPLACE VIEW proto_checkpoints_view AS
+    SELECT
+        c.uuid::text AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time as report_time,
+        'STATE_' || c.state AS state,
+        c.resources,
+        c.metadata,
+        -- Build a training substruct for protobuf.
+        jsonb_build_object(
+            'trial_id', c.trial_id,
+            'experiment_id', c.experiment_id,
+            'experiment_config', c.experiment_config,
+            'hparams', c.hparams,
+            -- construct training metrics from the untyped jsonb deterministically, since older
+            -- versions may have old keys (e.g., num_inputs) and our unmarshaling is strict.
+            'training_metrics', jsonb_build_object(
+                'avg_metrics', c.training_metrics->'avg_metrics',
+                'batch_metrics', c.training_metrics->'batch_metrics'
+            ),
+            'validation_metrics', json_build_object('avg_metrics', c.validation_metrics),
+            'searcher_metric', c.searcher_metric
+        ) AS training
+    FROM checkpoints_view AS c;

--- a/master/static/migrations/20230908100300_fix-dupe-checkpoints.tx.up.sql
+++ b/master/static/migrations/20230908100300_fix-dupe-checkpoints.tx.up.sql
@@ -1,0 +1,54 @@
+DROP VIEW proto_checkpoints_view;
+DROP VIEW checkpoints_view;
+
+CREATE OR REPLACE VIEW checkpoints_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        t.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        t.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        CAST(c.metadata->>'steps_completed' AS int) as steps_completed,
+        c.size
+    FROM checkpoints_v2 AS c
+    LEFT JOIN trial_id_task_id AS task ON c.task_id = task.task_id
+    LEFT JOIN trials AS t on t.id = task.trial_id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN raw_validations AS v on CAST(c.metadata->>'steps_completed' AS int) = v.total_batches and t.id = v.trial_id AND NOT v.archived
+    LEFT JOIN raw_steps AS s on CAST(c.metadata->>'steps_completed' AS int) = s.total_batches and t.id = s.trial_id AND NOT s.archived;
+
+CREATE OR REPLACE VIEW proto_checkpoints_view AS
+    SELECT
+        c.uuid::text AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time as report_time,
+        'STATE_' || c.state AS state,
+        c.resources,
+        c.metadata,
+        -- Build a training substruct for protobuf.
+        jsonb_build_object(
+            'trial_id', c.trial_id,
+            'experiment_id', c.experiment_id,
+            'experiment_config', c.experiment_config,
+            'hparams', c.hparams,
+            -- construct training metrics from the untyped jsonb deterministically, since older
+            -- versions may have old keys (e.g., num_inputs) and our unmarshaling is strict.
+            'training_metrics', jsonb_build_object(
+                'avg_metrics', c.training_metrics->'avg_metrics',
+                'batch_metrics', c.training_metrics->'batch_metrics'
+            ),
+            'validation_metrics', json_build_object('avg_metrics', c.validation_metrics),
+            'searcher_metric', c.searcher_metric
+        ) AS training
+    FROM checkpoints_view AS c;


### PR DESCRIPTION
## Description


Bug in checkpoints view's where clause.

We left join on raw_steps and raw_validations but messed up the WHERE clause.

We start with
```
WHERE s.archived IS NULL OR (s.archived = false AND v.archived IS NULL) OR v.archived = false
```


Assume s.archived IS NULL and v.archived IS NULL is false they almost always will be
```
WHERE false OR (s.archived = false AND FALSE) OR v.archived = false 
```

```
WHERE false OR false OR v.archived = false
```

We are left with, which with a checkpoint on an steps_completed that had a training step archived, would give us the dupe checkpoints. 
```
WHERE v.archived = false 
```



## Test Plan

covered by integration test.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
