### PR TITLE
fix: error message for `det agent [enable|disable]`.

### DIFF
--- a/harness/determined/cli/agent.py
+++ b/harness/determined/cli/agent.py
@@ -156,9 +156,13 @@ def patch_agent(enabled: bool) -> Callable[[argparse.Namespace], None]:
     @authentication.required
     def patch(args: argparse.Namespace) -> None:
         check.check_false(args.all and args.agent_id)
+        action = "enable" if enabled else "disable"
 
         if not (args.all or args.agent_id):
-            raise errors.CliError("Must specify exactly on of --all or --agent-id")
+            raise errors.CliError(
+                "Please pass agent id or --all option. "
+                f"See `det agent {action} --help` for details."
+            )
 
         if args.agent_id:
             agent_ids = [args.agent_id]
@@ -169,7 +173,6 @@ def patch_agent(enabled: bool) -> Callable[[argparse.Namespace], None]:
         drain_mode = None if enabled else args.drain
 
         for agent_id in agent_ids:
-            action = "enable" if enabled else "disable"
             path = f"api/v1/agents/{agent_id}/{action}"
 
             payload = None


### PR DESCRIPTION
## Description

`det agent [enable|disable]` error message was incorrectly suggesting we have `--agent-id` option which is not true.

fixes #7831 

## Test Plan

Running `det agent disable` displays a sensible error.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
