### PR TITLE
feat: Allow passing in swagger json as an argument

### DIFF
--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -480,10 +480,11 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--input", "-i", action="store", default=SWAGGER, help="input swagger file")
     parser.add_argument("--output", "-o", action="store", required=True, help="output file")
     args = parser.parse_args()
 
-    swagger = swagger_parser.parse(SWAGGER)
+    swagger = swagger_parser.parse(args.input)
     bindings = pybindings(swagger)
     with open(args.output, "w") as f:
         print(bindings, file=f)

--- a/bindings/generate_bindings_ts.py
+++ b/bindings/generate_bindings_ts.py
@@ -594,10 +594,11 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--input", "-i", action="store", default=SWAGGER, help="input swagger file")
     parser.add_argument("--output", "-o", action="store", required=True, help="output folder")
     args = parser.parse_args()
 
-    swagger = swagger_parser.parse(SWAGGER)
+    swagger = swagger_parser.parse(args.input)
     bindings = tsbindings(swagger)
 
     if os.path.isdir(args.output):


### PR DESCRIPTION
feat: Allow passing in swagger json as an argument


This is to support external openapi 2.0 json files for generating python and ts clients.
