### PR TITLE
fix: Always load experiment yaml in ForkModal callback [WEB-1663]

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -186,7 +186,7 @@ const ExperimentCreateModalComponent = ({
       };
     });
     // avoid calling form.setFields inside setModalState:
-    if (modalState.isAdvancedMode && form) {
+    if (form) {
       try {
         const newConfig = (yaml.load(modalState.configString) || {}) as RawJson;
         const isFork = modalState.type === CreateExperimentType.Fork;


### PR DESCRIPTION
## Description

The problem: in forking a single- or multi-trial experiment, when first clicking "Show Full Config", the textbox is empty. It can be populated by returning to simple config, or by waiting several seconds.

Inside of the simple/full config toggle, the line `if (modalState.isAdvancedMode && form) { ... }` looks at the current modalState and not the mode which we're changing to. Removing this line means that we will load the experiment config on toggling config.

This line wouldn't have caused the recent change in behavior, but we can resolve the issue here

## Test Plan

- Open a single-trial experiment, click Fork, then Show Full Config. The code editor component should load for a second and then display YAML
- Open a multi-trial experiment, click Fork, then Show Full Config. The code editor component should load for a second and then display YAML

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.