### PR TITLE
fix: Always load experiment yaml in ForkModal callback [WEB-1663]

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -338,6 +338,7 @@ const ExperimentCreateModalComponent = ({
       const newModalState = {
         ...prev,
         config: publicConfig,
+        configString: prev.configString || yaml.dump(publicConfig),
         experiment,
         open: true,
         trial,


### PR DESCRIPTION
## Description

The problem: in forking a single- or multi-trial experiment, when first clicking "Show Full Config", the textbox is empty. It can be populated by returning to simple config, or by waiting several seconds.

Updated with new fix: configString is passed but not overwritten; fixes issue related to #7688

## Test Plan

- Open an experiment, click Fork, then Show Full Config. The code editor component should load for a second and then display YAML.
- If you change the YAML and then leave the modal open for several seconds, the modal does not undo your change or return to simple editor mode

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.