### PR TITLE
fix: fix how we are calling the bert embedding example

### DIFF
--- a/examples/features/torch_batch_process_embeddings/bert_embedding_generation.py
+++ b/examples/features/torch_batch_process_embeddings/bert_embedding_generation.py
@@ -24,7 +24,7 @@ class EmbeddingProcessor(experimental.TorchBatchProcessor):
 
         self.context = context
         self.last_index = 0
-        self.rank = self.context.distributed.get_rank()
+        self.rank = self.context.get_distributed_rank()
 
         self.output_dir = "/tmp/data/bert_scidocs_embeddings"
         os.makedirs(self.output_dir, exist_ok=True)


### PR DESCRIPTION
## Description
This fixes one of the e2e_test examples that didn't get updated properly with the https://github.com/determined-ai/determined/pull/7592 PR.

## Test Plan
CI passes

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
