### PR TITLE
feat: Input should capture the Esc button and Clicks while focused [WEB-1251]

### DIFF
--- a/webui/react/src/components/kit/Input.tsx
+++ b/webui/react/src/components/kit/Input.tsx
@@ -6,8 +6,10 @@ import React, {
   ForwardRefExoticComponent,
   ReactNode,
   RefAttributes,
+  RefObject,
 } from 'react';
 
+import { useModalTextEscape } from 'hooks/useModalEscape';
 interface InputProps {
   addonAfter?: ReactNode;
   allowClear?: boolean | { clearIcon: ReactNode };
@@ -21,8 +23,8 @@ interface InputProps {
   max?: number;
   maxLength?: number;
   min?: number;
-  onBlur?: (
-    e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+  onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.FocusEvent<T> | React.KeyboardEvent<T>,
     previousValue?: string,
   ) => void;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -57,7 +59,11 @@ interface GroupProps {
 }
 
 const Input: Input = forwardRef<AntdInputRef, InputProps>((props: InputProps, ref) => {
-  return <AntdInput {...props} ref={ref} />;
+  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref, props.onBlur);
+
+  return (
+    <AntdInput {...props} ref={inputRef as RefObject<InputRef>} onBlur={onBlur} onFocus={onFocus} />
+  );
 }) as Input;
 
 type Input = ForwardRefExoticComponent<InputProps & RefAttributes<AntdInputRef>> & {
@@ -69,11 +75,20 @@ type Input = ForwardRefExoticComponent<InputProps & RefAttributes<AntdInputRef>>
 Input.Group = AntdInput.Group;
 
 Input.Password = forwardRef<AntdInputRef, PasswordProps>((props: PasswordProps, ref) => {
-  return <AntdInput.Password {...props} ref={ref} />;
+  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref);
+  return (
+    <AntdInput.Password
+      {...props}
+      ref={inputRef as RefObject<InputRef>}
+      onBlur={onBlur}
+      onFocus={onFocus}
+    />
+  );
 });
 
 Input.TextArea = forwardRef<AntdInputRef, TextAreaProps>((props: TextAreaProps, ref) => {
-  return <AntdInput.TextArea {...props} ref={ref} />;
+  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref);
+  return <AntdInput.TextArea {...props} ref={inputRef} onBlur={onBlur} onFocus={onFocus} />;
 });
 
 export type InputRef = AntdInputRef;

--- a/webui/react/src/components/kit/Input.tsx
+++ b/webui/react/src/components/kit/Input.tsx
@@ -9,7 +9,7 @@ import React, {
   RefObject,
 } from 'react';
 
-import { useModalTextEscape } from 'hooks/useModalEscape';
+import { useModalTextEscape } from 'hooks/useInputEscape';
 interface InputProps {
   addonAfter?: ReactNode;
   allowClear?: boolean | { clearIcon: ReactNode };

--- a/webui/react/src/components/kit/Input.tsx
+++ b/webui/react/src/components/kit/Input.tsx
@@ -9,7 +9,7 @@ import React, {
   RefObject,
 } from 'react';
 
-import { useModalTextEscape } from 'hooks/useInputEscape';
+import { useInputEscape } from 'hooks/useInputEscape';
 interface InputProps {
   addonAfter?: ReactNode;
   allowClear?: boolean | { clearIcon: ReactNode };
@@ -59,7 +59,7 @@ interface GroupProps {
 }
 
 const Input: Input = forwardRef<AntdInputRef, InputProps>((props: InputProps, ref) => {
-  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref, props.onBlur);
+  const { onFocus, onBlur, inputRef } = useInputEscape(ref, props.onBlur);
 
   return (
     <AntdInput {...props} ref={inputRef as RefObject<InputRef>} onBlur={onBlur} onFocus={onFocus} />
@@ -75,7 +75,7 @@ type Input = ForwardRefExoticComponent<InputProps & RefAttributes<AntdInputRef>>
 Input.Group = AntdInput.Group;
 
 Input.Password = forwardRef<AntdInputRef, PasswordProps>((props: PasswordProps, ref) => {
-  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref);
+  const { onFocus, onBlur, inputRef } = useInputEscape(ref);
   return (
     <AntdInput.Password
       {...props}
@@ -87,7 +87,7 @@ Input.Password = forwardRef<AntdInputRef, PasswordProps>((props: PasswordProps, 
 });
 
 Input.TextArea = forwardRef<AntdInputRef, TextAreaProps>((props: TextAreaProps, ref) => {
-  const { onFocus, onBlur, inputRef } = useModalTextEscape(ref);
+  const { onFocus, onBlur, inputRef } = useInputEscape(ref);
   return <AntdInput.TextArea {...props} ref={inputRef} onBlur={onBlur} onFocus={onFocus} />;
 });
 

--- a/webui/react/src/components/kit/InputNumber.tsx
+++ b/webui/react/src/components/kit/InputNumber.tsx
@@ -1,7 +1,7 @@
 import { InputNumber as AntdInputNumber } from 'antd';
 import React, { forwardRef } from 'react';
 
-import { useModalNumberEscape } from 'hooks/useModalEscape';
+import { useModalNumberEscape } from 'hooks/useInputEscape';
 interface InputNumberProps {
   className?: string;
   defaultValue?: number;

--- a/webui/react/src/components/kit/InputNumber.tsx
+++ b/webui/react/src/components/kit/InputNumber.tsx
@@ -1,6 +1,7 @@
 import { InputNumber as AntdInputNumber } from 'antd';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
+import { useModalNumberEscape } from 'hooks/useModalEscape';
 interface InputNumberProps {
   className?: string;
   defaultValue?: number;
@@ -15,7 +16,11 @@ interface InputNumberProps {
   onPressEnter?: (e: React.KeyboardEvent) => void;
 }
 
-const InputNumber: React.FC<InputNumberProps> = (props: InputNumberProps) => {
-  return <AntdInputNumber {...props} />;
-};
+const InputNumber: React.FC<InputNumberProps> = forwardRef(
+  ({ ...props }: InputNumberProps, ref: React.ForwardedRef<HTMLInputElement>) => {
+    const { onFocus, onBlur, inputRef } = useModalNumberEscape(ref);
+    return <AntdInputNumber {...props} ref={inputRef} onBlur={onBlur} onFocus={onFocus} />;
+  },
+);
+
 export default InputNumber;

--- a/webui/react/src/components/kit/InputNumber.tsx
+++ b/webui/react/src/components/kit/InputNumber.tsx
@@ -1,7 +1,7 @@
 import { InputNumber as AntdInputNumber } from 'antd';
 import React, { forwardRef } from 'react';
 
-import { useModalNumberEscape } from 'hooks/useInputEscape';
+import { useInputNumberEscape } from 'hooks/useInputEscape';
 interface InputNumberProps {
   className?: string;
   defaultValue?: number;
@@ -18,7 +18,7 @@ interface InputNumberProps {
 
 const InputNumber: React.FC<InputNumberProps> = forwardRef(
   ({ ...props }: InputNumberProps, ref: React.ForwardedRef<HTMLInputElement>) => {
-    const { onFocus, onBlur, inputRef } = useModalNumberEscape(ref);
+    const { onFocus, onBlur, inputRef } = useInputNumberEscape(ref);
     return <AntdInputNumber {...props} ref={inputRef} onBlur={onBlur} onFocus={onFocus} />;
   },
 );

--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, useCallback, useMemo, useState } from 'react';
 
 import Icon from 'components/kit/Icon';
 import Label, { LabelTypes } from 'components/kit/internal/Label';
-import { useModalSelectEscape } from 'hooks/useModalEscape';
+import { useModalSelectEscape } from 'hooks/useInputEscape';
 
 import css from './Select.module.scss';
 

--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -4,7 +4,7 @@ import React, { forwardRef, useCallback, useMemo, useState } from 'react';
 
 import Icon from 'components/kit/Icon';
 import Label, { LabelTypes } from 'components/kit/internal/Label';
-import { useModalSelectEscape } from 'hooks/useInputEscape';
+import { useSelectEscape } from 'hooks/useInputEscape';
 
 import css from './Select.module.scss';
 
@@ -84,7 +84,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
   const classes = [css.base];
 
   const divRef = React.createRef<HTMLDivElement>();
-  const { onBlur, onFocus, inputRef } = useModalSelectEscape(divRef, isOpen, ref);
+  const { onBlur, onFocus, inputRef } = useSelectEscape(divRef, isOpen, ref);
 
   if (disableTags) classes.push(css.disableTags);
 

--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -4,6 +4,7 @@ import React, { forwardRef, useCallback, useMemo, useState } from 'react';
 
 import Icon from 'components/kit/Icon';
 import Label, { LabelTypes } from 'components/kit/internal/Label';
+import { useModalSelectEscape } from 'hooks/useModalEscape';
 
 import css from './Select.module.scss';
 
@@ -74,12 +75,16 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
     width,
     value,
     children,
+    onDropdownVisibleChange,
     ...passthrough
   }: React.PropsWithChildren<SelectProps>,
   ref?: React.Ref<RefSelectProps>,
 ) {
   const [isOpen, setIsOpen] = useState(false);
   const classes = [css.base];
+
+  const divRef = React.createRef<HTMLDivElement>();
+  const { onBlur, onFocus, inputRef } = useModalSelectEscape(divRef, isOpen, ref);
 
   if (disableTags) classes.push(css.disableTags);
 
@@ -111,7 +116,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
   }, []);
 
   return (
-    <div className={classes.join(' ')}>
+    <div className={classes.join(' ')} ref={divRef}>
       {label && <Label type={LabelTypes.TextOnly}>{label}</Label>}
       <AntdSelect
         disabled={disabled || loading}
@@ -120,12 +125,14 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
         maxTagCount={maxTagCount}
         maxTagPlaceholder={maxTagPlaceholder}
         options={options}
-        ref={ref}
+        ref={inputRef}
         showSearch={!!onSearch || !!filterOption || searchable}
         style={{ width }}
         suffixIcon={!loading ? <Icon name="arrow-down" size="tiny" title="Open" /> : undefined}
         value={value}
+        onBlur={onBlur}
         onDropdownVisibleChange={handleDropdownVisibleChange}
+        onFocus={onFocus}
         onSearch={onSearch}
         {...passthrough}>
         {children}

--- a/webui/react/src/components/kit/Tags.tsx
+++ b/webui/react/src/components/kit/Tags.tsx
@@ -67,25 +67,22 @@ const Tags: React.FC<Props> = ({ compact, disabled = false, ghost, tags, onActio
 
   const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
 
-  const handleInputConfirm = useCallback(
-    (
-      e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
-      previousValue?: string,
-      tagID?: number,
-    ) => {
-      const newTag = (e.target as HTMLInputElement).value.trim();
-      const oldTag = previousValue?.trim();
-      if (newTag) {
-        if (oldTag && newTag !== oldTag) {
-          onAction?.(TagAction.Update, newTag, tagID);
-        } else {
-          onAction?.(TagAction.Add, newTag);
-        }
+  const handleInputConfirm = (
+    e: React.FocusEvent | React.KeyboardEvent,
+    previousValue?: string,
+    tagID?: number,
+  ) => {
+    const newTag = (e.target as HTMLInputElement).value.trim();
+    const oldTag = previousValue?.trim();
+    if (newTag) {
+      if (oldTag && newTag !== oldTag) {
+        onAction?.(TagAction.Update, newTag, tagID);
+      } else {
+        onAction?.(TagAction.Add, newTag);
       }
-      setState((state) => ({ ...state, editInputIndex: -1, inputVisible: false }));
-    },
-    [onAction],
-  );
+    }
+    setState((state) => ({ ...state, editInputIndex: -1, inputVisible: false }));
+  };
 
   const { editInputIndex, inputVisible, inputWidth } = state;
 

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -102,19 +102,17 @@ export const useInputNumberEscape = (
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
-      if (focused && event.key === 'Escape') {
-        onEsc(focused, inputRef, event, setFocused);
-      }
+      onEsc(focused, inputRef, event, setFocused);
     };
 
     const handleClick = (event: MouseEvent) => {
       onClick(blurred, focused, inputRef, event, setFocused);
     };
 
-    input?.addEventListener('keydown', handleEsc);
+    window.addEventListener('keydown', handleEsc, true);
     window.addEventListener('click', handleClick, true);
     return () => {
-      input?.removeEventListener('keydown', handleEsc);
+      window.removeEventListener('keydown', handleEsc, true);
       window.removeEventListener('click', handleClick, true);
     };
   }, [blurred, focused, input, inputRef]);
@@ -150,9 +148,7 @@ export const useInputEscape = <T>(
 
   useEffect(() => {
     const handleEsc = (event: KeyboardEvent) => {
-      if (focused && event.key === 'Escape') {
-        onEsc(focused, inputRef, event, setFocused);
-      }
+      onEsc(focused, inputRef, event, setFocused);
     };
     const handleClick = (event: MouseEvent) => {
       onClick(blurred, focused, inputRef, event, setFocused);
@@ -211,17 +207,16 @@ export const useSelectEscape = (
     };
 
     const handleEsc = (event: KeyboardEvent) => {
-      if (focused && event.key === 'Escape') {
-        onEsc(focused, inputRef, event, setFocused);
-      }
+      onEsc(focused, inputRef, event, setFocused);
     };
-    input?.addEventListener('keydown', handleEsc, true);
+
+    input?.addEventListener('keydown', handleEsc);
     window.addEventListener('click', handleClick, true);
     return () => {
-      input?.addEventListener('keydown', handleEsc, true);
+      input?.addEventListener('keydown', handleEsc);
       window.removeEventListener('click', handleClick, true);
     };
-  }, [blurred, focused, input, inputRef, containerRef, setFocused, isOpen, hasOpened]);
+  }, [blurred, focused, inputRef, input, setFocused, isOpen, hasOpened]);
 
   const handleBlur = (
     e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -24,8 +24,8 @@ const getOverlayAndMenuBodyElement = () => {
       : (document.getElementsByClassName(DRAWER_BODY_CLASSNAME)?.[0] as HTMLElement);
 
   return {
-    menuBody,
-    overlay,
+    focusMenu: () => menuBody.focus(),
+    overlayClassname: overlay?.className,
   };
 };
 
@@ -68,7 +68,7 @@ const onEsc = (
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
-    getOverlayAndMenuBodyElement()?.menuBody?.focus();
+    getOverlayAndMenuBodyElement()?.focusMenu();
     handleFocused(false);
   }
 };
@@ -81,7 +81,7 @@ const onClick = (
   handleFocused: (focused: boolean) => void,
 ) => {
   const overlayClicked =
-    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlay?.className;
+    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlayClassname;
 
   if (blurred && focused && overlayClicked) {
     event.stopPropagation();
@@ -100,7 +100,7 @@ const onClickSelect = (
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
   const isTargetOverlay =
-    getOverlayAndMenuBodyElement()?.overlay?.className === (event.target as HTMLElement).className;
+    getOverlayAndMenuBodyElement()?.overlayClassname === (event.target as HTMLElement).className;
   if (isTargetOverlay && (isOpen || hasOpened)) {
     event.stopPropagation();
     if (!isOpen) setHasOpened(false);
@@ -117,7 +117,7 @@ const onEscSelect = (
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
-    getOverlayAndMenuBodyElement()?.menuBody?.focus();
+    getOverlayAndMenuBodyElement()?.focusMenu();
     handleFocused(false);
     setHasOpened(false);
   }

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -27,8 +27,12 @@ const getOverlayAndMenuBodyElement = () => {
       : (document.getElementsByClassName(DRAWER_BODY_CLASSNAME)?.[0] as HTMLElement);
 
   return {
-    focusMenu: () => menuBody.focus(),
+    focusMenu: () => menuBody?.focus(),
     overlayClassname: overlay?.className,
+    // If an overlay does not exist then the input is not
+    // inside of a menu or modal and we do not want to
+    // alter any event behavior
+    overlayExists: !!overlay,
   };
 };
 
@@ -68,6 +72,8 @@ const onEsc = (
   event: KeyboardEvent,
   handleFocused: (focused: boolean) => void,
 ) => {
+  const { overlayExists } = getOverlayAndMenuBodyElement();
+  if (!overlayExists) return;
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
@@ -83,8 +89,9 @@ const onClick = (
   event: MouseEvent,
   handleFocused: (focused: boolean) => void,
 ) => {
-  const overlayClicked =
-    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlayClassname;
+  const { overlayClassname, overlayExists } = getOverlayAndMenuBodyElement();
+  if (!overlayExists) return;
+  const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
 
   if (focused && overlayClicked) {
     event.stopPropagation();
@@ -102,7 +109,8 @@ const onClickSelect = (
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
   const targetClassname = (event.target as HTMLElement).className;
-  const overlayClassname = getOverlayAndMenuBodyElement()?.overlayClassname;
+  const { overlayClassname, overlayExists } = getOverlayAndMenuBodyElement();
+  if (!overlayExists) return;
   if (isOpen && targetClassname === overlayClassname) {
     event.stopPropagation();
   }
@@ -129,10 +137,12 @@ const onEscSelect = (
   handleFocused: (focused: boolean) => void,
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
+  const { overlayExists, focusMenu } = getOverlayAndMenuBodyElement();
+  if (!overlayExists) return;
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
-    getOverlayAndMenuBodyElement()?.focusMenu();
+    focusMenu();
     handleFocused(false);
     setHasOpened(false);
   }

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -99,17 +99,26 @@ const onClickSelect = (
   hasOpened: boolean,
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
-  const overlayClassname = getOverlayAndMenuBodyElement()?.overlay?.className;
-  if (isOpen && (event.target as HTMLElement).className === overlayClassname) {
+  const isTargetOverlay =
+    getOverlayAndMenuBodyElement()?.overlay?.className === (event.target as HTMLElement).className;
+  if (isTargetOverlay && (isOpen || hasOpened)) {
     event.stopPropagation();
+    if (!isOpen) setHasOpened(false);
   }
+};
 
-  if (hasOpened && !isOpen && (event.target as HTMLElement).className === overlayClassname) {
+const onEscSelect = (
+  focused: boolean,
+  inputRef: React.RefObject<HTMLInputElement | AntdInputRef | RefSelectProps>,
+  event: KeyboardEvent,
+  handleFocused: (focused: boolean) => void,
+  setHasOpened: (hasOpened: boolean) => void,
+) => {
+  if (focused && event.key === 'Escape') {
     event.stopPropagation();
-    // If hasOpened is true in this instance
-    // then the event above will close the
-    // currently open Modal or Menu so we must stop the
-    // event.
+    inputRef.current?.blur();
+    getOverlayAndMenuBodyElement()?.menuBody?.focus();
+    handleFocused(false);
     setHasOpened(false);
   }
 };
@@ -239,7 +248,7 @@ export const useSelectEscape = (
     };
 
     const handleEsc = (event: KeyboardEvent) => {
-      onEsc(focused, inputRef, event, setFocused);
+      onEscSelect(focused, inputRef, event, setFocused, setHasOpened);
     };
 
     containerRef.current?.addEventListener('keydown', handleEsc);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -94,17 +94,31 @@ const onClick = (
 };
 
 const onClickSelect = (
+  blurred: boolean,
   event: MouseEvent,
   isOpen: boolean,
   hasOpened: boolean,
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
-  const isTargetOverlay =
-    getOverlayAndMenuBodyElement()?.overlayClassname === (event.target as HTMLElement).className;
-  if (isTargetOverlay && (isOpen || hasOpened)) {
+  const targetClassname = (event.target as HTMLElement).className;
+  const overlayClassname = getOverlayAndMenuBodyElement()?.overlayClassname;
+  if (isOpen && targetClassname === overlayClassname) {
     event.stopPropagation();
-    if (!isOpen) setHasOpened(false);
   }
+
+  if (hasOpened && !isOpen && targetClassname === overlayClassname) {
+    event.stopPropagation();
+    // If hasOpened is true in this instance
+    // then the event above will close the
+    // currently open Modal or Menu so we must stop the
+    // event.
+    setHasOpened(false);
+  }
+
+  // If any element besides the overlay has been clicked
+  // set hasOpened as false to signify that the
+  // dropdown is now closed
+  if (blurred && hasOpened && targetClassname !== overlayClassname) setHasOpened(false);
 };
 
 const onEscSelect = (
@@ -244,7 +258,7 @@ export const useSelectEscape = (
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
-      onClickSelect(event, isOpen, hasOpened, setHasOpened);
+      onClickSelect(blurred, event, isOpen, hasOpened, setHasOpened);
     };
 
     const handleEsc = (event: KeyboardEvent) => {
@@ -277,6 +291,7 @@ export const useSelectEscape = (
     previousValue?: string,
   ) => {
     setBlurred(true);
+    setFocused(false);
     onBlur?.(e, previousValue);
   };
 

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -134,8 +134,6 @@ export const useInputNumberEscape = (
   const inputRef = useRef<HTMLInputElement>(null);
   useImperativeHandle(ref, () => inputRef?.current as HTMLInputElement);
 
-  const input = inputRef?.current;
-
   const [focused, setFocused] = useState(false);
   const [blurred, setBlurred] = useState(false);
 
@@ -154,7 +152,7 @@ export const useInputNumberEscape = (
       window.removeEventListener('keydown', handleEsc, true);
       window.removeEventListener('click', handleClick, true);
     };
-  }, [blurred, focused, input, inputRef]);
+  }, [blurred, focused]);
 
   const handleBlur = <HTMLInputElement>(
     e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
@@ -198,7 +196,7 @@ export const useInputEscape = <T>(
       document.removeEventListener('keydown', handleEsc, true);
       document.removeEventListener('click', handleClick, true);
     };
-  }, [focused, inputRef, blurred]);
+  }, [focused, blurred]);
 
   const handleBlur = <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.FocusEvent<T> | React.KeyboardEvent<T>,
@@ -259,7 +257,7 @@ export const useSelectEscape = (
 
       window.removeEventListener('click', handleClick, true);
     };
-  }, [blurred, containerRef, focused, inputRef, setFocused, isOpen, hasOpened]);
+  }, [blurred, containerRef, focused, setFocused, isOpen, hasOpened]);
 
   const handleBlur = (
     e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -152,7 +152,7 @@ export const useInputNumberEscape = (
     previousValue?: string,
   ) => {
     setBlurred(true);
-    if (onBlur) onBlur(e, previousValue);
+    onBlur?.(e, previousValue);
   };
 
   const onFocus = () => {
@@ -196,7 +196,7 @@ export const useInputEscape = <T>(
     previousValue?: string,
   ) => {
     setBlurred(true);
-    if (onBlur) onBlur(e, previousValue);
+    onBlur?.(e, previousValue);
   };
 
   const onFocus = () => {
@@ -230,9 +230,7 @@ export const useSelectEscape = (
     // hasOpened is used in place of "isOpen" to check
     // if the select is still open at the time of the click
     // event.
-    if (isOpen) {
-      setHasOpened(true);
-    }
+    if (isOpen) setHasOpened(true);
   }, [isOpen]);
 
   useEffect(() => {
@@ -259,7 +257,7 @@ export const useSelectEscape = (
     previousValue?: string,
   ) => {
     setBlurred(true);
-    if (onBlur) onBlur(e, previousValue);
+    onBlur?.(e, previousValue);
   };
 
   const onFocus = () => {

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -94,7 +94,9 @@ const onInputNumberClick = (
   const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
 
   if (focused && (overlayClicked || event.target !== inputRef.current)) {
-    event.stopPropagation();
+    if (overlayClicked) {
+      event.stopPropagation();
+    }
     handleFocused(false);
     // If the input is not already blurred then perform the blur
     if (!blurred) inputRef.current?.blur();
@@ -113,7 +115,9 @@ const onInputClick = (
   const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
 
   if (focused && (overlayClicked || event.target !== inputRef.current?.input)) {
-    event.stopPropagation();
+    if (overlayClicked) {
+      event.stopPropagation();
+    }
     handleFocused(false);
     // If the input is not already blurred then perform the blur
     if (!blurred) inputRef.current?.blur();

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -82,10 +82,10 @@ const onEsc = (
   }
 };
 
-const onClick = (
+const onInputNumberClick = (
   blurred: boolean,
   focused: boolean,
-  inputRef: React.RefObject<HTMLInputElement | AntdInputRef>,
+  inputRef: React.RefObject<HTMLInputElement>,
   event: MouseEvent,
   handleFocused: (focused: boolean) => void,
 ) => {
@@ -93,7 +93,26 @@ const onClick = (
   if (!overlayExists) return;
   const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
 
-  if (focused && overlayClicked) {
+  if (focused && (overlayClicked || event.target !== inputRef.current)) {
+    event.stopPropagation();
+    handleFocused(false);
+    // If the input is not already blurred then perform the blur
+    if (!blurred) inputRef.current?.blur();
+  }
+};
+
+const onInputClick = (
+  blurred: boolean,
+  focused: boolean,
+  inputRef: React.RefObject<AntdInputRef>,
+  event: MouseEvent,
+  handleFocused: (focused: boolean) => void,
+) => {
+  const { overlayClassname, overlayExists } = getOverlayAndMenuBodyElement();
+  if (!overlayExists) return;
+  const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
+
+  if (focused && (overlayClicked || event.target !== inputRef.current?.input)) {
     event.stopPropagation();
     handleFocused(false);
     // If the input is not already blurred then perform the blur
@@ -168,7 +187,7 @@ export const useInputNumberEscape = (
     };
 
     const handleClick = (event: MouseEvent) => {
-      onClick(blurred, focused, inputRef, event, setFocused);
+      onInputNumberClick(blurred, focused, inputRef, event, setFocused);
     };
 
     window.addEventListener('keydown', handleEsc, true);
@@ -213,7 +232,7 @@ export const useInputEscape = <T>(
       onEsc(focused, inputRef, event, setFocused);
     };
     const handleClick = (event: MouseEvent) => {
-      onClick(blurred, focused, inputRef, event, setFocused);
+      onInputClick(blurred, focused, inputRef, event, setFocused);
     };
     document.addEventListener('keydown', handleEsc, true);
     document.addEventListener('click', handleClick, true);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -16,6 +16,9 @@ const getOverlayAndMenuBodyElement = () => {
     ...document.getElementsByClassName(DRAWER_MASK_CLASSNAME),
   ];
 
+  // Only one overlay will exist when a menu is open
+  // the overlay that we want will be the first item
+  // in the list.
   const overlay = overlays?.[0] as HTMLElement;
 
   const menuBody =

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -76,6 +76,10 @@ const onClickSelect = (
 
   if (hasOpened && !isOpen && (event.target as HTMLElement).className === MODAL_WRAP_CLASSNAME) {
     event.stopPropagation();
+    // If hasOpened is true in this instance
+    // then the event above will close the
+    // currently open Modal or Menu so we must stop the
+    // event.
     setHasOpened(false);
   }
 };
@@ -190,6 +194,12 @@ export const useSelectEscape = (
   useImperativeHandle(ref, () => inputRef.current as RefSelectProps);
 
   useEffect(() => {
+    // By the time a click event is captured in an
+    // event handler the Select will have otherwise already
+    // become unfocused and isOpen will be false.
+    // hasOpened is used in place of "isOpen" to check
+    // if the select is still open at the time of the click
+    // event.
     if (isOpen) {
       setHasOpened(true);
     }
@@ -209,6 +219,7 @@ export const useSelectEscape = (
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
       containerRef.current?.removeEventListener('keydown', handleEsc);
+
       window.removeEventListener('click', handleClick, true);
     };
   }, [blurred, containerRef, focused, inputRef, setFocused, isOpen, hasOpened]);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -16,12 +16,13 @@ const getOverlayAndMenuBodyElement = () => {
     ...document.getElementsByClassName(DRAWER_MASK_CLASSNAME),
   ];
 
-  const overlay = overlays[0] as HTMLElement;
+  const overlay = overlays?.[0] as HTMLElement;
 
   const menuBody =
-    overlay.className === MODAL_WRAP_CLASSNAME
+    overlay?.className === MODAL_WRAP_CLASSNAME
       ? overlay
-      : (document.getElementsByClassName(DRAWER_BODY_CLASSNAME)[0] as HTMLElement);
+      : (document.getElementsByClassName(DRAWER_BODY_CLASSNAME)?.[0] as HTMLElement);
+
   return {
     menuBody,
     overlay,
@@ -67,7 +68,7 @@ const onEsc = (
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
-    getOverlayAndMenuBodyElement().menuBody.focus();
+    getOverlayAndMenuBodyElement()?.menuBody?.focus();
     handleFocused(false);
   }
 };
@@ -84,7 +85,7 @@ const onClick = (
     handleFocused(false);
   } else if (
     focused &&
-    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement().overlay.className
+    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlay?.className
   ) {
     event.stopPropagation();
     inputRef.current?.blur();
@@ -98,7 +99,7 @@ const onClickSelect = (
   hasOpened: boolean,
   setHasOpened: (hasOpened: boolean) => void,
 ) => {
-  const overlayClassname = getOverlayAndMenuBodyElement().overlay.className;
+  const overlayClassname = getOverlayAndMenuBodyElement()?.overlay?.className;
   if (isOpen && (event.target as HTMLElement).className === overlayClassname) {
     event.stopPropagation();
   }

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -83,13 +83,11 @@ const onClick = (
   const overlayClicked =
     (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlayClassname;
 
-  if (blurred && focused && overlayClicked) {
+  if (focused && overlayClicked) {
     event.stopPropagation();
     handleFocused(false);
-  } else if (focused && overlayClicked) {
-    event.stopPropagation();
-    inputRef.current?.blur();
-    handleFocused(false);
+    // If the input is not already blurred then perform the blur
+    if (!blurred) inputRef.current?.blur();
   }
 };
 

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -80,13 +80,13 @@ const onClick = (
   event: MouseEvent,
   handleFocused: (focused: boolean) => void,
 ) => {
-  if (blurred && focused) {
+  const overlayClicked =
+    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlay?.className;
+
+  if (blurred && focused && overlayClicked) {
     event.stopPropagation();
     handleFocused(false);
-  } else if (
-    focused &&
-    (event.target as HTMLElement).className === getOverlayAndMenuBodyElement()?.overlay?.className
-  ) {
+  } else if (focused && overlayClicked) {
     event.stopPropagation();
     inputRef.current?.blur();
     handleFocused(false);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -1,5 +1,5 @@
 import { InputRef as AntdInputRef, InputRef, RefSelectProps } from 'antd';
-import React, { Ref, RefObject, useEffect, useImperativeHandle, useState } from 'react';
+import React, { Ref, RefObject, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
 const DRAWER_BODY_CLASSNAME = 'ant-drawer-open';
 const DRAWER_MASK_CLASSNAME = 'ant-drawer-mask';
@@ -131,7 +131,7 @@ export const useInputNumberEscape = (
     tagID?: string,
   ) => void,
 ): InputNumberEscape => {
-  const inputRef = React.createRef<HTMLInputElement>();
+  const inputRef = useRef<HTMLInputElement>(null);
   useImperativeHandle(ref, () => inputRef?.current as HTMLInputElement);
 
   const input = inputRef?.current;
@@ -179,7 +179,7 @@ export const useInputEscape = <T>(
     tagID?: string,
   ) => void,
 ): InputTextEscape => {
-  const inputRef = React.createRef<AntdInputRef>();
+  const inputRef = useRef<AntdInputRef>(null);
   const [focused, setFocused] = useState(false);
   const [blurred, setBlurred] = useState(false);
 
@@ -225,7 +225,7 @@ export const useSelectEscape = (
     tagID?: string,
   ) => void,
 ): SelectEscape => {
-  const inputRef = React.createRef<RefSelectProps>();
+  const inputRef = useRef<RefSelectProps>(null);
   const [focused, setFocused] = useState(false);
   const [blurred, setBlurred] = useState(false);
   const [hasOpened, setHasOpened] = useState(false);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -231,12 +231,14 @@ export const useSelectEscape = (
   useImperativeHandle(ref, () => inputRef.current as RefSelectProps);
 
   useEffect(() => {
-    // By the time a click event is captured in an
-    // event handler the Select will have otherwise already
-    // become unfocused and isOpen will be false.
-    // hasOpened is used in place of "isOpen" to check
-    // if the select is still open at the time of the click
-    // event.
+    /**
+    By the time a click event is captured in an
+    event handler the Select will have otherwise already
+    become unfocused and isOpen will be false.
+    hasOpened is used in place of "isOpen" to check
+    if the select is still open at the time of the click
+    event.
+     */
     if (isOpen) setHasOpened(true);
   }, [isOpen]);
 
@@ -248,6 +250,17 @@ export const useSelectEscape = (
     const handleEsc = (event: KeyboardEvent) => {
       onEscSelect(focused, inputRef, event, setFocused, setHasOpened);
     };
+
+    /**
+     *  The Select component is a special case where
+     *  a seperate container is needed in order to
+     *  properly handle blurring the component.
+     *  In this implementation the event handler is attached to the
+     *  containerRef, when the Select is unfocused
+     *  the containerRef is unmounted which allows
+     *  the "Escape" events to propogate
+     *  normally.
+     */
 
     containerRef.current?.addEventListener('keydown', handleEsc);
     window.addEventListener('click', handleClick, true);

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -3,10 +3,6 @@ import React, { Ref, RefObject, useEffect, useImperativeHandle, useState } from 
 
 const MODAL_WRAP_CLASSNAME = 'ant-modal-wrap';
 
-const getModalContainer = () => {
-  return document.getElementsByClassName(MODAL_WRAP_CLASSNAME)?.[0] as HTMLElement;
-};
-
 interface InputEscape {
   onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.FocusEvent<T> | React.KeyboardEvent<T>,
@@ -46,7 +42,7 @@ const onEsc = (
   if (focused && event.key === 'Escape') {
     event.stopPropagation();
     inputRef.current?.blur();
-    getModalContainer().focus();
+    (document.getElementsByClassName(MODAL_WRAP_CLASSNAME)?.[0] as HTMLElement)?.focus();
     handleFocused(false);
   }
 };

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -114,7 +114,10 @@ const onInputClick = (
   if (!overlayExists) return;
   const overlayClicked = (event.target as HTMLElement).className === overlayClassname;
 
-  if (focused && (overlayClicked || event.target !== inputRef.current?.input)) {
+  if (
+    focused &&
+    (overlayClicked || (!!inputRef.current?.input && event.target !== inputRef.current?.input))
+  ) {
     if (overlayClicked) {
       event.stopPropagation();
     }

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -193,8 +193,6 @@ export const useSelectEscape = (
 
   useImperativeHandle(ref, () => inputRef.current as RefSelectProps);
 
-  const input = containerRef.current;
-
   useEffect(() => {
     if (isOpen) {
       setHasOpened(true);
@@ -210,13 +208,14 @@ export const useSelectEscape = (
       onEsc(focused, inputRef, event, setFocused);
     };
 
-    input?.addEventListener('keydown', handleEsc);
+    containerRef.current?.addEventListener('keydown', handleEsc);
     window.addEventListener('click', handleClick, true);
     return () => {
-      input?.addEventListener('keydown', handleEsc);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      containerRef.current?.removeEventListener('keydown', handleEsc);
       window.removeEventListener('click', handleClick, true);
     };
-  }, [blurred, focused, inputRef, input, setFocused, isOpen, hasOpened]);
+  }, [blurred, containerRef, focused, inputRef, setFocused, isOpen, hasOpened]);
 
   const handleBlur = (
     e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,

--- a/webui/react/src/hooks/useInputEscape.ts
+++ b/webui/react/src/hooks/useInputEscape.ts
@@ -7,7 +7,7 @@ const getModalContainer = () => {
   return document.getElementsByClassName(MODAL_WRAP_CLASSNAME)?.[0] as HTMLElement;
 };
 
-interface ModalEscapeHandlers {
+interface InputEscape {
   onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.FocusEvent<T> | React.KeyboardEvent<T>,
     previousValue?: string,
@@ -15,19 +15,19 @@ interface ModalEscapeHandlers {
   ) => void;
 }
 
-interface ModalTextEscape extends ModalEscapeHandlers {
+interface InputTextEscape extends InputEscape {
   inputRef?: React.RefObject<HTMLInputElement | InputRef>;
   onFocus: <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.FocusEvent<T & EventTarget, Element>,
   ) => void;
 }
 
-interface ModalNumberEscape extends ModalEscapeHandlers {
+interface InputNumberEscape extends InputEscape {
   onFocus: (e: React.FocusEvent<HTMLInputElement & EventTarget, Element>) => void;
   inputRef?: Ref<HTMLInputElement>;
 }
 
-interface ModalSelectEscape {
+interface SelectEscape {
   inputRef?: React.RefObject<RefSelectProps>;
   onFocus: <T extends HTMLInputElement>(e: React.FocusEvent<T & EventTarget, Element>) => void;
   onBlur?: (
@@ -84,14 +84,14 @@ const onClickSelect = (
   }
 };
 
-export const useModalNumberEscape = (
+export const useInputNumberEscape = (
   ref: React.ForwardedRef<HTMLInputElement>,
   onBlur?: <HTMLInputElement>(
     e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
     previousValue?: string,
     tagID?: string,
   ) => void,
-): ModalNumberEscape => {
+): InputNumberEscape => {
   const inputRef = React.createRef<HTMLInputElement>();
   useImperativeHandle(ref, () => inputRef?.current as HTMLInputElement);
 
@@ -134,14 +134,14 @@ export const useModalNumberEscape = (
   return { inputRef, onBlur: handleBlur, onFocus };
 };
 
-export const useModalTextEscape = <T>(
+export const useInputEscape = <T>(
   ref?: React.ForwardedRef<T>,
   onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
     e: React.FocusEvent<T> | React.KeyboardEvent<T>,
     previousValue?: string,
     tagID?: string,
   ) => void,
-): ModalTextEscape => {
+): InputTextEscape => {
   const inputRef = React.createRef<AntdInputRef>();
   const [focused, setFocused] = useState(false);
   const [blurred, setBlurred] = useState(false);
@@ -180,7 +180,7 @@ export const useModalTextEscape = <T>(
   return { inputRef, onBlur: handleBlur, onFocus };
 };
 
-export const useModalSelectEscape = (
+export const useSelectEscape = (
   containerRef: RefObject<HTMLDivElement>,
   isOpen: boolean,
   ref?: React.ForwardedRef<RefSelectProps>,
@@ -189,7 +189,7 @@ export const useModalSelectEscape = (
     previousValue?: string,
     tagID?: string,
   ) => void,
-): ModalSelectEscape => {
+): SelectEscape => {
   const inputRef = React.createRef<RefSelectProps>();
   const [focused, setFocused] = useState(false);
   const [blurred, setBlurred] = useState(false);
@@ -234,5 +234,6 @@ export const useModalSelectEscape = (
   const onFocus = () => {
     setFocused(true);
   };
+
   return { inputRef, onBlur: handleBlur, onFocus };
 };

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -612,7 +612,7 @@ const useModalHyperparameterSearch = ({
         </Form>
       ),
       icon: null,
-      maskClosable: false,
+      maskClosable: true,
       title: 'Hyperparameter Search',
       width: 700,
     };

--- a/webui/react/src/hooks/useModalEscape.ts
+++ b/webui/react/src/hooks/useModalEscape.ts
@@ -1,0 +1,239 @@
+import { InputRef as AntdInputRef, InputRef, RefSelectProps } from 'antd';
+import React, { Ref, RefObject, useEffect, useImperativeHandle, useState } from 'react';
+
+const MODAL_WRAP_CLASSNAME = 'ant-modal-wrap';
+
+const getModalContainer = () => {
+  return document.getElementsByClassName(MODAL_WRAP_CLASSNAME)?.[0] as HTMLElement;
+};
+
+interface ModalEscapeHandlers {
+  onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.FocusEvent<T> | React.KeyboardEvent<T>,
+    previousValue?: string,
+    tagID?: number,
+  ) => void;
+}
+
+interface ModalTextEscape extends ModalEscapeHandlers {
+  inputRef?: React.RefObject<HTMLInputElement | InputRef>;
+  onFocus: <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.FocusEvent<T & EventTarget, Element>,
+  ) => void;
+}
+
+interface ModalSelectEscape {
+  inputRef?: React.RefObject<RefSelectProps>;
+  onFocus: <T extends HTMLInputElement>(e: React.FocusEvent<T & EventTarget, Element>) => void;
+  onBlur?: (
+    e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    previousValue?: string,
+    tagID?: number,
+  ) => void;
+}
+
+interface ModalNumberEscape extends ModalEscapeHandlers {
+  onFocus: (e: React.FocusEvent<HTMLInputElement & EventTarget, Element>) => void;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
+const onEsc = (
+  focused: boolean,
+  inputRef: React.RefObject<HTMLInputElement | AntdInputRef | RefSelectProps>,
+  event: KeyboardEvent,
+  handleFocused: (focused: boolean) => void,
+) => {
+  if (focused && event.key === 'Escape') {
+    event.stopPropagation();
+    inputRef.current?.blur();
+    getModalContainer().focus();
+    handleFocused(false);
+  }
+};
+
+const onClick = (
+  blurred: boolean,
+  focused: boolean,
+  inputRef: React.RefObject<HTMLInputElement | AntdInputRef>,
+  event: MouseEvent,
+  handleFocused: (focused: boolean) => void,
+) => {
+  if (blurred && focused) {
+    event.stopPropagation();
+    handleFocused(false);
+  } else if (focused && (event.target as HTMLElement).className === MODAL_WRAP_CLASSNAME) {
+    event.stopPropagation();
+    inputRef.current?.blur();
+    handleFocused(false);
+  }
+};
+
+const onClickSelect = (
+  event: MouseEvent,
+  isOpen: boolean,
+  hasOpened: boolean,
+  setHasOpened: (hasOpened: boolean) => void,
+) => {
+  if (isOpen && (event.target as HTMLElement).className === MODAL_WRAP_CLASSNAME) {
+    event.stopPropagation();
+  }
+
+  if (hasOpened && !isOpen && (event.target as HTMLElement).className === MODAL_WRAP_CLASSNAME) {
+    event.stopPropagation();
+    event.preventDefault();
+    setHasOpened(false);
+  }
+};
+
+export const useModalNumberEscape = (
+  ref: React.ForwardedRef<HTMLInputElement>,
+  onBlur?: <HTMLInputElement>(
+    e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+    previousValue?: string,
+    tagID?: string,
+  ) => void,
+): ModalNumberEscape => {
+  const inputRef = React.createRef<HTMLInputElement>();
+  useImperativeHandle(ref, () => inputRef?.current as HTMLInputElement);
+
+  const input = inputRef?.current;
+
+  const [focused, setFocused] = useState(false);
+  const [blurred, setBlurred] = useState(false);
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (focused && event.key === 'Escape') {
+        onEsc(focused, inputRef, event, setFocused);
+      }
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      onClick(blurred, focused, inputRef, event, setFocused);
+    };
+
+    input?.addEventListener('keydown', handleEsc);
+    window.addEventListener('click', handleClick, true);
+    return () => {
+      input?.removeEventListener('keydown', handleEsc);
+      window.removeEventListener('click', handleClick, true);
+    };
+  }, [blurred, focused, input, inputRef]);
+
+  const handleBlur = <HTMLInputElement>(
+    e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>,
+    previousValue?: string,
+  ) => {
+    setBlurred(true);
+    if (onBlur) onBlur(e, previousValue);
+  };
+
+  const onFocus = () => {
+    setFocused(true);
+    setBlurred(false);
+  };
+  return { inputRef, onBlur: handleBlur, onFocus };
+};
+
+export const useModalTextEscape = <T>(
+  ref?: React.ForwardedRef<T>,
+  onBlur?: <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.FocusEvent<T> | React.KeyboardEvent<T>,
+    previousValue?: string,
+    tagID?: string,
+  ) => void,
+): ModalTextEscape => {
+  const inputRef = React.createRef<AntdInputRef>();
+  const [focused, setFocused] = useState(false);
+  const [blurred, setBlurred] = useState(false);
+
+  useImperativeHandle(ref, () => inputRef?.current as T);
+
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (focused && event.key === 'Escape') {
+        onEsc(focused, inputRef, event, setFocused);
+      }
+    };
+    const handleClick = (event: MouseEvent) => {
+      onClick(blurred, focused, inputRef, event, setFocused);
+    };
+    document.addEventListener('keydown', handleEsc, true);
+    document.addEventListener('click', handleClick, true);
+    return () => {
+      document.removeEventListener('keydown', handleEsc, true);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [focused, inputRef, blurred]);
+
+  const handleBlur = <T extends HTMLInputElement | HTMLTextAreaElement>(
+    e: React.FocusEvent<T> | React.KeyboardEvent<T>,
+    previousValue?: string,
+  ) => {
+    setBlurred(true);
+    if (onBlur) onBlur(e, previousValue);
+  };
+
+  const onFocus = () => {
+    setFocused(true);
+    setBlurred(false);
+  };
+  return { inputRef, onBlur: handleBlur, onFocus };
+};
+
+export const useModalSelectEscape = (
+  containerRef: RefObject<HTMLDivElement>,
+  isOpen: boolean,
+  ref?: React.ForwardedRef<RefSelectProps>,
+  onBlur?: (
+    e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    previousValue?: string,
+    tagID?: string,
+  ) => void,
+): ModalSelectEscape => {
+  const inputRef = React.createRef<RefSelectProps>();
+  const [focused, setFocused] = useState(false);
+  const [blurred, setBlurred] = useState(false);
+  const [hasOpened, setHasOpened] = useState(false);
+
+  useImperativeHandle(ref, () => inputRef.current as RefSelectProps);
+
+  const input = containerRef.current;
+
+  useEffect(() => {
+    if (isOpen) {
+      setHasOpened(true);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      onClickSelect(event, isOpen, hasOpened, setHasOpened);
+    };
+
+    const handleEsc = (event: KeyboardEvent) => {
+      if (focused && event.key === 'Escape') {
+        onEsc(focused, inputRef, event, setFocused);
+      }
+    };
+    input?.addEventListener('keydown', handleEsc, true);
+    window.addEventListener('click', handleClick, true);
+    return () => {
+      input?.addEventListener('keydown', handleEsc, true);
+      window.removeEventListener('click', handleClick, true);
+    };
+  }, [blurred, focused, input, inputRef, containerRef, setFocused, isOpen, hasOpened]);
+
+  const handleBlur = (
+    e: React.FocusEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+    previousValue?: string,
+  ) => {
+    setBlurred(true);
+    if (onBlur) onBlur(e, previousValue);
+  };
+
+  const onFocus = () => {
+    setFocused(true);
+  };
+  return { inputRef, onBlur: handleBlur, onFocus };
+};

--- a/webui/react/src/hooks/useModalEscape.ts
+++ b/webui/react/src/hooks/useModalEscape.ts
@@ -22,6 +22,11 @@ interface ModalTextEscape extends ModalEscapeHandlers {
   ) => void;
 }
 
+interface ModalNumberEscape extends ModalEscapeHandlers {
+  onFocus: (e: React.FocusEvent<HTMLInputElement & EventTarget, Element>) => void;
+  inputRef?: Ref<HTMLInputElement>;
+}
+
 interface ModalSelectEscape {
   inputRef?: React.RefObject<RefSelectProps>;
   onFocus: <T extends HTMLInputElement>(e: React.FocusEvent<T & EventTarget, Element>) => void;
@@ -30,11 +35,6 @@ interface ModalSelectEscape {
     previousValue?: string,
     tagID?: number,
   ) => void;
-}
-
-interface ModalNumberEscape extends ModalEscapeHandlers {
-  onFocus: (e: React.FocusEvent<HTMLInputElement & EventTarget, Element>) => void;
-  inputRef?: Ref<HTMLInputElement>;
 }
 
 const onEsc = (
@@ -80,7 +80,6 @@ const onClickSelect = (
 
   if (hasOpened && !isOpen && (event.target as HTMLElement).className === MODAL_WRAP_CLASSNAME) {
     event.stopPropagation();
-    event.preventDefault();
     setHasOpened(false);
   }
 };


### PR DESCRIPTION
## Description

This PR introduces the ability for inputs to correctly handle "Escape" button presses and clicks to ensure that the inputs themselves lose focus, instead of having the entire modal close. 

Example showing text, number, and dropdown inputs losing focus and then the modal closing. 


https://github.com/determined-ai/determined/assets/103522725/54683ec0-c9d8-4ba8-87c0-053b53e15d79

**Note:** The functionality handles all inputs in the UI Kit, however there are some input instances throughout the UI, such as some `Select` inputs that do not currently use UI Kit components. The plan is to ensure that there is a follow-up ticket to ensure all inputs use the `UI Kit` components

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
## Test Plan

1. Navigate to the Workspaces list page.
2. Click on the `New Workspace` button.
3. Click outside the modal, the modal should close.
4.  Click on the `New Workspace` button again.
5. Hit the "Escape" key, the modal should close.
6. Click inside the Workspace name input.
7. Click the escape key. The input should become unfocused and the modal should still be open.
8. Click the escape key again. The modal should now close. 
9. Click on the `New Workspace` button again.
10. Click inside the Workspace name input.
11. Click outside the modal. The input should become unfocused and the modal should still be open.
12. Click outside the modal again. The modal should now close. 
13. Click on the `New Workspace` button again.
14. Click inside the Workspace name input.
15. Click the escape key. The input should become unfocused and the modal should still be open.
16. Click outside the modal. The modal should now close.
17. Click on the `New Workspace` button again.
18. Click inside the Workspace name input.
19. Click outside the modal. The input should become unfocused and the modal should still be open.
20.  Click the escape key . The modal should now close.  
21. Navigate to the Home page.
22. Click the "Launch JupyterLab" button in the top right corner. Repeat steps 3-20 with the "Slots" number input. 
23. Navigate to the "Models" page and click "New Model". Repeat steps 3-20 with the "Description"  textarea input.
24. Click "New Model".  Repeat steps 3-20 with the "Workspace" dropdown. 
25. Click "New Model". Repeat steps 3-20 with the "Description"  textarea input.
26. Click your username in the top left of the page and choose "Settings" in the dropdown. Repeat steps 3-20 with the "Username"  text input.


<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1251
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
