### PR TITLE
fix: Change measure of text lines in log containers [WEB-1664]

### DIFF
--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -144,7 +144,7 @@ const LogViewer: React.FC<Props> = ({
   const [logs, setLogs] = useState<ViewerLog[]>([]);
   const { refObject: logsRef, refCallback, size: containerSize } = useResize();
   const { size: pageSize } = useResize();
-  const charMeasures = useGetCharMeasureInContainer(logsRef);
+  const charMeasures = useGetCharMeasureInContainer(logsRef, containerSize);
 
   const { dateTimeWidth, maxCharPerLine } = useMemo(() => {
     const dateTimeWidth = charMeasures.width * MAX_DATETIME_LENGTH;

--- a/webui/react/src/components/kit/LogViewer/LogViewer.tsx
+++ b/webui/react/src/components/kit/LogViewer/LogViewer.tsx
@@ -148,9 +148,10 @@ const LogViewer: React.FC<Props> = ({
 
   const { dateTimeWidth, maxCharPerLine } = useMemo(() => {
     const dateTimeWidth = charMeasures.width * MAX_DATETIME_LENGTH;
-    const maxCharPerLine = Math.floor(
-      (containerSize.width - ICON_WIDTH - dateTimeWidth - 2 * PADDING) / charMeasures.width,
-    );
+    const maxCharPerLine =
+      Math.floor(
+        (containerSize.width - ICON_WIDTH - dateTimeWidth - 2 * PADDING) / charMeasures.width,
+      ) - 2;
     return { dateTimeWidth, maxCharPerLine };
   }, [charMeasures.width, containerSize.width]);
 

--- a/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
+++ b/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
@@ -1,38 +1,51 @@
-import { RefObject, useMemo } from 'react';
+import { RefObject, useEffect, useMemo, useState } from 'react';
 
 export interface CharMeasure {
   height: number;
   width: number;
 }
 
-const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMeasure => {
-  const containerInner = container.current;
+const useEffectInEvent = (set?: () => void) => {
+  useEffect(() => {
+    set?.();
+    if (set) {
+      window.addEventListener("resize", set);
+      return () => window.removeEventListener("resize", set);
+    }
+  }, []);
+};
 
-  const elem = document.createElement('div');
-  elem.style.display = 'inline';
-  elem.style.opacity = '0';
-  elem.style.position = 'fixed';
-  elem.style.top = '0';
-  elem.style.width = 'auto';
-  elem.style.visibility = 'hidden';
-  elem.textContent = 'W';
-  containerInner?.appendChild?.(elem);
+const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMeasure => {
+  const [rect, setRect] = useState<DOMRect>();
+  const set = () => setRect(container.current?.getBoundingClientRect());
+  useEffectInEvent(set);
 
   return useMemo(() => {
-    if (!containerInner) {
+    if (!rect) {
       return {
         height: 0,
         width: 0,
       };
     }
 
+    const elem = document.createElement('div');
+    elem.style.display = 'inline';
+    elem.style.opacity = '0';
+    elem.style.position = 'fixed';
+    elem.style.top = '0';
+    elem.style.width = 'auto';
+    elem.style.visibility = 'hidden';
+    elem.textContent = 'W';
+    container.current?.appendChild?.(elem);
+
     const charRect = elem.getBoundingClientRect();
+    elem.remove();
 
     return {
       height: charRect.height,
       width: charRect.width,
     };
-  }, [containerInner, elem]);
+  }, [rect]);
 };
 
 export default useGetCharMeasureInContainer;

--- a/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
+++ b/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
@@ -8,6 +8,16 @@ export interface CharMeasure {
 const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMeasure => {
   const containerInner = container.current;
 
+  const elem = document.createElement('div');
+  elem.style.display = 'inline';
+  elem.style.opacity = '0';
+  elem.style.position = 'fixed';
+  elem.style.top = '0';
+  elem.style.width = 'auto';
+  elem.style.visibility = 'hidden';
+  elem.textContent = 'W';
+  containerInner?.appendChild?.(elem);
+
   return useMemo(() => {
     if (!containerInner) {
       return {
@@ -16,24 +26,13 @@ const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMe
       };
     }
 
-    const elem = document.createElement('div');
-    elem.style.display = 'inline';
-    elem.style.opacity = '0';
-    elem.style.position = 'fixed';
-    elem.style.top = '0';
-    elem.style.width = 'auto';
-    elem.textContent = 'W';
-    containerInner.appendChild(elem);
-
     const charRect = elem.getBoundingClientRect();
-
-    elem.remove();
 
     return {
       height: charRect.height,
       width: charRect.width,
     };
-  }, [containerInner]);
+  }, [containerInner, elem]);
 };
 
 export default useGetCharMeasureInContainer;

--- a/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
+++ b/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
@@ -1,15 +1,16 @@
 import { RefObject, useMemo } from 'react';
 
-import useResize from 'components/kit/internal/useResize';
+import { SizeInfo } from 'components/kit/internal/useResize';
 
 export interface CharMeasure {
   height: number;
   width: number;
 }
 
-const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMeasure => {
-  const { size } = useResize(container);
-
+const useGetCharMeasureInContainer = (
+  container: RefObject<HTMLElement>,
+  containerSize?: SizeInfo,
+): CharMeasure => {
   return useMemo(() => {
     if (!container.current) {
       return {
@@ -36,7 +37,7 @@ const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMe
       width: charRect.width,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [size, container]);
+  }, [container, containerSize]);
 };
 
 export default useGetCharMeasureInContainer;

--- a/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
+++ b/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
@@ -9,9 +9,10 @@ const useEffectInEvent = (set?: () => void) => {
   useEffect(() => {
     set?.();
     if (set) {
-      window.addEventListener("resize", set);
-      return () => window.removeEventListener("resize", set);
+      window.addEventListener('resize', set);
+      return () => window.removeEventListener('resize', set);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };
 
@@ -45,7 +46,7 @@ const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMe
       height: charRect.height,
       width: charRect.width,
     };
-  }, [rect]);
+  }, [rect, container]);
 };
 
 export default useGetCharMeasureInContainer;

--- a/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
+++ b/webui/react/src/components/kit/internal/useGetCharMeasureInContainer.ts
@@ -1,28 +1,17 @@
-import { RefObject, useEffect, useMemo, useState } from 'react';
+import { RefObject, useMemo } from 'react';
+
+import useResize from 'components/kit/internal/useResize';
 
 export interface CharMeasure {
   height: number;
   width: number;
 }
 
-const useEffectInEvent = (set?: () => void) => {
-  useEffect(() => {
-    set?.();
-    if (set) {
-      window.addEventListener('resize', set);
-      return () => window.removeEventListener('resize', set);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-};
-
 const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMeasure => {
-  const [rect, setRect] = useState<DOMRect>();
-  const set = () => setRect(container.current?.getBoundingClientRect());
-  useEffectInEvent(set);
+  const { size } = useResize(container);
 
   return useMemo(() => {
-    if (!rect) {
+    if (!container.current) {
       return {
         height: 0,
         width: 0,
@@ -46,7 +35,8 @@ const useGetCharMeasureInContainer = (container: RefObject<HTMLElement>): CharMe
       height: charRect.height,
       width: charRect.width,
     };
-  }, [rect, container]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [size, container]);
 };
 
 export default useGetCharMeasureInContainer;

--- a/webui/react/src/components/kit/internal/useResize.ts
+++ b/webui/react/src/components/kit/internal/useResize.ts
@@ -20,8 +20,8 @@ const DEFAULT_SIZE = {
   y: 0,
 };
 
-const useResize = (ref?: RefObject<HTMLElement>): ResizeHook => {
-  const elementRef = useRef<HTMLElement>(ref?.current ?? document.body);
+const useResize = (): ResizeHook => {
+  const elementRef = useRef<HTMLElement>(document.body);
   const isMeasured = useRef(false);
   const observer = useRef<ResizeObserver>();
   const [resizeInfo, setResizeInfo] = useState<SizeInfo>({ ...DEFAULT_SIZE });

--- a/webui/react/src/components/kit/internal/useResize.ts
+++ b/webui/react/src/components/kit/internal/useResize.ts
@@ -20,8 +20,8 @@ const DEFAULT_SIZE = {
   y: 0,
 };
 
-const useResize = (): ResizeHook => {
-  const elementRef = useRef<HTMLElement>(document.body);
+const useResize = (ref?: RefObject<HTMLElement>): ResizeHook => {
+  const elementRef = useRef<HTMLElement>(ref?.current ?? document.body);
   const isMeasured = useRef(false);
   const observer = useRef<ResizeObserver>();
   const [resizeInfo, setResizeInfo] = useState<SizeInfo>({ ...DEFAULT_SIZE });

--- a/webui/react/src/components/kit/internal/useResize.ts
+++ b/webui/react/src/components/kit/internal/useResize.ts
@@ -1,6 +1,6 @@
 import { RefCallback, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
-interface SizeInfo {
+export interface SizeInfo {
   height: number;
   width: number;
   x: number;


### PR DESCRIPTION
## Description

Bug is that on low-to-mid width windows, TaskLogs puts unnecessary vertical space between log messages.

Both TaskLogs and TrialLogs use the LogViewer component, but TaskLogs inserts more lines because `useGetCharMeasureInContainer` estimates width-per-character to be 50% wider. After some tests, this could be a timing issue because we measure the width of a one-character div while loading the page, then delete the div.
~My proposal is to keep the div, with `visibility: hidden`, and have it as a dependency to the width. This gets called more times, and catches the correct width-per-character.~
New version uses the `visibility: hidden` div and deletes it after, but in connection with a resize event handler.

## Test Plan

- With latest-main backend, visit `/det/shell/d400880a-ecad-4ae8-87ea-f5d78d156d53/logs?id=Shell%20(lately-concise-molly)` and test loading the page with different initial page widths
- After the logs load, drag the browser window to increase and decrease width; the logviewer should adjust

\+
- With a console.log in the useMemo code block, fork an existing experiment to watch running logs. The console.log will run on resizes and not from adding new logs

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.