### PR TITLE
docs: Adjust the tutorials index page

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -12,24 +12,12 @@
 To get started with your first experiment, visit the :ref:`Quickstart for Model Developers
 <qs-mdldev>`.
 
-*******************************************************
- Get Started with a :ref:`Trial API <high-level-apis>`
-*******************************************************
+******************************
+ Get Started with a Trial API
+******************************
 
-+---------------------------------+--------------------------------------------------------------+
-| Title                           | Description                                                  |
-+=================================+==============================================================+
-| :doc:`pytorch-mnist-tutorial`   | Based on the `PyTorch MNIST example`_, this tutorial shows   |
-|                                 | you how to port a simple image classification model for the  |
-|                                 | MNIST dataset.                                               |
-+---------------------------------+--------------------------------------------------------------+
-| :doc:`pytorch-porting-tutorial` | The PyTorch porting tutorial provides helpful hints to       |
-|                                 | successfully integrate PyTorch code with the Determined      |
-|                                 | PyTorchTrial API.                                            |
-+---------------------------------+--------------------------------------------------------------+
-| :doc:`tf-mnist-tutorial`        | The TensorFlow Keras Fashion MNIST tutorial describes how to |
-|                                 | port a ``tf.keras`` model to Determined.                     |
-+---------------------------------+--------------------------------------------------------------+
+To get started with a :ref:`Trial API <high-level-apis>`, visit the :ref:`pytorch-mnist-tutorial`.
+This tutorial shows you how to port a simple image classification model for the MNIST dataset.
 
 **********************************************
  Want to Learn About a Specific Training API?
@@ -38,9 +26,9 @@ To get started with your first experiment, visit the :ref:`Quickstart for Model 
 :ref:`Training API Guides <apis-howto-overview>` describe how to take your existing model code and
 train your model in Determined.
 
-***********************
- Looking for Examples?
-***********************
+****************
+ Try an Example
+****************
 
 Examples let you build off of an existing model that already runs on Determined. Visit our
 :ref:`Examples <example-solutions>` to see if the model you'd like to train is already available.


### PR DESCRIPTION
purpose: Adjust the table now that we only have one item. Adjust a few headers.

status: closed

reason: this has been included as part of examples pruning part II #7858 
