### PR TITLE
fix: Project move/delete updates UI state [WEB-1668]

### DIFF
--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -19,8 +19,8 @@ interface Props {
   className?: string;
   direction?: 'vertical' | 'horizontal';
   isContextMenu?: boolean;
-  onComplete?: () => void;
   onDelete?: () => void;
+  onEdit?: () => void;
   onVisibleChange?: (visible: boolean) => void;
   project: Project;
   showChildrenIfEmpty?: boolean;
@@ -28,8 +28,9 @@ interface Props {
 }
 
 interface ProjectMenuPropsIn {
-  onComplete?: () => void;
   onDelete?: () => void;
+  onEdit?: () => void;
+  onMove?: () => void;
   project?: Project;
   workspaceArchived?: boolean;
 }
@@ -41,8 +42,9 @@ interface ProjectMenuPropsOut {
 }
 
 export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPropsOut = ({
-  onComplete,
   onDelete,
+  onEdit,
+  onMove,
   project,
   workspaceArchived = false,
 }: ProjectMenuPropsIn) => {
@@ -55,18 +57,17 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
       <>
         {project && (
           <>
-            <ProjectMoveModal.Component project={project} onClose={onComplete} />
+            <ProjectMoveModal.Component project={project} onMove={onMove} />
             <ProjectDeleteModal.Component
               project={project}
-              onClose={onComplete}
               onDelete={onDelete}
             />
-            <ProjectEditModal.Component project={project} onClose={onComplete} />
+            <ProjectEditModal.Component project={project} onEdit={onEdit} />
           </>
         )}
       </>
     );
-  }, [ProjectMoveModal, ProjectEditModal, ProjectDeleteModal, onComplete, onDelete, project]);
+  }, [ProjectMoveModal, ProjectEditModal, ProjectDeleteModal, onDelete, onEdit, onMove, project]);
 
   const { canDeleteProjects, canModifyProjects, canMoveProjects } = usePermissions();
 
@@ -76,19 +77,19 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
     if (project.archived) {
       try {
         await unarchiveProject({ id: project.id });
-        onComplete?.();
+        onEdit?.();
       } catch (e) {
         handleError(e, { publicSubject: 'Unable to unarchive project.' });
       }
     } else {
       try {
         await archiveProject({ id: project.id });
-        onComplete?.();
+        onEdit?.();
       } catch (e) {
         handleError(e, { publicSubject: 'Unable to archive project.' });
       }
     }
-  }, [onComplete, project]);
+  }, [onEdit, project]);
 
   const MenuKey = {
     Delete: 'delete',
@@ -151,12 +152,12 @@ const ProjectActionDropdown: React.FC<Props> = ({
   showChildrenIfEmpty = true,
   className,
   direction = 'vertical',
-  onComplete,
+  onEdit,
   onDelete,
   workspaceArchived = false,
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
-    onComplete,
+    onEdit,
     onDelete,
     project,
     workspaceArchived,

--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -58,10 +58,7 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
         {project && (
           <>
             <ProjectMoveModal.Component project={project} onMove={onMove} />
-            <ProjectDeleteModal.Component
-              project={project}
-              onDelete={onDelete}
-            />
+            <ProjectDeleteModal.Component project={project} onDelete={onDelete} />
             <ProjectEditModal.Component project={project} onEdit={onEdit} />
           </>
         )}
@@ -157,8 +154,8 @@ const ProjectActionDropdown: React.FC<Props> = ({
   workspaceArchived = false,
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
-    onEdit,
     onDelete,
+    onEdit,
     project,
     workspaceArchived,
   });

--- a/webui/react/src/components/ProjectActionDropdown.tsx
+++ b/webui/react/src/components/ProjectActionDropdown.tsx
@@ -20,8 +20,8 @@ interface Props {
   direction?: 'vertical' | 'horizontal';
   isContextMenu?: boolean;
   onDelete?: () => void;
-  onEdit?: () => void;
-  onVisibleChange?: (visible: boolean) => void;
+  onEdit?: (name: string, archived: boolean) => void;
+  onMove?: () => void;
   project: Project;
   showChildrenIfEmpty?: boolean;
   workspaceArchived?: boolean;
@@ -29,7 +29,7 @@ interface Props {
 
 interface ProjectMenuPropsIn {
   onDelete?: () => void;
-  onEdit?: () => void;
+  onEdit?: (name: string, archived: boolean) => void;
   onMove?: () => void;
   project?: Project;
   workspaceArchived?: boolean;
@@ -74,14 +74,14 @@ export const useProjectActionMenu: (props: ProjectMenuPropsIn) => ProjectMenuPro
     if (project.archived) {
       try {
         await unarchiveProject({ id: project.id });
-        onEdit?.();
+        onEdit?.(project.name, false);
       } catch (e) {
         handleError(e, { publicSubject: 'Unable to unarchive project.' });
       }
     } else {
       try {
         await archiveProject({ id: project.id });
-        onEdit?.();
+        onEdit?.(project.name, true);
       } catch (e) {
         handleError(e, { publicSubject: 'Unable to archive project.' });
       }
@@ -151,11 +151,13 @@ const ProjectActionDropdown: React.FC<Props> = ({
   direction = 'vertical',
   onEdit,
   onDelete,
+  onMove,
   workspaceArchived = false,
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
     onDelete,
     onEdit,
+    onMove,
     project,
     workspaceArchived,
   });

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -15,6 +15,7 @@ import css from './ProjectCard.module.scss';
 
 interface Props {
   hideActionMenu?: boolean;
+  onEdit?: (name: string, archived: boolean) => void;
   onRemove?: () => void;
   project: Project;
   showWorkspace?: boolean;
@@ -24,12 +25,14 @@ interface Props {
 const ProjectCard: React.FC<Props> = ({
   hideActionMenu,
   onRemove,
+  onEdit,
   project,
   showWorkspace,
   workspaceArchived,
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
     onDelete: onRemove,
+    onEdit,
     onMove: onRemove,
     project,
     workspaceArchived,

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -14,21 +14,23 @@ import { useProjectActionMenu } from './ProjectActionDropdown';
 import css from './ProjectCard.module.scss';
 
 interface Props {
-  fetchProjects?: () => void;
+  hideActionMenu?: boolean;
+  onRemove?: () => void;
   project: Project;
   showWorkspace?: boolean;
   workspaceArchived?: boolean;
 }
 
 const ProjectCard: React.FC<Props> = ({
+  hideActionMenu,
+  onRemove,
   project,
-  fetchProjects,
-  workspaceArchived,
   showWorkspace,
+  workspaceArchived,
 }: Props) => {
   const { contextHolders, menu, onClick } = useProjectActionMenu({
-    onComplete: fetchProjects,
-    onDelete: fetchProjects,
+    onDelete: onRemove,
+    onMove: onRemove,
     project,
     workspaceArchived,
   });
@@ -39,7 +41,7 @@ const ProjectCard: React.FC<Props> = ({
   return (
     <>
       <Card
-        actionMenu={!project.immutable ? menu : undefined}
+        actionMenu={!project.immutable && !hideActionMenu ? menu : undefined}
         href={paths.projectDetails(project.id)}
         onDropdown={onClick}>
         <div className={classnames.join(' ')}>

--- a/webui/react/src/components/ProjectDeleteModal.tsx
+++ b/webui/react/src/components/ProjectDeleteModal.tsx
@@ -24,7 +24,7 @@ const ProjectDeleteModalComponent: React.FC<Props> = ({ onClose, project, onDele
   const handleSubmit = useCallback(async () => {
     try {
       await deleteProject({ id: project.id });
-      if (onDelete) onDelete();
+      onDelete?.();
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,

--- a/webui/react/src/components/ProjectEditModal.tsx
+++ b/webui/react/src/components/ProjectEditModal.tsx
@@ -15,11 +15,11 @@ interface FormInputs {
 }
 
 interface Props {
-  onClose?: () => void;
+  onEdit?: () => void;
   project: Project;
 }
 
-const ProjectEditModalComponent: React.FC<Props> = ({ onClose, project }: Props) => {
+const ProjectEditModalComponent: React.FC<Props> = ({ onEdit, project }: Props) => {
   const [form] = Form.useForm<FormInputs>();
   const projectName = Form.useWatch('projectName', form);
 
@@ -54,7 +54,7 @@ const ProjectEditModalComponent: React.FC<Props> = ({ onClose, project }: Props)
       title="Edit Project"
       onClose={() => {
         form.resetFields();
-        onClose?.();
+        onEdit?.();
       }}>
       <Form autoComplete="off" form={form} id={FORM_ID} layout="vertical">
         <Form.Item

--- a/webui/react/src/components/ProjectEditModal.tsx
+++ b/webui/react/src/components/ProjectEditModal.tsx
@@ -15,7 +15,7 @@ interface FormInputs {
 }
 
 interface Props {
-  onEdit?: () => void;
+  onEdit?: (name: string, archived: boolean) => void;
   project: Project;
 }
 
@@ -30,6 +30,7 @@ const ProjectEditModalComponent: React.FC<Props> = ({ onEdit, project }: Props) 
 
     try {
       await patchProject({ description, id: project.id, name });
+      onEdit?.(name, project.archived);
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,
@@ -39,7 +40,7 @@ const ProjectEditModalComponent: React.FC<Props> = ({ onEdit, project }: Props) 
         type: ErrorType.Server,
       });
     }
-  }, [form, project.id]);
+  }, [onEdit, form, project.id, project.archived]);
 
   return (
     <Modal
@@ -54,7 +55,6 @@ const ProjectEditModalComponent: React.FC<Props> = ({ onEdit, project }: Props) 
       title="Edit Project"
       onClose={() => {
         form.resetFields();
-        onEdit?.();
       }}>
       <Form autoComplete="off" form={form} id={FORM_ID} layout="vertical">
         <Form.Item

--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -20,11 +20,11 @@ import css from './ProjectMoveModal.module.scss';
 const { Option } = Select;
 
 interface Props {
-  onClose?: () => void;
+  onMove?: () => void;
   project: Project;
 }
 
-const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props) => {
+const ProjectMoveModalComponent: React.FC<Props> = ({ onMove, project }: Props) => {
   const [destinationWorkspaceId, setDestinationWorkspaceId] = useState<number>();
   const { canMoveProjectsTo } = usePermissions();
   const workspaces = Loadable.match(useObservable(workspaceStore.unarchived), {
@@ -51,7 +51,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
         ),
         message: 'Move Success',
       });
-      onClose?.();
+      onMove?.();
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,
@@ -61,7 +61,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
         type: ErrorType.Server,
       });
     }
-  }, [destinationWorkspaceId, onClose, project.id, project.name, workspaces]);
+  }, [destinationWorkspaceId, onMove, project.id, project.name, workspaces]);
 
   const handleWorkspaceSelect = useCallback(
     (selectedWorkspaceId: SelectValue) => {
@@ -85,8 +85,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onClose, project }: Props)
         handler: handleSubmit,
         text: 'Move Project',
       }}
-      title="Move Project"
-      onClose={onClose}>
+      title="Move Project">
       <label htmlFor="workspace">Workspace</label>
       <Select
         id="workspace"

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -197,12 +197,7 @@ const Dashboard: React.FC = () => {
         <Section title="Recently Viewed Projects">
           <Card.Group size="small" wrap={false}>
             {projects.map((project) => (
-              <ProjectCard
-                hideActionMenu
-                key={project.id}
-                project={project}
-                showWorkspace
-              />
+              <ProjectCard hideActionMenu key={project.id} project={project} showWorkspace />
             ))}
           </Card.Group>
         </Section>

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -198,7 +198,7 @@ const Dashboard: React.FC = () => {
           <Card.Group size="small" wrap={false}>
             {projects.map((project) => (
               <ProjectCard
-                fetchProjects={fetchProjects}
+                hideActionMenu
                 key={project.id}
                 project={project}
                 showWorkspace

--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -197,7 +197,7 @@ const Dashboard: React.FC = () => {
         <Section title="Recently Viewed Projects">
           <Card.Group size="small" wrap={false}>
             {projects.map((project) => (
-              <ProjectCard hideActionMenu key={project.id} project={project} showWorkspace />
+              <ProjectCard key={project.id} project={project} showWorkspace />
             ))}
           </Card.Group>
         </Section>

--- a/webui/react/src/pages/ProjectDetails.tsx
+++ b/webui/react/src/pages/ProjectDetails.tsx
@@ -75,8 +75,9 @@ const ProjectDetails: React.FC = () => {
   }, [id]);
 
   const { contextHolders, menu, onClick } = useProjectActionMenu({
-    onComplete: fetchProject,
     onDelete: onProjectDelete,
+    onEdit: fetchProject,
+    onMove: fetchProject,
     project,
     workspaceArchived: workspace?.archived,
   });

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -171,6 +171,20 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
     }
   }, []);
 
+  const onProjectRemove = useCallback(
+    (id: number) => {
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+    },
+    [setProjects],
+  );
+
+  const onProjectEdit = useCallback(
+    (id: number, name: string, archived: boolean) => {
+      setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, archived, name } : p)));
+    },
+    [setProjects],
+  );
+
   const columns = useMemo(() => {
     const projectNameRenderer = (value: string, record: Project) => (
       <Link path={paths.projectDetails(record.id)}>{value}</Link>
@@ -180,7 +194,9 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
       <ProjectActionDropdown
         project={record}
         workspaceArchived={workspace?.archived}
-        onDelete={fetchProjects}
+        onDelete={() => onProjectRemove(record.id)}
+        onEdit={(name: string, archived: boolean) => onProjectEdit(record.id, name, archived)}
+        onMove={() => onProjectRemove(record.id)}
       />
     );
 
@@ -265,7 +281,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         title: '',
       },
     ] as ColumnDef<Project>[];
-  }, [fetchProjects, saveProjectDescription, workspace?.archived, users]);
+  }, [saveProjectDescription, workspace?.archived, users, onProjectEdit, onProjectRemove]);
 
   const switchShowArchived = useCallback(
     (showArchived: boolean) => {
@@ -305,33 +321,19 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   );
 
   const actionDropdown = useCallback(
-    ({
-      record,
-      onVisibleChange,
-      children,
-    }: {
-      children: React.ReactNode;
-      onVisibleChange?: (visible: boolean) => void;
-      record: Project;
-    }) => (
+    ({ record, children }: { children: React.ReactNode; record: Project }) => (
       <ProjectActionDropdown
         isContextMenu
         project={record}
         workspaceArchived={workspace?.archived}
-        onDelete={fetchProjects}
-        onVisibleChange={onVisibleChange}>
+        onDelete={() => onProjectRemove(record.id)}
+        onEdit={(name: string, archived: boolean) => onProjectEdit(record.id, name, archived)}
+        onMove={() => onProjectRemove(record.id)}>
         {children}
       </ProjectActionDropdown>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [workspace?.archived],
-  );
-
-  const onProjectRemove = useCallback(
-    (id: number) => {
-      setProjects((prev) => prev.filter((p) => p.id !== id));
-    },
-    [setProjects],
   );
 
   const projectsList = useMemo(() => {
@@ -346,6 +348,9 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
                 key={project.id}
                 project={project}
                 workspaceArchived={workspace?.archived}
+                onEdit={(name: string, archived: boolean) =>
+                  onProjectEdit(project.id, name, archived)
+                }
                 onRemove={() => onProjectRemove(project.id)}
               />
             ))}
@@ -378,6 +383,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
     columns,
     isLoading,
     loadableUsers,
+    onProjectEdit,
     onProjectRemove,
     pageRef,
     projects,

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -180,7 +180,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
       <ProjectActionDropdown
         project={record}
         workspaceArchived={workspace?.archived}
-        onComplete={fetchProjects}
+        onDelete={fetchProjects}
       />
     );
 
@@ -318,7 +318,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
         isContextMenu
         project={record}
         workspaceArchived={workspace?.archived}
-        onComplete={fetchProjects}
+        onDelete={fetchProjects}
         onVisibleChange={onVisibleChange}>
         {children}
       </ProjectActionDropdown>
@@ -336,8 +336,8 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
           <Card.Group size="small">
             {projects.map((project) => (
               <ProjectCard
-                fetchProjects={fetchProjects}
                 key={project.id}
+                onRemove={() => onProjectRemove(project.id)}
                 project={project}
                 workspaceArchived={workspace?.archived}
               />

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -327,6 +327,13 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
     [workspace?.archived],
   );
 
+  const onProjectRemove = useCallback(
+    (id: number) => {
+      setProjects((prev) => prev.filter((p) => p.id !== id));
+    },
+    [setProjects],
+  );
+
   const projectsList = useMemo(() => {
     if (!settings) return <Spinner spinning />;
 
@@ -337,9 +344,9 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
             {projects.map((project) => (
               <ProjectCard
                 key={project.id}
-                onRemove={() => onProjectRemove(project.id)}
                 project={project}
                 workspaceArchived={workspace?.archived}
+                onRemove={() => onProjectRemove(project.id)}
               />
             ))}
           </Card.Group>
@@ -369,9 +376,9 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
   }, [
     actionDropdown,
     columns,
-    fetchProjects,
     isLoading,
     loadableUsers,
+    onProjectRemove,
     pageRef,
     projects,
     settings,


### PR DESCRIPTION
## Description

Addresses feedback from release party a few weeks ago: https://github.com/orgs/determined-ai/projects/18/views/1?pane=issue&itemId=36080269

Old version: we would pass `fetchProjects` to the project action menu so after move/delete succeeded, we would trigger a refresh of the page data

New version: remove uncertainty from the `onClose` and `onComplete` functions with specific options for `onEdit`, `onMove`, and `onDelete`. On a Project's ProjectDetails page we continue using the `fetchProject` callback (or redirect if we are deleting this project). On a WorkspaceProjects list, this adds an `onProjectRemove` and `onProjectEdit` callbacks to quickly update the UI.

Extra change: I hid these project action menus on the dashboard. Will ask design about this

<img width="1081" alt="Screen Shot 2023-09-13 at 9 53 21 AM" src="https://github.com/determined-ai/determined/assets/643918/e52f7319-a4d9-4ced-8eb2-6547c424edc8">


## Test Plan

- On `/det/` (dashboard) hover over recent project cards, and verify that there is no menu in the upper right
- Visit a workspace and create empty projects which you can delete
- From the WorkspaceDetails page, cards view, delete a project. The UI should update as soon as the modal closes.
- From the WorkspaceDetails page, cards view, test changing a project name or archive/unarchive. The UI should update quickly.
- In the WorkspaceDetails table view, test right-clicking menu and three-dots menu at the right end of the row
- Select a project to visit the ProjectDetails page, and confirm you can edit, move, and delete this project from the action / dropdown menu next to the name.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.