### PR TITLE
test: enable command run tests for hpc

### DIFF
--- a/e2e_tests/tests/command/__init__.py
+++ b/e2e_tests/tests/command/__init__.py
@@ -1,7 +1,7 @@
 from .command import (
     get_command,
     get_command_config,
-    get_num_running_commands,
+    get_num_active_commands,
     interactive_command,
     print_command_logs,
 )

--- a/e2e_tests/tests/command/command.py
+++ b/e2e_tests/tests/command/command.py
@@ -87,14 +87,24 @@ def interactive_command(*args: str) -> Iterator[_InteractiveCommandProcess]:
             p.kill()
 
 
-def get_num_running_commands() -> int:
+def get_num_active_commands() -> int:
     # TODO: refactor tests to not use cli singleton auth.
     certs.cli_cert = certs.default_load(conf.make_master_url())
     authentication.cli_auth = authentication.Authentication(conf.make_master_url())
     r = api.get(conf.make_master_url(), "api/v1/commands")
     assert r.status_code == requests.codes.ok, r.text
 
-    return len([command for command in r.json()["commands"] if command["state"] == "STATE_RUNNING"])
+    return len(
+        [
+            command
+            for command in r.json()["commands"]
+            if (
+                command["state"] == "STATE_PULLING"
+                or command["state"] == "STATE_STARTING"
+                or command["state"] == "STATE_RUNNING"
+            )
+        ]
+    )
 
 
 def get_command(command_id: str) -> Any:

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -398,7 +398,11 @@ def test_cmd_kill() -> None:
         assert command.task_id is not None
         for line in command.stdout:
             if "hello world" in line:
-                assert cmd.get_num_running_commands() == 1
+                # For HPC job, dispatcher does the polling of the job state happens
+                # every 10 seconds. For example, it is very likely the current job state is
+                # STATE_PULLING when job is actually running on HPC. So instead of checking
+                # for STATE_RUNNING, we check for other active states as well.
+                assert cmd.get_num_active_commands() == 1
                 break
 
 


### PR DESCRIPTION
## Description

This will enable running the command run tests for HPC slurm/pbs jobs.

Once this is merged, will add @pytest.mark.e2e_slurm and @pytest.mark.e2e_pbs tags to determined-ee. See https://github.com/determined-ai/determined-ee/pull/1044


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
