### PR TITLE
chore: bunify & tidy up internal/user

### DIFF
--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -357,7 +357,7 @@ func (a *apiServer) CheckpointsRemoveFiles(
 	// Submit checkpoint GC tasks for all checkpoints.
 	for i, expIDcUUIDs := range groupCUUIDsByEIDs {
 		i := i
-		agentUserGroup, err := user.GetAgentUserGroup(curUser.ID, workspaceIDs[i])
+		agentUserGroup, err := user.GetAgentUserGroup(ctx, curUser.ID, workspaceIDs[i])
 		if err != nil {
 			return nil, err
 		}

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -81,7 +81,8 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 			status.Errorf(codes.Unauthenticated, "failed to get the user: %s", err)
 	}
 
-	agentUserGroup, err := user.GetAgentUserGroup(userModel.ID, int(cmdSpec.Metadata.WorkspaceID))
+	// TODO(ilia): When commands are workspaced, also use workspace AgentUserGroup here.
+	agentUserGroup, err := user.GetAgentUserGroup(ctx, userModel.ID, int(cmdSpec.Metadata.WorkspaceID))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -469,7 +469,7 @@ func (a *apiServer) deleteExperiments(exps []*model.Experiment, userModel *model
 			defer func() { <-sema }()
 			defer wg.Done()
 
-			agentUserGroup, err := user.GetAgentUserGroup(*exp.OwnerID, workspaceIDs[i])
+			agentUserGroup, err := user.GetAgentUserGroup(context.TODO(), *exp.OwnerID, workspaceIDs[i])
 			if err != nil {
 				log.WithError(err).Errorf("failed to delete experiment: %d", exp.ID)
 				return
@@ -1281,7 +1281,7 @@ func (a *apiServer) PatchExperiment(
 			if err != nil {
 				return nil, err
 			}
-			agentUserGroup, err := user.GetAgentUserGroup(*modelExp.OwnerID, workspaceID[0])
+			agentUserGroup, err := user.GetAgentUserGroup(context.TODO(), *modelExp.OwnerID, workspaceID[0])
 			if err != nil {
 				return nil, err
 			}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -194,7 +194,7 @@ func newExperiment(
 		telemetry.ReportExperimentCreated(expModel.ID, activeConfig)
 	}
 
-	agentUserGroup, err := user.GetAgentUserGroup(*expModel.OwnerID, workspaceID)
+	agentUserGroup, err := user.GetAgentUserGroup(context.TODO(), *expModel.OwnerID, workspaceID)
 	if err != nil {
 		return nil, launchWarnings, err
 	}

--- a/master/internal/user/external_users.go
+++ b/master/internal/user/external_users.go
@@ -4,8 +4,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
-// UserByExternalToken returns a user session derived from an external authentication token.
-func UserByExternalToken(tokenText string,
+// ByExternalToken returns a user session derived from an external authentication token.
+func ByExternalToken(tokenText string,
 	ext *model.ExternalSessions,
 ) (*model.User, *model.UserSession, error) {
 	return nil, nil, nil

--- a/master/internal/user/postgres_agentusergroup.go
+++ b/master/internal/user/postgres_agentusergroup.go
@@ -12,21 +12,21 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
-func getAgentUserGroupFromUser(userID model.UserID) (*model.AgentUserGroup, error) {
+func getAgentUserGroupFromUser(
+	ctx context.Context,
+	userID model.UserID,
+) (*model.AgentUserGroup, error) {
 	var aug model.AgentUserGroup
-	err := db.Bun().NewSelect().Model(&aug).
-		Relation("RelatedUser").
-		Where("related_user.id = ?", userID).
-		Scan(context.TODO())
-	if err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
-			return nil, nil
-		}
-
+	switch err := db.Bun().NewSelect().Table("agent_user_groups").
+		Where("user_id = ?", userID).
+		Scan(ctx, &aug); {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, nil
+	case err != nil:
 		return nil, err
+	default:
+		return &aug, nil
 	}
-
-	return &aug, nil
 }
 
 type optionalAgentUserGroup struct {
@@ -37,25 +37,30 @@ type optionalAgentUserGroup struct {
 	GID   *int
 }
 
-// TODO(ilia): Bun me.
-func getAgentUserGroupFromWorkspaceID(workspaceID int) (*optionalAgentUserGroup, error) {
-	aug := optionalAgentUserGroup{}
-	err := db.Bun().NewRaw(`
-SELECT
-	uid, user_ as user, gid, group_ as group
-FROM workspaces WHERE id = ?`,
-		workspaceID).Scan(context.TODO(), &aug)
+func getAgentUserGroupFromWorkspaceID(
+	ctx context.Context,
+	workspaceID int,
+) (*optionalAgentUserGroup, error) {
+	var aug optionalAgentUserGroup
+	err := db.Bun().NewSelect().Table("workspaces").
+		ColumnExpr("uid, user_ AS user, gid, group_ AS group").
+		Where("id = ?", workspaceID).Scan(ctx, &aug)
+
 	return &aug, err
 }
 
-// GetAgentUserGroup returns AgentUserGroup for a user + a workspace ID.
-func GetAgentUserGroup(userID model.UserID, workspaceID int) (*model.AgentUserGroup, error) {
-	workspaceAug, err := getAgentUserGroupFromWorkspaceID(workspaceID)
+// GetAgentUserGroup returns AgentUserGroup for a user + (optional) workspace.
+func GetAgentUserGroup(
+	ctx context.Context,
+	userID model.UserID,
+	workspaceID int,
+) (*model.AgentUserGroup, error) {
+	workspaceAug, err := getAgentUserGroupFromWorkspaceID(ctx, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get agent user group from experiment: %w", err)
 	}
 
-	userAug, err := getAgentUserGroupFromUser(userID)
+	userAug, err := getAgentUserGroupFromUser(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get agent user group from user: %w", err)
 	}
@@ -64,7 +69,7 @@ func GetAgentUserGroup(userID model.UserID, workspaceID int) (*model.AgentUserGr
 		userAug = &config.GetMasterConfig().Security.DefaultTask
 	}
 
-	// Merge exp AUG and user AUG.
+	// Merge workspace AUG and user AUG.
 	result := model.AgentUserGroup{
 		UID:   userAug.UID,
 		User:  userAug.User,

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -297,7 +297,7 @@ func ByToken(ctx context.Context, token string, ext *model.ExternalSessions) (
 	var session model.UserSession
 
 	if ext.JwtKey != "" {
-		return UserByExternalToken(token, ext)
+		return ByExternalToken(token, ext)
 	}
 
 	v2 := paseto.NewV2()

--- a/master/pkg/model/agent_user_group.go
+++ b/master/pkg/model/agent_user_group.go
@@ -25,8 +25,6 @@ type AgentUserGroup struct {
 	// The Group is the primary group of the user.
 	Group string `db:"group_" bun:"group_" json:"group"`
 	GID   int    `db:"gid" json:"gid"`
-
-	RelatedUser *User `bun:"rel:belongs-to,join:user_id=id"`
 }
 
 // Validate validates the fields of the AgentUserGroup.


### PR DESCRIPTION
## Description
Related to  https://github.com/determined-ai/determined/pull/7769, this bunifies & tidies up `master/internal/user/postgres_agentusergroup.go` and moves the methods in `master/internal/user/external_users.go` to `postgres_users.go`

## Test Plan
Create a user & experiment & test getting its agent user group.

Add tests postgres_agentusergroup.go as part of https://github.com/determined-ai/determined/pull/7875

For EE: circle CI checks (https://app.circleci.com/pipelines/github/determined-ai/determined-ee?branch=postgres-agent-user-groups), test branch (https://github.com/determined-ai/determined-ee/tree/postgres-agent-user-groups)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9841
