### PR TITLE
fix: api_command.go does not merge map values when overrides TaskContainerDefaults [FE-114]

### DIFF
--- a/master/pkg/model/environment_config.go
+++ b/master/pkg/model/environment_config.go
@@ -62,19 +62,15 @@ func (r *RuntimeItem) UnmarshalJSON(data []byte) error {
 		return errors.Wrapf(err, "failed to parse runtime item")
 	}
 
-	// A map to hold the decoded the JSON structure.
+	// Overwrite the images only if the device type (i.e., "CPU", "CUDA",
+	// "ROCM") is present in the JSON. We don't want to unconditionally copy
+	// the device type from the "jsonItem" because if the device type is not
+	// present in the JSON, we would overwrite the current value with an empty
+	// string.
 	imagesMap := make(map[string]json.RawMessage)
-
-	// Decode the JSON data into our map.
 	if err := json.Unmarshal(data, &imagesMap); err != nil {
 		return errors.Wrapf(err, "failed to decode JSON runtime item into map")
 	}
-
-	// Overwrite the images only if the device type (i.e., "CPU", "CUDA",
-	// "ROCM") is contained in the JSON. We don't want to unconditionally copy
-	// the device type from the "jsonItem" because it will be an empty string
-	// if the device type is not contained in the JSON, and we would overwrite
-	// the original value with an empty string.
 	if _, ok := imagesMap["cpu"]; ok {
 		r.CPU = jsonItem.CPU
 	}


### PR DESCRIPTION
## Description

When the user runs det command run and specifies a specific image to use for a particular device type (i.e., cpu, cuda, rocm), the other device types from TaskContainerDefaults are lost.

For example, if the user runs:

```
det command run --config "environment.image.cuda=anoophpe/app-qa:6.0" echo hello
```

Then the `cpu` and `rocm` images from TaskContainerDefaults are lost when the image in user-specified configuration is merged with the images from the TaskContainerDefaults.

When the same command above is run with 0 slots specified, as shown below, it will fail with the error `unable to launch job: No image is configured for slot_type: cpu`.

```
det command run --config "resources.slots=0" --config "environment.image.cuda=anoophpe/app-qa:6.0" echo "hello"
```

This is because the `dispatcher resource manager` will use the `cpu` image when 0 slots is specified, but the `cpu` image was lost when `TaskContainerDefaults` and the user-specific configuration were merged.

The reason why the `cpu` image from `TaskContainerDefaults` is lost is as follows.  The `--config "environment.image.cuda=anoophpe/app-qa:6.0"` is converted to JSON, then the JSON is converted to the `RuntimeItem` structure shown below.  Since `environment.image.cpu` was not specified in the `--config`, it is not included in the JSON.   Because `environment.image.cpu` is not included in the JSON, the JSON to object conversion sets the `CPU` variable in the `RuntimeItem` structure to an empty string.  That empty string is then copied over the `CPU` variable of the `RuntimeItem` belonging to `TaskContainerDefaults`, wiping out the original value.

```
type RuntimeItem struct {
	CPU  string `json:"cpu,omitempty"`
	CUDA string `json:"cuda,omitempty"`
	ROCM string `json:"rocm,omitempty"`
}
```

To resolve this issue, first check if the device type (i.e. `CPU`, `CUDA`, `ROCM`) is included in the JSON before overwriting the `CPU` variable of the `RuntimeItem` belonging to `TaskContainerDefaults` with the `CPU` variable of the `RuntimeItem` that was created from the JSON.

## Test Plan

**Test Case #1: Run `det command run` with no additional options.**

When no options are used, we expect the default images in `master/pkg/schemas/expconf/const.go` to be used.

```
// Default task environment docker image names.
const (
	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-2b7e2a1"
	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2b7e2a1"
	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-2b7e2a1"
)
```

We can see that when we run the command with no additional options, it completes successfully.

(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % det command run echo "hello"
CLI version 0.24.0-dev0 is less than master version 0.25.1-dev0. Consider upgrading the CLI.
Launched command (id: a292a0cb-e0dd-4e52-9f5e-038259a3bc17).
[2023-09-18T13:52:03.397733Z]          || INFO: Scheduling Command (slowly-enormous-boar) (id: a292a0cb-e0dd-4e52-9f5e-038259a3bc17.1)
[2023-09-18T13:52:14.027858Z]          || INFO: HPC Job ID: 1727
[2023-09-18T13:52:14.027994Z]          || INFO: Command (slowly-enormous-boar) was assigned to an agent
[2023-09-18T13:52:15.463343Z] [cont=0] || WARNING: [1309315] root: falling back to naive proxy ip resolution (error=None)
[2023-09-18T13:52:15.904868Z] [cont=0] || hello
[2023-09-18T13:52:23.897384Z]          || INFO: Resources for Command (slowly-enormous-boar) have started
[2023-09-18T13:53:24.020791Z]          || INFO: resources exited successfully with a zero exit code
[2023-09-18T13:53:24.051603Z]          || INFO: Command (slowly-enormous-boar) was terminated: allocation stopped early after all resources exited: resources exited successfully with a zero exit code
Task log stream ended. To reopen log stream, run: det task logs -f a292a0cb-e0dd-4e52-9f5e-038259a3bc17

We can see from the launcher log file that the default CUDA image (i.e., `cuda-11.3-pytorch-1.12-tf-2.11-gpu-2b7e2a1`) was used:

```
/home/opt/slurm/slurm-23.02.3/bin/srun --ntasks=1 singularity run --no-eval --pwd /var/tmp --nv --writable-tmpfs --no-mount tmp --env-file /home/users/corujor/.launcher/jobs/environments/corujor/a292a0cb-e0dd-4e52-9f5e-038259a3bc17.1/ai_cmd-a292a0cb-e0dd-4e52-9f5e-038259a3bc17-vars.sh --bind /etc/hosts:/etc/hosts,/home/users/corujor/.launcher/archiveVolumes/corujor/a292a0cb-e0dd-4e52-9f5e-038259a3bc17.1/determined_local_fs:/determined_local_fs,/home/users/corujor/.launcher/archiveVolumes/corujor/a292a0cb-e0dd-4e52-9f5e-038259a3bc17.1/run/determined:/run/determined,/home/users/corujor/.launcher/archiveVolumes/corujor/a292a0cb-e0dd-4e52-9f5e-038259a3bc17.1/opt/determined:/opt/determined docker://determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2b7e2a1 /determined_local_fs/dispatcher-wrapper.sh /run/determined/command-entrypoint.sh echo hello 
```

**Test Case #2: Run `det command run` requesting 0 slots.**

We can see that when we run the command requesting 0 slots that the commands completes successfully.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % det command run --config "resources.slots=0" --config "environment.image.cuda=anoophpe/app-qa:6.0"  echo "hello"
CLI version 0.24.0-dev0 is less than master version 0.25.1-dev0. Consider upgrading the CLI.
Launched command (id: 4278d67a-b9ce-4d0c-a4c5-e513daa8610e).
[2023-09-18T14:00:28.003507Z]          || INFO: Scheduling Command (smoothly-crisp-dinosaur) (id: 4278d67a-b9ce-4d0c-a4c5-e513daa8610e.1)
[2023-09-18T14:00:33.922027Z]          || INFO: HPC Job ID: 1728
[2023-09-18T14:00:33.922090Z]          || INFO: Command (smoothly-crisp-dinosaur) was assigned to an agent
[2023-09-18T14:00:39.072892Z] [cont=0] || WARNING: [1309812] root: falling back to naive proxy ip resolution (error=None)
[2023-09-18T14:00:39.508742Z] [cont=0] || hello
[2023-09-18T14:00:43.779354Z]          || INFO: Resources for Command (smoothly-crisp-dinosaur) have started
[2023-09-18T14:01:43.920895Z]          || INFO: resources exited successfully with a zero exit code
[2023-09-18T14:01:43.942037Z]          || INFO: Command (smoothly-crisp-dinosaur) was terminated: allocation stopped early after all resources exited: resources exited successfully with a zero exit code
Task log stream ended. To reopen log stream, run: det task logs -f 4278d67a-b9ce-4d0c-a4c5-e513daa8610e
```

We can also see from the launcher log that the default CPU image (i.e., `py-3.8-pytorch-1.12-tf-2.11-cpu-2b7e2a1`) was used.

```
/home/opt/slurm/slurm-23.02.3/bin/srun --ntasks=1 singularity run --no-eval --pwd /var/tmp --writable-tmpfs --no-mount tmp --env-file /home/users/corujor/.launcher/jobs/environments/corujor/4278d67a-b9ce-4d0c-a4c5-e513daa8610e.1/ai_cmd-4278d67a-b9ce-4d0c-a4c5-e513daa8610e-vars.sh --bind /etc/hosts:/etc/hosts,/home/users/corujor/.launcher/archiveVolumes/corujor/4278d67a-b9ce-4d0c-a4c5-e513daa8610e.1/determined_local_fs:/determined_local_fs,/home/users/corujor/.launcher/archiveVolumes/corujor/4278d67a-b9ce-4d0c-a4c5-e513daa8610e.1/run/determined:/run/determined,/home/users/corujor/.launcher/archiveVolumes/corujor/4278d67a-b9ce-4d0c-a4c5-e513daa8610e.1/opt/determined:/opt/determined docker://determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-2b7e2a1 /determined_local_fs/dispatcher-wrapper.sh /run/determined/command-entrypoint.sh echo hello 
```

**Test Case #3: Run `det command run` requesting 0 slots with images specified in the master's `TaskContainerDefaults`.**

I added some fake images to `task_container_defaults` in `tools/devcluster-slurm.yaml`, just to show that the CPU image from `task_container_defaults` will get used, instead of the default image.

```
        task_container_defaults:
          image:
            cpu: determinedai/environments:cpu-fake
            rocm: determinedai/environments:rocm-fake
            cuda: determinedai/environments:cuda-fake
```

We can see that when we run the command requesting 0 slots, the fake CPU image is used.  The command will fail because it's a fake image, but it illustrates that we correctly used the CPU image from `TaskContainerDefaults`.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q cifar10_pytorch % det command run --config "resources.slots=0" --config "environment.image.cuda=anoophpe/app-qa:6.0"  echo "hello"
CLI version 0.24.0-dev0 is less than master version 0.25.1-dev0. Consider upgrading the CLI.
Launched command (id: 453719b3-a0da-4618-9baa-a1c2ca8708b0).
[2023-09-18T14:06:47.563386Z]          || INFO: Scheduling Command (scarcely-fond-elk) (id: 453719b3-a0da-4618-9baa-a1c2ca8708b0.1)
[2023-09-18T14:06:50.528979Z]          || INFO: HPC Job ID: 1729
[2023-09-18T14:06:50.529110Z]          || INFO: Command (scarcely-fond-elk) was assigned to an agent
[2023-09-18T14:08:00.842426Z]          || ERROR: Job failed in state FAILED. The job terminated with a non-zero exit code.
FATAL:   Unable to handle docker://determinedai/environments:cpu-fake uri: failed to get checksum for docker://determinedai/environments:cpu-fake: reading manifest cpu-fake in docker.io/determinedai/environments: manifest unknown
srun: error: node002: task 0: Exited with exit code 255
srun: Terminating StepId=1729.0

[2023-09-18T14:08:00.847289Z]          || ERROR: crashed: resources failed with non-zero exit code
[2023-09-18T14:08:00.874259Z]          || ERROR: Command (scarcely-fond-elk) was terminated: allocation failed: resources failed with non-zero exit code
Task log stream ended. To reopen log stream, run: det task logs -f 453719b3-a0da-4618-9baa-a1c2ca8708b0

```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
