### PR TITLE
fix: redefine user columns updated in postgres_users toUpdate

### DIFF
--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -73,10 +73,10 @@ func Update(
 	ug *model.AgentUserGroup,
 ) error {
 	return db.Bun().RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		for _, col := range toUpdate {
+		if len(toUpdate) > 0 {
 			if _, err := tx.NewUpdate().
 				Model(updated).
-				Column(col).
+				Column(toUpdate...).
 				Where("id = ?", updated.ID).Exec(ctx); err != nil {
 				return fmt.Errorf("error updating %q: %s", updated.Username, err)
 			}

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -73,11 +73,13 @@ func Update(
 	ug *model.AgentUserGroup,
 ) error {
 	return db.Bun().RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		if _, err := tx.NewUpdate().
-			Model(updated).
-			Column(toUpdate...).
-			Where("id = ?", updated.ID).Exec(ctx); err != nil {
-			return fmt.Errorf("error updating %q: %s", updated.Username, err)
+		for _, col := range toUpdate {
+			if _, err := tx.NewUpdate().
+				Model(updated).
+				Column(col).
+				Where("id = ?", updated.ID).Exec(ctx); err != nil {
+				return fmt.Errorf("error updating %q: %s", updated.Username, err)
+			}
 		}
 
 		if slices.Contains(toUpdate, "password_hash") {


### PR DESCRIPTION
## Description
Fix a bug where when only agent user groups are updated for a User, it empty updates all other fields.

## Test Plan
Pass all e2e tests, and make sure

```
// With fixes
det -u admin user link-with-agent-user admin --agent-uid 1 --agent-user 1 --agent-gid 1 --agent-group 1
User Id | Username  | Admin  | Active  | Remote  | Agent Uid  | Agent Gid  | Agent User  | Agent Group 
-----------+------------+---------+----------+----------+-------------+-------------+--------------+--------------- 
        1 | admin     | True   | True    | False   | N/A        | N/A        | N/A         | N/A 
        2 | determined | False  | True    | False   | N/A        | N/A        | N/A         | N/A

// No fixes
det -u admin user link-with-agent-user admin --agent-uid 1 --agent-user 1 --agent-gid 1 --agent-group 1
User Id | Username  | Admin  | Active  | Remote  | Agent Uid  | Agent Gid  | Agent User  | Agent Group 
-----------+------------+---------+----------+----------+-------------+-------------+--------------+--------------- 
        1 |           | False  | False   | False   | 1          | 1          | 1           | 1 
        2 | determined | False  | True    | False   | N/A        | N/A        | N/A         | N/A
```
(TODO: will make sure to add this case to https://github.com/determined-ai/determined/pull/7875).

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
Follow-up to DET-8238