### PR TITLE
fix: NTSC use workspace's agent group info [DET-9843]

### DIFF
--- a/docs/release-notes/agent-uid-workspaces.rst
+++ b/docs/release-notes/agent-uid-workspaces.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Workspaces: Fix an issue where Notebooks, Tensorboards, Shells, and Commands would not inherit
+   agent user group and agent user information from their workspace.

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -81,8 +81,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 			status.Errorf(codes.Unauthenticated, "failed to get the user: %s", err)
 	}
 
-	// TODO(ilia): When commands are workspaced, also use workspace AgentUserGroup here.
-	agentUserGroup, err := user.GetAgentUserGroup(userModel.ID, nil)
+	agentUserGroup, err := user.GetAgentUserGroup(userModel.ID, int(cmdSpec.Metadata.WorkspaceID))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -117,6 +117,30 @@ func TestPostWorkspace(t *testing.T) {
 	require.Equal(t, expected, getWorkResp.Workspace)
 }
 
+// This should eventually be in internal/workspaces.
+func TestWorkspacesIDsByExperimentIDs(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+
+	resp, err := workspace.WorkspacesIDsByExperimentIDs(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, resp, 0)
+
+	w0, p0 := createProjectAndWorkspace(ctx, t, api)
+	w1, p1 := createProjectAndWorkspace(ctx, t, api)
+
+	e0 := createTestExpWithProjectID(t, api, curUser, p0)
+	e1 := createTestExpWithProjectID(t, api, curUser, p1)
+	e2 := createTestExpWithProjectID(t, api, curUser, p0)
+
+	resp, err = workspace.WorkspacesIDsByExperimentIDs(ctx, []int{e0.ID, e1.ID, e2.ID})
+	require.NoError(t, err)
+	require.Equal(t, []int{w0, w1, w0}, resp)
+
+	resp, err = workspace.WorkspacesIDsByExperimentIDs(ctx, []int{e0.ID, e1.ID, -1})
+	require.Error(t, err)
+	require.Len(t, resp, 0)
+}
+
 func TestPatchWorkspace(t *testing.T) {
 	api, _, ctx := setupAPITest(t, nil)
 	resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: uuid.New().String()})

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -194,7 +194,7 @@ func newExperiment(
 		telemetry.ReportExperimentCreated(expModel.ID, activeConfig)
 	}
 
-	agentUserGroup, err := user.GetAgentUserGroup(*expModel.OwnerID, expModel)
+	agentUserGroup, err := user.GetAgentUserGroup(*expModel.OwnerID, workspaceID)
 	if err != nil {
 		return nil, launchWarnings, err
 	}

--- a/master/internal/workspace/postgres_workspace.go
+++ b/master/internal/workspace/postgres_workspace.go
@@ -84,6 +84,43 @@ func WorkspaceByProjectID(ctx context.Context, projectID int) (*model.Workspace,
 	return &w, nil
 }
 
+// WorkspacesIDsByExperimentIDs gets workspace IDs associated with each experiment.
+func WorkspacesIDsByExperimentIDs(ctx context.Context, expIDs []int) ([]int, error) {
+	if len(expIDs) == 0 {
+		return nil, nil
+	}
+
+	res := []struct {
+		ExperimentID int
+		WorkspaceID  int
+	}{}
+	err := db.Bun().NewRaw(`
+SELECT e.id AS experiment_id, p.workspace_id AS workspace_id
+FROM experiments e
+JOIN projects p ON e.project_id = p.id
+WHERE e.id IN (?)
+`, bun.In(expIDs)).Scan(ctx, &res)
+	if err != nil {
+		return nil, fmt.Errorf("getting experiment's %v workspace IDs: %w", expIDs, err)
+	}
+
+	if len(expIDs) != len(res) {
+		return nil, fmt.Errorf("expected %d results from expIDs %v got %d instead %v",
+			len(expIDs), expIDs, len(res), res)
+	}
+
+	expIDToWorkspace := make(map[int]int)
+	for _, r := range res {
+		expIDToWorkspace[r.ExperimentID] = r.WorkspaceID
+	}
+
+	var output []int
+	for _, expID := range expIDs {
+		output = append(output, expIDToWorkspace[expID])
+	}
+	return output, nil
+}
+
 // AllWorkspaces returns all the workspaces that exist.
 func AllWorkspaces(ctx context.Context) ([]*model.Workspace, error) {
 	var w []*model.Workspace


### PR DESCRIPTION
## Description

NTSC didn't inherit workspace's agent user group just since we added NTSC to workspace after we added this feature.

## Test Plan

e2e test + intg 

manual


```
det -u admin workspace create testg --agent-user 2000 --agent-uid 2001 --agent-group 1000 --agent-gid 1001
```

```
det cmd run -w testg "id"
```

You should get
```
[2023-09-14T19:54:14.504445Z] f4f90219 || uid=2001(2000) gid=1001(1000) groups=1001(1000)

```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
