### PR TITLE
test: enable tests to run on hpc slurm/pbs

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -22,6 +22,8 @@ LogFields = Union[bindings.v1TaskLogsFieldsResponse, bindings.v1TrialLogsFieldsR
 @pytest.mark.e2e_cpu_postgres
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 @pytest.mark.timeout(10 * 60)
 def test_trial_logs() -> None:
     # TODO: refactor tests to not use cli singleton auth.
@@ -59,6 +61,8 @@ def test_trial_logs() -> None:
 @pytest.mark.e2e_cpu_elastic
 @pytest.mark.e2e_cpu_cross_version
 @pytest.mark.e2e_gpu  # Note, e2e_gpu and not gpu_required hits k8s cpu tests.
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 @pytest.mark.timeout(5 * 60)
 @pytest.mark.parametrize(
     "task_type,task_config,log_regex",

--- a/e2e_tests/tests/command/test_notebook.py
+++ b/e2e_tests/tests/command/test_notebook.py
@@ -12,6 +12,8 @@ from tests.cluster.test_users import ADMIN_CREDENTIALS
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_basic_notebook_start_and_kill() -> None:
     lines = []  # type: List[str]
     with cmd.interactive_command("notebook", "start") as notebook:

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -89,6 +89,8 @@ def _run_cmd_with_config_expecting_failure(
 
 
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_exit_code_reporting() -> None:
     """
     Confirm that failed commands are not reported as successful, and confirm
@@ -100,6 +102,8 @@ def test_exit_code_reporting() -> None:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_basic_workflows(tmp_path: Path) -> None:
     with FileTree(tmp_path, {"hello.py": "print('hello world')"}) as tree:
         _run_and_verify_exit_code_zero(
@@ -242,6 +246,8 @@ if test != "TEST":
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_singleton_command() -> None:
     _run_and_verify_exit_code_zero(
         ["det", "-m", conf.make_master_url(), "cmd", "run", "echo hello && echo world"]
@@ -250,6 +256,8 @@ def test_singleton_command() -> None:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_environment_variables_command() -> None:
     _run_and_verify_exit_code_zero(
         [
@@ -389,6 +397,8 @@ bind_mounts:
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_cmd_kill() -> None:
     """Start a command, extract its task ID, and then kill it."""
 
@@ -601,6 +611,8 @@ def test_k8_resource_limits(using_k8s: bool, slots: int) -> None:
 
 
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_log_wait_timeout(tmp_path: Path, secrets: Dict[str, str]) -> None:
     # Start a subshell that prints after 5 and 20 seconds, then exit.
     cmd = 'sh -c "sleep 5; echo after 5; sleep 15; echo after 20" & echo main shell exiting'

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -8,6 +8,8 @@ from tests import command as cmd
 
 @pytest.mark.slow
 @pytest.mark.e2e_gpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_start_and_write_to_shell(tmp_path: Path) -> None:
     with cmd.interactive_command("shell", "start") as shell:
         # Call our cli to ensure that PATH and PYTHONUSERBASE are properly set.

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -106,6 +106,8 @@ def test_start_tensorboard_for_s3_experiment(
 
 @pytest.mark.slow
 @pytest.mark.e2e_cpu
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 @pytest.mark.tensorflow2
 def test_start_tensorboard_for_multi_experiment(tmp_path: Path, secrets: Dict[str, str]) -> None:
     """

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -200,6 +200,8 @@ def test_hf_trainer_api_integration() -> None:
 
 @pytest.mark.deepspeed
 @pytest.mark.gpu_required
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_deepspeed_moe() -> None:
     config = conf.load_config(conf.deepspeed_examples_path("cifar10_moe/moe.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
@@ -209,6 +211,8 @@ def test_deepspeed_moe() -> None:
 
 @pytest.mark.deepspeed
 @pytest.mark.gpu_required
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_deepspeed_zero() -> None:
     config = conf.load_config(conf.deepspeed_examples_path("cifar10_moe/zero_stages.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
@@ -245,6 +249,8 @@ def test_gpt_neox_zero1() -> None:
 
 @pytest.mark.deepspeed
 @pytest.mark.gpu_required
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_deepspeed_dcgan() -> None:
     config = conf.load_config(conf.deepspeed_examples_path("deepspeed_dcgan/mnist.yaml"))
     config = conf.set_max_length(config, {"batches": 200})
@@ -254,6 +260,8 @@ def test_deepspeed_dcgan() -> None:
 
 @pytest.mark.deepspeed
 @pytest.mark.gpu_required
+@pytest.mark.e2e_slurm
+@pytest.mark.e2e_pbs
 def test_deepspeed_cpu_offloading() -> None:
     config = conf.load_config(
         conf.deepspeed_examples_path("cifar10_cpu_offloading/zero_3_cpu_offload.yaml")


### PR DESCRIPTION
## Description

FE-127. Enable tests to run on slurm/pbs.


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
