### PR TITLE
Exclude ts bindings from webui code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,4 +24,6 @@
 /e2e_tests/tests/experiment       @determined-ai/ml-sys
 /e2e_tests/tests/nightly          @determined-ai/ml-sys
 
+# WebUI directory mapped to web team, except for auto-generated TS bindings.
 /webui @determined-ai/web
+/webui/react/src/services/api-ts-sdk/api.ts


### PR DESCRIPTION
## Description

This excludes auto-generated TypeScript bindings from mandatory review by the Web team.
If someone forgets to generate TS bindings, it will be caught by lint and build processes.
This will avoid the situation in PRs like #7731

This exclusion is consistent with the Python bindings, and it's part of a longer convo about identifying web PRs, but this was an easier change to make upfront

## Test Plan

CODEOWNERS file is accepted as valid
Only api.ts is affected

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.