### PR TITLE
feat: Add display name to user list in cli [MLG-930]

### DIFF
--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -14,6 +14,7 @@ FullUser = namedtuple(
     [
         "user_id",
         "username",
+        "display_name",
         "admin",
         "active",
         "remote",
@@ -28,6 +29,7 @@ FullUserNoAdmin = namedtuple(
     [
         "user_id",
         "username",
+        "display_name",
         "active",
         "remote",
         "agent_uid",


### PR DESCRIPTION
## Description

Add "display name" to `det user list` output.

## Test Plan

1. Edit a user in the WebUI and add a "Display Name"
2. Run `det user list`
3. Ensure that you see your display name in the output.

## Ticket
MLG-930