### PR TITLE
fix: avoid hiding tabs in single trial experiment [WEB-1651]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
@@ -1,7 +1,7 @@
 .pivoter {
   [role='tablist'] > div {
-    &::before {
-      box-shadow: none !important;
+    &:global(.ant-tabs-nav-wrap)::before {
+      box-shadow: none;
     }
     > div {
       transform: translate(0) !important;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
@@ -1,0 +1,10 @@
+.pivoter {
+  [role='tablist'] > div {
+    &::before {
+      box-shadow: none !important;
+    }
+    > div {
+      transform: translate(0) !important;
+    }
+  }
+}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -29,6 +29,7 @@ import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 
 import ExperimentCheckpoints from './ExperimentCheckpoints';
 import ExperimentCodeViewer from './ExperimentCodeViewer';
+import css from './ExperimentSingleTrialTabs.module.scss';
 
 const TabType = {
   Checkpoints: 'checkpoints',
@@ -348,18 +349,20 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
       hidePreview={tabKey === TabType.Logs}
       trial={trialDetails}
       onViewLogs={handleViewLogs}>
-      <Pivot
-        activeKey={tabKey}
-        items={tabItems}
-        tabBarExtraContent={
-          tabKey === TabType.Hyperparameters && showCreateExperiment && !experiment.unmanaged ? (
-            <div style={{ padding: 4 }}>
-              <Button onClick={handleHPSearch}>Hyperparameter Search</Button>
-            </div>
-          ) : undefined
-        }
-        onChange={handleTabChange}
-      />
+      <div className={css.pivoter}>
+        <Pivot
+          activeKey={tabKey}
+          items={tabItems}
+          tabBarExtraContent={
+            tabKey === TabType.Hyperparameters && showCreateExperiment && !experiment.unmanaged ? (
+              <div style={{ padding: 4 }}>
+                <Button onClick={handleHPSearch}>Hyperparameter Search</Button>
+              </div>
+            ) : undefined
+          }
+          onChange={handleTabChange}
+        />
+      </div>
       {modalHyperparameterSearchContextHolder}
     </TrialLogPreview>
   );


### PR DESCRIPTION
## Description

Avoids an issue where if someone reloads a single-trial experiment page on the Logs tab, the Antd Tabs component will "slide" to display this last tab. If this occurs while the page loads, it assumes the tab section has 0 width and hides other tabs to the left (note three dots selection menu at right). This is only fixed when someone clicks a tab and triggers re-rendering:

<img width="544" alt="Screen Shot 2023-09-15 at 2 05 40 PM" src="https://github.com/determined-ai/determined/assets/643918/7d7cbf64-aa9a-4adb-84eb-78e23afa623c">

The proposed solution is two pieces of CSS to overwrite Antd:
- `transform: translate(0)` to avoid sliding the tabs left
- `box-shadow: none` to avoid applying a semitransparent shadow to the left edge, indicating tabs hidden to the left

We don't hide the three-dots menu since it's unobtrusive and useful on narrow screens

## Test Plan

Visit a single-trial experiment such as `/det/experiments/1651/logs`
Refresh until you can see a hoverable three-dots menu on far right - this is the compacted UI with overwrite css applied:
<img width="1175" alt="Screen Shot 2023-09-15 at 2 11 35 PM" src="https://github.com/determined-ai/determined/assets/643918/c5a239f4-fe2f-409c-8291-c0640aa66869">

Confirm there are no issues with the UI or using the tabs in this state

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.