### PR TITLE
fix: mitigate user settings race conditions

### DIFF
--- a/webui/react/src/components/UserSettings.test.tsx
+++ b/webui/react/src/components/UserSettings.test.tsx
@@ -86,12 +86,11 @@ const setup = () =>
 describe('UserSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.clearAllTimers();
   });
 
   it('should render with correct values', async () => {
     setup();
-    expect(screen.getByText('Username')).toBeInTheDocument();
+    expect(await screen.findByText('Username')).toBeInTheDocument();
     expect(screen.getByText('Display Name')).toBeInTheDocument();
     expect(screen.getByText('Password')).toBeInTheDocument();
     expect(await screen.findByText(USERNAME)).toBeInTheDocument();

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -30,7 +30,6 @@ import {
 } from 'pages/F_ExpList/F_ExperimentList.settings';
 import { TableViewMode } from 'pages/F_ExpList/glide-table/GlideTable';
 import { RowHeight, rowHeightItems } from 'pages/F_ExpList/glide-table/OptionsMenu';
-import { patchUser } from 'services/api';
 import determinedStore from 'stores/determinedInfo';
 import userStore from 'stores/users';
 import userSettings from 'stores/userSettings';
@@ -79,11 +78,9 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
   const handleSaveDisplayName = useCallback(
     async (newValue: string): Promise<void | Error> => {
       try {
-        const user = await patchUser({
-          userId: currentUser?.id || 0,
-          userParams: { displayName: newValue as string },
+        await userStore.patchUser(currentUser?.id || 0, {
+          displayName: newValue as string,
         });
-        userStore.updateUsers(user);
         message.success(API_DISPLAYNAME_SUCCESS_MESSAGE);
       } catch (e) {
         handleError(e, { silent: false, type: ErrorType.Input });
@@ -96,11 +93,9 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
   const handleSaveUsername = useCallback(
     async (newValue: string): Promise<void | Error> => {
       try {
-        const user = await patchUser({
-          userId: currentUser?.id || 0,
-          userParams: { username: newValue as string },
+        await userStore.patchUser(currentUser?.id || 0, {
+          username: newValue as string,
         });
-        userStore.updateUsers(user);
         message.success(API_USERNAME_SUCCESS_MESSAGE);
       } catch (e) {
         message.error(API_USERNAME_ERROR_MESSAGE);

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -27,6 +27,7 @@ function isTypeC(codec: t.Encoder<any, any>): codec is t.TypeC<t.Props> {
  */
 export class UserSettingsStore extends PollingStore {
   readonly #settings: WritableObservable<Loadable<State>> = observable(NotLoaded);
+  #updates: Promise<void | DetError>[] = [];
 
   /**
    *
@@ -232,6 +233,11 @@ export class UserSettingsStore extends PollingStore {
 
   protected async poll(): Promise<void> {
     try {
+      // Wait 500ms for any in-flight updates to finish before getting new state
+      await Promise.race([
+        Promise.allSettled(this.#updates),
+        new Promise((resolve) => setTimeout(resolve, 500)),
+      ]);
       const response = await getUserSetting({ signal: this.canceler?.signal });
       this.updateSettingsFromResponse(response);
     } catch (error) {
@@ -302,15 +308,21 @@ export class UserSettingsStore extends PollingStore {
     } else {
       dbUpdates.push({ key: '_ROOT', storagePath: key, value: JSON.stringify(value) });
     }
-    return updateUserSetting({ settings: dbUpdates }).catch((e) =>
-      handleError(e, {
-        isUserTriggered: false,
-        publicMessage: `Unable to update user settings for key: ${key}.`,
-        publicSubject: 'Some POST user settings failed.',
-        silent: true,
-        type: ErrorType.Api,
-      }),
-    );
+    const promise = updateUserSetting({ settings: dbUpdates })
+      .then(() => {
+        this.#updates = this.#updates.filter((p) => p !== promise);
+      })
+      .catch((e) =>
+        handleError(e, {
+          isUserTriggered: false,
+          publicMessage: `Unable to update user settings for key: ${key}.`,
+          publicSubject: 'Some POST user settings failed.',
+          silent: true,
+          type: ErrorType.Api,
+        }),
+      );
+    this.#updates = [...this.#updates, promise];
+    return promise;
   }
 
   /**

--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -309,7 +309,7 @@ export class UserSettingsStore extends PollingStore {
       dbUpdates.push({ key: '_ROOT', storagePath: key, value: JSON.stringify(value) });
     }
     const promise = updateUserSetting({ settings: dbUpdates })
-      .then(() => {
+      .finally(() => {
         this.#updates = this.#updates.filter((p) => p !== promise);
       })
       .catch((e) =>


### PR DESCRIPTION

## Description

This mitigates an issue that appeaers on installations that have rbac enabled. When updating settings, it's sometimes possible that a race condition happens between the update request and the polled settings request. becaue we optimistically update the local state, this can cause the app to appear like it's not accepting the changes, only for it to eventually settle after the next polling call.

We fix this issue by adding a grace period to the beginning of the polling method. we keep track of all in-flight update calls and wait for up to 500ms for those to complete before making the `getUserSetting` call. If there are no updates in flight, the poll continues without waiting.



## Test Plan

workspace filters should be preserved on servers with rbac enabled.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

should mitigate/fix [WEB-1666]

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1666]: https://hpe-aiatscale.atlassian.net/browse/WEB-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ