### PR TITLE
Remove references to --auto-bind-mount

### DIFF
--- a/docs/interfaces/notebooks.rst
+++ b/docs/interfaces/notebooks.rst
@@ -217,12 +217,12 @@ or ``det deploy aws --deployment-type fsx`` creates a Network file system that i
 agents and is automatically mounted into Notebook containers at
 ``/run/determined/workdir/shared_fs/``.
 
-To launch a notebook with ``det deploy local cluster-up``, a user can add the ``--auto-bind-mount``
+To launch a notebook with ``det deploy local cluster-up``, a user can add the ``--auto-work-dir``
 flag, which mounts the user's home directory into the task containers by default:
 
 .. code::
 
-   $ det deploy local cluster-up --auto-bind-mount="/shared/home/jimmy"
+   $ det deploy local cluster-up --auto-work-dir="/shared/home/jimmy"
    $ det notebook start
 
 Working on a notebook file within the shared bind mounted directory will ensure that your code and

--- a/docs/setup-cluster/deploy-cluster/on-prem/deploy.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/deploy.rst
@@ -73,17 +73,17 @@ For single-agent clusters launched with:
 
 .. code::
 
-   det deploy local cluster-up --auto-bind-mount <absolute directory path>
+   det deploy local cluster-up --auto-work-dir <absolute directory path>
 
 the cluster will automatically make the specified directory available to tasks on the cluster as
-``./shared_fs``. If ``--auto-bind-mount`` is not specified, the cluster will default to mounting
-your home directory. This will allow you to access your local preferences and any relevant files
-stored in the specified directory with the cluster's notebooks, shells, and tensorboard tasks. To
-disable this feature, use:
+``./shared_fs``. If ``--auto-work-dir`` is not specified, the cluster will default to mounting your
+home directory. This will allow you to access your local preferences and any relevant files stored
+in the specified directory with the cluster's notebooks, shells, and tensorboard tasks. To disable
+this feature, use:
 
 .. code::
 
-   det deploy local cluster-up --no-auto-bind-mount
+   det deploy local cluster-up --no-auto-work-dir
 
 For production deployments, you'll want to :ref:`use a cluster configuration file
 <configuring-cluster-install>`. To provide this configuration file to ``det deploy``, use:


### PR DESCRIPTION
## Description

`--auto-bind-mount` support has been removed from det deploy local. (See: [release notes])(https://docs.determined.ai/latest/release-notes.html#version-0-17-0
).

This is a draft PR to analyze references to `--auto-bind-mount` in the documentation and remove or replace such references.

## Related

#2932 

## Impacts

- [Jupyter Notebooks](https://docs.determined.ai/latest/interfaces/notebooks.html#save-and-restore-notebook-state)
- [Install Determined using `det deploy`](https://docs.determined.ai/latest/setup-cluster/deploy-cluster/on-prem/deploy.html#install-using-deploy)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] Docs explain how to create a `shared_fs` directory
- [ ] User-facing changes meet style guidelines
- [ ] All impacted instances of `--auto-bind-mount` are addressed

