### PR TITLE
fix(cli): det model describe should call GET /model not GET /models

### DIFF
--- a/docs/release-notes/describe-model.rst
+++ b/docs/release-notes/describe-model.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Models: Fix a bug where `det model describe` and other methods in the CLI and SDK that act on a
+   single model would error if two models had similar names.

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -86,12 +86,7 @@ def list_models(args: Namespace) -> None:
 
 
 def model_by_name(args: Namespace) -> Model:
-    models = Determined(args.master, args.user).get_models(name=args.name)
-    if len(models) == 0:
-        raise Exception("No model was found with the given name.")
-    if len(models) > 1:
-        raise Exception("Multiple models were found with the given name.")
-    return models[0]
+    return Determined(args.master, args.user).get_model(identifier=args.name)
 
 
 @authentication.required


### PR DESCRIPTION
## Description
`model_by_name` was calling `GET /models?name=xyz` but `name=xyz` uses `ILIKE '%xyz%'` under the hood, so if you had two models, say `xyz` and `xyz2`, `det model describe` would explode upon finding two models.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [x] create some models, call many methods on them.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
There is a separate debate about whether `GET /models?name=xyz` should be calling `ILIKE '%...%'`. I don't believe it should, really, but I figured we can debate that separate of this bug fix.

report: https://hpe-aiatscale.slack.com/archives/CSG3W08JY/p1695042418994789

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
