### PR TITLE
chore: max_slots_per_pod can be per resource pool [DET-9771]

### DIFF
--- a/docs/reference/deploy/config/master-config-reference.rst
+++ b/docs/reference/deploy/config/master-config-reference.rst
@@ -154,8 +154,8 @@ The default bind mounts to pass to the Docker container. Ignored by resource man
 ``kubernetes``
 ==============
 
--  ``max_slots_per_pod`` See :ref:`resource_manager.max_slots
-   <master-config-reference-max-slots-per-pod>` for more details.
+``max_slots_per_pod`` See :ref:`resource_manager.max_slots
+<master-config-reference-max-slots-per-pod>` for more details.
 
 ``slurm``
 =========

--- a/docs/reference/deploy/config/master-config-reference.rst
+++ b/docs/reference/deploy/config/master-config-reference.rst
@@ -151,6 +151,12 @@ The default list of devices to pass to the Docker daemon. Ignored by resource ma
 The default bind mounts to pass to the Docker container. Ignored by resource managers of type
 ``kubernetes``. See :ref:`resources.devices <exp-bind-mounts>` for more details.
 
+``kubernetes``
+==============
+
+-  ``max_slots_per_pod`` See :ref:`resource_manager.max_slots
+   <master-config-reference-max-slots-per-pod>` for more details.
+
 ``slurm``
 =========
 
@@ -309,6 +315,8 @@ on using Determined with Kubernetes, see the :ref:`documentation <determined-on-
 
 The namespace where Determined will deploy Pods and ConfigMaps.
 
+.. _master-config-reference-max-slots-per-pod:
+
 ``max_slots_per_pod``
 ---------------------
 
@@ -319,6 +327,9 @@ you have a cluster of different size nodes, set ``max_slots_per_pod`` to the gre
 of all the sizes. For example, if you have some nodes with 4 GPUs and other nodes with 8 GPUs, set
 ``maxSlotsPerPod`` to ``4`` so that all distributed experiments will launch with 4 GPUs per pod
 (with two pods on 8-GPU nodes).
+
+This field can also be set in ``task_container_defaults.kubernetes.max_slots_per_pod`` to allow per
+resource pool ``max_slots_per_pod``.
 
 ``slot_type``
 -------------

--- a/docs/release-notes/max-slots-per-pod-per-rp.rst
+++ b/docs/release-notes/max-slots-per-pod-per-rp.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Kubernetes: On Kubernetes, ``max_slots_per_pod`` can now be configured at a resource pool level
+   through the master config option
+   ``resource_pools.task_container_defaults.kubernetes.max_slots_per_pod``.

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -109,6 +109,7 @@ data:
     resource_manager:
       type: "kubernetes"
       namespace: {{ .Release.Namespace }}
+      max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.defaultScheduler}}
       {{- $schedulerType := .Values.defaultScheduler | trim}}
@@ -136,9 +137,6 @@ data:
 
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
-      kubernetes:
-        max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
-
       {{- if .Values.taskContainerDefaults.networkMode }}
       network_mode: {{ .Values.taskContainerDefaults.networkMode }}
       {{- end }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -109,7 +109,6 @@ data:
     resource_manager:
       type: "kubernetes"
       namespace: {{ .Release.Namespace }}
-      max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.defaultScheduler}}
       {{- $schedulerType := .Values.defaultScheduler | trim}}
@@ -137,6 +136,9 @@ data:
 
     {{ if .Values.taskContainerDefaults -}}
     task_container_defaults:
+      kubernetes:
+        max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
+
       {{- if .Values.taskContainerDefaults.networkMode }}
       network_mode: {{ .Values.taskContainerDefaults.networkMode }}
       {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -312,10 +312,5 @@ telemetry:
 ## Configure the resource pools in the Determined cluster.
 resourcePools:
   - pool_name: default
-
-  #- pool_name: second_pool
-  #  task_container_defaults:
-  #    kubernetes:
-  #        max_slots_per_pod: 4
 # defaultAuxResourcePool: default
 # defaultComputeResourcePool: default

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -312,5 +312,10 @@ telemetry:
 ## Configure the resource pools in the Determined cluster.
 resourcePools:
   - pool_name: default
+
+  #- pool_name: second_pool
+  #  task_container_defaults:
+  #    kubernetes:
+  #        max_slots_per_pod: 4
 # defaultAuxResourcePool: default
 # defaultComputeResourcePool: default

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -236,16 +236,8 @@ func (c *Config) Resolve() error {
 			c.TaskContainerDefaults.Kubernetes = &model.KubernetesTaskContainerDefaults{}
 		}
 
-		var rmMaxSlots *int
-		if c.ResourceManager.KubernetesRM.MaxSlotsPerPod != 0 {
-			rmMaxSlots = &c.ResourceManager.KubernetesRM.MaxSlotsPerPod
-		}
-
-		var taskMaxSlots *int
-		if c.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod != 0 {
-			taskMaxSlots = &c.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
-		}
-
+		rmMaxSlots := c.ResourceManager.KubernetesRM.MaxSlotsPerPod
+		taskMaxSlots := c.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
 		if (rmMaxSlots != nil) == (taskMaxSlots != nil) {
 			return fmt.Errorf("must provide exactly one of " +
 				"resource_manager.max_slots_per_pod and " +
@@ -253,12 +245,12 @@ func (c *Config) Resolve() error {
 		}
 
 		if rmMaxSlots != nil {
-			c.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod = *rmMaxSlots
+			c.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod = rmMaxSlots
 		}
 		if taskMaxSlots != nil {
-			c.ResourceManager.KubernetesRM.MaxSlotsPerPod = *taskMaxSlots
+			c.ResourceManager.KubernetesRM.MaxSlotsPerPod = taskMaxSlots
 		}
-		if maxSlotsPerPod := c.ResourceManager.KubernetesRM.MaxSlotsPerPod; maxSlotsPerPod <= 0 {
+		if maxSlotsPerPod := *c.ResourceManager.KubernetesRM.MaxSlotsPerPod; maxSlotsPerPod < 0 {
 			return fmt.Errorf("max_slots_per_pod must be >= 0 got %d", maxSlotsPerPod)
 		}
 	}

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -583,6 +583,7 @@ resource_pools:
 			configRaw: `
 resource_manager:
   type: kubernetes
+  max_slots_per_pod: 2
 `,
 			rpName:            "",
 			preemptionEnabled: false,
@@ -593,6 +594,7 @@ resource_manager:
 resource_manager:
   type: kubernetes
   default_scheduler: preemption
+  max_slots_per_pod: 54
 `,
 			rpName:            "default",
 			preemptionEnabled: true,

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -117,7 +117,7 @@ type KubernetesResourceManagerConfig struct {
 	// Deprecated: this can be per resource pool now on taskContainerDefaults.
 	// This will always be the same as global
 	// task_container_defaults.kubernetes.max_slots_per_pod so use that.
-	MaxSlotsPerPod int `json:"max_slots_per_pod"`
+	MaxSlotsPerPod *int `json:"max_slots_per_pod"`
 
 	MasterServiceName        string                  `json:"master_service_name"`
 	LeaveKubernetesResources bool                    `json:"leave_kubernetes_resources"`

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -112,8 +112,13 @@ func (a AgentResourceManagerConfig) Validate() []error {
 
 // KubernetesResourceManagerConfig hosts configuration fields for the kubernetes resource manager.
 type KubernetesResourceManagerConfig struct {
-	Namespace                string                  `json:"namespace"`
-	MaxSlotsPerPod           int                     `json:"max_slots_per_pod"`
+	Namespace string `json:"namespace"`
+
+	// Deprecated: this can be per resource pool now on taskContainerDefaults.
+	// This will always be the same as global
+	// task_container_defaults.kubernetes.max_slots_per_pod so use that.
+	MaxSlotsPerPod int `json:"max_slots_per_pod"`
+
 	MasterServiceName        string                  `json:"master_service_name"`
 	LeaveKubernetesResources bool                    `json:"leave_kubernetes_resources"`
 	DefaultScheduler         string                  `json:"default_scheduler"`
@@ -181,7 +186,6 @@ func (k KubernetesResourceManagerConfig) Validate() []error {
 			k.SlotResourceRequests.CPU, float32(0), "slot_resource_requests.cpu must be > 0")
 	}
 	return []error{
-		check.GreaterThanOrEqualTo(k.MaxSlotsPerPod, 0, "max_slots_per_pod must be >= 0"),
 		checkSlotType,
 		checkCPUResource,
 	}

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -272,11 +272,14 @@ func (k *kubernetesResourceManager) Receive(ctx *actor.Context) error {
 		)
 
 		for _, poolConfig := range k.poolsConfig {
-			maxSlotsPerPod := k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod
+			maxSlotsPerPod := 0
+			if k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod != nil {
+				maxSlotsPerPod = *k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod
+			}
 			if poolConfig.TaskContainerDefaults != nil &&
 				poolConfig.TaskContainerDefaults.Kubernetes != nil &&
-				poolConfig.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod != 0 {
-				maxSlotsPerPod = poolConfig.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
+				poolConfig.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod != nil {
+				maxSlotsPerPod = *poolConfig.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
 			}
 
 			poolConfig := poolConfig
@@ -532,11 +535,14 @@ func (k *kubernetesResourceManager) createResourcePoolSummary(
 	}
 
 	// TODO actor refactor, this is just getting resourcePool[poolName].maxSlotsPerPod
-	slotsPerAgent := k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod
+	slotsPerAgent := 0
+	if k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod != nil {
+		slotsPerAgent = *k.taskContainerDefaults.Kubernetes.MaxSlotsPerPod
+	}
 	if pool.TaskContainerDefaults != nil &&
 		pool.TaskContainerDefaults.Kubernetes != nil &&
-		pool.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod != 0 {
-		slotsPerAgent = pool.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
+		pool.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod != nil {
+		slotsPerAgent = *pool.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
 	}
 
 	const na = "n/a"

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -31,7 +31,10 @@ const resourcePoolEnvVar = "DET_K8S_RESOURCE_POOL"
 type getResourceSummary struct{}
 
 type kubernetesResourcePool struct {
-	config     *config.KubernetesResourceManagerConfig
+	maxSlotsPerPod int
+
+	// config     *config.KubernetesResourceManagerConfig
+
 	poolConfig *config.ResourcePoolConfig
 
 	reqList                   *tasklist.TaskList
@@ -53,12 +56,12 @@ type kubernetesResourcePool struct {
 }
 
 func newResourcePool(
-	rmConfig *config.KubernetesResourceManagerConfig,
+	maxSlotsPerPod int,
 	poolConfig *config.ResourcePoolConfig,
 	podsActor *actor.Ref,
 ) *kubernetesResourcePool {
 	return &kubernetesResourcePool{
-		config:                    rmConfig,
+		maxSlotsPerPod:            maxSlotsPerPod,
 		poolConfig:                poolConfig,
 		reqList:                   tasklist.New(),
 		groups:                    map[*actor.Ref]*tasklist.Group{},
@@ -147,7 +150,7 @@ func (k *kubernetesResourcePool) Receive(ctx *actor.Context) error {
 		actors.NotifyAfter(ctx, ActionCoolDown, SchedulerTick{})
 
 	case sproto.ValidateCommandResourcesRequest:
-		fulfillable := k.config.MaxSlotsPerPod >= msg.Slots
+		fulfillable := k.maxSlotsPerPod >= msg.Slots
 		ctx.Respond(sproto.ValidateCommandResourcesResponse{Fulfillable: fulfillable})
 
 	default:
@@ -421,10 +424,10 @@ func (k *kubernetesResourcePool) correctJobQInfo(
 	jobIDToAllocatedSlots := map[model.JobID]int{}
 	for _, req := range reqs {
 		runningPods := k.allocationIDToRunningPods[req.AllocationID]
-		if req.SlotsNeeded <= k.config.MaxSlotsPerPod {
+		if req.SlotsNeeded <= k.maxSlotsPerPod {
 			jobIDToAllocatedSlots[req.JobID] += runningPods * req.SlotsNeeded
 		} else {
-			jobIDToAllocatedSlots[req.JobID] += runningPods * k.config.MaxSlotsPerPod
+			jobIDToAllocatedSlots[req.JobID] += runningPods * k.maxSlotsPerPod
 		}
 	}
 
@@ -457,25 +460,25 @@ func (k *kubernetesResourcePool) assignResources(
 	numPods := 1
 	slotsPerPod := req.SlotsNeeded
 	if req.SlotsNeeded > 1 {
-		if k.config.MaxSlotsPerPod == 0 {
+		if k.maxSlotsPerPod == 0 {
 			ctx.Log().WithField("allocation-id", req.AllocationID).Error(
 				"set max_slots_per_pod > 0 to schedule tasks with slots")
 			return
 		}
 
-		if req.SlotsNeeded <= k.config.MaxSlotsPerPod {
+		if req.SlotsNeeded <= k.maxSlotsPerPod {
 			numPods = 1
 			slotsPerPod = req.SlotsNeeded
 		} else {
-			if req.SlotsNeeded%k.config.MaxSlotsPerPod != 0 {
+			if req.SlotsNeeded%k.maxSlotsPerPod != 0 {
 				ctx.Log().WithField("allocation-id", req.AllocationID).Errorf(
 					"task number of slots (%d) is not schedulable on the configured "+
-						"max_slots_per_pod (%d)", req.SlotsNeeded, k.config.MaxSlotsPerPod)
+						"max_slots_per_pod (%d)", req.SlotsNeeded, k.maxSlotsPerPod)
 				return
 			}
 
-			numPods = req.SlotsNeeded / k.config.MaxSlotsPerPod
-			slotsPerPod = k.config.MaxSlotsPerPod
+			numPods = req.SlotsNeeded / k.maxSlotsPerPod
+			slotsPerPod = k.maxSlotsPerPod
 		}
 	}
 

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -33,8 +33,6 @@ type getResourceSummary struct{}
 type kubernetesResourcePool struct {
 	maxSlotsPerPod int
 
-	// config     *config.KubernetesResourceManagerConfig
-
 	poolConfig *config.ResourcePoolConfig
 
 	reqList                   *tasklist.TaskList

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -29,12 +29,13 @@ type TaskContainerDefaultsConfig struct {
 	GLOOPortRange          string                `json:"gloo_port_range,omitempty"`
 	ShmSizeBytes           int64                 `json:"shm_size_bytes,omitempty"`
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
-	CPUPodSpec             *k8sV1.Pod            `json:"cpu_pod_spec"`
-	GPUPodSpec             *k8sV1.Pod            `json:"gpu_pod_spec"`
-	Image                  *RuntimeItem          `json:"image,omitempty"`
-	RegistryAuth           *types.AuthConfig     `json:"registry_auth,omitempty"`
-	ForcePullImage         bool                  `json:"force_pull_image,omitempty"`
-	EnvironmentVariables   *RuntimeItems         `json:"environment_variables,omitempty"`
+	// TODO we should move these over to KubernetesTaskContainerDefaults.
+	CPUPodSpec           *k8sV1.Pod        `json:"cpu_pod_spec"`
+	GPUPodSpec           *k8sV1.Pod        `json:"gpu_pod_spec"`
+	Image                *RuntimeItem      `json:"image,omitempty"`
+	RegistryAuth         *types.AuthConfig `json:"registry_auth,omitempty"`
+	ForcePullImage       bool              `json:"force_pull_image,omitempty"`
+	EnvironmentVariables *RuntimeItems     `json:"environment_variables,omitempty"`
 
 	AddCapabilities  []string      `json:"add_capabilities"`
 	DropCapabilities []string      `json:"drop_capabilities"`
@@ -44,6 +45,10 @@ type TaskContainerDefaultsConfig struct {
 	WorkDir    *string               `json:"work_dir"`
 	Slurm      expconf.SlurmConfigV0 `json:"slurm"`
 	Pbs        expconf.PbsConfigV0   `json:"pbs"`
+
+	// TODO we should probably eventually move this to expconf and allow setting
+	// on a per task level.
+	Kubernetes *KubernetesTaskContainerDefaults `json:"kubernetes"`
 }
 
 // DefaultTaskContainerDefaults returns the default for TaskContainerDefaultsConfig.
@@ -85,6 +90,12 @@ func (c *TaskContainerDefaultsConfig) Validate() []error {
 	errs = append(errs, validatePodSpec(c.GPUPodSpec)...)
 
 	return errs
+}
+
+// KubernetesTaskContainerDefaults is task container defaults specific to Kubernetes.
+// TODO eventually move podSpec here and eventually move this to expconf too.
+type KubernetesTaskContainerDefaults struct {
+	MaxSlotsPerPod int `json:"max_slots_per_pod"`
 }
 
 // MergeIntoExpConfig sets any unset ExperimentConfig values from TaskContainerDefaults.

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -94,7 +94,7 @@ func (c *TaskContainerDefaultsConfig) Validate() []error {
 
 // KubernetesTaskContainerDefaults is task container defaults specific to Kubernetes.
 type KubernetesTaskContainerDefaults struct {
-	MaxSlotsPerPod int `json:"max_slots_per_pod"`
+	MaxSlotsPerPod *int `json:"max_slots_per_pod"`
 }
 
 // MergeIntoExpConfig sets any unset ExperimentConfig values from TaskContainerDefaults.

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -29,7 +29,7 @@ type TaskContainerDefaultsConfig struct {
 	GLOOPortRange          string                `json:"gloo_port_range,omitempty"`
 	ShmSizeBytes           int64                 `json:"shm_size_bytes,omitempty"`
 	NetworkMode            container.NetworkMode `json:"network_mode,omitempty"`
-	// TODO we should move these over to KubernetesTaskContainerDefaults.
+	// TODO(DET-9855) we should move these over to KubernetesTaskContainerDefaults.
 	CPUPodSpec           *k8sV1.Pod        `json:"cpu_pod_spec"`
 	GPUPodSpec           *k8sV1.Pod        `json:"gpu_pod_spec"`
 	Image                *RuntimeItem      `json:"image,omitempty"`
@@ -46,7 +46,7 @@ type TaskContainerDefaultsConfig struct {
 	Slurm      expconf.SlurmConfigV0 `json:"slurm"`
 	Pbs        expconf.PbsConfigV0   `json:"pbs"`
 
-	// TODO we should probably eventually move this to expconf and allow setting
+	// TODO(DET-9856) we should probably eventually move this to expconf and allow setting
 	// on a per task level.
 	Kubernetes *KubernetesTaskContainerDefaults `json:"kubernetes"`
 }
@@ -93,7 +93,6 @@ func (c *TaskContainerDefaultsConfig) Validate() []error {
 }
 
 // KubernetesTaskContainerDefaults is task container defaults specific to Kubernetes.
-// TODO eventually move podSpec here and eventually move this to expconf too.
 type KubernetesTaskContainerDefaults struct {
 	MaxSlotsPerPod int `json:"max_slots_per_pod"`
 }


### PR DESCRIPTION
## Description

Put ```max_slots_per_pod``` into ```task_container_defaults```. Also mirror ```task_container_defaults``` config with rp config. 

## Test Plan

Unit test config stuff

Run a cluster with 2 GPUs on a single node.


Throw this in Helm values.
```
resourcePools:
  - pool_name: default
    task_container_defaults:
      kubernetes:
        max_slots_per_pod: 2
  - pool_name: second
```

run with global ```maxSlotsPerPod = 1``` (just by setting the helm value)

Spot check helm is set right
```
det -u admin master config | grep max_slots
  max_slots_per_pod: 1
      max_slots_per_pod: 2
    max_slots_per_pod: 1
```

Run
```
det e create examples/tutorials/mnist_pytorch/const.yaml examples/tutorials/mnist_pytorch/ --config="resources.slots_per_trial=2" --config="resources.resource_pool=default" -f
```

```kubectl get pods``` should show one pod

Run
```
det e create examples/tutorials/mnist_pytorch/const.yaml examples/tutorials/mnist_pytorch/ --config="resources.slots_per_trial=2" --config="resources.resource_pool=second" -f
```

```kubectl get pods``` should show one pod


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
