### PR TITLE
chore: adding test for multiple AddAllocation's

### DIFF
--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -4,7 +4,6 @@
 package db
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"go/ast"
@@ -52,10 +51,9 @@ func TestAddAllocationTimes(t *testing.T) {
 	_, err = db.AllocationByID(mockAllocation.AllocationID)
 	require.NoError(t, err)
 
-	// Update the allocation's end time manually.
-	_, err = Bun().NewUpdate().Table("allocations").
-		Where("allocation_id = ?", mockAllocation.AllocationID).
-		Set("end_time = ?", time.Now().UTC()).Exec(context.TODO())
+	// Update the allocation's end time.
+	mockAllocation.EndTime = ptrs.Ptr(time.Now().UTC())
+	err = db.CompleteAllocation(&mockAllocation)
 	require.NoError(t, err)
 
 	// Now check that the end time is greater than the start time.


### PR DESCRIPTION
## Description
As a preliminary step to fixing the allocation bug where allocations with `end_time < start_time` are found & stored, write a unit test to recreate the buggy behavior. The hypothesis is that for allocations that have already ended, if master shuts down & restarts before the allocation is marked as started, the allocation will re-start & update its start time, but not reset its end time (as its set from when the master shuts down).

## Test Plan
Pass the included test (once it's merged).

## Commentary (optional)
A separate PR fixes the bug: https://github.com/determined-ai/determined/pull/7928
For the time being, this PR compares merging into `main`, which doesn't have the fix yet, but will prove that the test fails under the current `AddAllocation` implementation.

As for the order of merging commits;
- first, #7928  with changes ONLY to postgres_tasks.go.
- second, rebase this branch against main to pick up the changes. This test will now pass.
- finally, merge changes ONLY to postgres_tasks_intg_test.go.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9496