### PR TITLE
docs: document prometheus auth

### DIFF
--- a/docs/integrations/prometheus/prometheus.rst
+++ b/docs/integrations/prometheus/prometheus.rst
@@ -137,7 +137,7 @@ This example startup script includes the default setup docker commands provided 
 
    -  The ``PATH_TO_TOKEN`` specifies a path to an authorization token for the Determined master.
       This can be kept in a local file by running the ``token-refresh.sh`` script in the same
-      directory with a CRON job (set to run daily).`
+      directory with a CRON job (set to run daily).
 
 *******************
  Configure Grafana

--- a/docs/integrations/prometheus/prometheus.rst
+++ b/docs/integrations/prometheus/prometheus.rst
@@ -128,11 +128,14 @@ This example startup script includes the default setup docker commands provided 
    <https://github.com/determined-ai/works-with-determined#observability-tools>`__ configuration
    file.
 
-#. The Prometheus configuration file needs a manual change to replace the placeholder master
-   address.
+#. The Prometheus configuration file needs a manual change to replace the ``MASTER_URL_WITHOUT_SCHEME``, 
+``$MASTER_URL``, and ``PATH_TO_TOKEN``, 
 
    The ``metric_relabel_configs`` parameter edits certain label names in jobs for joining in PromQL.
-   - The ``scrape_interval`` parameter values can be modified to optimize for resolution/size/time.
+    - The ``scrape_interval`` parameter values can be modified to optimize for resolution/size/time.
+
+    - The ``PATH_TO_TOKEN`` specifies a path to a authorization token for the determined master that can
+   be kept in a local file by running the ``token-refresh.sh`` script in the same directory daily with a CRON job.
 
 *******************
  Configure Grafana

--- a/docs/integrations/prometheus/prometheus.rst
+++ b/docs/integrations/prometheus/prometheus.rst
@@ -121,6 +121,10 @@ This example startup script includes the default setup docker commands provided 
  Configure Prometheus
 **********************
 
+`**********************
+ Configure Prometheus
+**********************
+
 #. `Install Prometheus <https://prometheus.io/docs/prometheus/latest/installation/>`__ on any node
    in the monitored cluster.
 
@@ -128,14 +132,16 @@ This example startup script includes the default setup docker commands provided 
    <https://github.com/determined-ai/works-with-determined#observability-tools>`__ configuration
    file.
 
-#. The Prometheus configuration file needs a manual change to replace the ``MASTER_URL_WITHOUT_SCHEME``, 
-``$MASTER_URL``, and ``PATH_TO_TOKEN``, 
+#. To replace the placeholder master address, you'll need to edit the Prometheus configuration file.
 
-   The ``metric_relabel_configs`` parameter edits certain label names in jobs for joining in PromQL.
-    - The ``scrape_interval`` parameter values can be modified to optimize for resolution/size/time.
+   -  The ``metric_relabel_configs`` parameter edits certain label names in jobs for joining in
+      PromQL.
 
-    - The ``PATH_TO_TOKEN`` specifies a path to a authorization token for the determined master that can
-   be kept in a local file by running the ``token-refresh.sh`` script in the same directory daily with a CRON job.
+   -  The ``scrape_interval`` parameter values can be modified to optimize for resolution/size/time.
+
+   -  The ``PATH_TO_TOKEN`` specifies a path to an authorization token for the Determined master.
+      This can be kept in a local file by running the ``token-refresh.sh`` script in the same
+      directory with a CRON job (set to run daily).`
 
 *******************
  Configure Grafana

--- a/docs/integrations/prometheus/prometheus.rst
+++ b/docs/integrations/prometheus/prometheus.rst
@@ -121,10 +121,6 @@ This example startup script includes the default setup docker commands provided 
  Configure Prometheus
 **********************
 
-`**********************
- Configure Prometheus
-**********************
-
 #. `Install Prometheus <https://prometheus.io/docs/prometheus/latest/installation/>`__ on any node
    in the monitored cluster.
 


### PR DESCRIPTION
## Description

adds documentation of how to authenticate prometheus for use with determined. is this needed when running on agent?


goes with: https://github.com/determined-ai/works-with-determined/pull/24
