### PR TITLE
chore: Improve failure diagnostics in shell test [FE-216]

### DIFF
--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -12,10 +12,16 @@ def test_start_and_write_to_shell(tmp_path: Path) -> None:
     with cmd.interactive_command("shell", "start") as shell:
         # Call our cli to ensure that PATH and PYTHONUSERBASE are properly set.
         shell.stdin.write(b"COLUMNS=80 det --version\n")
+        # Exit the shell, so we can read output below until EOF instead of timeout
+        shell.stdin.write(b"exit\n")
         shell.stdin.close()
 
+        lines = ""
         for line in shell.stdout:
             if str(det.__version__) in line:
                 break
+            lines += "OUTPUT:" + line
         else:
-            pytest.fail(f"Did not find expected input {det.__version__} in shell stdout.")
+            pytest.fail(
+                f"Did not find expected input {det.__version__} in shell stdout." + lines + "\n"
+            )


### PR DESCRIPTION
## Description

We are getting spurious failures of this test and it provide no info when it fails.  On failure it also hangs until the shell times out since the shell is still executing and therefore
doesn't close the stream we are reading.   Add an exit to force
an EOF so the test fails quickly on failure.

## Test Plan

On failure the error will now include the stdout read to help with triage:
```
>               pytest.fail(f"Did not find expected input {det.__version__} in shell stdout." + lines + "\n")
shell (id: 02060eba-4de3-4739-8257-f9d7a4e5cfef) is ready.                      OUTPUT:
E               OUTPUT:jerryharrow@jerryharrow-dev-box:~$ COLUMNS=80 det --version
E               OUTPUT:det 0.25.2-dev0
E               OUTPUT:jerryharrow@jerryharrow-dev-box:~$ exit
E               OUTPUT:logout
E               OUTPUT:To reconnect, run: det shell open 02060eba-4de3-4739-8257-f9d7a4e5cfef

command/test_shell.py:25: Failed
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-216
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
