### PR TITLE
docs: Add another top nav link

### DIFF
--- a/docs/_templates/toggle-primary-sidebar.html
+++ b/docs/_templates/toggle-primary-sidebar.html
@@ -11,4 +11,5 @@
 <div class="header-links-left">
   <a href="{{ pathto("cluster-setup-guide/deploy-cluster/index") }}">Set Up</a>
   <a href="{{ pathto("reference/overview") }}">Reference</a>
+  <a href="{{ pathto("model-dev-guide/index") }}">Dev Guide</a>
 </div>


### PR DESCRIPTION
Dev guide is too hard to scroll down to. This is an interim solution while we work on a collapsible sidenav.
