### PR TITLE
chore: allow attaching select dropdown to select container

### DIFF
--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -118,6 +118,8 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
   }, []);
 
   const getPopupContainer = (triggerNode: Element) => {
+    // triggerNode.parentElement can be falsy, so instead of a ternary, we fall back
+    // to document.body
     return (attachDropdownToContainer && triggerNode.parentElement) || document.body;
   };
 

--- a/webui/react/src/components/kit/Select.tsx
+++ b/webui/react/src/components/kit/Select.tsx
@@ -15,6 +15,7 @@ export { Option, OptGroup, SelectValue };
 type Options = DefaultOptionType | DefaultOptionType[];
 export interface SelectProps<T extends SelectValue = SelectValue> {
   allowClear?: boolean;
+  attachDropdownToContainer?: boolean;
   autoFocus?: boolean;
   defaultValue?: T;
   disableTags?: boolean;
@@ -63,6 +64,7 @@ const countOptions = (children: React.ReactNode, options?: Options): number => {
 
 const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(function Select(
   {
+    attachDropdownToContainer,
     disabled,
     disableTags = false,
     searchable = true,
@@ -115,6 +117,10 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
     return !!label && label.toLocaleLowerCase().includes(search.toLocaleLowerCase());
   }, []);
 
+  const getPopupContainer = (triggerNode: Element) => {
+    return (attachDropdownToContainer && triggerNode.parentElement) || document.body;
+  };
+
   return (
     <div className={classes.join(' ')} ref={divRef}>
       {label && <Label type={LabelTypes.TextOnly}>{label}</Label>}
@@ -122,6 +128,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = forwardRef(functi
         disabled={disabled || loading}
         dropdownMatchSelectWidth={dropdownMatchSelectWidth}
         filterOption={filterOption ?? (searchable ? handleFilter : true)}
+        getPopupContainer={getPopupContainer}
         maxTagCount={maxTagCount}
         maxTagPlaceholder={maxTagPlaceholder}
         options={options}


### PR DESCRIPTION
## Description

This adds a prop for selects which attaches the menu dropdown inline for cases where the select is in a context that scrolls independent of the body (for example, in larger modals)


## Test Plan

no testing needed


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[WEB-1670]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1670]: https://hpe-aiatscale.atlassian.net/browse/WEB-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ