### PR TITLE
fix: avoid hiding tabs in single trial experiment [WEB-1651]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
@@ -1,7 +1,7 @@
 .pivoter {
   [role='tablist'] > div {
-    &::before {
-      box-shadow: none !important;
+    &:global(.ant-tabs-nav-wrap)::before {
+      box-shadow: none;
     }
     > div {
       transform: translate(0) !important;

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
@@ -1,0 +1,10 @@
+.pivoter {
+  [role='tablist'] > div {
+    &::before {
+      box-shadow: none !important;
+    }
+    > div {
+      transform: translate(0) !important;
+    }
+  }
+}

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -29,6 +29,7 @@ import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 
 import ExperimentCheckpoints from './ExperimentCheckpoints';
 import ExperimentCodeViewer from './ExperimentCodeViewer';
+import css from './ExperimentSingleTrialTabs.module.scss';
 
 const TabType = {
   Checkpoints: 'checkpoints',
@@ -348,18 +349,20 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
       hidePreview={tabKey === TabType.Logs}
       trial={trialDetails}
       onViewLogs={handleViewLogs}>
-      <Pivot
-        activeKey={tabKey}
-        items={tabItems}
-        tabBarExtraContent={
-          tabKey === TabType.Hyperparameters && showCreateExperiment && !experiment.unmanaged ? (
-            <div style={{ padding: 4 }}>
-              <Button onClick={handleHPSearch}>Hyperparameter Search</Button>
-            </div>
-          ) : undefined
-        }
-        onChange={handleTabChange}
-      />
+      <div className={css.pivoter}>
+        <Pivot
+          activeKey={tabKey}
+          items={tabItems}
+          tabBarExtraContent={
+            tabKey === TabType.Hyperparameters && showCreateExperiment && !experiment.unmanaged ? (
+              <div style={{ padding: 4 }}>
+                <Button onClick={handleHPSearch}>Hyperparameter Search</Button>
+              </div>
+            ) : undefined
+          }
+          onChange={handleTabChange}
+        />
+      </div>
       {modalHyperparameterSearchContextHolder}
     </TrialLogPreview>
   );


### PR DESCRIPTION
## Description

This is a redo of #7904 , to the restored main branch

## Test Plan

Previously approved

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.