### PR TITLE
fix(allocation): allocation lifetimes should contain resource lifetimes

### DIFF
--- a/master/internal/rm/actorrm/actor_resource_manager.go
+++ b/master/internal/rm/actorrm/actor_resource_manager.go
@@ -125,9 +125,6 @@ func (r *ResourceManager) Allocate(
 // Release releases some resources.
 func (r *ResourceManager) Release(ctx actor.Messenger, msg sproto.ResourcesReleased) {
 	r.Tell(ctx, msg)
-	if msg.ResourcesID == nil { // ResourceID == nil => everything is released
-		rmevents.Publish(msg.AllocationID, sproto.ResourcesReleasedEvent{})
-	}
 }
 
 // GetResourcePools requests information about the available resource pools.

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -347,8 +347,9 @@ func (rp *resourcePool) resourcesReleased(
 	case allocated == nil:
 		ctx.Log().Infof("released before allocated for %s", msg.AllocationID)
 		rp.taskList.RemoveTaskByID(msg.AllocationID)
+		rmevents.Publish(msg.AllocationID, sproto.ResourcesReleasedEvent{})
 	case msg.ResourcesID != nil:
-		ctx.Log().Infof("resources %v are released for %s", *msg.ResourcesID, msg.AllocationID)
+		ctx.Log().Infof("incrementally released resources %v for %s", *msg.ResourcesID, msg.AllocationID)
 		for rID, r := range allocated.Resources {
 			if r.Summary().ResourcesID != *msg.ResourcesID {
 				continue
@@ -366,6 +367,7 @@ func (rp *resourcePool) resourcesReleased(
 			ctx.Tell(typed.agent.Handler, deallocateContainer{containerID: typed.containerID})
 		}
 		rp.taskList.RemoveTaskByID(msg.AllocationID)
+		rmevents.Publish(msg.AllocationID, sproto.ResourcesReleasedEvent{})
 	}
 }
 

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -601,6 +601,7 @@ func (k *kubernetesResourcePool) resourcesReleased(
 	}
 
 	ctx.Log().Infof("resources are released for %s", msg.AllocationID)
+
 	group := k.groups[req.Group]
 	if group != nil {
 		k.slotsUsedPerGroup[group] -= req.SlotsNeeded
@@ -616,6 +617,7 @@ func (k *kubernetesResourcePool) resourcesReleased(
 			break
 		}
 	}
+	rmevents.Publish(msg.AllocationID, sproto.ResourcesReleasedEvent{})
 }
 
 func (k *kubernetesResourcePool) getOrCreateGroup(


### PR DESCRIPTION
## Description
We saw a NPE when the a scheduler group was removed before one of its allocations, since there is periodically code that wants the group for an allocation. Allocations should never outlive groups in the scheduler; the messages are sent in the right order but because the group message goes through from group actor->RP and the allocation message goes from allocation->RM->RP, if the RM is backed up the removals can happen out of order.
 
Since groups already wait on allocation exits, the fix just makes sure allocations wait for RMs to confirm receipt of the ResourcesReleased message before exiting.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [x] add a time.Sleep(time.Second) to the agent RM with the priority scheduler and run an experiment, should fail without this patch and succeed with it.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
Corresponding dispatcher RM PR required. Better NPE handling in the scheduler coming after that. Also could use a PR to handle if the RP crashes and never sends the ResourcesReleased ack, so allocations don't hang waiting on it (but the hang isn't that bad, considering just failing isn't any more useful and a restart would be required to fix the RP anyway).

Testing this is really difficult because you need a full cluster (experiment, trial, allocation and a full resource manager) to make sure the flow is executed correctly, even with delays. A unit or integration would be pretty ineffective as far as I can tell. I'll look into a test after I get the rest up, though.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
