### PR TITLE
fix: show deep files in experiment code viewer

### DIFF
--- a/webui/react/src/components/kit/CodeEditor.tsx
+++ b/webui/react/src/components/kit/CodeEditor.tsx
@@ -158,7 +158,7 @@ const CodeEditor: React.FC<Props> = ({
     let fileDir = files;
     for (let dir = 0; dir < splitFilePath.length; dir++) {
       matchTopFileOrFolder = fileDir.find(
-        (f) => f.key === splitFilePath[dir] || f.key === selectedFilePath,
+        (f) => f.key === splitFilePath.slice(0, dir + 1).join('/') || f.key === selectedFilePath,
       );
       if (matchTopFileOrFolder?.children) {
         fileDir = matchTopFileOrFolder.children;


### PR DESCRIPTION
## Description

This fixes an issue where files more than one folder deep were not viewable in the experiment code view. The code to find which file node in the file list is active assumed that the node keys would only contain the last path segment (i.e: a file at `foo/bar/baz` would have a key of `baz`) or fully match the selected file path. For files 1 folder deep, the search would match the folder, then fully match the file, but because deeper files needed to match more of the partial path, it would fail.

This is fixed by instead matching the current path with all previously matched segments with the node key. Because the only consumer of CodeEditor that this effects is ExperimentCodeViewer, this should be fine.


## Test Plan

- submit an experiment with files that are more than one level deep
- in the code viewer, all files should be accessible



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[WEB-1696]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1696]: https://hpe-aiatscale.atlassian.net/browse/WEB-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ