### PR TITLE
fix: summary metrics got null's from a migration

### DIFF
--- a/master/static/migrations/20230817155037_fix-summary-nulls.tx.down.sql
+++ b/master/static/migrations/20230817155037_fix-summary-nulls.tx.down.sql
@@ -1,0 +1,1 @@
+-- Can't go back.

--- a/master/static/migrations/20230817155037_fix-summary-nulls.tx.up.sql
+++ b/master/static/migrations/20230817155037_fix-summary-nulls.tx.up.sql
@@ -1,0 +1,27 @@
+WITH summary_metrics_with_mean AS (
+  SELECT
+    trials.id,
+    jsonb_object_agg(
+      metric_group,
+      CASE
+        WHEN summary_metrics->metric_group = 'null'::JSONB OR
+          summary_metrics->metric_group IS NULL THEN '{}'::JSONB
+        ELSE summary_metrics->metric_group
+      END
+    ) AS summary_metrics
+  FROM
+    trials,
+    jsonb_object_keys(summary_metrics) as metric_group
+  WHERE
+    summary_metrics IS NOT NULL
+  GROUP BY
+    trials.id
+)
+UPDATE
+  trials
+SET
+  summary_metrics = summary_metrics_with_mean.summary_metrics
+FROM
+  summary_metrics_with_mean
+WHERE
+  trials.id = summary_metrics_with_mean.id;


### PR DESCRIPTION
## Description

https://github.com/determined-ai/determined/pull/7518/files could have left summary metrics migration in an unusable state for some trials

For example run 
```
det e create examples/tutorials/core_api/1_metrics.yaml examples/tutorials/core_api/ -f
```

but change the validation metric to report ```{}```
```
    core_context.train.report_validation_metrics(steps_completed=steps_completed, metrics={})
```

Run the migration and we have "validations": null
```
./determined/master/static/migrations/20230817155036_use-summary-metrics.tx.up.sql
```

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Check migration fixes above case


## Commentary (optional)

Originally I wanted to update every query that uses summary metrics to handle this case but I think it too complicated and would be more risk

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
