### PR TITLE
docs: quick fix for version dropdown

### DIFF
--- a/docs/_static/version-switcher/versions.json
+++ b/docs/_static/version-switcher/versions.json
@@ -4,6 +4,10 @@
         "url": "https://docs.determined.ai/latest/"
     },
     {
+        "version": "0.25.1",
+        "url": "https://docs.determined.ai/0.25.1/"
+    },
+    {
         "version": "0.25.0",
         "url": "https://docs.determined.ai/0.25.0/"
     },


### PR DESCRIPTION
The longterm-fix is still ticked, but hasn't happened yet.