### PR TITLE
fix: return searcher_metric_value as-is [WEB-1707]

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2397,7 +2397,7 @@ func (a *apiServer) SearchExperiments(
 				'num_inputs', bv.metrics->'num_inputs') AS best_validation`).
 		ColumnExpr("null::jsonb AS best_checkpoint").
 		ColumnExpr("null::jsonb AS wall_clock_time").
-		ColumnExpr("searcher_metric_value_signed AS searcher_metric_value").
+		Column("searcher_metric_value").
 		Column("trials.external_trial_id").
 		Join("LEFT JOIN validations bv ON trials.best_validation_id = bv.id").
 		Join("LEFT JOIN validations lv ON trials.latest_validation_id = lv.id").


### PR DESCRIPTION
## Description

The API is returning -1x the searcher metric values when config has `smaller_is_better: False`
This line was introduced in #7518 for sorting 'better' or 'worse' values of the metric, but we handle sorting in other parts of code

## Test Plan

With the original code, sort experiments by searcher metric value. Find a negative value
With the updated code, typically there will be no more negative values

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.