### PR TITLE
fix: Update tensorboard modal to filter managed experiments serverside

### DIFF
--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -477,9 +477,13 @@ func (a *apiServer) getTensorBoardConfigsFromReq(
 			return nil, err
 		}
 
-		conf, err := db.LegacyExperimentConfigByID(int(expID))
+		conf, unmanaged, err := db.LegacyExperimentConfigForTensorBoard(int(expID))
 		if err != nil {
 			return nil, err
+		}
+		if unmanaged {
+			// cannot create TensorBoard for external/unmanaged experiment
+			continue
 		}
 
 		confByID[expID] = &tensorboardConfig{ExperimentID: expID, Config: conf}
@@ -496,9 +500,13 @@ func (a *apiServer) getTensorBoardConfigsFromReq(
 			return nil, err
 		}
 
-		conf, err := db.LegacyExperimentConfigByID(expID)
+		conf, unmanaged, err := db.LegacyExperimentConfigForTensorBoard(expID)
 		if err != nil {
 			return nil, err
+		}
+		if unmanaged {
+			// cannot create TensorBoard for external/unmanaged experiment
+			continue
 		}
 
 		if conf, ok := confByID[int32(expID)]; ok {

--- a/webui/react/src/components/ExperimentTensorBoardModal.tsx
+++ b/webui/react/src/components/ExperimentTensorBoardModal.tsx
@@ -2,12 +2,11 @@ import { Modal } from 'components/kit/Modal';
 import { UNMANAGED_EXPERIMENT_ANNOTATION_MESSAGE } from 'constant';
 import { openOrCreateTensorBoard } from 'services/api';
 import { V1BulkExperimentFilters } from 'services/api-ts-sdk';
-import { ProjectExperiment } from 'types';
 import handleError from 'utils/error';
 import { openCommandResponse } from 'utils/wait';
 
 interface Props {
-  selectedExperiments: ProjectExperiment[];
+  selectedExperiments: { id: number; unmanaged: boolean | undefined }[];
   filters?: V1BulkExperimentFilters;
   workspaceId?: number;
 }

--- a/webui/react/src/components/ExperimentTensorBoardModal.tsx
+++ b/webui/react/src/components/ExperimentTensorBoardModal.tsx
@@ -33,9 +33,9 @@ const ExperimentTensorBoardModal = ({
       submit={{
         handleError,
         handler: handleSubmit,
-        text: 'confirm',
+        text: 'Confirm',
       }}
-      title="Tensorboard confirmation">
+      title="TensorBoard confirmation">
       {UNMANAGED_EXPERIMENT_ANNOTATION_MESSAGE}
     </Modal>
   );

--- a/webui/react/src/components/ExperimentTensorBoardModal.tsx
+++ b/webui/react/src/components/ExperimentTensorBoardModal.tsx
@@ -6,22 +6,19 @@ import handleError from 'utils/error';
 import { openCommandResponse } from 'utils/wait';
 
 interface Props {
-  selectedExperiments: { id: number; unmanaged: boolean | undefined }[];
+  selectedExperimentIds: number[];
   filters?: V1BulkExperimentFilters;
   workspaceId?: number;
 }
 
 const ExperimentTensorBoardModal = ({
   workspaceId,
-  selectedExperiments,
+  selectedExperimentIds,
   filters,
 }: Props): JSX.Element => {
   const handleSubmit = async () => {
-    const managedExperimentIds = selectedExperiments
-      .filter((exp) => !exp.unmanaged)
-      .map((exp) => exp.id);
     openCommandResponse(
-      await openOrCreateTensorBoard({ experimentIds: managedExperimentIds, filters, workspaceId }),
+      await openOrCreateTensorBoard({ experimentIds: selectedExperimentIds, filters, workspaceId }),
     );
   };
 

--- a/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/TableActionBar.tsx
@@ -156,9 +156,9 @@ const TableActionBar: React.FC<Props> = ({
 
   const selectedExperiments = useMemo(
     () =>
-      Array.from(selectedExperimentIds).flatMap((id) =>
-        id in experimentMap ? [experimentMap[id]] : [],
-      ),
+      Array.from(selectedExperimentIds).flatMap((id) => [
+        { id, unmanaged: id in experimentMap ? experimentMap[id].unmanaged : false },
+      ]),
     [experimentMap, selectedExperimentIds],
   );
 


### PR DESCRIPTION
## Description

When the user launches TensorBoard, we filter out unmanaged experiments on the client-side and display a warning modal. Since #7921, we skip  selected experiments which are not currently on the page / in `experimentMap`

In this fix:
- we send selected IDs to TensorBoard unless frontend knows it is unmanaged
- unmanaged experiments are filtered out server-side (LegacyExperimentConfigByID is renamed to LegacyExperimentConfigForTensorBoard; it's used only here)
- small change to modal text

## Test Plan

Select any **managed** experiment.
Use the Bulk Actions menu to select Open TensorBoard. Click it and the "If..." warning modal appears
Uncheck all
Select an **unmanaged** experiment, and the Bulk Actions menu disables "Open TensorBoard"
Select a mix of managed and unmanaged experiments and the Bulk Actions menu allows "Open TensorBoard"

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.