### PR TITLE
fix: Force GCP node name length to be less than maximum length

### DIFF
--- a/master/internal/rm/agentrm/provisioner/gcp/gcp.go
+++ b/master/internal/rm/agentrm/provisioner/gcp/gcp.go
@@ -20,6 +20,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
+const MAX_INSTANCE_NAME_LENGTH = 63
+
 // gcpCluster wraps a GCE client. Determined recognizes agent GCE instances by:
 // 1. A specific key/value pair label.
 // 2. Names of agents that are equal to the instance names.
@@ -164,7 +166,13 @@ func (c *gcpCluster) stateFromInstance(inst *compute.Instance) model.InstanceSta
 }
 
 func (c *gcpCluster) generateInstanceNamePattern() string {
-	return c.config.NamePrefix + petname.Generate(2, "-") + "-#####"
+	gen_name := c.config.NamePrefix + petname.Generate(2, "-")
+	suffix := "-#####"
+	// We make sure that the generated name is less than the max length
+	if len(gen_name) > MAX_INSTANCE_NAME_LENGTH-len(suffix) {
+		return gen_name[:MAX_INSTANCE_NAME_LENGTH-len(suffix)] + suffix
+	}
+	return gen_name + suffix
 }
 
 func (c *gcpCluster) List() ([]*model.Instance, error) {


### PR DESCRIPTION
## Description

## Test Plan


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9789

