### PR TITLE
chore: put grpc panics and other logs into 'master logs'

### DIFF
--- a/docs/release-notes/master-logs.rst
+++ b/docs/release-notes/master-logs.rst
@@ -2,4 +2,5 @@
 
 **Improvements**
 
--  Logging: Some API logs would previously only go to stdout of the running master but now will also be returned from ``det master logs``.
+-  Logging: Some API logs would previously only go to stdout of the running master but now will also
+   be returned from ``det master logs``.

--- a/docs/release-notes/master-logs.rst
+++ b/docs/release-notes/master-logs.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  Logging: Some API logs would previously only go to stdout of the running master but now will also be returned from ``det master logs``.

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -666,7 +666,9 @@ func (m *Master) startServers(ctx context.Context, cert *tls.Certificate) error 
 	// gRPC server (logger initialization, maybe more). Found by --race.
 	gRPCServer := grpcutil.NewGRPCServer(m.db, &apiServer{m: m},
 		m.config.Observability.EnablePrometheus,
-		&m.config.InternalConfig.ExternalSessions)
+		&m.config.InternalConfig.ExternalSessions,
+		m.logs,
+	)
 
 	err = grpcutil.RegisterHTTPProxy(ctx, m.echo, m.config.Port, cert)
 	if err != nil {


### PR DESCRIPTION
## Description

We would log API panics to stdout/stderr of master but not ```det master logs```.


## Test Plan

Edit GetExperiments to add a ```panic("test")```, run ```det e``` and then in ```det master logs``` we should see the panic stack trace.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
