### PR TITLE
fix: bring back logging for `core.train.report_*` calls.

### DIFF
--- a/harness/determined/core/_train.py
+++ b/harness/determined/core/_train.py
@@ -121,6 +121,9 @@ class TrainContext:
         but may be accessed from the master using the CLI for post-processing.
         """
 
+        logger.info(
+            f"report_training_metrics(steps_completed={steps_completed}, metrics={metrics})"
+        )
         self._report_trial_metrics(util._LEGACY_TRAINING, steps_completed, metrics, batch_metrics)
 
     def report_validation_metrics(
@@ -134,6 +137,9 @@ class TrainContext:
         metric using ``SearcherOperation.report_completed()`` in the Searcher API.
         """
 
+        logger.info(
+            f"report_validation_metrics(steps_completed={steps_completed}, metrics={metrics})"
+        )
         self._report_trial_metrics(util._LEGACY_VALIDATION, steps_completed, metrics)
 
     def report_metrics(
@@ -155,6 +161,9 @@ class TrainContext:
                 When reporting metrics with the same ``group`` and ``steps_completed`` values,
                 the dictionary keys must not overlap.
         """
+        logger.info(
+            f"report_metrics(group={group}, steps_completed={steps_completed}, metrics={metrics})"
+        )
         self._report_trial_metrics(group, steps_completed, metrics)
 
     def get_tensorboard_path(self) -> pathlib.Path:
@@ -266,34 +275,10 @@ class DummyTrainContext(TrainContext):
         metrics: Dict[str, Any],
         batch_metrics: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
-        """
-        Report trial metrics to the master.
-
-        You can include a list of ``batch_metrics``.  Batch metrics are not be shown in the WebUI
-        but may be accessed from the master using the CLI for post-processing.
-        """
-        logger.info(
-            f"_report_trial_metrics(group={group}, steps_completed={steps_completed},"
-            f"metrics={metrics})"
-        )
         logger.debug(
             f"_report_trial_metrics(group={group}, steps_completed={steps_completed},"
-            f" batch_metrics={batch_metrics})"
+            f"metrics={metrics}), batch_metrics={batch_metrics})"
         )
-
-    def report_training_metrics(
-        self,
-        steps_completed: int,
-        metrics: Dict[str, Any],
-        batch_metrics: Optional[List[Dict[str, Any]]] = None,
-    ) -> None:
-        self._report_trial_metrics(util._LEGACY_TRAINING, steps_completed, metrics, batch_metrics)
-
-    def report_validation_metrics(self, steps_completed: int, metrics: Dict[str, Any]) -> None:
-        self._report_trial_metrics(util._LEGACY_VALIDATION, steps_completed, metrics)
-
-    def report_metrics(self, group: str, steps_completed: int, metrics: Dict[str, Any]) -> None:
-        self._report_trial_metrics(group, steps_completed, metrics)
 
     def upload_tensorboard_files(
         self,


### PR DESCRIPTION
## Description

We've got a [user complaint](https://github.com/determined-ai/determined/issues/7966) that core api report_training_metrics are no longer printed in the trial logs.

These were removed in https://github.com/determined-ai/determined/pull/7407. let's bring them back.

Also simplify `DummyTrainContext` because it inherits from `TrainContext`. 

## Test Plan

Run any trial and ensure it has `determined.core: report_training_metrics(` log lines.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
