### PR TITLE
fix: report searcher progress according to reporting period [MLG-988]

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -223,8 +223,15 @@ class _PyTorchTrialController:
         if local_training:
             self.trial_id = 0
             assert self.max_length, "max_length must be specified for local-training mode."
+            self.searcher_unit = self.max_length._to_searcher_unit()
         else:
             self.trial_id = self.core_context.train._trial_id
+            configured_units = self.core_context.searcher.get_configured_units()
+            if configured_units is None:
+                raise ValueError(
+                    "Searcher units must be configured for training with PyTorchTrial."
+                )
+            self.searcher_unit = configured_units
 
         # Don't initialize the state here because it will be invalid until we load a checkpoint.
         self.state = None  # type: Optional[_TrialState]
@@ -240,10 +247,6 @@ class _PyTorchTrialController:
         self.smaller_is_better = smaller_is_better
         self.global_batch_size = global_batch_size
 
-        if local_training:
-            self.searcher_unit = self.max_length._to_searcher_unit()
-        else:
-            self.searcher_unit = self.core_context.searcher.get_configured_units()
         if self.searcher_unit == core.Unit.RECORDS:
             if self.global_batch_size is None:
                 raise ValueError("global_batch_size required for searcher unit RECORDS.")

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -765,7 +765,10 @@ class _PyTorchTrialController:
                     continue
 
                 # Train step limits reached, proceed accordingly.
-                if train_boundary.step_type == _TrainBoundaryType.TRAIN:
+                if train_boundary.step_type in (
+                    _TrainBoundaryType.TRAIN,
+                    _TrainBoundaryType.REPORT,
+                ):
                     if not op._completed and self.is_chief:
                         self._report_searcher_progress(op, self.searcher_unit)
                 elif train_boundary.step_type == _TrainBoundaryType.VALIDATE:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -122,6 +122,7 @@ class Epoch(TrainUnit):
     """
     Epoch step type (e.g. Epoch(1) defines 1 epoch)
     """
+
     pass
 
 

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1246,7 +1246,7 @@ class TestPyTorchTrial:
             max_batches=100,
         )
         controller.run()
-        assert mock_report_progress.call_count == 100 // 10
+        
         exp_prog = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         got_prog = [x.args[0] for x in mock_report_progress.call_args_list]
         assert exp_prog == got_prog

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1235,6 +1235,22 @@ class TestPyTorchTrial:
             controller.core_context.train.get_experiment_best_validation.reset_mock()
             controller._checkpoint.reset_mock()
 
+    def test_searcher_progress_reporting(self):
+        trial, controller = pytorch_utils.create_trial_and_trial_controller(
+            trial_class=pytorch_onevar_model.OneVarTrial,
+            scheduling_unit=10,
+            hparams=self.hparams,
+            trial_seed=self.trial_seed,
+            max_batches=100,
+        )
+
+        controller._report_searcher_progress = mock.MagicMock()
+
+        controller.run()
+
+        # Expect progress reports every scheduling unit step + 1 on training end.
+        assert controller._report_searcher_progress.call_count == (100 / 10) + 1
+
     @pytest.mark.parametrize(
         "ckpt",
         [

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1247,8 +1247,9 @@ class TestPyTorchTrial:
         )
         controller.run()
         assert mock_report_progress.call_count == 100 // 10
-        for i, step in enumerate(range(10, 110, 10)):
-            assert mock_report_progress.call_args_list[i].args[0] == step
+        exp_prog = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        got_prog = [x.args[0] for x in mock_report_progress.call_args_list]
+        assert exp_prog == got_prog
 
     @pytest.mark.parametrize(
         "ckpt",

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -6,7 +6,6 @@ import os
 import pathlib
 import sys
 import typing
-import unittest.mock
 from unittest import mock
 
 import numpy as np

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1246,7 +1246,7 @@ class TestPyTorchTrial:
             max_batches=100,
         )
         controller.run()
-        
+
         exp_prog = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         got_prog = [x.args[0] for x in mock_report_progress.call_args_list]
         assert exp_prog == got_prog


### PR DESCRIPTION
## Description

fix a bug where searcher progress was not being reported according to `reporting_period`/`scheduling_unit`
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

submit a pytorch experiment, verify that searcher progress is reported per `scheduling_unit` in the expconf. in the web UI, the progress bar should update incrementally as training progresses.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
