### PR TITLE
fix: Hide action menu on dashboard project cards [WEB-1667]

### DIFF
--- a/webui/react/src/pages/Dashboard.tsx
+++ b/webui/react/src/pages/Dashboard.tsx
@@ -197,7 +197,7 @@ const Dashboard: React.FC = () => {
         <Section title="Recently Viewed Projects">
           <Card.Group size="small" wrap={false}>
             {projects.map((project) => (
-              <ProjectCard key={project.id} project={project} showWorkspace />
+              <ProjectCard hideActionMenu key={project.id} project={project} showWorkspace />
             ))}
           </Card.Group>
         </Section>


### PR DESCRIPTION
## Description

Small change - only on the Dashboard, remove this action menu from ProjectCards, using `hideActionMenu` prop introduced in #7870

 
<img width="1081" alt="Screen Shot 2023-09-13 at 9 53 21 AM" src="https://github.com/determined-ai/determined/assets/643918/0b1ab94b-e2a6-498c-a4ae-a3bb61baead5">


## Test Plan

After dashboard has fully loaded, the three dots menu does not appear when hovering over a ProjectCard


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.