### PR TITLE
ci: more precisely select files for splitting in E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,19 +541,27 @@ commands:
           name: Split tests
           working_directory: ~/project/e2e_tests
           command: |
-            # If a test mark is specified, preselect only files that contain tests with that mark to
-            # minimize how wrong CircleCI's splitting can get things.
-            if [ -n "<<parameters.mark>>" ]; then
-              mark="<<parameters.mark>>"
-              # Extract the first mark for complex conditions such as 'mark1 and not mark2'.
-              mark_prefix=${mark%% and*}
-              find tests -name 'test*.py' -print0 | xargs -0 grep -rl "pytest\.mark\.$mark_prefix"
-            else
-              circleci tests glob 'tests/**/test*.py'
-            fi | circleci tests split --split-by=timings > /tmp/tests-to-run
+            # Preselect the files that contain any matching tests to minimize how wrong CircleCI's
+            # splitting can get things. (The presence of files with no tests can cause the files
+            # with tests to be bunched up incorrectly, making the split suboptimal.)
+
+            # `--setup-plan` tells pytest to not run any tests but instead print out a description
+            # of the tests that would be run, along with some other stuff. Each file containing
+            # any selected tests is printed on a line by itself, except for (for some reason) a
+            # single trailing space.
+            pytest --setup-plan -m '<<parameters.mark>>' | grep '\.py $' | sed 's/ $//' > /tmp/all-relevant-files
+
+            echo 'All files with tests matching mark "<<parameters.mark>>":'
+            sed 's/^/- /' </tmp/all-relevant-files
+
+            circleci tests split --split-by=timings < /tmp/all-relevant-files > /tmp/tests-to-run
             echo "Running tests from these files:"
             sed 's/^/- /' </tmp/tests-to-run
 
+            if [ ! -s /tmp/tests-to-run ]; then
+              echo 'No test files found!'
+              exit 1
+            fi
       - when:
           condition:
             and:


### PR DESCRIPTION
## Description

In ef59afa4b2fc, a pre-splitting selection step was added to work around an unfortunate behavior of CircleCI's splitting tool when passed a file with no tests to be run. The code was later amended to try to handle slightly more complex marks, and a whole other thing was done on top of that in EE, but really we should just use pytest itself to print out exactly the right set of files without reimplementing any of its logic.

This change also adds code to defend against something going wrong and causing no files to be selected, which would cause all tests to be run in every split. (That's what happened in EE that led to this change getting done.)
## Test Plan

- [x] run in CI (https://app.circleci.com/pipelines/github/determined-ai/determined?branch=fix-splits), check that times across splits are reasonably even and the same number of tests are run as in previous commit (https://app.circleci.com/pipelines/github/determined-ai/determined/45383/workflows/57ad303a-e0b4-4753-a0f6-e4277940fa6d)
