### PR TITLE
fix: Return ResourcePools rather than names

### DIFF
--- a/harness/determined/common/experimental/workspace.py
+++ b/harness/determined/common/experimental/workspace.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from determined.common import api
 from determined.common.api import bindings
+from determined.common.experimental import resource_pool
 
 
 class Workspace:
@@ -57,7 +58,7 @@ class Workspace:
 
         self._hydrate(workspace_bindings)
 
-    def list_pools(self) -> List[str]:
+    def list_pools(self) -> List[resource_pool.ResourcePool]:
         """
         Lists the resources pools that the workspace has access to. Tasks submitted to this
         workspace can only use the resource pools listed here.
@@ -71,11 +72,11 @@ class Workspace:
             )
 
         resps = api.read_paginated(get_with_offset)
-        resource_pools = [
+        resource_pool_names = [
             rp for r in resps if r.resourcePools is not None for rp in r.resourcePools
         ]
 
-        return resource_pools
+        return [resource_pool.ResourcePool(self._session, name=rp) for rp in resource_pool_names]
 
 
 def _get_workspace_id_from_name(session: api.Session, name: str) -> int:

--- a/harness/tests/determined/common/experimental/test_workspace.py
+++ b/harness/tests/determined/common/experimental/test_workspace.py
@@ -87,21 +87,3 @@ def test_workspace_constructor_populates_id_from_name(
 def test_workspace_constructor_doesnt_populate_name_from_id(standard_session: api.Session) -> None:
     ws = workspace.Workspace(session=standard_session, workspace_id=1)
     assert ws.name is None
-
-
-@responses.activate
-def test_list_bounded_resource_pools(
-    standard_session: api.Session,
-    single_item_workspaces: bindings.v1GetWorkspacesResponse,
-    single_item_rps_bound_to_workspace: bindings.v1ListRPsBoundToWorkspaceResponse,
-) -> None:
-    workspace_id = single_item_workspaces.workspaces[0].id
-    responses.get(f"{_MASTER}/api/v1/workspaces", json=single_item_workspaces.to_json())
-    responses.get(
-        f"{_MASTER}/api/v1/workspaces/{workspace_id}/available-resource-pools",
-        json=single_item_rps_bound_to_workspace.to_json(),
-    )
-
-    ws = workspace.Workspace(session=standard_session, workspace_id=workspace_id)
-    rps = ws.list_pools()
-    assert rps == ["foo"]


### PR DESCRIPTION
BREAKING CHANGE: calls to `workspace.Workspace.list_pools` return objects rather than strings.

ResourcePool objects are dumb because they're not backed by a table like other resources. The only attribute a ResourcePool can have is its name.

Nevertheless, `list_pools` should return actual, typed ResourcePool objects rather than their names for conformity with the rest of the SDK.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
The following now returns ResourcePool objects rather than strings:

```python
from determined.experimental import client
client.login(<details>)
ws = client.get_workspace(<workspace>)
ws.list_pools()
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
