### PR TITLE
fix: Version dropdown in docs is scrollable [WEB-1706]

### DIFF
--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -51,6 +51,11 @@ html[data-theme="dark"] {
   margin-left: 8px;
 }
 
+.version-switcher__menu {
+  max-height: 230px;
+  overflow-y: scroll;
+}
+
 .bd-header-article {
   min-width: 488px;
   z-index: 200; /* sphinx-book-theme default is 1020, lower this enough to stay below algolia modal */


### PR DESCRIPTION
## Description

Versions list dropdown in the docs is getting a little long. This adds a max-height and scrollbar to the list of versions.

<img width="276" alt="Screen Shot 2023-09-26 at 11 45 25 AM" src="https://github.com/determined-ai/determined/assets/643918/9787dad9-da31-441a-a60a-c1ada4b9189f">


## Test Plan

- Docs builds successfully
- Adding new versions would make the older versions visible by scrolling

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.