### PR TITLE
refactor: add delete cascade to tables involved in experiment deletion

### DIFF
--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -922,51 +922,6 @@ func (db *PgDB) DeleteExperiments(ctx context.Context, ids []int) error {
 		}
 	}()
 	var delIDs []int32
-	if _, err = tx.NewDelete().Model(&delIDs).Table("raw_steps").
-		Where("trial_id IN (SELECT id FROM trials WHERE experiment_id IN (?))", bun.In(ids)).
-		Returning("id").
-		Exec(ctx); err != nil {
-		return errors.Wrapf(err, "error deleting steps for experiments %v", ids)
-	}
-
-	if _, err = tx.NewDelete().Model(&delIDs).Table("raw_validations").
-		Where("trial_id IN (SELECT id FROM trials WHERE experiment_id IN (?))", bun.In(ids)).
-		Returning("id").
-		Exec(ctx); err != nil {
-		return errors.Wrapf(err, "error deleting validations for experiments %v", ids)
-	}
-
-	// Even with migration away from checkpoints_v1,
-	// Keeping this to keep behavior of fully deleting checkpoints.
-	if _, err = tx.NewDelete().Model(&delIDs).Table("raw_checkpoints").
-		Where("trial_id IN (SELECT id FROM trials WHERE experiment_id IN (?))", bun.In(ids)).
-		Returning("id").
-		Exec(ctx); err != nil {
-		return errors.Wrapf(err, "error deleting checkpoints for experiments %v", ids)
-	}
-
-	if _, err = tx.NewDelete().Model(&delIDs).Table("checkpoints_v2").
-		Where(`task_id IN (
-	SELECT tt.task_id
-	FROM trial_id_task_id tt
-	JOIN trials t ON t.id = tt.trial_id
-	WHERE experiment_id IN (?)
-)`, bun.In(ids)).
-		Returning("id").
-		Exec(ctx); err != nil {
-		return errors.Wrapf(err, "error deleting checkpoints (v2) for experiments %v", ids)
-	}
-
-	if err := db.DeleteSnapshotsForExperiments(ids)(ctx, &tx); err != nil {
-		return errors.Wrapf(err, "error deleting snapshots for experiments %v", ids)
-	}
-
-	if _, err = tx.NewDelete().Model(&delIDs).Table("trials").
-		Where("experiment_id IN (?)", bun.In(ids)).
-		Returning("id").
-		Exec(ctx); err != nil {
-		return errors.Wrapf(err, "error deleting trials for experiments %v", ids)
-	}
 
 	_, err = tx.NewDelete().Model(&delIDs).Table("experiments").
 		Where("id IN (?)", bun.In(ids)).

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils/protoconverter"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/searcher"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/commonv1"
 	"github.com/determined-ai/determined/proto/pkg/modelv1"
@@ -516,4 +518,220 @@ func TestTopTrialsByMetric(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteExperiments(t *testing.T) {
+	ctx := context.Background()
+
+	require.NoError(t, etc.SetRootPath(RootFromDB))
+	db := MustResolveTestPostgres(t)
+	MustMigrateTestPostgres(t, db, MigrationsFromDB)
+	user := RequireMockUser(t, db)
+
+	var experimentIDs []int
+	var trialIDs []int
+	var checkpointIDs []int
+
+	/* Removed ID maps should function as sets (the integer that usually serves as the value
+	in the map is always 0). */
+	removedExperimentIDs := make(map[int]int)
+	removedTrialIDs := make(map[int]int)
+	removedCheckpointIDs := make(map[int]int)
+
+	numExpts := 4
+	numTrs := 2       // Trials per experiment
+	numChkpts := 2    // Checkpoints per trial
+	numMtrsRaw := 2   // Training metrics per trial
+	numMtrsVal := 1   // Validation metrics per trial
+	numExptSns := 1   // Experiment snapshots per experiment
+	numRawChkpts := 2 // Raw checkpoints per trial
+
+	createMetric := func(sc int32, mv float64, trID int) *trialv1.TrialMetrics {
+		m := &trialv1.TrialMetrics{
+			TrialId:        int32(trID),
+			StepsCompleted: sc,
+			Metrics: &commonv1.Metrics{
+				AvgMetrics: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						defaultSearcherMetric: {
+							Kind: &structpb.Value_NumberValue{
+								NumberValue: mv,
+							},
+						},
+					},
+				},
+				BatchMetrics: []*structpb.Struct{},
+			},
+		}
+		return m
+	}
+
+	checkPointIndex := 1
+	for i := 0; i < numExpts; i++ { // Create experiments
+		exp := RequireMockExperiment(t, db, user)
+		experimentIDs = append(experimentIDs, exp.ID)
+
+		for j := 0; j < numTrs; j++ { // Create trials
+			tr, task := RequireMockTrial(t, db, exp)
+			allocation := RequireMockAllocation(t, db, task.TaskID)
+			trialIDs = append(trialIDs, tr.ID)
+
+			for k := 0; k < numChkpts; k++ { // Create checkpoints
+				ckpt := uuid.New()
+				checkpoint := MockModelCheckpoint(ckpt, allocation)
+				err := AddCheckpointMetadata(ctx, &checkpoint)
+				require.NoError(t, err)
+				// checkpoint.ID = checkPointIndex
+				checkpointIDs = append(checkpointIDs, checkpoint.ID)
+
+				// rawcheckpoint metrics (raw_checkpoints)
+				_, err = db.sql.Exec(
+					`INSERT INTO raw_checkpoints (id, trial_id, trial_run_id, total_batches, state)
+				VALUES ($1, $2, $3, $4, $5)`, checkpoint.ID, tr.ID, checkPointIndex, checkPointIndex, "ACTIVE")
+				require.NoError(t, err)
+				checkPointIndex++
+			}
+
+			// training metrics (raw_steps)
+			mRaw1 := createMetric(10, 0.5, tr.ID)
+			err := db.AddTrainingMetrics(ctx, mRaw1)
+			require.NoError(t, err)
+			mRaw2 := createMetric(11, 0.9, tr.ID)
+			err = db.AddTrainingMetrics(ctx, mRaw2)
+			require.NoError(t, err)
+
+			//  validation metrics (raw_validations)
+			mValidation := createMetric(12, 0.95, tr.ID)
+			err = db.AddValidationMetrics(ctx, mValidation)
+			require.NoError(t, err)
+		}
+
+		// Create experiment snapshot
+		config := expconf.SearcherConfig{
+			RawCustomConfig: &expconf.CustomConfig{},
+		}
+		searcher1 := searcher.NewSearcher(3, searcher.NewSearchMethod(config), nil)
+		_, err := searcher1.InitialOperations()
+		require.NoError(t, err)
+		_, err = searcher1.TrialExitedEarly(model.RequestID(uuid.New()), model.Errored)
+		require.NoError(t, err)
+
+		snapshot, err := searcher1.Snapshot()
+		require.NoError(t, err)
+		err = db.SaveSnapshot(exp.ID, 2, snapshot)
+		require.NoError(t, err)
+	}
+
+	type expected struct {
+		numExperiments         int
+		numTrials              int
+		numCheckpoints         int
+		numMetricsRaw          int
+		numMetricsValidation   int
+		numExperimentSnapshots int
+		numRawCheckpoints      int
+	}
+
+	/*
+		Checks that the correct number of rows exist for the specified table and
+		column and checks that desired elements are in each row.
+	*/
+	verifyNumAndElems := func(table string, column string, removed map[int]int, num int) {
+		var ids []int
+		err := Bun().NewSelect().Table(table).Column(column).Scan(context.Background(), &ids)
+		require.NoError(t, err)
+		require.Equal(t, num, len(ids))
+
+		for _, id := range ids {
+			_, inRm := removed[id]
+			require.Equal(t, false, inRm)
+		}
+	}
+
+	/* Checks accuracy of tables with `ON DELETE CASCADE` that should
+	be affected by experiment deletion. */
+	verifyData := func(e expected) {
+		verifyNumAndElems("experiments", "id", removedExperimentIDs, e.numExperiments)
+		verifyNumAndElems("trials", "id", removedTrialIDs, e.numTrials)
+		verifyNumAndElems("checkpoints_v2", "id", removedCheckpointIDs, e.numCheckpoints)
+		verifyNumAndElems("raw_steps", "trial_id", removedTrialIDs, e.numMetricsRaw)
+		verifyNumAndElems("raw_validations", "trial_id", removedTrialIDs, e.numMetricsValidation)
+		verifyNumAndElems("experiment_snapshots", "experiment_id", removedExperimentIDs,
+			e.numExperimentSnapshots)
+		verifyNumAndElems("raw_checkpoints", "trial_id", removedTrialIDs, e.numRawCheckpoints)
+	}
+
+	// Adds IDs of database elements (experiments, trials, checkpoints) to rmIDs set.
+	addToMap := func(st, end int, rmIds map[int]int, ids []int) map[int]int {
+		var i int
+		for i = st; i < end; i++ {
+			rmIds[ids[i]] = 0
+		}
+		return rmIds
+	}
+
+	subtractRows := func(e expected, amt int) expected {
+		e.numExperiments -= amt
+		e.numTrials -= amt * numTrs
+		e.numCheckpoints -= amt * numChkpts * numTrs
+		e.numMetricsRaw -= amt * numMtrsRaw * numTrs
+		e.numMetricsValidation -= amt * numMtrsVal * numTrs
+		e.numExperimentSnapshots -= amt * numExptSns
+		e.numRawCheckpoints -= amt * numRawChkpts * numTrs
+		return e
+	}
+
+	// Capture current state of database tables that will be altered by experiment deletion.
+	currExpts, err := Bun().NewSelect().Table("experiments").Count(ctx)
+	require.NoError(t, err)
+
+	currTrials, err := Bun().NewSelect().Table("trials").Count(ctx)
+	require.NoError(t, err)
+
+	currChkpts, err := Bun().NewSelect().Table("checkpoints_v2").Count(ctx)
+	require.NoError(t, err)
+
+	currMetricsRaw, err := Bun().NewSelect().Table("raw_steps").Count(ctx)
+	require.NoError(t, err)
+
+	currMetricsVal, err := Bun().NewSelect().Table("raw_validations").Count(ctx)
+	require.NoError(t, err)
+
+	currExptSns, err := Bun().NewSelect().Table("experiment_snapshots").Count(ctx)
+	require.NoError(t, err)
+
+	currRawChkpts, err := Bun().NewSelect().Table("raw_checkpoints").Count(ctx)
+	require.NoError(t, err)
+
+	e := expected{
+		numExperiments: currExpts, numTrials: currTrials, numCheckpoints: currChkpts,
+		numMetricsRaw: currMetricsRaw, numMetricsValidation: currMetricsVal,
+		numExperimentSnapshots: currExptSns, numRawCheckpoints: currRawChkpts,
+	}
+
+	verifyData(e)
+
+	require.NoError(t, db.DeleteExperiments(ctx, experimentIDs[:1]))
+	removedExperimentIDs[experimentIDs[0]] = 0
+	removedTrialIDs = addToMap(0, 2, removedTrialIDs, trialIDs)
+	removedCheckpointIDs = addToMap(0, 4, removedCheckpointIDs, checkpointIDs)
+	e = subtractRows(e, 1)
+
+	verifyData(e)
+
+	require.NoError(t, db.DeleteExperiments(ctx, experimentIDs[1:3]))
+	removedExperimentIDs = addToMap(1, 3, removedExperimentIDs, experimentIDs)
+	addToMap(2, 6, removedTrialIDs, trialIDs)
+	addToMap(4, 12, removedCheckpointIDs, checkpointIDs)
+	e = subtractRows(e, 2)
+
+	verifyData(e)
+
+	require.NoError(t, db.DeleteExperiments(ctx, experimentIDs[3:]))
+	removedExperimentIDs[experimentIDs[3]] = 0
+	removedTrialIDs = addToMap(6, 8, removedTrialIDs, trialIDs)
+	removedCheckpointIDs = addToMap(12, 16, removedCheckpointIDs, checkpointIDs)
+	e = subtractRows(e, 1)
+
+	verifyData(e)
 }

--- a/master/static/migrations/20230925175048_exp_add_fkey_on_del_casc.tx.down.sql
+++ b/master/static/migrations/20230925175048_exp_add_fkey_on_del_casc.tx.down.sql
@@ -1,0 +1,43 @@
+/* 
+The following tables:
+
+    * raw_steps
+    * raw_validations
+    * experiment_snapshots
+    * trials 
+    
+all contained foreign key constraints from prior migrations. 
+In order to add `ON DELETE CASCADE` to a previously existing constraint, we remove the constraint from the table
+and add it back with the cascade during its recreation.
+*/
+
+ALTER TABLE raw_steps
+DROP CONSTRAINT steps_trial_id_fkey;
+
+ALTER TABLE raw_steps
+ADD CONSTRAINT steps_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id);
+
+ALTER TABLE raw_validations
+DROP CONSTRAINT raw_validations_trial_id_fkey;
+
+ALTER TABLE raw_validations
+ADD CONSTRAINT raw_validations_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id);
+
+ALTER TABLE experiment_snapshots 
+DROP CONSTRAINT fk_experiment_snapshots_experiments_experiment_id;
+
+ALTER TABLE experiment_snapshots
+ADD CONSTRAINT fk_experiment_snapshots_experiments_experiment_id FOREIGN KEY (experiment_id) REFERENCES experiments(id);
+
+ALTER TABLE trials
+DROP CONSTRAINT trials_experiment_id_fkey;
+
+ALTER TABLE trials
+ADD CONSTRAINT trials_experiment_id_fkey FOREIGN KEY (experiment_id) REFERENCES experiments(id);
+
+ALTER TABLE raw_checkpoints
+DROP CONSTRAINT raw_checkpoints_trial_id_fkey;
+
+ALTER TABLE checkpoints_v2
+DROP CONSTRAINT cp_v2_task_id_fkey;
+

--- a/master/static/migrations/20230925175048_exp_add_fkey_on_del_casc.tx.up.sql
+++ b/master/static/migrations/20230925175048_exp_add_fkey_on_del_casc.tx.up.sql
@@ -1,0 +1,48 @@
+/* 
+The following tables:
+
+    * raw_steps
+    * raw_validations
+    * experiment_snapshots
+    * trials 
+    
+all contained foreign key constraints from prior migrations. 
+In order to add `ON DELETE CASCADE` to a previously existing constraint, we remove the constraint from the table
+and add it back with the cascade during its recreation.
+*/
+
+ALTER TABLE raw_steps
+DROP CONSTRAINT steps_trial_id_fkey;
+
+ALTER TABLE raw_steps
+ADD CONSTRAINT steps_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;
+
+ALTER TABLE raw_validations
+DROP CONSTRAINT raw_validations_trial_id_fkey;
+
+ALTER TABLE raw_validations
+ADD CONSTRAINT raw_validations_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;
+
+ALTER TABLE experiment_snapshots
+DROP CONSTRAINT fk_experiment_snapshots_experiments_experiment_id;
+
+ALTER TABLE experiment_snapshots
+ADD CONSTRAINT fk_experiment_snapshots_experiments_experiment_id FOREIGN KEY (experiment_id) REFERENCES experiments(id)
+ON DELETE CASCADE;
+
+ALTER TABLE trials
+DROP CONSTRAINT trials_experiment_id_fkey;
+
+ALTER TABLE trials
+ADD CONSTRAINT trials_experiment_id_fkey FOREIGN KEY (experiment_id) REFERENCES experiments(id)
+ON DELETE CASCADE;
+
+ALTER TABLE raw_checkpoints
+ADD CONSTRAINT raw_checkpoints_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;
+
+ALTER TABLE checkpoints_v2
+ADD CONSTRAINT cp_v2_task_id_fkey FOREIGN KEY (task_id) REFERENCES trial_id_task_id(task_id)
+ON DELETE CASCADE;


### PR DESCRIPTION
## Description
add `ON DELETE CASCADE` constraint to tables involved in experiment deletion.
Now, experiment deletion can be accomplished with one database call since the delete cascade will clean up child tables that contain the IDs of removed experiments or trials spawned from such experiments. 

The delete cascade was added to the following tables:

- trials (trials)
- checkpoints (checkpoints_v2 and raw_checkpoints)
- training metrics (raw_steps)
- validation metrics (raw_validations)
- experiment snapshots (experiment_snapshots)

addresses the following JIRA ticket: [DET-9463]

## Test Plan
Up migration:
- performed integration testing on `DeleteExperiments()` function by creating 4 experiments each containing trials, checkpoints, and metrics. Removed experiments from the database and checked that corresponding rows for all dependent tables were subsequently deleted with the cascade migration.

Down migration: 
- migrated up to `20230925175048` and observed foreign key constraints with delete cascade added to the database. Then, migrated back down to `20230908153131` and observed the database to see that such constraints were removed.

## Commentary
The following tables:
1. raw_steps
2. raw_validations
3. experiment_snapshots
4. trials 

already contained foreign key constraints from prior migrations. 
In order to add `ON DELETE CASCADE` to a previously existing constraint, we remove the constraint from the table
and add it back with the cascade during its recreation.

## Ticket
DET-9463
Refactor db schema and add `ON DELETE CASCADE` constraints for experiment deletion and experiment, trials, task, and metrics tables.

[DET-9463]: https://hpe-aiatscale.atlassian.net/browse/DET-9463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ