### PR TITLE
fix: fix sorting in GetUsers endpoint

### DIFF
--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -178,9 +178,9 @@ func (a *apiServer) GetUsers(
 	if !ok {
 		return nil, fmt.Errorf("unsupported sort by %s", req.SortBy)
 	}
-	query = query.OrderExpr("? ?", bun.Ident(sortColumn), bun.Safe(orderBy))
+	query.OrderExpr("? ?", bun.Ident(sortColumn), bun.Safe(orderBy))
 	if sortColumn != "id" {
-		query = query.OrderExpr("id asc")
+		query.OrderExpr("id asc")
 	}
 
 	err := query.Scan(ctx)


### PR DESCRIPTION


## Description
This fixes an issue where adding a sort parameter in the `GetUsers` endpoint would result in the endpoint throwing a 500 error. This is because the order expression was invalid due to how bun escapes the input to `Order`. We instead clean up the logic by always ordering by the sort column and only adding the id sort if the other sort didn't add it already.



## Test Plan

hitting `/api/v1/users` with sort parameters should work.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
No ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
