### PR TITLE
feat: new user management filters

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -157,7 +157,12 @@ module.exports = {
         html: true,
       },
     ],
-    'react-hooks/exhaustive-deps': 'error',
+    'react-hooks/exhaustive-deps': [
+      'error',
+      {
+        additionalHooks: 'useAsync',
+      },
+    ],
     'require-await': 'error',
     'semi': ['error', 'always'],
     'sort-imports': [

--- a/webui/react/src/components/Table/Table.tsx
+++ b/webui/react/src/components/Table/Table.tsx
@@ -110,7 +110,7 @@ export const HumanReadableNumberRenderer = (num: number): React.ReactNode => {
 };
 
 export const relativeTimeRenderer = (date: Date): React.ReactNode => {
-  return <TimeAgo className={css.timeAgo} datetime={date} />;
+  return <TimeAgo datetime={date} />;
 };
 
 export const stateRenderer: Renderer<{ state: StateOfUnion }> = (_, record) => (

--- a/webui/react/src/hooks/useAsync.ts
+++ b/webui/react/src/hooks/useAsync.ts
@@ -11,8 +11,8 @@ type LoadablePromiser<T> = (canceler: AbortController) => Promise<T | Loadable<T
  * hook returns the return value wrapped in `Loaded`. If the function returns a
  * `Loadable`, the value isn't wrapped. When any value in the deps array
  * changes, the function is run again as a render effect. If the deps array
- * changes before the async function returns, the older call will not trigger an
- * update on return.
+ * changes before the async function returns, useAsync will discard the results
+ * of the older call.
  * @param loadableFunc (canceler: AbortController) => Promise<T | Loadable<T>>
  * @param deps readonly unknown[]
  * @returns Loadable<T>

--- a/webui/react/src/hooks/useAsync.ts
+++ b/webui/react/src/hooks/useAsync.ts
@@ -1,6 +1,5 @@
+import { Loadable, Loaded, NotLoaded } from 'determined-ui/utils/loadable';
 import { useCallback, useEffect, useInsertionEffect, useRef, useState } from 'react';
-
-import { Loadable, Loaded, NotLoaded } from 'components/kit/utils/loadable';
 
 type LoadablePromiser<T> = (canceler: AbortController) => Promise<T | Loadable<T>>;
 

--- a/webui/react/src/hooks/useLoadable.ts
+++ b/webui/react/src/hooks/useLoadable.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useInsertionEffect, useRef, useState } from 'react';
+
+import { Loadable, Loaded, NotLoaded } from 'components/kit/utils/loadable';
+
+type LoadablePromiser<T> = (canceler: AbortController) => Promise<T | Loadable<T>>;
+export const useLoadable = <T>(
+  loadableFunc: LoadablePromiser<T>,
+  deps: readonly unknown[],
+): Loadable<T> => {
+  const [state, setState] = useState<Loadable<T>>(NotLoaded);
+
+  // funky polyfill for useEffectEvent, which would allow us to mark the
+  // function as non-reactive for the useEffect
+  const funcRef = useRef<LoadablePromiser<T>>(loadableFunc);
+  useInsertionEffect(() => {
+    funcRef.current = loadableFunc;
+  }, [loadableFunc]);
+  const callFunc = useCallback(
+    (canceler: AbortController) => {
+      return funcRef.current(canceler);
+    },
+    [funcRef],
+  );
+
+  useEffect(() => {
+    const internalCanceler = new AbortController();
+    (async () => {
+      const retVal = await callFunc(internalCanceler);
+      if (!internalCanceler.signal.aborted) {
+        setState(Loadable.isLoadable(retVal) ? retVal : Loaded(retVal));
+      }
+    })();
+    return () => {
+      internalCanceler.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [callFunc, ...deps]);
+
+  return state;
+};

--- a/webui/react/src/pages/Admin/UserManagement.module.scss
+++ b/webui/react/src/pages/Admin/UserManagement.module.scss
@@ -8,3 +8,6 @@
 .rightAligned {
   text-align: right;
 }
+.actionBar {
+  margin-bottom: 8px;
+}

--- a/webui/react/src/pages/Admin/UserManagement.settings.ts
+++ b/webui/react/src/pages/Admin/UserManagement.settings.ts
@@ -1,9 +1,8 @@
-import { array, boolean, literal, number, string, undefined as undefinedType, union } from 'io-ts';
+import * as t from 'io-ts';
 
-import { InteractiveTableSettings } from 'components/Table/InteractiveTable';
 import { MINIMUM_PAGE_SIZE } from 'components/Table/Table';
-import { SettingsConfig } from 'hooks/useSettings';
 import { V1GetUsersRequestSortBy } from 'services/api-ts-sdk';
+import { ValueOf } from 'types';
 
 export type UserColumnName =
   | 'action'
@@ -30,68 +29,55 @@ export const DEFAULT_COLUMN_WIDTHS: Record<UserColumnName, number> = {
   modifiedAt: 80,
 };
 
-export interface UserManagementSettings extends InteractiveTableSettings {
-  name?: string;
-  sortDesc: boolean;
-  sortKey: V1GetUsersRequestSortBy;
-}
+export const UserStatus = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;
+export type UserStatus = ValueOf<typeof UserStatus>;
 
-const config: SettingsConfig<UserManagementSettings> = {
-  settings: {
-    columns: {
-      defaultValue: DEFAULT_COLUMNS,
-      skipUrlEncoding: true,
-      storageKey: 'columns',
-      type: array(string),
-    },
-    columnWidths: {
-      defaultValue: DEFAULT_COLUMNS.map((col: UserColumnName) => DEFAULT_COLUMN_WIDTHS[col]),
-      skipUrlEncoding: true,
-      storageKey: 'columnWidths',
-      type: array(number),
-    },
-    name: {
-      defaultValue: undefined,
-      storageKey: 'name',
-      type: union([string, undefinedType]),
-    },
-    row: {
-      defaultValue: undefined,
-      skipUrlEncoding: true,
-      storageKey: 'row',
-      type: union([array(number), array(string), undefinedType]),
-    },
-    sortDesc: {
-      defaultValue: true,
-      storageKey: 'sortDesc',
-      type: boolean,
-    },
-    sortKey: {
-      defaultValue: V1GetUsersRequestSortBy.MODIFIEDTIME,
-      storageKey: 'sortKey',
-      type: union([
-        literal(V1GetUsersRequestSortBy.ACTIVE),
-        literal(V1GetUsersRequestSortBy.ADMIN),
-        literal(V1GetUsersRequestSortBy.DISPLAYNAME),
-        literal(V1GetUsersRequestSortBy.MODIFIEDTIME),
-        literal(V1GetUsersRequestSortBy.UNSPECIFIED),
-        literal(V1GetUsersRequestSortBy.USERNAME),
-        literal(V1GetUsersRequestSortBy.NAME),
-        literal(V1GetUsersRequestSortBy.LASTAUTHTIME),
-      ]),
-    },
-    tableLimit: {
-      defaultValue: MINIMUM_PAGE_SIZE,
-      storageKey: 'tableLimit',
-      type: number,
-    },
-    tableOffset: {
-      defaultValue: 0,
-      storageKey: 'tableOffset',
-      type: number,
-    },
-  },
-  storagePath: 'user-management',
+export const UserRole = {
+  ADMIN: 'admin',
+  MEMBER: 'member',
+} as const;
+export type UserRole = ValueOf<typeof UserRole>;
+
+export const UserManagementSettings = t.intersection([
+  t.type({
+    columns: t.array(t.string),
+    columnWidths: t.array(t.number),
+    sortDesc: t.boolean,
+    tableLimit: t.number,
+    tableOffset: t.number,
+  }),
+  t.partial({
+    name: t.string,
+    roleFilter: t.keyof({
+      [UserRole.ADMIN]: null,
+      [UserRole.MEMBER]: null,
+    }),
+    row: t.union([t.array(t.number), t.array(t.string)]),
+    sortKey: t.keyof({
+      [V1GetUsersRequestSortBy.ACTIVE]: null,
+      [V1GetUsersRequestSortBy.ADMIN]: null,
+      [V1GetUsersRequestSortBy.DISPLAYNAME]: null,
+      [V1GetUsersRequestSortBy.MODIFIEDTIME]: null,
+      [V1GetUsersRequestSortBy.UNSPECIFIED]: null,
+      [V1GetUsersRequestSortBy.USERNAME]: null,
+      [V1GetUsersRequestSortBy.NAME]: null,
+      [V1GetUsersRequestSortBy.LASTAUTHTIME]: null,
+    }),
+    statusFilter: t.keyof({
+      [UserStatus.ACTIVE]: null,
+      [UserStatus.INACTIVE]: null,
+    }),
+  }),
+]);
+export type UserManagementSettings = t.TypeOf<typeof UserManagementSettings>;
+export const DEFAULT_SETTINGS: UserManagementSettings = {
+  columns: DEFAULT_COLUMNS,
+  columnWidths: DEFAULT_COLUMNS.map((col) => DEFAULT_COLUMN_WIDTHS[col]),
+  sortDesc: true,
+  sortKey: V1GetUsersRequestSortBy.MODIFIEDTIME,
+  tableLimit: MINIMUM_PAGE_SIZE,
+  tableOffset: 0,
 };
-
-export default config;

--- a/webui/react/src/pages/Admin/UserManagement.settings.ts
+++ b/webui/react/src/pages/Admin/UserManagement.settings.ts
@@ -43,8 +43,6 @@ export type UserRole = ValueOf<typeof UserRole>;
 
 export const UserManagementSettings = t.intersection([
   t.type({
-    columns: t.array(t.string),
-    columnWidths: t.array(t.number),
     sortDesc: t.boolean,
     tableLimit: t.number,
     tableOffset: t.number,
@@ -74,8 +72,6 @@ export const UserManagementSettings = t.intersection([
 ]);
 export type UserManagementSettings = t.TypeOf<typeof UserManagementSettings>;
 export const DEFAULT_SETTINGS: UserManagementSettings = {
-  columns: DEFAULT_COLUMNS,
-  columnWidths: DEFAULT_COLUMNS.map((col) => DEFAULT_COLUMN_WIDTHS[col]),
   sortDesc: true,
   sortKey: V1GetUsersRequestSortBy.MODIFIEDTIME,
   tableLimit: MINIMUM_PAGE_SIZE,

--- a/webui/react/src/pages/Admin/UserManagement.settings.ts
+++ b/webui/react/src/pages/Admin/UserManagement.settings.ts
@@ -4,13 +4,15 @@ import { MINIMUM_PAGE_SIZE } from 'components/Table/Table';
 import { V1GetUsersRequestSortBy } from 'services/api-ts-sdk';
 import { ValueOf } from 'types';
 
-export type UserColumnName =
-  | 'action'
-  | 'displayName'
-  | 'isActive'
-  | 'isAdmin'
-  | 'modifiedAt'
-  | 'lastAuthAt';
+export const DEFAULT_COLUMN_WIDTHS = {
+  displayName: 170,
+  isActive: 20,
+  isAdmin: 20,
+  lastAuthAt: 30,
+  modifiedAt: 30,
+} as const satisfies Record<string, number>;
+
+export type UserColumnName = keyof typeof DEFAULT_COLUMN_WIDTHS;
 
 export const DEFAULT_COLUMNS: UserColumnName[] = [
   'displayName',
@@ -19,15 +21,6 @@ export const DEFAULT_COLUMNS: UserColumnName[] = [
   'modifiedAt',
   'lastAuthAt',
 ];
-
-export const DEFAULT_COLUMN_WIDTHS: Record<UserColumnName, number> = {
-  action: 20,
-  displayName: 60,
-  isActive: 40,
-  isAdmin: 40,
-  lastAuthAt: 80,
-  modifiedAt: 80,
-};
 
 export const UserStatus = {
   ACTIVE: 'active',
@@ -48,11 +41,6 @@ export const UserManagementSettings = t.intersection([
     tableOffset: t.number,
   }),
   t.partial({
-    name: t.string,
-    roleFilter: t.keyof({
-      [UserRole.ADMIN]: null,
-      [UserRole.MEMBER]: null,
-    }),
     row: t.union([t.array(t.number), t.array(t.string)]),
     sortKey: t.keyof({
       [V1GetUsersRequestSortBy.ACTIVE]: null,
@@ -63,10 +51,6 @@ export const UserManagementSettings = t.intersection([
       [V1GetUsersRequestSortBy.USERNAME]: null,
       [V1GetUsersRequestSortBy.NAME]: null,
       [V1GetUsersRequestSortBy.LASTAUTHTIME]: null,
-    }),
-    statusFilter: t.keyof({
-      [UserStatus.ACTIVE]: null,
-      [UserStatus.INACTIVE]: null,
     }),
   }),
 ]);

--- a/webui/react/src/pages/Admin/UserManagement.settings.ts
+++ b/webui/react/src/pages/Admin/UserManagement.settings.ts
@@ -5,11 +5,12 @@ import { V1GetUsersRequestSortBy } from 'services/api-ts-sdk';
 import { ValueOf } from 'types';
 
 export const DEFAULT_COLUMN_WIDTHS = {
-  displayName: 170,
-  isActive: 20,
-  isAdmin: 20,
-  lastAuthAt: 30,
-  modifiedAt: 30,
+  action: 20,
+  displayName: 120,
+  isActive: 40,
+  isAdmin: 40,
+  lastAuthAt: 50,
+  modifiedAt: 50,
 } as const satisfies Record<string, number>;
 
 export type UserColumnName = keyof typeof DEFAULT_COLUMN_WIDTHS;
@@ -17,9 +18,9 @@ export type UserColumnName = keyof typeof DEFAULT_COLUMN_WIDTHS;
 export const DEFAULT_COLUMNS: UserColumnName[] = [
   'displayName',
   'isActive',
+  'lastAuthAt',
   'isAdmin',
   'modifiedAt',
-  'lastAuthAt',
 ];
 
 export const UserStatus = {

--- a/webui/react/src/pages/Admin/UserManagement.test.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.test.tsx
@@ -11,7 +11,7 @@ import authStore from 'stores/auth';
 import userStore from 'stores/users';
 import { DetailedUser } from 'types';
 
-import UserManagement, { CREATE_USER, USER_TITLE } from './UserManagement';
+import UserManagement, { CREATE_USER } from './UserManagement';
 
 const DISPLAY_NAME = 'Test Name';
 const USERNAME = 'test_username1';
@@ -81,7 +81,6 @@ describe('UserManagement', () => {
     setup();
 
     expect(await screen.findByText(CREATE_USER)).toBeInTheDocument();
-    expect(await screen.findByText(USER_TITLE)).toBeInTheDocument();
 
     expect(await screen.findByText(DISPLAY_NAME)).toBeInTheDocument();
     expect(await screen.findByText(USERNAME)).toBeInTheDocument();

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -185,7 +185,7 @@ const columnSettings = {
 const userManagementSettings = userSettings.get(UserManagementSettings, 'user-management');
 const UserManagement: React.FC = () => {
   const [selectedUserIds, setSelectedUserIds] = useState<React.Key[]>([]);
-  const [refresh, setRefresh] = useState({});
+  const [refresh, setRefresh] = useState<Record<string, never>>({});
   const pageRef = useRef<HTMLElement>(null);
   const loadableSettings = useObservable(userManagementSettings);
   const settings = useMemo(() => {
@@ -230,8 +230,8 @@ const UserManagement: React.FC = () => {
   const users = useMemo(
     () =>
       Loadable.match(userResponse, {
-        Loaded: (r) => r.users,
         _: () => [],
+        Loaded: (r) => r.users,
       }),
     [userResponse],
   );
@@ -260,8 +260,8 @@ const UserManagement: React.FC = () => {
   const groups = useMemo(
     () =>
       Loadable.match(groupsResponse, {
-        Loaded: (g) => g.groups || [],
         _: () => [],
+        Loaded: (g) => g.groups || [],
       }),
     [groupsResponse],
   );
@@ -431,14 +431,7 @@ const UserManagement: React.FC = () => {
       },
     ];
     return rbacEnabled ? columns.filter((c) => c.dataIndex !== 'isAdmin') : columns;
-  }, [
-    fetchUsers,
-    filterIcon,
-    groups,
-    info.userManagementEnabled,
-    rbacEnabled,
-    settings,
-  ]);
+  }, [fetchUsers, filterIcon, groups, info.userManagementEnabled, rbacEnabled, settings]);
 
   return (
     <>

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -22,7 +22,6 @@ import SetUserRolesModalComponent from 'components/SetUserRolesModal';
 import InteractiveTable, { onRightClickableCell } from 'components/Table/InteractiveTable';
 import SkeletonTable from 'components/Table/SkeletonTable';
 import {
-  checkmarkRenderer,
   defaultRowClassName,
   getFullPaginationConfig,
   relativeTimeRenderer,
@@ -376,7 +375,7 @@ const UserManagement: React.FC = () => {
         defaultWidth: DEFAULT_COLUMN_WIDTHS['isActive'],
         key: V1GetUsersRequestSortBy.ACTIVE,
         onCell: onRightClickableCell,
-        render: checkmarkRenderer,
+        render: (isActive: boolean) => <>{isActive ? 'Active' : 'Inactive'}</>,
         sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(a.isActive, b.isActive),
         title: 'Status',
       },
@@ -387,7 +386,7 @@ const UserManagement: React.FC = () => {
         defaultWidth: DEFAULT_COLUMN_WIDTHS['isAdmin'],
         key: V1GetUsersRequestSortBy.ADMIN,
         onCell: onRightClickableCell,
-        render: checkmarkRenderer,
+        render: (isAdmin: boolean) => <>{isAdmin ? 'Admin' : 'Member'}</>,
         sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(a.isAdmin, b.isAdmin),
         title: 'Role',
       },

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -164,12 +164,12 @@ const UserActionDropdown = ({ fetchUsers, user, groups, userManagementEnabled }:
 
 const roleOptions = [
   { label: 'Admin', value: UserRole.ADMIN },
-  { label: 'Member', value: UserRole.MEMBER },
+  { label: 'Non-Admin', value: UserRole.MEMBER },
 ];
 
 const statusOptions = [
-  { label: 'Active', value: UserStatus.ACTIVE },
-  { label: 'Inactive', value: UserStatus.INACTIVE },
+  { label: 'Active Users', value: UserStatus.ACTIVE },
+  { label: 'Deactivated Users', value: UserStatus.INACTIVE },
 ];
 type UserManagementSettingsWithColumns = UserManagementSettings & {
   columns: string[];
@@ -366,7 +366,7 @@ const UserManagement: React.FC = () => {
         sorter: (a: DetailedUser, b: DetailedUser) => {
           return alphaNumericSorter(a.displayName || a.username, b.displayName || b.username);
         },
-        title: 'Name',
+        title: 'User',
       },
       {
         dataIndex: 'isActive',
@@ -443,14 +443,14 @@ const UserManagement: React.FC = () => {
                 <Input
                   allowClear
                   defaultValue={settings.name}
-                  placeholder="Display name or user name"
-                  prefix={<Icon color="cancel" decorative name="search" />}
+                  placeholder="Find user"
+                  prefix={<Icon color="cancel" decorative name="search" size="tiny" />}
                   onChange={handleNameSearchApply}
                 />
                 <Select
                   allowClear
                   options={roleOptions}
-                  placeholder="All roles"
+                  placeholder="All Roles"
                   searchable={false}
                   value={settings.roleFilter}
                   onChange={handleRoleFilterApply}
@@ -458,7 +458,7 @@ const UserManagement: React.FC = () => {
                 <Select
                   allowClear
                   options={statusOptions}
-                  placeholder="All statuses"
+                  placeholder="All Users"
                   searchable={false}
                   value={settings.statusFilter}
                   width={100}

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -33,6 +33,7 @@ import { getGroups, getUsers, patchUsers } from 'services/api';
 import { V1GetUsersRequestSortBy, V1GroupSearchResult, V1OrderBy } from 'services/api-ts-sdk';
 import determinedStore from 'stores/determinedInfo';
 import roleStore from 'stores/roles';
+import userStore from 'stores/users';
 import userSettings from 'stores/userSettings';
 import { DetailedUser } from 'types';
 import handleError, { ErrorType } from 'utils/error';
@@ -186,6 +187,7 @@ const UserManagement: React.FC = () => {
   const [selectedUserIds, setSelectedUserIds] = useState<React.Key[]>([]);
   const [refresh, setRefresh] = useState<Record<string, never>>({});
   const pageRef = useRef<HTMLElement>(null);
+  const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
   const loadableSettings = useObservable(userManagementSettings);
   const settings = useMemo(() => {
     return Loadable.match(loadableSettings, {
@@ -336,8 +338,6 @@ const UserManagement: React.FC = () => {
     setSelectedUserIds([]);
   }, []);
 
-  const filterIcon = useCallback(() => <Icon name="search" size="tiny" title="Search" />, []);
-
   const columns = useMemo(() => {
     const actionRenderer = (_: string, record: DetailedUser) => {
       return (
@@ -430,7 +430,7 @@ const UserManagement: React.FC = () => {
       },
     ];
     return rbacEnabled ? columns.filter((c) => c.dataIndex !== 'isAdmin') : columns;
-  }, [fetchUsers, filterIcon, groups, info.userManagementEnabled, rbacEnabled, settings]);
+  }, [fetchUsers, groups, info.userManagementEnabled, rbacEnabled, settings]);
 
   return (
     <>
@@ -501,6 +501,16 @@ const UserManagement: React.FC = () => {
             })}
             rowClassName={defaultRowClassName({ clickable: false })}
             rowKey="id"
+            rowSelection={{
+              columnWidth: '20px',
+              fixed: true,
+              getCheckboxProps: (record) => ({
+                disabled: record.id === currentUser?.id, // disable the current user not to select onself
+              }),
+              onChange: handleTableRowSelect,
+              preserveSelectedRowKeys: false,
+              selectedRowKeys: selectedUserIds,
+            }}
             settings={settings}
             showSorterTooltip={false}
             size="small"

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -441,6 +441,7 @@ const UserManagement: React.FC = () => {
               <Columns>
                 {/* input is uncontrolled to prevent settings overwriting during composition */}
                 <Input
+                  allowClear
                   defaultValue={settings.name}
                   placeholder="Display name or user name"
                   prefix={<Icon color="cancel" decorative name="search" />}

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -378,7 +378,7 @@ const UserManagement: React.FC = () => {
         onCell: onRightClickableCell,
         render: checkmarkRenderer,
         sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(a.isActive, b.isActive),
-        title: 'Active',
+        title: 'Status',
       },
       {
         dataIndex: 'isAdmin',
@@ -389,7 +389,7 @@ const UserManagement: React.FC = () => {
         onCell: onRightClickableCell,
         render: checkmarkRenderer,
         sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(a.isAdmin, b.isAdmin),
-        title: 'Admin',
+        title: 'Role',
       },
       {
         dataIndex: 'modifiedAt',
@@ -450,6 +450,7 @@ const UserManagement: React.FC = () => {
                 {/* input is uncontrolled to prevent settings overwriting during composition */}
                 <Input
                   defaultValue={settings.name}
+                  placeholder="Display name or user name"
                   prefix={<Icon color="cancel" decorative name="search" />}
                   onChange={handleNameSearchApply}
                 />
@@ -467,6 +468,7 @@ const UserManagement: React.FC = () => {
                   placeholder="All statuses"
                   searchable={false}
                   value={settings.statusFilter}
+                  width={100}
                   onChange={handleStatusFilterApply}
                 />
               </Columns>

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -199,7 +199,7 @@ const UserManagement: React.FC = () => {
         name: settings.name,
         offset: settings.tableOffset,
         orderBy: settings.sortDesc ? V1OrderBy.DESC : V1OrderBy.ASC,
-        sortBy: settings.sortKey || V1GetUsersRequestSortBy.UNSPECIFIED,
+        sortBy: settings.sortKey,
       });
     } catch (e) {
       handleError(e, { publicSubject: 'Could not fetch user search results' });
@@ -425,47 +425,49 @@ const UserManagement: React.FC = () => {
   return (
     <>
       <Section className={css.usersTable}>
-        <Columns>
-          <Column>
-            <Columns>
-              {/* input is uncontrolled to prevent settings overwriting during composition */}
-              <Input
-                defaultValue={settings.name}
-                prefix={<Icon color="cancel" decorative name="search" />}
-                onChange={handleNameSearchApply}
-              />
-              <Select
-                allowClear
-                options={roleOptions}
-                placeholder="All roles"
-                searchable={false}
-                value={settings.roleFilter}
-                onChange={handleRoleFilterApply}
-              />
-              <Select
-                allowClear
-                options={statusOptions}
-                placeholder="All statuses"
-                searchable={false}
-                value={settings.statusFilter}
-                onChange={handleStatusFilterApply}
-              />
-            </Columns>
-          </Column>
-          <Column align="right">
-            {selectedUserIds.length > 0 && (
-              <Dropdown menu={actionDropdownMenu} onClick={handleActionDropdown}>
-                <Button>Actions</Button>
-              </Dropdown>
-            )}
-            <Button
-              aria-label={CREATE_USER_LABEL}
-              disabled={!info.userManagementEnabled || !canModifyUsers}
-              onClick={CreateUserModal.open}>
-              {CREATE_USER}
-            </Button>
-          </Column>
-        </Columns>
+        <div className={css.actionBar}>
+          <Columns>
+            <Column>
+              <Columns>
+                {/* input is uncontrolled to prevent settings overwriting during composition */}
+                <Input
+                  defaultValue={settings.name}
+                  prefix={<Icon color="cancel" decorative name="search" />}
+                  onChange={handleNameSearchApply}
+                />
+                <Select
+                  allowClear
+                  options={roleOptions}
+                  placeholder="All roles"
+                  searchable={false}
+                  value={settings.roleFilter}
+                  onChange={handleRoleFilterApply}
+                />
+                <Select
+                  allowClear
+                  options={statusOptions}
+                  placeholder="All statuses"
+                  searchable={false}
+                  value={settings.statusFilter}
+                  onChange={handleStatusFilterApply}
+                />
+              </Columns>
+            </Column>
+            <Column align="right">
+              {selectedUserIds.length > 0 && (
+                <Dropdown menu={actionDropdownMenu} onClick={handleActionDropdown}>
+                  <Button>Actions</Button>
+                </Dropdown>
+              )}
+              <Button
+                aria-label={CREATE_USER_LABEL}
+                disabled={!info.userManagementEnabled || !canModifyUsers}
+                onClick={CreateUserModal.open}>
+                {CREATE_USER}
+              </Button>
+            </Column>
+          </Columns>
+        </div>
         {settings ? (
           <InteractiveTable<DetailedUser, UserManagementSettings>
             columns={columns}

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -28,7 +28,7 @@ import {
   relativeTimeRenderer,
 } from 'components/Table/Table';
 import UserBadge from 'components/UserBadge';
-import { useLoadable } from 'hooks/useLoadable';
+import { useAsync } from 'hooks/useAsync';
 import usePermissions from 'hooks/usePermissions';
 import { getGroups, getUsers, patchUsers } from 'services/api';
 import { V1GetUsersRequestSortBy, V1GroupSearchResult, V1OrderBy } from 'services/api-ts-sdk';
@@ -190,7 +190,7 @@ const UserManagement: React.FC = () => {
     [],
   );
 
-  const userResponse = useLoadable(async () => {
+  const userResponse = useAsync(async () => {
     try {
       return await getUsers({
         active: settings.statusFilter && settings.statusFilter === UserStatus.ACTIVE,
@@ -205,7 +205,17 @@ const UserManagement: React.FC = () => {
       handleError(e, { publicSubject: 'Could not fetch user search results' });
       return NotLoaded;
     }
-  }, [settings, refresh]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    settings.name,
+    settings.roleFilter,
+    settings.sortDesc,
+    settings.sortKey,
+    settings.statusFilter,
+    settings.tableLimit,
+    settings.tableOffset,
+    refresh,
+  ]);
 
   const users = useMemo(
     () =>
@@ -229,7 +239,7 @@ const UserManagement: React.FC = () => {
     setRefresh({});
   }, [settings, setRefresh]);
 
-  const groupsResponse = useLoadable(async (canceler) => {
+  const groupsResponse = useAsync(async (canceler) => {
     try {
       return await getGroups({ limit: 500 }, { signal: canceler.signal });
     } catch (e) {

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -164,11 +164,13 @@ const UserActionDropdown = ({ fetchUsers, user, groups, userManagementEnabled }:
 };
 
 const roleOptions = [
+  { label: 'All Roles', value: '' },
   { label: 'Admin', value: UserRole.ADMIN },
   { label: 'Non-Admin', value: UserRole.MEMBER },
 ];
 
 const statusOptions = [
+  { label: 'All Statuses', value: '' },
   { label: 'Active Users', value: UserStatus.ACTIVE },
   { label: 'Deactivated Users', value: UserStatus.INACTIVE },
 ];
@@ -186,9 +188,9 @@ const userManagementSettings = userSettings.get(UserManagementSettings, 'user-ma
 const UserManagement: React.FC = () => {
   const [selectedUserIds, setSelectedUserIds] = useState<React.Key[]>([]);
   const [refresh, setRefresh] = useState<Record<string, never>>({});
-  const [nameFilter, setNameFilter] = useState<string | undefined>();
-  const [roleFilter, setRoleFilter] = useState<UserRole | number[] | undefined>();
-  const [statusFilter, setStatusFilter] = useState<UserStatus | undefined>();
+  const [nameFilter, setNameFilter] = useState<string>('');
+  const [roleFilter, setRoleFilter] = useState<UserRole | number[] | ''>('');
+  const [statusFilter, setStatusFilter] = useState<UserStatus | ''>('');
   const pageRef = useRef<HTMLElement>(null);
   const currentUser = Loadable.getOrElse(undefined, useObservable(userStore.currentUser));
   const loadableSettings = useObservable(userManagementSettings);
@@ -207,8 +209,7 @@ const UserManagement: React.FC = () => {
   const userResponse = useAsync(async () => {
     try {
       const params = {
-        active: statusFilter && statusFilter === UserStatus.ACTIVE,
-        admin: roleFilter && roleFilter === UserRole.ADMIN,
+        active: (statusFilter || undefined) && statusFilter === UserStatus.ACTIVE,
         limit: settings.tableLimit,
         name: nameFilter,
         offset: settings.tableOffset,
@@ -220,7 +221,7 @@ const UserManagement: React.FC = () => {
             roleIdAssignedDirectlyToUser: roleFilter,
           }
         : {
-            admin: roleFilter && roleFilter === UserRole.ADMIN,
+            admin: (roleFilter || undefined) && roleFilter === UserRole.ADMIN,
           };
       return await getUsers({
         ...params,
@@ -417,11 +418,7 @@ const UserManagement: React.FC = () => {
         key: V1GetUsersRequestSortBy.LASTAUTHTIME,
         onCell: onRightClickableCell,
         render: (value: number | undefined): React.ReactNode => {
-          return value ? (
-            relativeTimeRenderer(new Date(value))
-          ) : (
-            <div className={css.rightAligned}>N/A</div>
-          );
+          return value ? relativeTimeRenderer(new Date(value)) : 'N/A';
         },
         sorter: (a: DetailedUser, b: DetailedUser) => numericSorter(a.lastAuthAt, b.lastAuthAt),
         title: 'Last Seen',
@@ -455,21 +452,17 @@ const UserManagement: React.FC = () => {
                   onChange={handleNameSearchApply}
                 />
                 <Select
-                  allowClear
                   options={roleOptions}
-                  placeholder="All Roles"
                   searchable={false}
                   value={roleFilter}
-                  width={110}
+                  width={120}
                   onChange={handleRoleFilterApply}
                 />
                 <Select
-                  allowClear
                   options={statusOptions}
-                  placeholder="All Users"
                   searchable={false}
                   value={statusFilter}
-                  width={160}
+                  width={170}
                   onChange={handleStatusFilterApply}
                 />
               </Columns>

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -367,6 +367,7 @@ const UserManagement: React.FC = () => {
         dataIndex: 'displayName',
         defaultSortOrder:
           defaultSortKey === V1GetUsersRequestSortBy.NAME ? defaultSortOrder : undefined,
+        defaultWidth: DEFAULT_COLUMN_WIDTHS['displayName'],
         key: V1GetUsersRequestSortBy.NAME,
         onCell: onRightClickableCell,
         render: (_: string, r: DetailedUser) => <UserBadge user={r} />,
@@ -379,6 +380,7 @@ const UserManagement: React.FC = () => {
         dataIndex: 'isActive',
         defaultSortOrder:
           defaultSortKey === V1GetUsersRequestSortBy.ACTIVE ? defaultSortOrder : undefined,
+        defaultWidth: DEFAULT_COLUMN_WIDTHS['isActive'],
         key: V1GetUsersRequestSortBy.ACTIVE,
         onCell: onRightClickableCell,
         render: (isActive: boolean) => <>{isActive ? 'Active' : 'Inactive'}</>,
@@ -389,6 +391,7 @@ const UserManagement: React.FC = () => {
         dataIndex: 'isAdmin',
         defaultSortOrder:
           defaultSortKey === V1GetUsersRequestSortBy.ADMIN ? defaultSortOrder : undefined,
+        defaultWidth: DEFAULT_COLUMN_WIDTHS['isAdmin'],
         key: V1GetUsersRequestSortBy.ADMIN,
         onCell: onRightClickableCell,
         render: (isAdmin: boolean) => <>{isAdmin ? 'Admin' : 'Member'}</>,
@@ -399,6 +402,7 @@ const UserManagement: React.FC = () => {
         dataIndex: 'modifiedAt',
         defaultSortOrder:
           defaultSortKey === V1GetUsersRequestSortBy.MODIFIEDTIME ? defaultSortOrder : undefined,
+        defaultWidth: DEFAULT_COLUMN_WIDTHS['modifiedAt'],
         key: V1GetUsersRequestSortBy.MODIFIEDTIME,
         onCell: onRightClickableCell,
         render: (value: number): React.ReactNode => relativeTimeRenderer(new Date(value)),
@@ -409,6 +413,7 @@ const UserManagement: React.FC = () => {
         dataIndex: 'lastAuthAt',
         defaultSortOrder:
           defaultSortKey === V1GetUsersRequestSortBy.LASTAUTHTIME ? defaultSortOrder : undefined,
+        defaultWidth: DEFAULT_COLUMN_WIDTHS['lastAuthAt'],
         key: V1GetUsersRequestSortBy.LASTAUTHTIME,
         onCell: onRightClickableCell,
         render: (value: number | undefined): React.ReactNode => {
@@ -424,6 +429,7 @@ const UserManagement: React.FC = () => {
       {
         className: 'fullCell',
         dataIndex: 'action',
+        defaultWidth: 46,
         key: 'action',
         onCell: onRightClickableCell,
         render: actionRenderer,

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -51,7 +51,6 @@ import {
   UserStatus,
 } from './UserManagement.settings';
 
-export const USER_TITLE = 'Users';
 export const CREATE_USER = 'Add User';
 export const CREATE_USER_LABEL = 'add_user';
 

--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -453,6 +453,7 @@ const UserManagement: React.FC = () => {
                   placeholder="All Roles"
                   searchable={false}
                   value={settings.roleFilter}
+                  width={110}
                   onChange={handleRoleFilterApply}
                 />
                 <Select
@@ -461,7 +462,7 @@ const UserManagement: React.FC = () => {
                   placeholder="All Users"
                   searchable={false}
                   value={settings.statusFilter}
-                  width={100}
+                  width={160}
                   onChange={handleStatusFilterApply}
                 />
               </Columns>

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -114,8 +114,18 @@ export const getUsers: DetApi<
     pagination: decoder.mapV1Pagination(response.pagination),
     users: decoder.mapV1UserList(response),
   }),
-  request: (params) =>
-    detApi.Users.getUsers(params.sortBy, params.orderBy, params.offset, params.limit, params.name),
+  request: (params, options) =>
+    detApi.Users.getUsers(
+      params.sortBy,
+      params.orderBy,
+      params.offset,
+      params.limit,
+      params.name,
+      params.active,
+      params.admin,
+      params.roleIdAssignedDirectlyToUser,
+      options,
+    ),
 };
 
 export const getUser: DetApi<Service.GetUserParams, Api.V1GetUserResponse, Type.DetailedUser> = {

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -333,14 +333,11 @@ export interface GetJobQStatsParams extends FetchOptions {
 }
 
 export interface GetUsersParams extends PaginationParams {
+  active?: boolean;
+  admin?: boolean;
   name?: string;
-  sortBy?:
-    | 'SORT_BY_UNSPECIFIED'
-    | 'SORT_BY_USER_NAME'
-    | 'SORT_BY_DISPLAY_NAME'
-    | 'SORT_BY_ADMIN'
-    | 'SORT_BY_ACTIVE'
-    | 'SORT_BY_MODIFIED_TIME';
+  roleIdAssignedDirectlyToUser?: Array<number>;
+  sortBy?: Api.V1GetUsersRequestSortBy;
 }
 export interface GetUserParams {
   userId: number;

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -338,6 +338,7 @@ export interface GetUsersParams extends PaginationParams {
   name?: string;
   roleIdAssignedDirectlyToUser?: Array<number>;
   sortBy?: Api.V1GetUsersRequestSortBy;
+  roleIdAssignedDirectlyToUser?: number[];
 }
 export interface GetUserParams {
   userId: number;

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -336,9 +336,8 @@ export interface GetUsersParams extends PaginationParams {
   active?: boolean;
   admin?: boolean;
   name?: string;
-  roleIdAssignedDirectlyToUser?: Array<number>;
-  sortBy?: Api.V1GetUsersRequestSortBy;
   roleIdAssignedDirectlyToUser?: number[];
+  sortBy?: Api.V1GetUsersRequestSortBy;
 }
 export interface GetUserParams {
   userId: number;


### PR DESCRIPTION


## Description
This updates the user management table to have more and clearer filter functionality. The name filter is extracted out from the header menu into a search bar above the table, and role and status filters are added as well. There's a refactor of the user management table as well -- we've removed the dependency on `useSettings`, instead reading/writing directly from tue user store. In addition, we no longer read the user data from the user store, instead doing filtering and sorting on the backend.

As there are other places where we have this pattern (read-only remote data is requested only when dependent values change), we introduce a new `useLoadable` hook which handles holding the internal state, throwing out stale updates, and setting up cancelers while also allowing us to use the `async/await` style we're used to. The only oddity with the API is that the hook infers its return type from the function passed in -- when handling errors or otherwise indicating that the result shouldn't be loaded, the user has to return `NotLoaded` instead of not returning anything.



## Test Plan

as an admin, go to the users page
observe new filters at the top of the table:
- text box should filter on either username or displayname
- role select should filter on user.admin
- status select should filter on user.active

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[WEB-1642]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1642]: https://hpe-aiatscale.atlassian.net/browse/WEB-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ