### PR TITLE
fix: report searcher progress according to reporting period [MLG-988] 

### DIFF
--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1235,6 +1235,21 @@ class TestPyTorchTrial:
             controller.core_context.train.get_experiment_best_validation.reset_mock()
             controller._checkpoint.reset_mock()
 
+    @mock.patch.object(det.core.DummySearcherOperation, "report_progress")
+    def test_searcher_progress_reporting(self, mock_report_progress: mock.MagicMock):
+        trial, controller = pytorch_utils.create_trial_and_trial_controller(
+            trial_class=pytorch_onevar_model.OneVarTrial,
+            scheduling_unit=10,
+            hparams=self.hparams,
+            trial_seed=self.trial_seed,
+            max_batches=100,
+        )
+        controller.run()
+
+        exp_prog = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+        got_prog = [x.args[0] for x in mock_report_progress.call_args_list]
+        assert exp_prog == got_prog
+
     @pytest.mark.parametrize(
         "ckpt",
         [


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

fix a bug where searcher progress was not being reported according to reporting_period/scheduling_unit



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

submit a pytorch experiment, verify that searcher progress is reported per scheduling_unit in the expconf. in the web UI, the progress bar should update incrementally as training progresses.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
