### PR TITLE
feat: "det notebook|shell|tensorboard open" doesn't error when task not ready

### DIFF
--- a/docs/release-notes/shell-open-bugfix.rst
+++ b/docs/release-notes/shell-open-bugfix.rst
@@ -1,6 +1,5 @@
 :orphan:
 
-**Bug Fixes**
+**Improvements**
 
--  Shells: Fix an issue where running ``det shell start --detach`` then running ``det shell open
-   <shell-id>`` could cause the CLI to hang.
+-  CLI: ``det notebook|shell|tensorboard open <id>`` will now wait for the item to be ready instead of giving an error if it was not ready.

--- a/docs/release-notes/shell-open-bugfix.rst
+++ b/docs/release-notes/shell-open-bugfix.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Shells: Fix an issue where running ``det shell start --detach`` then running ``det shell open
+   <shell-id>`` could cause the CLI to hang.

--- a/docs/release-notes/shell-open-bugfix.rst
+++ b/docs/release-notes/shell-open-bugfix.rst
@@ -2,4 +2,5 @@
 
 **Improvements**
 
--  CLI: ``det notebook|shell|tensorboard open <id>`` will now wait for the item to be ready instead of giving an error if it was not ready.
+-  CLI: ``det notebook|shell|tensorboard open <id>`` will now wait for the item to be ready instead
+   of giving an error if it was not ready.

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -1,14 +1,10 @@
 from pathlib import Path
 
-import pexpect
 import pytest
 
 import determined as det
-from determined.common.api import task_is_ready
 from tests import command as cmd
-from tests.api_utils import determined_test_session
 from tests.cluster.test_users import det_spawn
-from tests.cluster.utils import wait_for_task_state
 
 
 @pytest.mark.slow
@@ -37,17 +33,6 @@ def test_open_shell() -> None:
     with cmd.interactive_command("shell", "start", "--detach") as shell:
         task_id = shell.task_id
         assert task_id is not None
-
-        wait_for_task_state("shell", task_id, "RUNNING")
-
-        # Shell should fail because it is not ready yet it should not hang.
-        child = det_spawn(["shell", "open", task_id])
-        child.expect(pexpect.EOF, timeout=5)
-        child.wait()
-        print(child.exitstatus)
-        assert child.exitstatus != 0
-
-        task_is_ready(determined_test_session(), task_id)
 
         child = det_spawn(["shell", "open", task_id])
         child.setecho(True)

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -1,9 +1,14 @@
 from pathlib import Path
 
+import pexpect
 import pytest
 
 import determined as det
+from determined.common.api import task_is_ready
 from tests import command as cmd
+from tests.api_utils import determined_test_session
+from tests.cluster.test_users import det_spawn
+from tests.cluster.utils import wait_for_task_state
 
 
 @pytest.mark.slow
@@ -25,3 +30,31 @@ def test_start_and_write_to_shell(tmp_path: Path) -> None:
             pytest.fail(
                 f"Did not find expected input {det.__version__} in shell stdout." + lines + "\n"
             )
+
+
+@pytest.mark.e2e_cpu
+def test_open_shell() -> None:
+    with cmd.interactive_command("shell", "start", "--detach") as shell:
+        task_id = shell.task_id
+        assert task_id is not None
+
+        wait_for_task_state("shell", task_id, "RUNNING")
+
+        # Shell should fail because it is not ready yet it should not hang.
+        child = det_spawn(["shell", "open", task_id])
+        child.expect(pexpect.EOF, timeout=5)
+        child.wait()
+        print(child.exitstatus)
+        assert child.exitstatus != 0
+
+        task_is_ready(determined_test_session(), task_id)
+
+        child = det_spawn(["shell", "open", task_id])
+        child.setecho(True)
+        child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.")
+        child.sendline("det user whoami")
+        child.expect("You are logged in as user \\'(.*)\\'", timeout=10)
+        child.sendline("exit")
+        child.read()
+        child.wait()
+        assert child.exitstatus == 0

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -147,7 +147,7 @@ def _open_shell(
     print_only: bool,
 ) -> None:
     task = bindings.get_GetTask(sess, taskId=shell["id"]).task
-    check_eq(len(task.allocations), 1, "Shell must have only one allocation")
+    check_gt(len(task.allocations), 0, "Shell must have at least one allocation")
     check_true(task.allocations[0].isReady, "Shell must be ready")
 
     cache_dir = None

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -19,7 +19,7 @@ from determined import cli
 from determined.cli import command, render, task
 from determined.common import api
 from determined.common.api import authentication, bindings, certs
-from determined.common.check import check_eq, check_true
+from determined.common.check import check_gt, check_true
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
 

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -19,7 +19,7 @@ from determined import cli
 from determined.cli import command, render, task
 from determined.common import api
 from determined.common.api import authentication, bindings, certs
-from determined.common.check import check_eq
+from determined.common.check import check_eq, check_true
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
 
@@ -55,6 +55,7 @@ def start_shell(args: Namespace) -> None:
 
     shell = bindings.get_GetShell(session, shellId=sid).shell
     _open_shell(
+        cli.setup_session(args),
         args.master,
         shell.to_json(),
         args.ssh_opts,
@@ -68,6 +69,7 @@ def open_shell(args: Namespace) -> None:
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     _open_shell(
+        cli.setup_session(args),
         args.master,
         shell,
         args.ssh_opts,
@@ -80,7 +82,14 @@ def open_shell(args: Namespace) -> None:
 def show_ssh_command(args: Namespace) -> None:
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
-    _open_shell(args.master, shell, args.ssh_opts, retain_keys_and_print=True, print_only=True)
+    _open_shell(
+        cli.setup_session(args),
+        args.master,
+        shell,
+        args.ssh_opts,
+        retain_keys_and_print=True,
+        print_only=True,
+    )
 
 
 def _prepare_key(retention_dir: Union[Path, None]) -> Tuple[ContextManager[IO], str]:
@@ -130,14 +139,18 @@ def _prepare_cert_bundle(retention_dir: Union[Path, None]) -> Union[str, bool, N
 
 
 def _open_shell(
+    sess: api.Session,
     master: str,
     shell: Dict[str, Any],
     additional_opts: List[str],
     retain_keys_and_print: bool,
     print_only: bool,
 ) -> None:
+    task = bindings.get_GetTask(sess, taskId=shell["id"]).task
+    check_eq(len(task.allocations), 1, "Shell must have only one allocation")
+    check_true(task.allocations[0].isReady, "Shell must be ready")
+
     cache_dir = None
-    check_eq(shell["state"], "STATE_RUNNING", "Shell must be in a running state")
     if retain_keys_and_print:
         cache_dir = Path(appdirs.user_cache_dir("determined")) / "shell" / shell["id"]
         if not cache_dir.exists():

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -73,7 +73,6 @@ type ResourceManager interface {
 
 	// Job queue
 	GetJobQ(actor.Messenger, sproto.GetJobQ) (map[model.JobID]*sproto.RMJobInfo, error)
-	GetJobQStats(actor.Messenger, sproto.GetJobQStats) (*jobv1.QueueStats, error)
 	GetJobQueueStatsRequest(
 		actor.Messenger,
 		*apiv1.GetJobQueueStatsRequest,

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -73,6 +73,7 @@ type ResourceManager interface {
 
 	// Job queue
 	GetJobQ(actor.Messenger, sproto.GetJobQ) (map[model.JobID]*sproto.RMJobInfo, error)
+	GetJobQStats(actor.Messenger, sproto.GetJobQStats) (*jobv1.QueueStats, error)
 	GetJobQueueStatsRequest(
 		actor.Messenger,
 		*apiv1.GetJobQueueStatsRequest,


### PR DESCRIPTION
## Description

"det notebook|shell|tensorboard open" doesn't error when task not ready and instead waits for the task to be ready.

For notebooks / tensorboards we let the UI be the "waiting" page. For shells we wait in the CLI.

## Test Plan

Open a queued notebook / tensorboard with
```
det notebook|tensorboard open ID
```

and you should get taken to the ui with a queued tag.

Open a killed notebook / tensorboard / shell with and you should get
```
det notebook|tensorboard|shell open ID
Notebook / tensorboard / task has ended 
```

Opening a queued shell should wait in CLI
```
det shell start --detach
det shell open
```


## Commentary (optional)

Notebooks and tensorboards technically do this but the proxy code handles this in a way that is more user friendly than erroring if it is not ready.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
