### PR TITLE
fix: sort files for conflict resolution in sharded checkpoints

### DIFF
--- a/harness/determined/core/_checkpoint.py
+++ b/harness/determined/core/_checkpoint.py
@@ -355,7 +355,8 @@ class CheckpointContext:
     ) -> Dict[str, int]:
         all_conflicts = conflicts.copy()
 
-        for fname in conflicts:
+        # Make sure each rank processes files in the same order.
+        for fname in sorted(conflicts):
             ranks = conflicts[fname]
             if self._dist.rank in ranks:
                 assert ckpt_dir


### PR DESCRIPTION
## Description
Using a new image on the Houston server I noticed that uploading sharded checkpoints fails due to random ordering of files during conflict resolution. In a nutshell, each rank was able to process files in different order and md5 hashes would not match, leading to an error (no wonder). 

It's clear to me that it is a bug in the code, however, I don't understand why the same code is failing consistently with the new image and works equally consistently with either the current det image or one of the older example images. My guess is Pytorch 3.10? Also, I could not reproduce this failure on AWS (with any of the images).


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Test on Houston server.
Use `hf_trainer_api\hf_language_modeling` with  `deepspeed.yaml` config and with the following images:
* open `deepspeed.py` and change `ds_configs/ds_config_stage_1.json` to `ds_configs/ds_config_stage_3.json`
* run with the example image: `gpu: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-0.22.1`
* run with det default image:
  * add `deepspeed` to `requirements.txt`
  * comment out `gpu: ...` in `deepspeed.yaml`
* run with custom image: `gpu: determinedai/environments-dev:python-3.10-pytorch-2.0-deepspeed-0.10.2-smartsim`

Check if all experiments are completed and have a checkpoint.

If Houston server is not up to newest det, you can test it by adding the following line to the startup-hook.sh:
```
sed -i 's/for fname in conflicts:/for fname in sorted(conflicts):/' /run/determined/pythonuserbase/lib/python3.10/site-packages/determined/core/_checkpoint.py
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
