### PR TITLE
refactor: add delete cascade to tables affected by experiment deletion

### DIFF
--- a/master/static/migrations/20231011104015_add-exp-trials-on-del-casc.tx.down.sql
+++ b/master/static/migrations/20231011104015_add-exp-trials-on-del-casc.tx.down.sql
@@ -1,0 +1,43 @@
+/* 
+The following tables:
+
+    * raw_steps
+    * raw_validations
+    * experiment_snapshots
+    * checkpoints_v2
+    * trials 
+    
+all contained foreign key constraints from prior migrations. 
+In order to remove `ON DELETE CASCADE` from a previously existing constraint, we remove the constraint from the table
+and add it back without the cascade during its recreation.
+*/
+
+ALTER TABLE raw_steps
+DROP CONSTRAINT steps_trial_id_fkey;
+
+ALTER TABLE raw_steps
+ADD CONSTRAINT steps_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id);
+
+ALTER TABLE raw_validations
+DROP CONSTRAINT raw_validations_trial_id_fkey;
+
+ALTER TABLE raw_validations
+ADD CONSTRAINT raw_validations_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id);
+
+ALTER TABLE experiment_snapshots 
+DROP CONSTRAINT fk_experiment_snapshots_experiments_experiment_id;
+
+ALTER TABLE experiment_snapshots
+ADD CONSTRAINT fk_experiment_snapshots_experiments_experiment_id FOREIGN KEY (experiment_id) REFERENCES experiments(id);
+
+ALTER TABLE trials
+DROP CONSTRAINT trials_experiment_id_fkey;
+
+ALTER TABLE trials
+ADD CONSTRAINT trials_experiment_id_fkey FOREIGN KEY (experiment_id) REFERENCES experiments(id);
+
+ALTER TABLE checkpoints_v2
+DROP CONSTRAINT checkpoints_v2_task_id_fkey;
+
+ALTER TABLE checkpoints_v2
+ADD CONSTRAINT checkpoints_v2_task_id_fkey FOREIGN KEY (task_id) REFERENCES trial_id_task_id(task_id);

--- a/master/static/migrations/20231011104015_add-exp-trials-on-del-casc.tx.up.sql
+++ b/master/static/migrations/20231011104015_add-exp-trials-on-del-casc.tx.up.sql
@@ -1,0 +1,48 @@
+/* 
+The following tables:
+
+    * raw_steps
+    * raw_validations
+    * experiment_snapshots
+    * checkpoints_v2
+    * trials 
+    
+all contained foreign key constraints from prior migrations. 
+In order to add `ON DELETE CASCADE` to a previously existing constraint, we remove the constraint from the table
+and add it back with the cascade during its recreation.
+*/
+
+ALTER TABLE raw_steps
+DROP CONSTRAINT steps_trial_id_fkey;
+
+ALTER TABLE raw_steps
+ADD CONSTRAINT steps_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;
+
+ALTER TABLE raw_validations
+DROP CONSTRAINT raw_validations_trial_id_fkey;
+
+ALTER TABLE raw_validations
+ADD CONSTRAINT raw_validations_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;
+
+ALTER TABLE experiment_snapshots
+DROP CONSTRAINT fk_experiment_snapshots_experiments_experiment_id;
+
+ALTER TABLE experiment_snapshots
+ADD CONSTRAINT fk_experiment_snapshots_experiments_experiment_id FOREIGN KEY (experiment_id) REFERENCES experiments(id)
+ON DELETE CASCADE;
+
+ALTER TABLE trials
+DROP CONSTRAINT trials_experiment_id_fkey;
+
+ALTER TABLE trials
+ADD CONSTRAINT trials_experiment_id_fkey FOREIGN KEY (experiment_id) REFERENCES experiments(id)
+ON DELETE CASCADE;
+
+ALTER TABLE checkpoints_v2
+DROP CONSTRAINT checkpoints_v2_task_id_fkey;
+
+ALTER TABLE checkpoints_v2
+ADD CONSTRAINT checkpoints_v2_task_id_fkey FOREIGN KEY (task_id) REFERENCES trial_id_task_id(task_id)
+ON DELETE CASCADE;


### PR DESCRIPTION
## Description
add `ON DELETE CASCADE` constraint to tables involved in experiment deletion.
Now, experiment deletion can be accomplished with one database call since the delete cascade will clean up child tables that contain the IDs of removed experiments or trials spawned from such experiments. 

The delete cascade was added to the following tables:
- trials (trials)
- checkpoints (checkpoints_v2)
- training metrics (raw_steps)
- validation metrics (raw_validations)
- experiment snapshots (experiment_snapshots)

addresses the following JIRA ticket: [DET-9463]

## Test Plan
Up migration:
- performed integration testing on `DeleteExperiments()` function by creating 4 experiments each containing trials, checkpoints, and metrics. Removed experiments from the database and checked that corresponding rows for all dependent tables were subsequently deleted with the cascade migration.

Down migration: 
- migrated up to `20230927183238` and observed foreign key constraints with delete cascade added to the database. Then, migrated back down to `20230908153131` and observed the database to see that such constraints were removed.

## Commentary
The following tables:
1. raw_steps
2. raw_validations
3. experiment_snapshots
4. checkpoints_v2
5. trials 

already contained foreign key constraints from prior migrations. 
In order to add `ON DELETE CASCADE` to a previously existing constraint, we remove the constraint from the table
and add it back with the cascade during its recreation.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9463
Refactor db schema and add `ON DELETE CASCADE` constraints for experiment deletion and experiment, trials, task, and metrics tables.

[DET-9463]: https://hpe-aiatscale.atlassian.net/browse/DET-9463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ