### PR TITLE
fix: Modal cannot be closed and reset by stray click [WEB-1691]

### DIFF
--- a/webui/react/src/components/kit/Modal.tsx
+++ b/webui/react/src/components/kit/Modal.tsx
@@ -136,7 +136,7 @@ export const Modal: React.FC<ModalProps> = ({
         </div>
       }
       key={key}
-      maskClosable={true}
+      maskClosable={false}
       open={isOpen}
       title={
         <div className={css.header}>

--- a/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
+++ b/webui/react/src/hooks/useModal/Checkpoint/useModalCheckpointRegister.tsx
@@ -334,7 +334,7 @@ const useModalCheckpointRegister = ({ onClose }: Props = {}): ModalHooks => {
         closable: true,
         content: getModalContent(state),
         icon: null,
-        maskClosable: true,
+        maskClosable: false,
         okButtonProps: { disabled: selectedModelName == null },
         okText: 'Register Checkpoint',
         onCancel: handleCancel,

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -615,7 +615,7 @@ const useModalHyperparameterSearch = ({
         </Form>
       ),
       icon: null,
-      maskClosable: true,
+      maskClosable: false,
       title: 'Hyperparameter Search',
       width: 700,
     };

--- a/webui/react/src/hooks/useModal/useModal.tsx
+++ b/webui/react/src/hooks/useModal/useModal.tsx
@@ -129,7 +129,7 @@ function useModal<T = RecordUnknown>(config: ModalConfig = {}): ModalHooks<T> {
     if (!modalProps || modalProps === prevModalProps) return;
 
     const completeModalProps: ModalFuncProps = {
-      maskClosable: true,
+      maskClosable: false,
       open: true,
       style: { minWidth: 280 },
       ...modalProps,


### PR DESCRIPTION
## Description

As requested in ticket, clicking outside of a modal no longer closes that window. You can close modals by clicking "cancel", the "x" on top, or hitting the Escape key.

Applies to UI Kit component and some older modals, found by searching all instances of `maskClosable`.

## Test Plan

Open an experiment
Use the three-dots menu at right and select Edit
Attempt to close the modal by clicking outside of the modal - it will not work
Successfully close the modal with x, escape, cancel

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.