### PR TITLE
fix: Note UI respects project permissions [WEB-637]

### DIFF
--- a/webui/react/src/components/kit/NoteCards.tsx
+++ b/webui/react/src/components/kit/NoteCards.tsx
@@ -142,7 +142,7 @@ const NoteCards: React.FC<Props> = ({
         description={
           <>
             <p>No notes for this project</p>
-            <Button onClick={handleNewPage}>+ New Note</Button>
+            {!disabled && <Button onClick={handleNewPage}>+ New Note</Button>}
           </>
         }
         icon="document"
@@ -153,9 +153,11 @@ const NoteCards: React.FC<Props> = ({
   return (
     <>
       <div className={css.tabOptions}>
-        <Button type="text" onClick={onNewPage}>
-          + New Note
-        </Button>
+        {!disabled && (
+          <Button type="text" onClick={onNewPage}>
+            + New Note
+          </Button>
+        )}
       </div>
       <div className={css.base}>
         {notes.length > 0 && (

--- a/webui/react/src/pages/ProjectNotes.tsx
+++ b/webui/react/src/pages/ProjectNotes.tsx
@@ -4,6 +4,7 @@ import { useSetDynamicTabBar } from 'components/DynamicTabs';
 import { useModal } from 'components/kit/Modal';
 import Notes from 'components/kit/Notes';
 import ProjectNoteDeleteModalComponent from 'components/ProjectNoteDeleteModal';
+import usePermissions from 'hooks/usePermissions';
 import { addProjectNote, setProjectNotes } from 'services/api';
 import { Note, Project } from 'types';
 import handleError from 'utils/error';
@@ -24,6 +25,9 @@ const ProjectNotes: React.FC<Props> = ({ project, fetchProject }) => {
       handleError(e);
     }
   }, [fetchProject, project?.id]);
+
+  const { canCreateExperiment } = usePermissions();
+  const editPermission = canCreateExperiment({ workspace: { id: project.workspaceId } });
 
   const handleSaveNotes = useCallback(
     async (notes: Note[]) => {
@@ -58,7 +62,7 @@ const ProjectNotes: React.FC<Props> = ({ project, fetchProject }) => {
   return (
     <>
       <Notes
-        disabled={project?.archived}
+        disabled={project?.archived || !editPermission}
         multiple
         notes={project?.notes ?? []}
         onDelete={handleDeleteNote}


### PR DESCRIPTION
## Description

Ticket is from a long time ago, but worth fixing
In the Project Notes section, we should disable UI for adding/deleting notes when the user has only Viewer permission. I had thought to use `canModifyProjects` but this affected OSS users on others' projects, so I chose `canCreateExperiment`
Disabling the project should hide the [+ New Note] button

## Test Plan

The state is the same as archiving a project, so you can mimic this by temporarily archiving a project and browsing notes. Archiving should remove options to add and delete notes.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.