### PR TITLE
fix: nil ptr for Proto() on users who haven't logged in

### DIFF
--- a/master/pkg/model/user.go
+++ b/master/pkg/model/user.go
@@ -128,7 +128,7 @@ func (user *User) UpdatePasswordHash(password string) error {
 
 // Proto converts a user to its protobuf representation.
 func (user *User) Proto() *userv1.User {
-	return &userv1.User{
+	u := &userv1.User{
 		Id:          int32(user.ID),
 		Username:    user.Username,
 		DisplayName: user.DisplayName.ValueOrZero(),
@@ -136,8 +136,11 @@ func (user *User) Proto() *userv1.User {
 		Active:      user.Active,
 		ModifiedAt:  timestamppb.New(user.ModifiedAt),
 		Remote:      user.Remote,
-		LastLogin:   timestamppb.New(*user.LastLogin),
 	}
+	if user.LastLogin != nil {
+		u.LastLogin = timestamppb.New(*user.LastLogin)
+	}
+	return u
 }
 
 // Users is a slice of User objects—primarily useful for its methods.

--- a/master/pkg/model/user_test.go
+++ b/master/pkg/model/user_test.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserNilLastLoginProto(t *testing.T) {
+	u := User{}
+	require.Nil(t, u.Proto().LastLogin)
+}
+
+func TestUserNonNilLastLoginProto(t *testing.T) {
+	expectedTime := time.Now()
+	u := User{LastLogin: &expectedTime}
+	require.Equal(t, expectedTime, u.Proto().LastLogin.AsTime())
+}

--- a/master/pkg/model/user_test.go
+++ b/master/pkg/model/user_test.go
@@ -15,5 +15,5 @@ func TestUserNilLastLoginProto(t *testing.T) {
 func TestUserNonNilLastLoginProto(t *testing.T) {
 	expectedTime := time.Now()
 	u := User{LastLogin: &expectedTime}
-	require.Equal(t, expectedTime, u.Proto().LastLogin.AsTime())
+	require.WithinDuration(t, expectedTime, u.Proto().LastLogin.AsTime(), time.Millisecond)
 }


### PR DESCRIPTION
## Description

Fix a nil ptr exception for users who haven't logged in.

## Test Plan

Unit test

plus rbac test passes here
https://app.circleci.com/pipelines/github/determined-ai/determined-ee/9485/workflows/5e9154ff-a75e-48d2-8479-94762e6b9eae

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
