### PR TITLE
fix: Longer titles on HParam scatter plots [WEB-373]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpHeatMaps.module.scss
@@ -23,4 +23,7 @@
     padding: 12px;
     width: 100%;
   }
+  :global(.u-title) {
+    word-break: break-all;
+  }
 }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.module.scss
@@ -8,4 +8,7 @@
   .container > [class*='Message_base'] {
     height: 400px;
   }
+  :global(.u-title) {
+    word-break: break-all;
+  }
 }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.tsx
@@ -74,7 +74,7 @@ const ScatterPlots: React.FC<Props> = ({
 
     return selectedHParams.reduce((acc, hParam) => {
       const xLabel = hParam;
-      const yLabel = metricToStr(selectedMetric);
+      const yLabel = metricToStr(selectedMetric, 60);
       const title = `${yLabel} (y) vs ${xLabel} (x)`;
       const hpLabels = chartData?.hpLabels[hParam];
       const isLogarithmic = chartData?.hpLogScales[hParam];


### PR DESCRIPTION
## Description

Avoid truncating hyperparameter names on the scatter plot tabs (scatter plot and heat map)

This is an older ticket and Heat Map titles have not been truncated since #3474
For Scatter Plot tab, I doubled the length of a metric name before it is truncated
On both tabs, we want to avoid long titles going over the edge of the chart without wrapping, so I added `word-break: break-all`

## Test Plan

Titles appear correctly on `/det/experiments/1757/visualization/hp-scatter-plots`
You can also use web inspector to increase length of a parameter in the title, leads to a line break

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.