### PR TITLE
test: fix shell open test flake

### DIFF
--- a/e2e_tests/tests/cluster/test_job_queue.py
+++ b/e2e_tests/tests/cluster/test_job_queue.py
@@ -35,6 +35,9 @@ def test_job_queue_adjust_weight() -> None:
         new_weight = jobs.get_job_weight(ordered_ids[1])
         assert new_weight == "10"
     finally:
+        # Avoid leaking experiments even if this test fails.
+        # Leaking experiments can block the cluster and other tests from running other tasks
+        # while the experiments finish.
         exp.kill_experiments(exp_ids)
 
 

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -36,7 +36,7 @@ def test_open_shell() -> None:
 
         child = det_spawn(["shell", "open", task_id])
         child.setecho(True)
-        child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.")
+        child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.", timeout=180)
         child.sendline("det user whoami")
         child.expect("You are logged in as user \\'(.*)\\'", timeout=10)
         child.sendline("exit")


### PR DESCRIPTION
## Description

Fixes test flake 

https://app.circleci.com/pipelines/github/determined-ai/determined/45745/workflows/2915ba9a-92bf-413d-b774-7b2940b3dfb1/jobs/1894469/parallel-runs/3

test_job_queue_adjust_weight was letting an experiment run after the test was completed causing shells take longer to start up.

## Test Plan

CI passes



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
