### PR TITLE
Ft hw failure k8s and agent scheduler constraints

### DIFF
--- a/master/internal/ft/alerts.go
+++ b/master/internal/ft/alerts.go
@@ -1,18 +1,32 @@
 package ft
 
 import (
-	"github.com/determined-ai/determined/master/internal/sproto"
+	"fmt"
+
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 /*
 write through cache the alerts. or nvm just use the db or in memory for first milestone.
 */
 
-// NodeBlacklist returns a list of nodes that should be blacklisted for the given allocation
-func NodeBlacklist(ar *sproto.AllocateRequest) ([]string, error) {
+// DisallowedNodes returns a list of nodes that should be blacklisted for the given allocation
+func DisallowedNodes(taskID model.TaskID) map[string]bool {
+	fmt.Println(taskID)
+
+	return map[string]bool{"agent1": true}
+
 	// maybe just taskid is enough. go off of task id and GetAlerts
-	return nil, nil
+	return nil
 }
+
+/*
+func CanTaskBeOnNode(taskID model.TaskID, agentID string) bool {
+	fmt.Println("CAN TASK BE ON NODE", taskID, agentID)
+	// TODO write through cache.
+	return true
+}
+*/
 
 func UserOwnsTask(userID, taskID string) (bool, error) {
 	return true, nil

--- a/master/internal/ft/alerts.go
+++ b/master/internal/ft/alerts.go
@@ -17,6 +17,7 @@ func DisallowedNodes(taskID model.TaskID) *set.Set[string] {
 
 	s := set.New[string]()
 	s.Insert("agent1")
+	s.Insert("gke-nblaskey-test2-node-pool-name-bae40778-jq79")
 	return &s
 
 	// maybe just taskid is enough. go off of task id and GetAlerts

--- a/master/internal/ft/alerts.go
+++ b/master/internal/ft/alerts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/set"
 )
 
 /*
@@ -11,10 +12,12 @@ write through cache the alerts. or nvm just use the db or in memory for first mi
 */
 
 // DisallowedNodes returns a list of nodes that should be blacklisted for the given allocation
-func DisallowedNodes(taskID model.TaskID) map[string]bool {
+func DisallowedNodes(taskID model.TaskID) *set.Set[string] {
 	fmt.Println(taskID)
 
-	return map[string]bool{"agent1": true}
+	s := set.New[string]()
+	s.Insert("agent1")
+	return &s
 
 	// maybe just taskid is enough. go off of task id and GetAlerts
 	return nil

--- a/master/internal/rm/agentrm/fitting.go
+++ b/master/internal/rm/agentrm/fitting.go
@@ -73,10 +73,6 @@ func findFits(
 	req *sproto.AllocateRequest, agents map[*actor.Ref]*agentState, fittingMethod SoftConstraint,
 	allowHeterogeneousFits bool,
 ) []*fittingState {
-	// TODO: or filter agents by blacklist viability here
-	// constraints := []HardConstraint{agentSlotUnusedSatisfied, agentPermittedSatisfied}
-	// if isViable(req, agent, constraints...) {
-
 	// TODO(DET-4035): Some of this code is duplicated in calculateDesiredNewAgentNum()
 	//    to prevent the provisioner from scaling up for jobs that can never be scheduled in
 	//    the current cluster configuration.

--- a/master/internal/rm/agentrm/fitting_methods.go
+++ b/master/internal/rm/agentrm/fitting_methods.go
@@ -9,7 +9,7 @@ import (
 
 // Hard Constraints
 func agentPermittedSatisfied(req *sproto.AllocateRequest, agent *agentState) bool {
-	return !ft.DisallowedNodes(req.TaskID)[agent.Handler.Address().Local()]
+	return !ft.DisallowedNodes(req.TaskID).Contains(agent.Handler.Address().Local())
 }
 
 func slotsSatisfied(req *sproto.AllocateRequest, agent *agentState) bool {

--- a/master/internal/rm/agentrm/fitting_methods.go
+++ b/master/internal/rm/agentrm/fitting_methods.go
@@ -3,14 +3,13 @@ package agentrm
 import (
 	"fmt"
 
+	"github.com/determined-ai/determined/master/internal/ft"
 	"github.com/determined-ai/determined/master/internal/sproto"
 )
 
 // Hard Constraints
 func agentPermittedSatisfied(req *sproto.AllocateRequest, agent *agentState) bool {
-	// TODO get the blacklist for task and check if agent is blacklisted
-	// blacklist, err := ft.NodeBlacklist(req)
-	return true
+	return !ft.DisallowedNodes(req.TaskID)[agent.Handler.Address().Local()]
 }
 
 func slotsSatisfied(req *sproto.AllocateRequest, agent *agentState) bool {


### PR DESCRIPTION
## Description

Adds a scheduling constraint against ```DisallowedNodes``` in k8s and agents. Doesn't do slurm yet to avoid EE split pain.

## Test Plan

No testing besides manually adding agent IDs to ```DisallowedNodes``` and seeing they don't get scheduled on the nodes.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
