### PR TITLE
chore: allow passing clusterID in master config

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -869,7 +869,7 @@ func (m *Master) Run(ctx context.Context) error {
 	}
 	defer closeWithErrCheck("db", m.db)
 
-	m.ClusterID, err = m.db.GetOrCreateClusterID()
+	m.ClusterID, err = m.db.GetOrCreateClusterID(m.config.Telemetry.ClusterID)
 	if err != nil {
 		return errors.Wrap(err, "could not fetch cluster id from database")
 	}

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -19,7 +19,7 @@ import (
 type DB interface {
 	Migrate(migrationURL string, actions []string) error
 	Close() error
-	GetOrCreateClusterID() (string, error)
+	GetOrCreateClusterID(telemetryID string) (string, error)
 	CheckExperimentExists(id int) (bool, error)
 	CheckTrialExists(id int) (bool, error)
 	TrialExperimentAndRequestID(id int) (int, model.RequestID, error)

--- a/master/internal/db/postgres_cluster.go
+++ b/master/internal/db/postgres_cluster.go
@@ -9,9 +9,13 @@ import (
 )
 
 // GetOrCreateClusterID queries the master uuid in the database, adding one if it doesn't exist.
-func (db *PgDB) GetOrCreateClusterID() (string, error) {
-	newUUID := uuid.New().String()
-
+func (db *PgDB) GetOrCreateClusterID(telemetryID string) (string, error) {
+	var newUUID string
+	if telemetryID != "" {
+		newUUID = telemetryID
+	} else {
+		newUUID = uuid.New().String()
+	}
 	if _, err := db.sql.Exec(`
 INSERT INTO cluster_id (cluster_id) SELECT ($1)
 WHERE NOT EXISTS ( SELECT * FROM cluster_id );

--- a/master/internal/db/postgres_cluster.go
+++ b/master/internal/db/postgres_cluster.go
@@ -9,6 +9,7 @@ import (
 )
 
 // GetOrCreateClusterID queries the master uuid in the database, adding one if it doesn't exist.
+// If a nonempty telemetryID is provided, it will be the one added, otherwise a uuid is generated.
 func (db *PgDB) GetOrCreateClusterID(telemetryID string) (string, error) {
 	var newUUID string
 	if telemetryID != "" {
@@ -33,7 +34,15 @@ WHERE NOT EXISTS ( SELECT * FROM cluster_id );
 			"expecting exactly one cluster_id from cluster_id table, %d values found", len(uuidVal),
 		)
 	}
-	return uuidVal[0], nil
+
+	clusterID := uuidVal[0]
+	if telemetryID != "" && telemetryID != clusterID {
+		log.Warnf(
+			"a telemetry cluster id: %s was provided, but cluster is already initialized with id: %s. ignoring.",
+			telemetryID, clusterID)
+	}
+
+	return clusterID, nil
 }
 
 // UpdateClusterHeartBeat updates the clusterheartbeat column in the cluster_id table.

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -20,7 +20,7 @@ func TestClusterAPI(t *testing.T) {
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
-	_, err := db.GetOrCreateClusterID()
+	_, err := db.GetOrCreateClusterID("")
 	require.NoError(t, err, "failed to get or create cluster id")
 
 	// Add a mock user

--- a/master/internal/mocks/db.go
+++ b/master/internal/mocks/db.go
@@ -706,23 +706,23 @@ func (_m *DB) GetExperimentStatus(experimentID int) (model.State, float64, error
 	return r0, r1, r2
 }
 
-// GetOrCreateClusterID provides a mock function with given fields:
-func (_m *DB) GetOrCreateClusterID() (string, error) {
-	ret := _m.Called()
+// GetOrCreateClusterID provides a mock function with given fields: telemetryID
+func (_m *DB) GetOrCreateClusterID(telemetryID string) (string, error) {
+	ret := _m.Called(telemetryID)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (string, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(telemetryID)
 	}
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(telemetryID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(telemetryID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -57,7 +57,7 @@ func New(
 	}
 
 	// TODO(DET-9833) clusterID should just be a `internal/config` package singleton.
-	clusterID, err := db.GetOrCreateClusterID()
+	clusterID, err := db.GetOrCreateClusterID("")
 	if err != nil {
 		panic(fmt.Errorf("getting clusterID: %w", err))
 	}

--- a/master/pkg/config/telemetry.go
+++ b/master/pkg/config/telemetry.go
@@ -7,4 +7,5 @@ type TelemetryConfig struct {
 	OtelEnabled              bool   `json:"otel_enabled"`
 	OtelExportedOtlpEndpoint string `json:"otel_endpoint"`
 	SegmentWebUIKey          string `json:"segment_webui_key"`
+	ClusterID                string `json:"cluster_id"`
 }


### PR DESCRIPTION
## Description

https://hpe-aiatscale.atlassian.net/browse/SAAS-1374

Allow for passing of `clusterID` in master config. 

If a cluster already has a `clusterID` it is ignored.



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
