### PR TITLE
fix: k8s custom pod spec affinity would get ignored

### DIFF
--- a/docs/release-notes/k8s-affininty-bug-fix.rst
+++ b/docs/release-notes/k8s-affininty-bug-fix.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where task's submitted with custom pod specs would have the custom
+   nodeAffinity ignored.
+
+   Upgrading from a version before this feature to a version after this feature only on Kubernetes
+   can cause queued allocations with a custom pod spec nodeAffinity to be killed. Users can pause
+   queued experiments to avoid this.

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -507,11 +507,11 @@ func (p *pods) dontReattachQueuedPreAgentDisabledPods(
 			if !reflect.DeepEqual(pod.Spec, before.Spec) {
 				p.deleteKubernetesResources(ctx, pods, configMaps)
 				return fmt.Errorf(
-					"unable to restore pod %s since it was queued and does not have "+
+					"unable to restore pod %s since it was queued and does not have the needed "+
 						"Determined's affinity to prevent scheduling on disabled nodes. "+
 						"This is expected to happen on allocations with queued pods "+
-						"when upgrading from before or equal to 0.25.1 "+
-						"to after or equal to 0.26.0", pod.Name)
+						"when upgrading from before 0.25.1 "+
+						"to after or equal to 0.26.1", pod.Name)
 			}
 		}
 	}

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -64,14 +64,11 @@ func TestAddNodeDisabledAffinityToPodSpec(t *testing.T) {
 		actualList := p.Spec.Affinity.
 			NodeAffinity.
 			RequiredDuringSchedulingIgnoredDuringExecution.
-			NodeSelectorTerms
-		expectedItem := k8sV1.NodeSelectorTerm{
-			MatchExpressions: []k8sV1.NodeSelectorRequirement{
-				{
-					Key:      "cluster-id",
-					Operator: k8sV1.NodeSelectorOpDoesNotExist,
-				},
-			},
+			NodeSelectorTerms[0].
+			MatchExpressions
+		expectedItem := k8sV1.NodeSelectorRequirement{
+			Key:      "cluster-id",
+			Operator: k8sV1.NodeSelectorOpDoesNotExist,
 		}
 		require.Contains(t, actualList, expectedItem)
 	}
@@ -105,13 +102,9 @@ func TestAddNodeDisabledAffinityToPodSpec(t *testing.T) {
 	hasDisabledLabel(p)
 	require.Len(t, p.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 7)
 
-	nodeSelectorTerm := k8sV1.NodeSelectorTerm{
-		MatchExpressions: []k8sV1.NodeSelectorRequirement{
-			{
-				Key:      "other-id",
-				Operator: k8sV1.NodeSelectorOpDoesNotExist,
-			},
-		},
+	nodeSelectorTerm := k8sV1.NodeSelectorRequirement{
+		Key:      "other-id",
+		Operator: k8sV1.NodeSelectorOpDoesNotExist,
 	}
 	p = &k8sV1.Pod{
 		Spec: k8sV1.PodSpec{
@@ -119,7 +112,11 @@ func TestAddNodeDisabledAffinityToPodSpec(t *testing.T) {
 				NodeAffinity: &k8sV1.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &k8sV1.NodeSelector{
 						NodeSelectorTerms: []k8sV1.NodeSelectorTerm{
-							nodeSelectorTerm,
+							{
+								MatchExpressions: []k8sV1.NodeSelectorRequirement{
+									nodeSelectorTerm,
+								},
+							},
 						},
 					},
 				},
@@ -131,7 +128,8 @@ func TestAddNodeDisabledAffinityToPodSpec(t *testing.T) {
 	require.Contains(t, p.Spec.Affinity.
 		NodeAffinity.
 		RequiredDuringSchedulingIgnoredDuringExecution.
-		NodeSelectorTerms, nodeSelectorTerm)
+		NodeSelectorTerms[0].
+		MatchExpressions, nodeSelectorTerm)
 }
 
 func TestLaterEnvironmentVariablesGetSet(t *testing.T) {


### PR DESCRIPTION
## Description

We broke custom affinities with  https://github.com/determined-ai/determined/pull/7779

We append the don't schedule onto disabled nodes affinity on this
```
// A node selector represents the union of the results of one or more label queries
// over a set of nodes; that is, it represents the OR of the selectors represented
// by the node selector terms.
type NodeSelector struct {
	//Required. A list of node selector terms. The terms are ORed.
	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms" protobuf:"bytes,1,rep,name=nodeSelectorTerms"`
}
```

This will have broken peoples affinity since it will ORed against the agent being enabled or not which will mostly be true. Fix is to append it a layer down in the requirement arrays here
```
// A null or empty node selector term matches no objects. The requirements of
// them are ANDed.
// The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
type NodeSelectorTerm struct {
	// A list of node selector requirements by node's labels.
	// +optional
	MatchExpressions []NodeSelectorRequirement `json:"matchExpressions,omitempty" protobuf:"bytes,1,rep,name=matchExpressions"`
	// A list of node selector requirements by node's fields.
	// +optional
	MatchFields []NodeSelectorRequirement `json:"matchFields,omitempty" protobuf:"bytes,2,rep,name=matchFields"`
}  
```

This may not always be perfect in all cases but it is the best I think we can do for now.

## Test Plan

Run ```examples/tutorials/mnsit_pytorch/const.yaml``` with this config against a k8s cluster and it shouldn't get scheduled and be stuck in queued.

```
name: mnist_pytorch_const
data:
  url: https://s3-us-west-2.amazonaws.com/determined-ai-test-data/pytorch_mnist.tar.gz
hyperparameters:
  learning_rate: 1.0
  global_batch_size: 64
  n_filters1: 32
  n_filters2: 64
  dropout1: 0.25
  dropout2: 0.5
searcher:
  name: single
  metric: validation_loss
  max_length:
      batches: 937 #60,000 training images with batch size 64
  smaller_is_better: true
entrypoint: model_def:MNistTrial
environment:
  pod_spec:
    apiVersion: v1
    kind: Pod
    metadata:
      labels:
        customLabel: task-specific-label
    spec:
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/hostname
                operator: In
                values:
                - example.com        
```



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
