### PR TITLE
fix: pass final forked config to server for new experiment

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -164,7 +164,7 @@ const ExperimentCreateModalComponent = ({
 
       // Validate the yaml syntax by attempting to load it.
       try {
-        yaml.load(newConfigString);
+        newModalState.config = yaml.load(newConfigString) as RawJson;
         newModalState.configError = undefined;
         newModalState.error = undefined;
       } catch (e) {


### PR DESCRIPTION
## Description

Patches the Fork Experiment / Continue Trial modal, so changes to the full config YAML are POSTed to the server, and not resending the original config

This bug may have come about in #7688 and #7849

## Test Plan

- Fork an experiment, editing the full config YAML to change the description. Verify this in the created experiment
- Fork an experiment, editing `resources.slots_per_trial` in the YAML

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.