### PR TITLE
feat: updating agent user group affects users.modified_at [WEB-1594]

### DIFF
--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -204,6 +204,14 @@ func addAgentUserGroup(
 		return err
 	}
 	_, err := idb.NewInsert().Model(&next).Returning("id").Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = idb.NewUpdate().Table("users").
+		Set("modified_at = NOW()").
+		Where("id = ?", userID).
+		Exec(ctx)
 	return err
 }
 


### PR DESCRIPTION
## Description

Implementing the suggested follow-up from #7665 -  when an agent user group is modified, it should update `users.modified_at`.

A query is added to `addAgentUserGroup`, where User.Update will affect it. The other relevant area of the code, `removeAgentUserGroup`, is called only where it is immediately followed by `addAgentUserGroup`.

## Test Plan

As an admin user, go to `/det/admin/user-management`
To the right of a user row, click the three-dots menu and select Configure Agent
Give the user agent and group a unique name for testing, and submit
The `modified_at` column value the user should update within a few seconds

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.