### PR TITLE
chore: change master config to k8s secret

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
    name: determined-master-config-{{ .Release.Name }}
    namespace: {{ .Release.Namespace }}
    labels:
      app: determined-master-{{ .Release.Name }}
      release: {{ .Release.Name }}
-data:
+stringData:
   master.yaml: |
     log:
       level: {{ .Values.logLevel  | quote | default "info" }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -111,8 +111,8 @@ spec:
       {{- end}}
       volumes:
         - name: master-config
-          configMap:
-            name: determined-master-config-{{ .Release.Name }}
+          secret:
+            secretName: determined-master-config-{{ .Release.Name }}
         {{- if .Values.tlsSecret }}
         - name: tls-secret
           secret:


### PR DESCRIPTION
## Description
We want data, especially credentials, in master-config.yaml in the helm chart to be encrypted. We can do this by changing it from a ConfigMap to a Secret

## Test Plan

Manual Testing with local k8s cluster

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9850
