### PR TITLE
chore(tests): fix data races in grpclog init during integrations

### DIFF
--- a/master/cmd/determined-master/root.go
+++ b/master/cmd/determined-master/root.go
@@ -62,7 +62,7 @@ func runRoot() error {
 	}
 
 	m := internal.New(logStore, config)
-	return m.Run(context.TODO())
+	return m.Run(context.TODO(), nil)
 }
 
 // initializeConfig initializes master config with the validated configuration populated from config

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -608,7 +608,7 @@ func (m *Master) findListeningPort(listener net.Listener) (uint16, error) {
 	return 0, errors.New("listener not found")
 }
 
-func (m *Master) startServers(ctx context.Context, cert *tls.Certificate) error {
+func (m *Master) startServers(ctx context.Context, cert *tls.Certificate, gRPCLogInitDone chan struct{}) error {
 	// Create the base socket listener by either fetching one passed to us from systemd or creating a
 	// TCP listener manually.
 	var baseListener net.Listener
@@ -716,6 +716,11 @@ func (m *Master) startServers(ctx context.Context, cert *tls.Certificate) error 
 	} else {
 		log.Infof("accepting incoming connections on port %d", m.config.Port)
 	}
+
+	if gRPCLogInitDone != nil {
+		close(gRPCLogInitDone)
+	}
+
 	select {
 	case err := <-errs:
 		return err
@@ -854,7 +859,11 @@ func (m *Master) postTaskLogs(c echo.Context) (interface{}, error) {
 }
 
 // Run causes the Determined master to connect the database and begin listening for HTTP requests.
-func (m *Master) Run(ctx context.Context) error {
+//
+// gRPCLogInitDone is closed when the grpclog package's logger singletons are set. This is just
+// used by tests to soothe -race, since we asynchronously launch a gRPC server and connect with a
+// gRPC client, in the same program, using the same singletons.
+func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	log.Infof("Determined master %s (built with %s)", version.Version, runtime.Version())
 
 	var err error
@@ -1215,5 +1224,5 @@ func (m *Master) Run(ctx context.Context) error {
 	webhooks.Init()
 	defer webhooks.Deinit()
 
-	return m.startServers(ctx, cert)
+	return m.startServers(ctx, cert, gRPCLogInitDone)
 }


### PR DESCRIPTION
## Description
Exactly what it says.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Is a test fix.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
part 1 of many
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
