### PR TITLE
chore: support "formData" in swagger bindings parsing

### DIFF
--- a/bindings/swagger_parser.py
+++ b/bindings/swagger_parser.py
@@ -77,13 +77,16 @@ class Parameter:
     name: str
     type: TypeAnno
     required: bool
-    where: typing_extensions.Literal["query", "body", "path", "definitions"]
+    where: typing_extensions.Literal["query", "body", "path", "definitions", "formData"]
     serialized_name: typing.Optional[str] = None
     title: typing.Optional[str] = None
 
     def __post_init__(self):
         # validations
-        assert self.where in ("query", "body", "path", "definitions"), (self.name, self.where)
+        assert self.where in ("query", "body", "path", "definitions", "formData"), (
+            self.name,
+            self.where,
+        )
         assert self.where != "path" or self.required, self.name
         if self.where == "path":
             if not isinstance(self.type, (String, Int)):

--- a/bindings/swagger_parser.py
+++ b/bindings/swagger_parser.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 import typing
 from dataclasses import dataclass, field
@@ -96,6 +97,16 @@ class Parameter:
             if not isinstance(underlying_typ, (String, Int, Bool, DateTime, Float)):
                 if not (isinstance(underlying_typ, Ref) and underlying_typ.url_encodable):
                     raise AssertionError(f"bad type in query parameter {self.name}: {self.type}")
+        if self.where == "formData":
+            logging.warning(
+                f"""The bindings for endpoints that use `formData` are not currently supported!
+
+We need to properly support Multipart FormData
+in our binding generation and requests library before these bindings can be safely used.
+
+This is a temporary workaround. Ticket for fixing this properly: https://hpe-aiatscale.atlassian.net/browse/MLG-1019
+"""
+            )
 
 
 @dataclass


### PR DESCRIPTION
## Description
We are using the swagger generation in lore, and need to support openapi.json that describe endpoints with `formData` as well. This doesn't change anything about the current bindings (which I ran with `make -C proto build && make -C bindings build && make -C master build && make -C proto gen-buf-image`)
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Tests pass. Shouldn't need release party support
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
