### PR TITLE
fix: shell open gives unfriendly message on terminated

### DIFF
--- a/harness/determined/common/api/_util.py
+++ b/harness/determined/common/api/_util.py
@@ -124,12 +124,12 @@ def task_is_ready(
         if len(task.allocations) == 0:
             return False, None
 
+        if task.endTime is not None:
+            return True, "task has been terminated."
+
         is_ready = task.allocations[0].isReady
         if is_ready:
             return True, None
-
-        if task.endTime is not None:
-            return True, "task has been terminated."
 
         return False, ""
 

--- a/harness/determined/common/api/_util.py
+++ b/harness/determined/common/api/_util.py
@@ -121,12 +121,11 @@ def task_is_ready(
         if progress_report:
             progress_report()
         assert task is not None, "task must be present."
-        if len(task.allocations) == 0:
-            return False, None
-
         if task.endTime is not None:
             return True, "task has been terminated."
 
+        if len(task.allocations) == 0:
+            return False, None
         is_ready = task.allocations[0].isReady
         if is_ready:
             return True, None


### PR DESCRIPTION
## Description

Fix an issue where terminated shells would give a verbose error message like

```
shell (id: fcace6b5-5ea4-4cd3-a390-1a12500a600f) is ready.
disconnecting websocket
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/Users/garrett/miniforge3/envs/det/lib/python3.9/threading.py", line 980, in _bootstrap_inner
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
To reconnect, run: det shell open fcace6b5-5ea4-4cd3-a390-1a12500a600f
```

## Test Plan

Start and kill a shell then try to open it

We should expect the message to be this
```
det shell open $ID
CLI version 0.26.1-dev0 is less than master version 0.26.1-rc0. Consider upgrading the CLI.
Waiting stopped: task has been terminated.                                      
task has been terminated.
```


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
