### PR TITLE
fix: Experiment name settable in fork config

### DIFF
--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -134,7 +134,9 @@ const ExperimentCreateModalComponent = ({
     setModalState((prev) => {
       if (prev.error) return { ...prev, error: undefined };
       const values = form.getFieldsValue();
-      prev.config.name = values[EXPERIMENT_NAME];
+      if (!prev.isAdvancedMode) {
+        prev.config.name = values[EXPERIMENT_NAME];
+      }
       if (values[MAX_LENGTH]) {
         const maxLengthType = getMaxLengthType(prev.config);
         if (maxLengthType) {
@@ -213,9 +215,6 @@ const ExperimentCreateModalComponent = ({
       const formValues = form.getFieldsValue();
       const newConfig = structuredClone(config);
 
-      if (formValues[EXPERIMENT_NAME]) {
-        newConfig.name = formValues[EXPERIMENT_NAME];
-      }
       if (formValues[MAX_LENGTH]) {
         const maxLengthType = getMaxLengthType(newConfig);
         if (maxLengthType === undefined) {


### PR DESCRIPTION
## Description

As discussed during release party, editing experiment YAML config during forking gets overwritten by the Name field

This change makes that field, and the YAML name field, unified and applied to the new experiment.

## Test Plan

- Find a simple experiment and select the Fork button. Rename the experiment while forking it. Name passes to new experiment
- Open the experiment fork modal, and rename the experiment in Simple Mode. Change to Advanced Mode and confirm that the YAML name field was changed by your renaming. Give the experiment a new name, then toggle back to Simple Mode to see the change is copied over to the form
- Return to Advanced Mode and set the name again. Complete forking the experiment, and confirm name passes to new experiment.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.