### PR TITLE
fix: Metric type is blank in comparison chart

### DIFF
--- a/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
+++ b/webui/react/src/pages/F_ExpList/CompareMetrics.tsx
@@ -45,7 +45,7 @@ const CompareMetrics: React.FC<Props> = ({ selectedExperiments, trials, metricDa
           series.push({
             ...m[key],
             color: colorMap[t.experimentId],
-            metricType: undefined,
+            metricType: '',
             name: expNameById[t.experimentId]
               ? `${expNameById[t.experimentId]} (${t.experimentId})`
               : String(t.experimentId),


### PR DESCRIPTION
## Description

On the ExperimentList, when comparing metrics between experiments, the metrics are being labeled "unknown.ExperimentName"

We send `metricType: undefined` but this gets replaced by 'unknown' in the code: `s.metricType ?? 'unknown'`
Instead we should send an empty string.

<img width="355" alt="Screen Shot 2023-10-05 at 2 15 45 PM" src="https://github.com/determined-ai/determined/assets/643918/7af30cdf-47db-43f0-9188-76969ce7ce53">


Related to: #7727 #7809 

## Test Plan

On `/det/projects/107/experiments`, check multiple experiments and open the Compare tab

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.