### PR TITLE
fix: ignore `last_auth_at` to update `modified_at` on users table

### DIFF
--- a/master/static/migrations/20231006105547_update-modified-at-for-certain-columns-on-users-table.tx.up.sql
+++ b/master/static/migrations/20231006105547_update-modified-at-for-certain-columns-on-users-table.tx.up.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER IF EXISTS autoupdate_users_modified_at ON users;
+
+CREATE TRIGGER autoupdate_users_modified_at
+  BEFORE INSERT OR UPDATE OF password_hash, admin, active, display_name, remote ON public.users
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.set_modified_time();


### PR DESCRIPTION
## Description
fix for https://github.com/determined-ai/release-party-issues/issues/786#issuecomment-1749503941

When `last_auth_at` is updated, trigger should ignore the change
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Check if `modified_at` column is updated only when one or more of `password_hash`, `admin`, `active`, `display_name`, `remote` column(s) are changed. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
