### PR TITLE
chore: make agent.yaml readable by default

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -68,7 +68,7 @@ nfpms:
         dst: "/etc/determined/agent.yaml"
         type: config|noreplace
         file_info:
-            mode: 0600
+            mode: 0644
       - src: "packaging/determined-agent.service"
         dst: "/lib/systemd/system/determined-agent.service"
 


### PR DESCRIPTION
## Description

FE-224. Allow the default /etc/determined/agent.yaml read access.

The released default agent.yaml file does not allow non-root user read access. determined-agent command failed to start:

-rw-------   1 root    root      592 Sep 11 18:49 agent.yaml

```
determined-agent --master-host=localhost --master-port=8080 --container-runtime  singularity

FATA[2023-09-21T14:34:45Z] fatal error running Determined agent          error="error reading configuration file: open /etc/determined/agent.yaml: permission denied"
```

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
