### PR TITLE
fix: Single point chart avoids issue with axis ranges

### DIFF
--- a/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
+++ b/webui/react/src/components/kit/internal/UPlot/SyncProvider.tsx
@@ -63,8 +63,10 @@ class SyncService {
     if (chartMin === undefined || chartMax === undefined) return;
 
     this.bounds.update((b) => {
-      const resetAxis = axis !== this.axis;
-      this.axis = axis;
+      const resetAxis = axis !== this.axis && !!axis && !!this.axis;
+      if (axis) {
+        this.axis = axis;
+      }
 
       const previousMin =
         b.dataBounds?.min !== undefined && isFinite(b.dataBounds?.min) && !resetAxis


### PR DESCRIPTION
## Description

This is based on a community-reported issue.

When we have a mix of experiments with some shared continuous metrics, and some single-point metrics at a much higher batch number,
This gives us a visible issue where the x-axis does not expand to contain the single-point metrics. The x-axis range is being reset between charts between `"batches"` and `undefined`.

The proposed change avoids ever setting `this.axis` to undefined, or `resetAxis` to true based on an undefined value.

## Test Plan

With latest-main as the backend (i.e. `make live`)
- On `/det/projects/1/experiments`, open the compare view and select experiment "wryyyyy" (id = 3763)
- Confirm chart x-axis has up to 200,000 batches; scroll up and down to see single-point and multi-point charts
- Select another experiment (I'm using id=4423, a nearby experiment based on cifar); you should see two lines on some charts, and single-point on other charts

<img width="661" alt="Screen Shot 2023-10-09 at 10 37 43 AM" src="https://github.com/determined-ai/determined/assets/643918/3cf27c06-2d34-4d64-b9d0-5f26e55cc46c">
<img width="661" alt="Screen Shot 2023-10-09 at 10 37 50 AM" src="https://github.com/determined-ai/determined/assets/643918/f77564a9-e2cc-4efd-8f4d-3422794b2338">

- Switch x-axis domain to time and back to batches. This doesn't look super great for these experiments with different timestamps, but checks that x-axis matches domain (i.e. does not use min/max batch to expect Unix time 0 - 200,000)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.