### PR TITLE
chore: Deprecate Trial.logs in favor of Trial.iter_logs

### DIFF
--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import inspect
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -85,6 +86,7 @@ class Trial:
         self.state: Optional[TrialState] = None
 
     def logs(self, *args: Any, **kwargs: Any) -> Iterable[str]:
+        """DEPRECATED: Use iter_logs instead."""
         warnings.warn(
             "Trial.logs() has been deprecated and will be removed in a future version."
             "Please call Trial.iter_logs() instead.",
@@ -184,6 +186,8 @@ class Trial:
             search_text=search_text,
         ):
             yield log.message
+
+    logs.__signature__ = inspect.signature(iter_logs)
 
     def kill(self) -> None:
         bindings.post_KillTrial(self._session, id=self.id)

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -84,7 +84,16 @@ class Trial:
         self.summary_metrics: Optional[Dict[str, Any]] = None
         self.state: Optional[TrialState] = None
 
-    def logs(
+    def logs(self, *args: Any, **kwargs: Any) -> Iterable[str]:
+        warnings.warn(
+            "Trial.logs() has been deprecated and will be removed in a future version."
+            "Please call Trial.iter_logs() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self.iter_logs(*args, **kwargs)
+
+    def iter_logs(
         self,
         follow: bool = False,
         *,

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -85,16 +85,6 @@ class Trial:
         self.summary_metrics: Optional[Dict[str, Any]] = None
         self.state: Optional[TrialState] = None
 
-    def logs(self, *args: Any, **kwargs: Any) -> Iterable[str]:
-        """DEPRECATED: Use iter_logs instead."""
-        warnings.warn(
-            "Trial.logs() has been deprecated and will be removed in a future version."
-            "Please call Trial.iter_logs() instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.iter_logs(*args, **kwargs)
-
     def iter_logs(
         self,
         follow: bool = False,
@@ -187,7 +177,18 @@ class Trial:
         ):
             yield log.message
 
-    logs.__signature__ = inspect.signature(iter_logs)
+    def logs(self, *args: Any, **kwargs: Any) -> Iterable[str]:
+        """DEPRECATED: Use iter_logs instead."""
+        warnings.warn(
+            "Trial.logs() has been deprecated and will be removed in a future version."
+            "Please call Trial.iter_logs() instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self.iter_logs(*args, **kwargs)
+
+    # type-checking suppression can be removed when mypy issue #12472 is resolved (or logs removed)
+    logs.__signature__ = inspect.signature(iter_logs)  # type: ignore
 
     def kill(self) -> None:
         bindings.post_KillTrial(self._session, id=self.id)


### PR DESCRIPTION
This renaming makes `logs` more consistent with the emerging `get_*` / `list_*` / `iter_*` standard.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
