### PR TITLE
fix: DET_CERT_MASTER_FILE=noverify det shell open

### DIFF
--- a/harness/determined/cli/proxy.py
+++ b/harness/determined/cli/proxy.py
@@ -36,14 +36,15 @@ class CustomSSLWebsocketSession(lomond.session.WebsocketSession):  # type: ignor
     ) -> None:
         super().__init__(socket)
         self.ctx = ssl.create_default_context()
-        if cert_file == "False" or cert_file is False:
+        self.cert_name = cert_name
+        if cert_file is False:
+            self.ctx.check_hostname = False
             self.ctx.verify_mode = ssl.CERT_NONE
             return
 
         if cert_file is not None:
             assert isinstance(cert_file, str)
             self.ctx.load_verify_locations(cafile=cert_file)
-        self.cert_name = cert_name
 
     def _wrap_socket(self, sock: socket.SocketType, host: str) -> socket.SocketType:
         return self.ctx.wrap_socket(sock, server_hostname=self.cert_name or host)

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -163,9 +163,15 @@ def _open_shell(
         proxy_cmd = f"{sys.executable} -m determined.cli.tunnel {master} %h"
 
         cert_bundle_path = _prepare_cert_bundle(cache_dir)
-        if cert_bundle_path is not None:
-            assert isinstance(cert_bundle_path, str), cert_bundle_path
+        if cert_bundle_path is False:
+            proxy_cmd += " --cert-file noverify"
+        elif isinstance(cert_bundle_path, str):
             proxy_cmd += f' --cert-file "{cert_bundle_path}"'
+        elif cert_bundle_path is not None:
+            raise RuntimeError(
+                f"unexpected cert_bundle_path ({cert_bundle_path}) "
+                f"of type ({type(cert_bundle_path).__name__})"
+            )
 
         cert = certs.cli_cert
         assert cert is not None, "cli_cert was not configured"

--- a/harness/determined/cli/tunnel.py
+++ b/harness/determined/cli/tunnel.py
@@ -26,11 +26,14 @@ if __name__ == "__main__":
         auth = authentication.Authentication(args.master_addr, args.user)
         authorization_token = auth.get_session_token(must=True)
 
+    # The special string "noverify" is passed to our certs.Cert object as a boolean False.
+    cert_file = False if args.cert_file == "noverify" else args.cert_file
+
     if args.listener:
         with http_tunnel_listener(
             args.master_addr,
             [ListenerConfig(service_id=args.service_uuid, local_port=args.listener)],
-            args.cert_file,
+            cert_file,
             args.cert_name,
             authorization_token,
         ):
@@ -38,5 +41,5 @@ if __name__ == "__main__":
                 time.sleep(1)
     else:
         http_connect_tunnel(
-            args.master_addr, args.service_uuid, args.cert_file, args.cert_name, authorization_token
+            args.master_addr, args.service_uuid, cert_file, args.cert_name, authorization_token
         )


### PR DESCRIPTION
## Commentary

As reported by @varlogtim.

## Test plan

- [ ] set up a master with an untrusted self-signed certificate, then run `DET_MASTER_CERT_FILE=noverify det shell start` and make sure it works.