### PR TITLE
docs: redirects.py moves subdirectories properly

### DIFF
--- a/docs/redirects.py
+++ b/docs/redirects.py
@@ -130,11 +130,11 @@ def rename_one(links, published, fullsrc, fulldst):
 
 def rename_into(links, published, src, dst, drop_src_root=False):
     """
-    Implement renaming many things into a directory.
+    Rename many things into a directory.
 
     drop_src_root=True indicates a `mv thing newdir/`, where `thing` isn't going to appear in the
     final destination path for any elements of `thing/`, because it will be called `newdir/`
-    isntead.
+    instead.
     """
     if not os.path.isdir(src):
         # src=basepath/base.rst, dst=dstpath/dst
@@ -149,10 +149,12 @@ def rename_into(links, published, src, dst, drop_src_root=False):
             # fulldst=dstpath/dst/[base/]a/b/c/d
             fullsrc = os.path.relpath(os.path.join(root, file), start=HERE)
             if drop_src_root:
+                # The fulldst=dstpath/dst/a/b/c/d case (remove basepath/base/).
                 relsrc = os.path.relpath(fullsrc, start=src)
-                fulldst = os.path.join(dst, relsrc)
             else:
-                fulldst = os.path.join(dst, fullsrc)
+                # The fulldst=dstpath/dst/base/a/b/c/d case (remove just basepath/).
+                relsrc = os.path.relpath(fullsrc, start=os.path.dirname(src))
+            fulldst = os.path.join(dst, relsrc)
             links = rename_one(links, published, fullsrc, fulldst)
     return links
 


### PR DESCRIPTION
There was a bug in rename_into where when renaming a directory called a/b into a directory c/, we would redirect to c/a/b instead of c/b.

## Test Plan

- [x] `./redirects.py mv setup-cluster/deploy-cluster/* setup-cluster` should not puke