### PR TITLE
chore: update metrics documentation

### DIFF
--- a/docs/reference/python-sdk.rst
+++ b/docs/reference/python-sdk.rst
@@ -59,7 +59,7 @@ Now that the experiment has completed, you can grab the top-performing checkpoin
 ==========
 
 .. automodule:: determined.experimental.client
-   :members: login, create_experiment, get_experiment, get_trial, get_checkpoint, create_model, get_model, get_models, stream_trials_metrics, stream_trials_training_metrics, stream_trials_validation_metrics
+   :members: login, create_experiment, get_experiment, get_trial, get_checkpoint, create_model, get_model, get_models, stream_trials_metrics
    :member-order: bysource
 
 ``Checkpoint``
@@ -123,18 +123,10 @@ Now that the experiment has completed, you can grab the top-performing checkpoin
 
 .. autoclass:: determined.experimental.client.TrialReference
    :members:
+   :exclude-members: stream_training_metrics, stream_validation_metrics
    :member-order: bysource
 
-``TrainingMetrics``
+``TrialMetrics``
 ===================
 
-.. autoclass:: determined.experimental.client.TrainingMetrics
-   :members:
-   :member-order: bysource
-
-``ValidationMetrics``
-=====================
-
-.. autoclass:: determined.experimental.client.ValidationMetrics
-   :members:
-   :member-order: bysource
+.. autoclass:: determined.experimental.client.TrialMetrics

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -423,15 +423,13 @@ class Determined:
 
         Arguments:
             trial_ids: The trial IDs to stream metrics for.
-            group: The metric group to stream.  Valid values are "validation" and "training".
+            group: The metric group to stream.  Common values are "validation" and "training", but
+                group can be any value passed to master when reporting metrics during training
+                (usually via a context's `report_metrics`).
 
         Returns:
             An iterable of :class:`~determined.experimental.TrialMetrics` objects.
         """
-        if group not in ("training", "validation"):
-            raise ValueError(
-                f"Invalid metric group: {group}. Valid values are 'training' and 'validation'"
-            )
         return trial._stream_trials_metrics(self._session, trial_ids, group=group)
 
     def stream_trials_training_metrics(

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -419,39 +419,47 @@ class Determined:
     def stream_trials_metrics(
         self, trial_ids: List[int], group: str
     ) -> Iterable[metrics.TrialMetrics]:
-        """
-        Streams metrics for one or more trials sorted by
-        trial_id, trial_run_id and steps_completed.
+        """Get a stream of metrics for this trial.
 
         Arguments:
-            trial_ids: List of trial IDs to get metrics for.
+            trial_ids: The trial IDs to stream metrics for.
+            group: The metric group to stream.  Valid values are "validation" and "training".
+
+        Returns:
+            An iterable of :class:`~determined.experimental.TrialMetrics` objects.
         """
+        if group not in ("training", "validation"):
+            raise ValueError(
+                f"Invalid metric group: {group}. Valid values are 'training' and 'validation'"
+            )
         return trial._stream_trials_metrics(self._session, trial_ids, group=group)
 
     def stream_trials_training_metrics(
         self, trial_ids: List[int]
     ) -> Iterable[metrics.TrainingMetrics]:
-        """
-        @deprecated: Use stream_trials_metrics instead with `group` set to "training"
+        """Streams training metrics for this trial.
 
-        Streams training metrics for one or more trials sorted by
-        trial_id, trial_run_id and steps_completed.
-
-        Arguments:
-            trial_ids: List of trial IDs to get metrics for.
+        DEPRECATED: Use stream_metrics instead with `group` set to "training"
         """
+        warnings.warn(
+            "Trial.stream_training_metrics is deprecated."
+            "Use Trial.stream_metrics instead with `group` set to 'training'",
+            FutureWarning,
+            stacklevel=2,
+        )
         return trial._stream_training_metrics(self._session, trial_ids)
 
     def stream_trials_validation_metrics(
         self, trial_ids: List[int]
     ) -> Iterable[metrics.ValidationMetrics]:
-        """
-        @deprecated: Use stream_trials_metrics instead with `group` set to "validation"
+        """Streams validation metrics for this trial.
 
-        Streams validation metrics for one or more trials sorted by
-        trial_id, trial_run_id and steps_completed.
-
-        Arguments:
-            trial_ids: List of trial IDs to get metrics for.
+        DEPRECATED: Use stream_metrics instead with `group` set to "validation"
         """
+        warnings.warn(
+            "Trial.stream_validation_metrics is deprecated."
+            "Use Trial.stream_metrics instead with `group` set to 'validation'",
+            FutureWarning,
+            stacklevel=2,
+        )
         return trial._stream_validation_metrics(self._session, trial_ids)

--- a/harness/determined/common/experimental/metrics.py
+++ b/harness/determined/common/experimental/metrics.py
@@ -14,9 +14,13 @@ class TrialMetrics:
         trial_id: The ID of the trial that reported the metric.
         trial_run_id: The ID of the trial run that reported the metric.
         steps_completed: The number of steps that the trial had completed when the metric was
-            reported.
+            reported. Most generally, the value passed to a call to report_metrics as
+            "steps_completed."
         end_time: The time when the metric was reported.
         metrics: A dict of metrics that the trial reported.
+        group: The group that the metric was reported under. Usually either "validation" or
+            "training", but this can be any value passed to master when reporting metrics during
+            training (usually via a context's `report_metrics`).
         batch_metrics: <do not use>
     """
 

--- a/harness/determined/common/experimental/metrics.py
+++ b/harness/determined/common/experimental/metrics.py
@@ -8,16 +8,16 @@ from determined.common.api import bindings
 
 @dataclasses.dataclass
 class TrialMetrics:
-    """
-    Specifies a metric that the trial reported.
+    """Specifies a metric that the trial reported.
 
     Attributes:
-        trial_id
-        trial_run_id
-        steps_completed
-        end_time
-        metrics
-        batch_metrics
+        trial_id: The ID of the trial that reported the metric.
+        trial_run_id: The ID of the trial run that reported the metric.
+        steps_completed: The number of steps that the trial had completed when the metric was
+            reported.
+        end_time: The time when the metric was reported.
+        metrics: A dict of metrics that the trial reported.
+        batch_metrics: A dict of metrics that the trial reported for each batch.
     """
 
     trial_id: int

--- a/harness/determined/common/experimental/metrics.py
+++ b/harness/determined/common/experimental/metrics.py
@@ -8,7 +8,7 @@ from determined.common.api import bindings
 
 @dataclasses.dataclass
 class TrialMetrics:
-    """Specifies a metric that the trial reported.
+    """Specifies collection of metrics that the trial reported.
 
     Attributes:
         trial_id: The ID of the trial that reported the metric.
@@ -17,7 +17,7 @@ class TrialMetrics:
             reported.
         end_time: The time when the metric was reported.
         metrics: A dict of metrics that the trial reported.
-        batch_metrics: A dict of metrics that the trial reported for each batch.
+        batch_metrics: <do not use>
     """
 
     trial_id: int

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -1,4 +1,5 @@
 import enum
+import warnings
 from typing import Any, Iterable, List, Optional, Union
 
 from determined.common import api
@@ -289,28 +290,46 @@ class TrialReference:
         return "Trial(id={})".format(self.id)
 
     def stream_metrics(self, group: str) -> Iterable[metrics.TrialMetrics]:
+        """Get a stream of metrics for this trial.
+
+        Arguments:
+            group: The metric group to stream.  Valid values are "validation" and "training".
+
+        Returns:
+            An iterable of :class:`~determined.experimental.TrialMetrics` objects.
         """
-        Streams metrics for this trial sorted by
-        trial_id, trial_run_id and steps_completed.
-        """
+        if group not in ("training", "validation"):
+            raise ValueError(
+                f"Invalid metric group: {group}. Valid values are 'training' and 'validation'"
+            )
+
         return _stream_trials_metrics(self._session, [self.id], group=group)
 
     def stream_training_metrics(self) -> Iterable[metrics.TrainingMetrics]:
-        """
-        @deprecated: Use stream_metrics instead with `group` set to "training"
+        """Streams training metrics for this trial.
 
-        Streams training metrics for this trial sorted by
-        trial_id, trial_run_id and steps_completed.
+        DEPRECATED: Use stream_metrics instead with `group` set to "training"
         """
+        warnings.warn(
+            "Trial.stream_training_metrics is deprecated."
+            "Use Trial.stream_metrics instead with `group` set to 'training'",
+            FutureWarning,
+            stacklevel=2,
+        )
+
         return _stream_training_metrics(self._session, [self.id])
 
     def stream_validation_metrics(self) -> Iterable[metrics.ValidationMetrics]:
-        """
-        @deprecated: Use stream_metrics instead with `group` set to "validation"
+        """Streams validation metrics for this trial.
 
-        Streams validation metrics for this trial sorted by
-        trial_id, trial_run_id and steps_completed.
+        DEPRECATED: Use stream_metrics instead with `group` set to "validation"
         """
+        warnings.warn(
+            "Trial.stream_validation_metrics is deprecated."
+            "Use Trial.stream_metrics instead with `group` set to 'validation'",
+            FutureWarning,
+            stacklevel=2,
+        )
         return _stream_validation_metrics(self._session, [self.id])
 
 

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -293,16 +293,13 @@ class TrialReference:
         """Get a stream of metrics for this trial.
 
         Arguments:
-            group: The metric group to stream.  Valid values are "validation" and "training".
+            group: The metric group to stream.  Common values are "validation" and "training", but
+                group can be any value passed to master when reporting metrics during training
+                (usually via a context's `report_metrics`).
 
         Returns:
             An iterable of :class:`~determined.experimental.TrialMetrics` objects.
         """
-        if group not in ("training", "validation"):
-            raise ValueError(
-                f"Invalid metric group: {group}. Valid values are 'training' and 'validation'"
-            )
-
         return _stream_trials_metrics(self._session, [self.id], group=group)
 
     def stream_training_metrics(self) -> Iterable[metrics.TrainingMetrics]:


### PR DESCRIPTION
This PR:
* removes generated documentation for deprecated TrainingMetrics and ValidationMetrics objects and methods
* adds generated documentation for their replacement TrialMetrics
* better documents the attributes within TrialMetrics
* adds deprecation warnings for methods docstrings claim are deprecated

[MLG-1030]

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

Check [SDK docs on main](http://latest-main.determined.ai:8080/docs/reference/python-sdk.html). There should be a description of TrialMetrics and its attributes and no description of ValidationMetrics or TrainingMetrics. It should include `stream_trials_metrics` from `client` and `Trial.stream_metrics`, and should not include either `stream_trials_training_metrics` or `stream_trials_validation_metrics` from `client` and should not include `Trial.stream_validation_metrics` or `Trial.stream_training_metrics`.

Codepaths that now have a deprecation warning:
```python
client.stream_trials_training_metrics
client.stream_trials_validation_metrics
Trial.stream_training_metrics
Trial.stream_validation_metrics
```

Handy snippets for client/Trial:
```python
from determined.experimental import client
client.login(<login>)
my_trial = client.get_trial(<trial_id>)
```

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-1030]: https://hpe-aiatscale.atlassian.net/browse/MLG-1030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ