### PR TITLE
fix: move couldn't-connect-to-master message into ship_logs.py

### DIFF
--- a/e2e_tests/tests/cluster/test_ship_logs.py
+++ b/e2e_tests/tests/cluster/test_ship_logs.py
@@ -34,8 +34,9 @@ class ShipLogServer:
     shuts down much faster.
     """
 
-    def __init__(self, ctx: Optional[ssl.SSLContext] = None) -> None:
+    def __init__(self, ctx: Optional[ssl.SSLContext] = None, reject_logs: bool = False) -> None:
         self.ctx = ctx
+        self.reject_logs = reject_logs
         self.quit = False
         self.logs: List[str] = []
 
@@ -91,6 +92,14 @@ class ShipLogServer:
                 # EOF
                 return
             hdrs += buf
+        # Detect the initial GET /api/v1/me probe.
+        if hdrs.startswith(b"GET"):
+            s.sendall(b"HTTP/1.1 200 OK\r\n\r\n")
+            return
+        # Are we supposed to misbehave?
+        if self.reject_logs:
+            s.sendall(b"HTTP/1.1 500 No! I don't wanna!\r\n\r\n")
+            return
         # Receive body until we have valid json.
         hdrs, body = hdrs.split(b"\r\n\r\n", maxsplit=1)
         while True:
@@ -290,15 +299,10 @@ class TestShipLogs:
     @pytest.mark.e2e_cpu
     def test_exit_wait_time_is_honored(self) -> None:
         cmd = mkcmd("print('hello world')")
-        # We need a misbehaving server to guarantee the shipper times out.
-        # This misbehaving server will listen without ever accepting.
-        with socket.socket() as listener:
-            listener.bind(("127.0.0.1", 0))
-            listener.listen(10)
-            _, port = listener.getsockname()
-            master_url = f"http://127.0.0.1:{port}"
+        # We configure the server to reject logs in order to guarantee the shipper times out.
+        with ShipLogServer(reject_logs=True) as srv:
             start = time.time()
-            exit_code = self.run_ship_logs(master_url, cmd, log_wait_time=0.1)
+            exit_code = self.run_ship_logs(srv.master_url(), cmd, log_wait_time=0.1)
             end = time.time()
             assert exit_code == 0, exit_code
             assert end - start < 1, end - start
@@ -365,7 +369,8 @@ class TestShipLogs:
         assert p.wait() == 0, "\n" + errmsgs
 
     @pytest.mark.e2e_cpu
-    def test_custom_certs(self) -> None:
+    @pytest.mark.parametrize("noverify", (True, False))
+    def test_custom_certs(self, noverify: bool) -> None:
         # Use the untrusted key and cert from the harness unit tests.
         untrusted = os.path.join(here, "../../../harness/tests/common/untrusted-root")
         keyfile = os.path.join(untrusted, "127.0.0.1-key.pem")
@@ -383,7 +388,7 @@ class TestShipLogs:
             exit_code = self.run_ship_logs(
                 master_url,
                 cmd,
-                cert_file=certfile,
+                cert_file="noverify" if noverify else certfile,
                 cert_name="127.0.0.1",
             )
             assert exit_code == 0, exit_code


### PR DESCRIPTION
A while ago, the first HTTP call we made to the master was in prep_container.py.  There, we emitted a special, super-detailed message to help users with broken container settings or proxy settings or certificate settings to help sysadmins debug their clusters.

That message now belongs in ship_logs.py.  Also, we do a special round-trip to the master just to check that connection, before we even start a child process.