### PR TITLE
docs: Remove ref to fluent bit

### DIFF
--- a/docs/reference/deploy/config/agent-config-reference.rst
+++ b/docs/reference/deploy/config/agent-config-reference.rst
@@ -125,29 +125,6 @@ Configuration settings for :ref:`TLS <tls>`.
 -  ``client_cert``/``client_key``: Paths to files containing the client TLS certificate and key to
    use when connecting to the master.
 
-************
- ``fluent``
-************
-
-fluentd settings.
-
-``image``
-=========
-
-Docker image to use for the managed Fluent Bit daemon. Defaults to ``fluent/fluent-bit:1.9.3``.
-
-``port``
-========
-
-TCP port for the Fluent Bit daemon to listen on. Defaults to port 24224. Should be unique when
-running multiple agents on the same node.
-
-``container_name``
-==================
-
-Name for the Fluent Bit container. Defaults to ``determined-fluent``. Should be unique when running
-multiple agents on the same node.
-
 ******************************
  ``agent_reconnect_attempts``
 ******************************

--- a/docs/reference/deploy/config/master-config-reference.rst
+++ b/docs/reference/deploy/config/master-config-reference.rst
@@ -363,23 +363,6 @@ Supports customizing the resource requests made when scheduling Kubernetes pods.
 
 The service account Determined uses to interact with the Kubernetes API.
 
-``fluent``
-----------
-
-Options for configuring how Fluent Bit sidecars are run.
-
-``image``
-^^^^^^^^^
-
-   The Fluent Bit image to use. Defaults to ``fluent/fluent-bit:1.9.3``.
-
-``uid``/``gid``
-^^^^^^^^^^^^^^^
-
-   The UID and GID to run the Fluent Bit sidecar as. If these are not specified, the container will
-   run as root when the associated task container is running as root and as a default non-root user
-   otherwise.
-
 .. _cluster-configuration-slurm:
 
 ``type: slurm`` or ``pbs``
@@ -1519,11 +1502,6 @@ Security-related configuration settings.
    -  ``certificate``: Path to a file containing the cluster's TLS certificate. Only needed if the
       certificate is not signed by a well-known CA; cannot be specified if ``skip_verify`` is
       enabled.
-
-   -  ``additional_fluent_outputs``: An optional configuration string containing additional Fluent
-         Bit outputs for advanced users to specify logging integrations. See the `Fluent Bit
-         documentation <https://docs.fluentbit.io/manual/pipeline/outputs>`__ for the format and
-         supported logging outputs.
 
 **********
  ``scim``

--- a/docs/setup-cluster/deploy-cluster/k8s/install-on-kubernetes.rst
+++ b/docs/setup-cluster/deploy-cluster/k8s/install-on-kubernetes.rst
@@ -51,9 +51,6 @@ are satisfied:
    using `kubectl create secret
    <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/>`_.
 
--  The nodes in the cluster already have or can pull the ``fluent/fluent-bit:1.9.3`` Docker image
-   from Docker Hub.
-
 -  Optional: for GPU-based training, the Kubernetes cluster should have `GPU support
    <https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/>`_ enabled.
 

--- a/docs/setup-cluster/deploy-cluster/on-prem/options/docker.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/options/docker.rst
@@ -156,17 +156,7 @@ To start an agent container with environment variables instead of a configuratio
    configure workload containers to use ``host`` network mode, as described :ref:`below
    <network-host>`. Alternatively, if the master machine has a static IP address from your router,
    you can use that. The key is ensuring that the master machine can be reliably addressed from both
-   inside and outside of Docker containers (because the Fluent Bit container will always use host
-   networking).
-
-Determined uses `Fluent Bit <https://fluentbit.io>`__ internally. The agent uses the
-``fluent/fluent-bit:1.9.3`` Docker image at runtime and will attempt to pull this image
-automatically. If the agent machines in the cluster cannot connect to Docker Hub, you'll need to
-manually load this image onto them before Determined can run.
-
-To use a different image for running Fluent Bit---generally to leverage a custom Docker registry, as
-the image doesn't usually require changing otherwise---you can use the agent's
-``--fluent-logging-image`` command-line option or ``fluent_logging_image`` config file option.
+   inside and outside of Docker containers.
 
 The ``--gpus`` flag should be used to specify which GPUs the agent container will have access to;
 without it, the agent will not have access to any GPUs. For example:

--- a/docs/setup-cluster/deploy-cluster/on-prem/options/wsl.rst
+++ b/docs/setup-cluster/deploy-cluster/on-prem/options/wsl.rst
@@ -403,14 +403,6 @@ and connected:
 
    powershell.exe /c start http://$WSLIP:8080/det/clusters
 
-Determined internally makes use of `Fluent Bit <https://fluentbit.io>`__. The agent uses the
-``fluent/fluent-bit:1.9.3`` Docker image at runtime. It will attempt to pull the image
-automatically. If the agent machines in the cluster are not able to connect to Docker Hub, you must
-manually place the image onto the agent machines in the cluster before Determined can run. To
-specify a different image to use for running Fluent Bit (generally to make use of a custom Docker
-registry---the image should not normally need to be changed otherwise), use the agent's
-``--fluent-logging-image`` command-line option or ``fluent_logging_image`` config file option.
-
 To ensure proper GPU access for the agent container, use the ``--gpus`` flag to specify the GPUs.
 Failure to include this flag will result in the agent not having access to any GPUs. For example:
 

--- a/docs/setup-cluster/security/tls.rst
+++ b/docs/setup-cluster/security/tls.rst
@@ -51,14 +51,6 @@ corresponding to the public IP address of the master, while the agent connects t
 its private IP address to prevent traffic from being routed over the public Internet. In that case,
 the option should be set to the DNS name contained in the certificate.
 
-.. note::
-
-   Due to a limitation of `Fluent Bit <https://fluentbit.io>`__, which Determined uses internally,
-   the certificate must be valid for at least one hostname that is not an IP address and the
-   ``security.tls.master_cert_name`` option must be set to that hostname if the agent is configured
-   to connect to the master using an IP address. The hostname does not need to be an actual DNS name
-   for the master---it is only used for certificate verification.
-
 When :ref:`dynamic agents <elastic-infrastructure>` and TLS are both in use, the dynamic agents that
 the master creates will automatically be configured to connect securely to the master over TLS.
 


### PR DESCRIPTION
Remove references to fluent bit as log shipper.
Fluent bit is no longer used for log shipping:
https://docs.determined.ai/latest/release-notes.html#version-0-25-1