### PR TITLE
chore: Post pruning hotfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2923,26 +2923,6 @@ workflows:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
 
       - test-e2e-gke:
-          name: test-e2e-gke-parallel-tfonly
-          context: gcp-ci
-          filters:
-            branches:
-              only: main
-          requires:
-            - package-and-push-system-dev
-          matrix:
-            parameters:
-              cluster-id-prefix: ["parallel-tfonly"]
-              mark: ["parallel and tensorflow2"]
-              parallelism: [1]
-              slack-mentions: ["${SLACK_USER_ID}"]
-              machine-type: ["n1-standard-32"]
-              gpus-per-machine: [4]
-              num-machines: [2]
-              environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
-
-      - test-e2e-gke:
           name: test-e2e-gke-single-cpu
           context: gcp-ci
           filters:
@@ -3135,25 +3115,6 @@ workflows:
               mark: ["e2e_gpu and tensorflow2"]
               parallelism: [1]
               slack-mentions: ["${SLACK_USER_ID}"]
-              environment-image:
-                - determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
-
-      - test-e2e-gke:
-          name: test-e2e-gke-parallel-tfonly
-          context: gcp-ci
-          filters: *upstream-feature-branch
-          requires:
-            - request-k8-tests
-            - package-and-push-system-dev
-          matrix:
-            parameters:
-              cluster-id-prefix: ["parallel-tfonly"]
-              mark: ["parallel and tensorflow2"]
-              parallelism: [1]
-              slack-mentions: ["${SLACK_USER_ID}"]
-              machine-type: ["n1-standard-32"]
-              gpus-per-machine: [4]
-              num-machines: [2]
               environment-image:
                 - determinedai/environments:cuda-11.1-pytorch-1.9-tf-2.4-gpu-0.19.10
 

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -33,7 +33,6 @@ def export_and_load_model(experiment_id: int) -> None:
 
 
 @pytest.mark.parallel
-@pytest.mark.tensorflow2
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])
 def test_tf_keras_parallel(
     aggregation_frequency: int, collect_trial_profiles: Callable[[int], None]

--- a/e2e_tests/tests/experiment/test_tf_keras.py
+++ b/e2e_tests/tests/experiment/test_tf_keras.py
@@ -33,6 +33,7 @@ def export_and_load_model(experiment_id: int) -> None:
 
 
 @pytest.mark.parallel
+@pytest.mark.tensorflow2
 @pytest.mark.parametrize("aggregation_frequency", [1, 4])
 def test_tf_keras_parallel(
     aggregation_frequency: int, collect_trial_profiles: Callable[[int], None]


### PR DESCRIPTION
## Description

Open PR for anything I overlooked with Examples Pruning. So far:

1. `test-e2e-gke-parallel-tfonly` is being removed since it's failing due to having no tests to run.



## Test Plan

CI is green.



## Commentary (optional)




## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
