### PR TITLE
fix: Move setting of playwright browsers path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1581,7 +1581,7 @@ jobs:
       - react-get-deps
       - run: npx playwright install --with-deps chrome firefox webkit
       - run: SERVER_ADDRESS=${PW_SERVER_ADDRESS} npm run build --prefix webui/react
-      - run: PW_USER_NAME=${PW_USER_NAME} PW_PASSWORD=${PW_PASSWORD} npm run e2e --prefix webui/react
+      - run: PW_USER_NAME=${PW_USER_NAME} PW_PASSWORD=${PW_PASSWORD} PLAYWRIGHT_BROWSERS_PATH=0 npm run e2e --prefix webui/react
       - store_artifacts:
           path: webui/react/src/e2e/playwright-report
       - store_artifacts:

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -26,7 +26,7 @@
     "format-check:css": "prettier --check \"src/**/*.{css,less,scss}\"",
     "format-check:misc": "prettier --check \"src/**/*.{md,json}\"",
     "test": "vitest",
-    "e2e": "PLAYWRIGHT_BROWSERS_PATH=0 playwright test",
+    "e2e": "playwright test",
     "test:coverage": "vitest --run --coverage --silent",
     "analyze": "source-map-explorer --no-border-checks 'build/assets/*.js'",
     "unimported": "unimported"


### PR DESCRIPTION
## Description

As suggested, put `PLAYWRIGHT_BROWSERS_PATH=0` in the CI config YAML instead of in package.json

## Test Plan

Tests run successfully

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context 

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.