### PR TITLE
chore: reinstate core_api example e2e tests

### DIFF
--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -439,3 +439,32 @@ def test_core_api_arbitrary_workload_order() -> None:
     assert len(validations) == 11
     checkpoints = exp.workloads_with_checkpoint(trial.workloads)
     assert len(checkpoints) == 11
+
+
+@pytest.mark.e2e_cpu
+@pytest.mark.parametrize(
+    "stage,ntrials,expect_workloads,expect_checkpoints",
+    [
+        ("0_start", 1, False, False),
+        ("1_metrics", 1, True, False),
+        ("2_checkpoints", 1, True, True),
+        ("3_hpsearch", 10, True, True),
+    ],
+)
+def test_core_api_tutorials(
+    stage: str, ntrials: int, expect_workloads: bool, expect_checkpoints: bool
+) -> None:
+    exp.run_basic_test(
+        conf.tutorials_path(f"core_api/{stage}.yaml"),
+        conf.tutorials_path("core_api"),
+        ntrials,
+        expect_workloads=expect_workloads,
+        expect_checkpoints=expect_checkpoints,
+    )
+
+
+@pytest.mark.parallel
+def test_core_api_distributed_tutorial() -> None:
+    exp.run_basic_test(
+        conf.tutorials_path("core_api/4_distributed.yaml"), conf.tutorials_path("core_api"), 1
+    )


### PR DESCRIPTION
## Description

We reinstated one of the pruned examples (`tutorials/core_api`)
This example had some e2e_tests. Reinstating those to make sure this example stays tested.



## Test Plan

CI Passes


## Commentary (optional)

Check out the new examples repo! https://github.com/determined-ai/determined-examples
Well, maybe after its first ever PR hits....


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
