### PR TITLE
fix: deepspeed e2e_tests fail when environment variable contains a newline character [FE-256]

### DIFF
--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -196,7 +196,7 @@ def create_deepspeed_env_file() -> None:
                 f.write(f"{line}\n")
             else:
                 logging.debug(
-                    f"Excluding environment variable {k} because it could not be formatted correctly."
+                    f"Excluding environment variable {k} because it contains a newline character."
                 )
 
 

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -195,7 +195,10 @@ def create_deepspeed_env_file() -> None:
             if "\n" not in line:
                 f.write(f"{line}\n")
             else:
-                logging.debug(f"Excluding environment variable {k} because it could not be formatted correctly.")
+                logging.debug(
+                    f"Excluding environment variable {k} because it could not be formatted correctly."
+                )
+
 
 def create_run_command(master_address: str, hostfile_path: Optional[str]) -> List[str]:
     # Construct the deepspeed command.

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -195,7 +195,7 @@ def create_deepspeed_env_file() -> None:
             if "\n" not in line:
                 f.write(f"{line}\n")
             else:
-                logging.debug(
+                logging.warning(
                     f"Excluding environment variable {k} because it contains a newline character."
                 )
 


### PR DESCRIPTION
## Description

The deepspeed tests all failed when I ran the `e2e_tests` on `sawmill` to test a ROCM image.  The `sawmill` cluster has a `bard` partition with ROCM GPUs, although there is no `gres` configured for Slurm.

```
tests/nightly/test_distributed.py::test_deepspeed_moe FAILED             [ 90%]
tests/nightly/test_distributed.py::test_deepspeed_zero FAILED            [ 93%]
tests/nightly/test_distributed.py::test_deepspeed_dcgan FAILED           [ 96%]
tests/nightly/test_distributed.py::test_deepspeed_cpu_offloading FAILED  [100%]
```

The root cause of the failure is that, by default, `IFS` is set to a space, a tab, and a newline character, so it is written to the `/determined_local_fs/procs/0/run/determined/workdir/.deepspeed_env` file as:

```
IFS='
'
```

The `.deepspeed_env` file is later consumed by `/opt/conda/envs/py_3.8/lib/python3.8/site-packages/deepspeed-0.10.2+79029ac0-py3.8.egg/deepspeed/launcher/runner.py`, and the single quote on its own line causes a parsing error:

```
[2023-10-12T17:59:48.120808Z] [cont=0] ||   File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/deepspeed-0.10.2+79029ac0-py3.8.egg/deepspeed/launcher/runner.py", line 559, in main
[2023-10-12T17:59:48.121397Z] [cont=0] ||     key, val = var.split('=', maxsplit=1)
[2023-10-12T17:59:48.121424Z] [cont=0] || ValueError: not enough values to unpack (expected 2, got 1)
[2023-10-12T18:01:34.274451Z]          || ERROR: Job failed in state FAILED. The job terminated with a non-zero exit code.
```

The tests pass when run on `casablanca-login`, because `casablanca-login` has the Slurm `gres` configured, and since the config file used by the deepspeed tests request 2 `slots_per_trial`, it will allocate 2 GPUs on a single node.  The `.deepspeed_env` is only written if multiple nodes are allocated, so it's not written on `casablanca-login` and, therefore, we don't see this problem.

On `sawmill`, since there is no Slurm `gres` configured, the 2 `slots_per_trial` translate to 2 nodes being allocated, where each node uses 1 GPU and, since there are 2 nodes allocated, the `.deepspeed_env` file is written, so we hit this problem.

To solve this issue, we will not write any environment variables to the `.deepspeed_env` file that contain a newline character.

## Test Plan

Ran the `e2e_slurm` tests.  All test passed including the 4 deepspeed tests at the end.

```
(determined) (base) rcorujo@C02FJ0T8MD6Q e2e_tests % DET_MAX_SLOTS=4 SHARED_CLUSTER=True pytest -m e2e_slurm -vvv --durations=0 --master-host="127.0.0.1" --master-port="8081" 2>&1 | tee /tmp/e2e_slurm.out                                                                    
============================= test session starts ==============================
platform darwin -- Python 3.9.5, pytest-7.3.1, pluggy-1.0.0 -- /Users/rcorujo/.virtualenvs/determined/bin/python3
cachedir: .pytest_cache
rootdir: /Users/rcorujo/IdeaProjects/update_slurmcluster_with_latest_rocm_iamge_for_bard_partition/determined-ee/e2e_tests
configfile: pytest.ini
plugins: timeout-2.1.0, requests-mock-1.10.0
collecting ... collected 448 items / 418 deselected / 30 selected

tests/cluster/test_logging.py::test_trial_logs PASSED                    [  3%]
tests/cluster/test_logging.py::test_task_logs[command cmd-task_config0-^.*hello.*$] PASSED [  6%]
tests/cluster/test_logging.py::test_task_logs[notebook-task_config1-^.*Jupyter Server .* is running.*$] PASSED [ 10%]
tests/cluster/test_logging.py::test_task_logs[shell-task_config2-^.*Server listening on.*$] PASSED [ 13%]
tests/cluster/test_logging.py::test_task_logs[tensorboard-task_config3-^.*TensorBoard .* at .*$] PASSED [ 16%]
tests/cluster/test_slurm.py::test_unsupported_option PASSED              [ 20%]
tests/cluster/test_slurm.py::test_docker_image PASSED                    [ 23%]
tests/cluster/test_slurm.py::test_node_not_available SKIPPED (no gpu available) [ 26%]
tests/cluster/test_slurm.py::test_bad_slurm_option PASSED                [ 30%]
tests/cluster/test_slurm.py::test_cifar10_pytorch_distributed SKIPPED (no gpu available) [ 33%]
tests/command/test_notebook.py::test_basic_notebook_start_and_kill PASSED [ 36%]
tests/command/test_run.py::test_exit_code_reporting PASSED               [ 40%]
tests/command/test_run.py::test_basic_workflows PASSED                   [ 43%]
tests/command/test_run.py::test_singleton_command PASSED                 [ 46%]
tests/command/test_run.py::test_environment_variables_command PASSED     [ 50%]
tests/command/test_run.py::test_cmd_kill PASSED                          [ 53%]
tests/command/test_run.py::test_log_wait_timeout SKIPPED (No S3 access)  [ 56%]
tests/command/test_shell.py::test_start_and_write_to_shell PASSED        [ 60%]
tests/command/test_slurm_verify_home.py::test_start_and_verify_hpc_home PASSED [ 63%]
tests/command/test_tensorboard.py::test_start_tensorboard_for_multi_experiment SKIPPED (No S3 access) [ 66%]
tests/experiment/test_hpc_launch.py::test_launch_embedded_quotes PASSED  [ 70%]
tests/experiment/test_hpc_launch.py::test_launch_embedded_single_quote PASSED [ 73%]
tests/experiment/test_launch.py::test_launch_layer_cifar PASSED          [ 76%]
tests/experiment/test_launch.py::test_launch_layer_exit PASSED           [ 80%]
tests/experiment/test_noop_hpc.py::test_noop_pause_hpc PASSED            [ 83%]
tests/experiment/test_pending_hpc.py::test_hpc_job_pending_reason SKIPPED (required config: 1 resource pool with 1 node, with only 8 slots.) [ 86%]
tests/nightly/test_distributed.py::test_deepspeed_moe PASSED             [ 90%]
tests/nightly/test_distributed.py::test_deepspeed_zero PASSED            [ 93%]
tests/nightly/test_distributed.py::test_deepspeed_dcgan PASSED           [ 96%]
tests/nightly/test_distributed.py::test_deepspeed_cpu_offloading PASSED  [100%]
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
