### PR TITLE
fix: user flag to prompt for password during unauthenticated user requests

### DIFF
--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -3,8 +3,10 @@ from pathlib import Path
 import pytest
 
 import determined as det
+import tests.config as conf
+from tests import api_utils
 from tests import command as cmd
-from tests.cluster.test_users import det_spawn
+from tests.cluster import test_users
 
 
 @pytest.mark.slow
@@ -36,7 +38,7 @@ def test_open_shell() -> None:
         task_id = shell.task_id
         assert task_id is not None
 
-        child = det_spawn(["shell", "open", task_id])
+        child = test_users.det_spawn(["shell", "open", task_id])
         child.setecho(True)
         child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.", timeout=180)
         child.sendline("det user whoami")
@@ -44,4 +46,47 @@ def test_open_shell() -> None:
         child.sendline("exit")
         child.read()
         child.wait()
+        assert child.exitstatus == 0
+
+
+@pytest.mark.e2e_cpu
+def test_user_flag_shell() -> None:
+    new_user_creds = api_utils.create_test_user(True)
+    new_user_username, _ = new_user_creds
+
+    with test_users.logged_in_user(new_user_creds):
+        with cmd.interactive_command("shell", "start", "--detach") as shell:
+            admin_username, admin_password = conf.ADMIN_CREDENTIALS
+            task_id = shell.task_id
+            assert task_id is not None
+
+            child = test_users.det_spawn(["shell", "open", task_id])
+            child.setecho(True)
+            child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.", timeout=180)
+
+            # Verify correct user credentials at the start of entering shell
+            child.sendline("det user whoami")
+            child.expect(f"You are logged in as user '{new_user_username}'")
+
+            # Use -u flag with logged in user and verify no password prompt.
+            child.sendline(f"det -u {new_user_username} user whoami")
+            child.expect(f"You are logged in as user '{new_user_username}'")
+
+            # Use the -u flag with logged out admin user and verify password prompt.
+            child.sendline(f"det -u {admin_username} user logout")
+            child.sendline(f"det -u {admin_username} user whoami")
+            child.expect(f"Password for user '{admin_username}'", timeout=10)
+            child.sendline(str(admin_password))
+            child.expect(f"You are logged in as user '{admin_username}'", timeout=10)
+
+            # Use -u flag with logged out user whose username and token are stored in environment
+            # and verify no password prompt.
+            child.sendline(f"det -u {new_user_username} user logout")
+            child.sendline(f"det -u {new_user_username} user whoami")
+            child.expect(f"You are logged in as user '{new_user_username}'")
+
+            child.sendline("exit")
+            child.read()
+            child.wait()
+
         assert child.exitstatus == 0

--- a/harness/tests/cli/test_auth.py
+++ b/harness/tests/cli/test_auth.py
@@ -72,13 +72,15 @@ def test_auth_user_from_env(
 
         requests_mock.get("/api/v1/me", status_code=200, json={"username": "alice"})
 
-        authentication = Authentication(MOCK_MASTER_URL, user)
         if has_token_store:
+            nop_password = "user_password"
+            authentication = Authentication(MOCK_MASTER_URL, user, nop_password)
             assert authentication.session.username == user or "determined"
             assert authentication.session.token == (
                 "det.token" if user == "determined" else "bob.token"
             )
         else:
+            authentication = Authentication(MOCK_MASTER_URL)
             assert authentication.session.username == "alice"
             assert authentication.session.token == "alice.token"
 


### PR DESCRIPTION
## Description

Fix -u flag for JupyterLab instances and Determined instantiated shell sessions. Now, when a user who is not logged in runs a `det user` command in a shell on a remote host, they will be prompted for a login password for the passed in user. Upon entering the correct password, the command will be executed for the user passed in with -u flag argument.


## Test Plan
Run e2e tests (specifically covered in `command/test_shell.py`). 

1. `cd .../determined/e2e_tests/tests`
2. `pytest -k "test_user_flag_shell"`

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9475
