### PR TITLE
fix: tensorboard sync for profiler data, Core API v2 managed mode [MLG-1063]

### DIFF
--- a/docs/release-notes/core-v2-tensorboard.rst
+++ b/docs/release-notes/core-v2-tensorboard.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Core API: On context closure, properly save all TensorBoard files not related to metrics
+   reporting, particularly the native profiler traces.
+-  Core API v2: Fix an issue where TensorBoard files were not saved for managed experiments.

--- a/e2e_tests/tests/fixtures/core_api/pytorch_profiler_sync.py
+++ b/e2e_tests/tests/fixtures/core_api/pytorch_profiler_sync.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import torch
+
+from determined.experimental import core_v2
+
+
+def main() -> None:
+    core_v2.init(
+        defaults=core_v2.DefaultConfig(
+            name="pytorch-profiler-sync-test",
+        ),
+    )
+
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU],
+        with_flops=True,
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(
+            str(core_v2.train.get_tensorboard_path())
+        ),
+    ):
+        state = torch.rand(100, 100)
+        for _i in range(1000):
+            state = torch.matmul(state, torch.rand(100, 100))
+            norm = torch.linalg.norm(state)
+            state = state / norm
+
+    core_v2.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e_tests/tests/fixtures/core_api/pytorch_profiler_sync.yaml
+++ b/e2e_tests/tests/fixtures/core_api/pytorch_profiler_sync.yaml
@@ -1,0 +1,9 @@
+name: pytorch-profiler-sync-test
+entrypoint: python3 pytorch_profiler_sync.py
+
+searcher:
+   name: single
+   metric: x
+   max_length: 1
+
+max_restarts: 0

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -254,6 +254,7 @@ def init(
             info.trial._config["checkpoint_storage"],
             container_path=constants.SHARED_FS_CONTAINER_PATH,
             async_upload=True,
+            sync_on_close=(tensorboard_mode == core.TensorboardMode.AUTO),
         )
         if tensorboard_mode == core.TensorboardMode.AUTO:
             tbd_writer = tensorboard.get_metric_writer()

--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -169,6 +169,7 @@ def main(argv: List[str]) -> None:
             storage_config,
             container_path=constants.SHARED_FS_CONTAINER_PATH,
             async_upload=False,
+            sync_on_close=False,
         )
         delete_tensorboards(tb_manager, dry_run=args.dry_run)
 

--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -18,7 +18,6 @@ import determined.common
 from determined.tensorboard import fetchers
 
 TENSORBOARD_TRIGGER_READY_MSG = "TensorBoard contains metrics"
-TRIGGER_WAITING_MSG = "TensorBoard waits on metrics"
 
 TICK_INTERVAL = 1  # How many seconds to wait on each iteration of our check loop
 MAX_WAIT_TIME = 600  # How many seconds to wait for the first metric file to download

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -34,6 +34,7 @@ class TensorboardManager(metaclass=abc.ABCMeta):
         base_path: pathlib.Path,
         sync_path: pathlib.Path,
         async_upload: bool = True,
+        sync_on_close: bool = True,
     ) -> None:
         self.base_path = base_path
         self.sync_path = sync_path
@@ -42,6 +43,7 @@ class TensorboardManager(metaclass=abc.ABCMeta):
         self.upload_thread = None
         if async_upload:
             self.upload_thread = _TensorboardUploadThread(self._sync_impl)
+        self.sync_on_close = sync_on_close
 
     def list_tb_files(
         self,
@@ -112,6 +114,8 @@ class TensorboardManager(metaclass=abc.ABCMeta):
             self.upload_thread.start()
 
     def close(self) -> None:
+        if self.sync_on_close:
+            self.sync()
         if self.upload_thread is not None and self.upload_thread.is_alive():
             self.upload_thread.close()
 

--- a/harness/determined/tensorboard/build.py
+++ b/harness/determined/tensorboard/build.py
@@ -78,6 +78,7 @@ def build(
     checkpoint_config: Union[Dict[str, Any], str],
     container_path: Optional[str] = None,
     async_upload: bool = True,
+    sync_on_close: bool = True,
 ) -> base.TensorboardManager:
     """
     Return a tensorboard manager defined by the value of the `type` key in
@@ -113,6 +114,7 @@ def build(
             base_path,
             sync_path,
             async_upload=async_upload,
+            sync_on_close=sync_on_close,
         )
 
     elif type_name == "gcs":
@@ -122,6 +124,7 @@ def build(
             base_path,
             sync_path,
             async_upload=async_upload,
+            sync_on_close=sync_on_close,
         )
 
     elif type_name == "s3":
@@ -134,6 +137,7 @@ def build(
             base_path,
             sync_path,
             async_upload=async_upload,
+            sync_on_close=sync_on_close,
         )
 
     elif type_name == "azure":
@@ -150,6 +154,7 @@ def build(
             base_path,
             sync_path,
             async_upload=async_upload,
+            sync_on_close=sync_on_close,
         )
 
     else:


### PR DESCRIPTION
## Description

- When tensorboard manager is in auto mode, automatically do the sync on closure. This should sync files written after the last metrics payload, e.g. native pytorch profiler traces.
- Core API v2 did not properly write tensorboard files while in managed mode.

## Test Plan

- Run a managed core api experiment which uses pytorch profiling *for the entire duration of the experiment*, and make sure the trace is saved and can be accessed in the tensorboard. See tests for an example.
- Run Core API v2 experiment in a managed mode (i.e. as an experiment), and make sure tensorboard captures the metrics.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
