### PR TITLE
refactor: `CliError` does not need `e_stack` property.

### DIFF
--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -307,7 +307,6 @@ def call_bindings(args: Namespace) -> None:
                 params,
             )
             + f"\n\n{str(e)}",
-            e,
         )
 
     print_response(output)

--- a/harness/determined/cli/errors.py
+++ b/harness/determined/cli/errors.py
@@ -1,6 +1,3 @@
-from typing import Optional
-
-
 class FeatureFlagDisabled(Exception):
     """
     Exception indicating that there is a currently disabled feature flag
@@ -17,9 +14,7 @@ class CliError(Exception):
 
     name: str
 
-    def __init__(
-        self, message: str, e_stack: Optional[Exception] = None, exit_code: int = 1
-    ) -> None:
+    def __init__(self, message: str, exit_code: int = 1) -> None:
         """
         Args:
         - e_stack: The exception that triggered this error.
@@ -28,5 +23,4 @@ class CliError(Exception):
         super().__init__(message)
         self.name = "Error"
         self.exit_code = exit_code
-        self.e_stack = e_stack
         self.message = message

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -105,7 +105,7 @@ def read_git_metadata(model_def_path: pathlib.Path) -> Tuple[str, str, str, str]
         remote_url = repo.git.config(f"remote.{remote_name}.url", get=True)
         print(f"Using remote URL '{remote_url}' from upstream branch '{upstream_branch}'")
     except Exception as e:
-        raise CliError("Failed to find the upstream branch: ", e)
+        raise CliError(f"Failed to find the upstream branch: {e}")
 
     return (remote_url, commit_hash, committer, commit_date)
 

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -91,10 +91,9 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
             output = aws.list_stacks(boto3_session)
         except NoCredentialsError:
             error_no_credentials()
-        except Exception as e:
+        except Exception:
             raise CliError(
                 "Listing stacks failed. Check the AWS CloudFormation Console for details.",
-                e_stack=e,
             )
         for item in output:
             print(item["StackName"])
@@ -126,10 +125,9 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
             aws.delete(args.cluster_id, boto3_session)
         except NoCredentialsError:
             error_no_credentials()
-        except Exception as e:
+        except Exception:
             raise CliError(
                 "Stack Deletion Failed. Check the AWS CloudFormation Console for details.",
-                e_stack=e,
             )
 
         print("Delete Successful")
@@ -265,9 +263,9 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         deployment_object.deploy(args.yes, args.update_terminate_agents)
     except NoCredentialsError:
         error_no_credentials()
-    except Exception as e:
+    except Exception:
         raise CliError(
-            "Stack Deployment Failed. Check the AWS CloudFormation Console for details.", e_stack=e
+            "Stack Deployment Failed. Check the AWS CloudFormation Console for details.",
         )
 
     if not args.no_wait_for_master:


### PR DESCRIPTION
## Description

`CliError.e_stack` is not used. whenever `DET_DEBUG=1` is set, the original exception traceback will be printed anyway thanks to python capturing the original exception automatically.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
