### PR TITLE
docs: update experiment config reference for records_per_epoch in PyTorchTrial [MLG-557]

### DIFF
--- a/docs/reference/training/experiment-config-reference.rst
+++ b/docs/reference/training/experiment-config-reference.rst
@@ -26,13 +26,9 @@ Some configuration settings, such as searcher training lengths and budgets,
 training units: records, batches, or epochs.
 
 -  ``records``: A *record* is a single labeled example (sometimes called a sample).
-
 -  ``batches``: A *batch* is a group of records. The number of records in a batch is configured via
    the ``global_batch_size`` hyperparameter.
-
--  ``epoch``: An *epoch* is a single copy of the entire training data set; the number of records in
-   an epoch is configured via the :ref:`records_per_epoch <config-records-per-epoch>` configuration
-   field.
+-  ``epoch``: An *epoch* is a single copy of the entire training data set.
 
 For example, to specify the ``max_length`` for a searcher in terms of batches, the configuration
 would read as shown below.
@@ -43,9 +39,10 @@ would read as shown below.
      batches: 900
 
 To express it in terms of records or epochs, ``records`` or ``epochs`` would be specified in place
-of ``batches``. In the case of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must also
-be specified. Below is an example that configures a ``single`` searcher to train a model for 64
-epochs.
+of ``batches``. For :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+:class:`~determined.keras.TFKerasTrial`, :ref:`records_per_epoch <config-records-per-epoch>` must
+also be specified if using epochs. Below is an example that configures a ``single`` searcher to
+train a model for 64 epochs.
 
 .. code:: yaml
 
@@ -266,9 +263,10 @@ Optional. The number of records in the training data set. It must be configured 
 specify ``min_validation_period``, ``min_checkpoint_period``, and ``searcher.max_length`` in units
 of ``epochs``.
 
--  The system does not attempt to determine the size of an epoch automatically, because the size of
-   the training set might vary based on data augmentation, changes to external storage, or other
-   factors.
+.. note::
+
+   For :class:`~determined.pytorch.PyTorchTrial`, epoch length is automatically determined using the
+   chief worker's dataset length, and this value will be ignored.
 
 .. _max-restarts:
 
@@ -301,8 +299,9 @@ Optional. Specifies the minimum frequency at which validation should be run for 
    min_validation_period:
       epochs: 2
 
--  If this is in the unit of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must be
-   specified.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If this is in the unit of epochs,
+   :ref:`records_per_epoch <config-records-per-epoch>` must be specified.
 
 .. _experiment-config-perform-initial-validation:
 
@@ -341,8 +340,9 @@ Optional. Specifies the minimum frequency for running checkpointing for each tri
       min_checkpoint_period:
          epochs: 2
 
--  If the unit is in epochs, you must also specify :ref:`records_per_epoch
-   <config-records-per-epoch>`.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If the unit is in epochs, you must also specify
+   :ref:`records_per_epoch <config-records-per-epoch>`.
 
 ``checkpoint_policy``
 =====================
@@ -799,8 +799,9 @@ Required. The length of the trial.
       max_length:
          epochs: 2
 
--  If this is in the unit of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must be
-      specified.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If this is in the unit of epochs,
+   :ref:`records_per_epoch <config-records-per-epoch>` must be specified.
 
 **Optional Fields**
 
@@ -857,8 +858,9 @@ Required. The length of each trial.
       max_length:
          epochs: 2
 
--  If this is in the unit of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must be
-   specified.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If this is in the unit of epochs,
+   :ref:`records_per_epoch <config-records-per-epoch>` must be specified.
 
 **Optional Fields**
 
@@ -913,8 +915,9 @@ Required. The length of each trial.
       max_length:
          epochs: 2
 
--  If this is in the unit of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must be
-   specified.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If this is in the unit of epochs,
+   :ref:`records_per_epoch <config-records-per-epoch>` must be specified.
 
 **Optional Fields**
 
@@ -974,8 +977,9 @@ to converge on the data set.
       max_length:
          epochs: 2
 
--  If this is in the unit of epochs, :ref:`records_per_epoch <config-records-per-epoch>` must be
-   specified.
+-  :class:`~determined.pytorch.deepspeed.DeepSpeedTrial` and
+   :class:`~determined.keras.TFKerasTrial`: If this is in the unit of epochs,
+   :ref:`records_per_epoch <config-records-per-epoch>` must be specified.
 
 ``max_trials``
 --------------

--- a/docs/tutorials/pytorch-mnist-tutorial.rst
+++ b/docs/tutorials/pytorch-mnist-tutorial.rst
@@ -276,7 +276,6 @@ fixed values for the model's hyperparameters:
      n_filters2: 64
      dropout1: 0.25
      dropout2: 0.5
-   records_per_epoch: 50_000
    searcher:
      name: single
      metric: validation_loss


### PR DESCRIPTION

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

Since PyTorchTrainer (0.21.0), `PyTorchTrial` no longer requires `records_per_epoch` when specifying training lengths in epochs. This PR updates the user-facing docs to reflect this.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
