### PR TITLE
fix: Display byte axis values using humanReadableBytes [DET-9906]

### DIFF
--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -8,6 +8,7 @@ import { ChartProps, MetricType } from 'pages/TrialDetails/Profiles/types';
 import { useFetchProfilerMetrics } from 'pages/TrialDetails/Profiles/useFetchProfilerMetrics';
 import { useFetchProfilerSeries } from 'pages/TrialDetails/Profiles/useFetchProfilerSeries';
 import {
+  getByteTickValues,
   getScientificNotationTickValues,
   getUnitForMetricName,
 } from 'pages/TrialDetails/Profiles/utils';
@@ -102,7 +103,11 @@ const SystemMetricChart: React.FC<ChartProps> = ({ trial }) => {
         xAxis={XAxisDomain.Time}
         xLabel="Time"
         yLabel={yLabel}
-        yTickValues={getScientificNotationTickValues}
+        yTickValues={
+          yLabel.substring(0, 5).toLowerCase() === 'bytes'
+            ? getByteTickValues
+            : getScientificNotationTickValues
+        }
       />
     </Section>
   );

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -103,11 +103,7 @@ const SystemMetricChart: React.FC<ChartProps> = ({ trial }) => {
         xAxis={XAxisDomain.Time}
         xLabel="Time"
         yLabel={yLabel}
-        yTickValues={
-          /^bytes/i.test(yLabel)
-            ? getByteTickValues
-            : getScientificNotationTickValues
-        }
+        yTickValues={/^bytes/i.test(yLabel) ? getByteTickValues : getScientificNotationTickValues}
       />
     </Section>
   );

--- a/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
+++ b/webui/react/src/pages/TrialDetails/Profiles/Charts/SystemMetricChart.tsx
@@ -104,7 +104,7 @@ const SystemMetricChart: React.FC<ChartProps> = ({ trial }) => {
         xLabel="Time"
         yLabel={yLabel}
         yTickValues={
-          yLabel.substring(0, 5).toLowerCase() === 'bytes'
+          /^bytes/i.test(yLabel)
             ? getByteTickValues
             : getScientificNotationTickValues
         }

--- a/webui/react/src/pages/TrialDetails/Profiles/utils.ts
+++ b/webui/react/src/pages/TrialDetails/Profiles/utils.ts
@@ -1,5 +1,7 @@
 import uPlot from 'uplot';
 
+import { humanReadableBytes } from 'utils/string';
+
 // key should be lowercase to match the metric name
 const MetricNameUnit = {
   cpu_util_simple: '%',
@@ -18,6 +20,10 @@ export const getUnitForMetricName = (metricName: string): string => {
   return metricName in MetricNameUnit
     ? MetricNameUnit[metricName as keyof typeof MetricNameUnit]
     : metricName;
+};
+
+export const getByteTickValues: uPlot.Axis['values'] = (_self, rawValue) => {
+  return rawValue.map(humanReadableBytes);
 };
 
 export const getScientificNotationTickValues: uPlot.Axis['values'] = (_self, rawValue) => {


### PR DESCRIPTION
## Description

In trial's Profiler tab, charts with Bytes values should be run through our `humanReadableBytes` function, so we see "1.0 GB" instead of "1.00 e+10" Bytes

A separate time axis issue is connected to a backend / query issue we saw in July

## Test Plan

Open an experiment with profiler tab (I use `/det/experiments/1788/profiler`). Scroll down to the System Metrics chart.

Use the dropdown to select each metric. If the axis is "Bytes" or "bytes/s", the human-readable number is displayed:

<img width="484" alt="Screen Shot 2023-10-18 at 12 28 50 PM" src="https://github.com/determined-ai/determined/assets/643918/3b637a1b-0556-41bf-b991-67324800c417">

Axis labels such as "Gigabytes" or "gigabit/s" are not modified.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.