### PR TITLE
fix: CLI uses default if pagination not included in args [DET-9908]

### DIFF
--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -118,8 +118,12 @@ def list_workspace_projects(args: Namespace) -> None:
 
     sort_key = args.sort_by
     sort_order = args.order_by
-    offset = args.offset or 0  # No passed offset is interpreted as a 0 offset
-    limit = args.limit
+    try:
+        offset = args.offset or 0 # No passed offset is interpreted as a 0 offset
+        limit = args.limit
+    except:
+        offset = 0
+        limit = 0
 
     # TODO: Remove typechecking suppression when mypy is upgraded to 1.4.0
     all_projects.sort(

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -92,7 +92,7 @@ def list_workspaces(args: Namespace) -> None:
         original_offset = args.offset or 0
         internal_offset = args.offset or 0
         limit = args.limit
-    except:
+    except AttributeError:
         original_offset = 0
         internal_offset = 0
         limit = 200
@@ -129,7 +129,7 @@ def list_workspace_projects(args: Namespace) -> None:
     try:
         offset = args.offset or 0  # No passed offset is interpreted as a 0 offset
         limit = args.limit
-    except:
+    except AttributeError:
         offset = 0
         limit = 200
 

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -88,19 +88,27 @@ def list_workspaces(args: Namespace) -> None:
     sess = cli.setup_session(args)
     orderArg = bindings.v1OrderBy[args.order_by.upper()]
     sortArg = bindings.v1GetWorkspacesRequestSortBy[args.sort_by.upper()]
-    internal_offset = args.offset or 0
+    try:
+        original_offset = args.offset or 0
+        internal_offset = args.offset or 0
+        limit = args.limit
+    except:
+        original_offset = 0
+        internal_offset = 0
+        limit = 200
+
     all_workspaces: List[bindings.v1Workspace] = []
     while True:
         workspaces = bindings.get_GetWorkspaces(
             sess,
-            limit=args.limit,
+            limit=limit,
             offset=internal_offset,
             orderBy=orderArg,
             sortBy=sortArg,
         ).workspaces
         all_workspaces += workspaces
         internal_offset += len(workspaces)
-        if args.offset or len(workspaces) < args.limit:
+        if original_offset is not None or len(workspaces) < limit:
             break
 
     if args.json:
@@ -119,11 +127,11 @@ def list_workspace_projects(args: Namespace) -> None:
     sort_key = args.sort_by
     sort_order = args.order_by
     try:
-        offset = args.offset or 0 # No passed offset is interpreted as a 0 offset
+        offset = args.offset or 0  # No passed offset is interpreted as a 0 offset
         limit = args.limit
     except:
         offset = 0
-        limit = 0
+        limit = 200
 
     # TODO: Remove typechecking suppression when mypy is upgraded to 1.4.0
     all_projects.sort(


### PR DESCRIPTION
## Description

We've recently have an issue where an EE test fails at `det w describe {workspace_name}`. The root issue is that it calls other CLI functions (`list_workspace_projects`) with its original `args`. This throws an error when `list_workspace_projects` tries to access its own args, `args.offset` and `args.limit` 

The fix catches the error and uses default values.

## Test Plan

Run `det w list --offset 10 --limit 1` - it returns one workspace
Run `det w describe WorkspaceName`
Run `det -m latest-main.determined.ai:8080 w list` - it returns all workspaces (it is not limited)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.