### PR TITLE
docs: responsive css for auto-generated toctree tiles

### DIFF
--- a/docs/assets/styles/determined.css
+++ b/docs/assets/styles/determined.css
@@ -598,3 +598,94 @@ h6 {
   src: local("OpenSans-Bold"),
     url("_static/fonts/OpenSans/OpenSans-Bold.ttf") format("truetype");
 }
+
+
+/* Toctreee Cards */
+
+.bd-article .toctree-wrapper > ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: flex-start;
+  align-items: flex-start;
+  
+}
+
+.bd-article .toctree-l1 {
+  display: flex;
+  flex-direction: column; /* Stack children vertically */
+  /* gap: 20px; */
+  border: 1px solid #e5e5e5;
+  padding: 1em;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  flex: 1 1 calc(100% - 20px); /* Default to full width minus gap */
+  min-height: 200px;
+}
+
+.bd-article .toctree-l1 ul {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+
+.bd-article .toctree-l1 > a {
+  font-size: 1.25em;
+  font-weight: bold;
+  text-align: left;
+  margin-bottom: 10px;
+}
+
+.homepage .toctree-l1 > a {
+
+  margin-bottom: 0px;
+}
+
+.bd-article .toctree-l2 > a {
+  font-size: .8rem !important;
+  color: var(--toc-l2-link);
+}
+
+.bd-article .toctree-l1 > a:hover,
+.bd-article .toctree-l1 > a:focus, 
+.bd-article .toctree-l2 > a:hover,
+.bd-article .toctree-l2 > a:focus  {
+  cursor: pointer;
+  color: var(--primary-color);
+  transition: color 0.3s ease;
+}
+
+
+/* Medium devices (tablets) */
+@media (min-width: 768px) {
+  .bd-article .toctree-l1 {
+    flex: 1 1 calc(50% - 20px);
+  }
+}
+
+/* Large devices (desktops) */
+@media (min-width: 992px) {
+  .bd-article .toctree-l1 {
+    flex: 1 1 calc(33.33% - 20px);
+  }
+
+  /* Target the last two .toctree-l1 elements */
+  .bd-article .toctree-wrapper > ul > .toctree-l1:nth-last-child(-n+2) {
+    flex: 1 1 calc(33.33% - 20px);
+    max-width: calc(33.33% - 20px);
+  }
+}
+
+.child-articles { 
+  padding: 25px;
+  border-top: 1px solid #e5e5e5;
+}
+
+.child-articles > div {
+  margin: 1em;
+}
+
+.homepage .toctree-l1 {
+  min-height: 0px;
+
+}


### PR DESCRIPTION
## Description

Adds new toctree styling for articles so that we can auto-generate cards instead of use inline html that is manually maintained.



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
