### PR TITLE
docs: sort articles by weight custom extension

### DIFF
--- a/docs/_extensions/sort_by_weight.py
+++ b/docs/_extensions/sort_by_weight.py
@@ -1,0 +1,33 @@
+import re
+import sys
+
+from docutils import nodes
+from sphinx.addnodes import toctree as toctreenode
+
+
+def post_order_documents(app, env, docnames):
+    # Order the documents to be processed so that children come before parents,
+    # since the TOC-sorting code relies on the metadata for child documents
+    # having already been read. (Just changing the priority of that hook doesn't
+    # work, since that doesn't change that hooks for a given document are
+    # executed all together, whereas we need to enforce ordering across
+    # documents.)
+    docnames.sort(key=lambda name: len(re.sub("_index$", "", name)), reverse=True)
+
+
+def sort_toctree_by_weight(app, doctree, *args):
+    def weight(doc):
+        return int(app.env.metadata[doc].get("weight", 0))
+
+    for node in doctree.traverse(toctreenode):
+        node["entries"].sort(key=lambda entry: weight(entry[1]))
+        node["includefiles"].sort(key=weight)
+
+
+def setup(app):
+    app.connect("env-before-read-docs", post_order_documents)
+    
+    # This needs to have a priority set so that it runs before
+    # sphinx.environment.collectors.TocTreeCollector, which looks at the values
+    # stored in the node and copies their order elsewhere for later usage.
+    app.connect("doctree-read", sort_toctree_by_weight, priority=0)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ import time
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+sys.path.append(os.path.abspath('./_extensions'))
 
 project = "Determined"
 html_title = "Determined AI Documentation"
@@ -100,6 +101,7 @@ html_use_index = True
 html_domain_indices = True
 
 extensions = [
+    "_extensions.sort_by_weight",
     "sphinx_ext_downloads",
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",


### PR DESCRIPTION
## Description

Added custom extension that enables contributors to add a `:weight:` field to an article and have the articles in a directory be sorted from lowest to highest number. 



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
