### PR TITLE
fix: remove 'contents' parameter from remove_notes

### DIFF
--- a/harness/tests/determined/common/experimental/test_project.py
+++ b/harness/tests/determined/common/experimental/test_project.py
@@ -50,21 +50,7 @@ def test_remove_note_raises_exception_when_name_not_found(
 
 
 @mock.patch("determined.common.api.bindings.get_GetProject")
-def test_remove_note_raises_exception_when_name_and_contents_not_found(
-    mock_get_project: mock.MagicMock, sample_project: project.Project
-) -> None:
-    bindings_project = api_responses.sample_get_project()
-    bindings_project.project.notes = [
-        bindings.v1Note(name="sample_name", contents="sample_contents")
-    ]
-    mock_get_project.return_value = bindings_project
-
-    with pytest.raises(ValueError):
-        sample_project.remove_note(name="sample_name", contents="nonexistent_contents")
-
-
-@mock.patch("determined.common.api.bindings.get_GetProject")
-def test_remove_note_raises_exception_when_multiple_names_found_contents_absent(
+def test_remove_note_raises_exception_when_multiple_matches_found(
     mock_get_project: mock.MagicMock, sample_project: project.Project
 ) -> None:
     bindings_project = api_responses.sample_get_project()
@@ -77,20 +63,3 @@ def test_remove_note_raises_exception_when_multiple_names_found_contents_absent(
 
     with pytest.raises(ValueError):
         sample_project.remove_note(name="repeated_note_name")
-
-
-@mock.patch("determined.common.api.bindings.get_GetProject")
-@responses.activate
-def test_remove_note_handles_removal_when_multiple_names_found_contents_present(
-    mock_get_project: mock.MagicMock, sample_project: project.Project
-) -> None:
-    bindings_project = api_responses.sample_get_project()
-    bindings_project.project.notes = [
-        bindings.v1Note(name="repeated_note_name", contents="1"),
-        bindings.v1Note(name="repeated_note_name", contents="2"),
-        bindings.v1Note(name="repeated_note_name", contents="3"),
-    ]
-    mock_get_project.return_value = bindings_project
-
-    responses.put(f"{_MASTER}/api/v1/projects/{sample_project.id}/notes", json={"notes": []})
-    sample_project.remove_note(name="repeated_note_name", contents="1")


### PR DESCRIPTION
Project notes have name and contents. There is no uniqueness constraint on name within a project. This gives an awkward interface for removing a note by its name.

Previously, we had logic that optionally took a "contents", so a user could narrow down _which_ note to delete when multiple notes had the name as the note to be removed. But this interface is complicated, and what's the likelihood that a user will event want it. Even more, we hadn't implemented all the if/then casing right with "contents", and this method had a bug as implemented.

This fixes the bug by removing the feature.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

Test `remove_note` functionality for when multiple notes of the same name exist. These notes can be added in the web UI or with `Project.add_note`. Ex:

```python
from determined.experimental import client

projects = client.get_workspace(<name>).list_projects()
proj = projects[<i>]

proj.add_note(...)
...

proj.remove_note(...)
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
