### PR TITLE
fix: Trigger function updates new user modified_at without error

### DIFF
--- a/master/static/migrations/20231019155909_new-trigger-by-username.tx.down.sql
+++ b/master/static/migrations/20231019155909_new-trigger-by-username.tx.down.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER IF EXISTS autoupdate_users_modified_at ON users;

--- a/master/static/migrations/20231019155909_new-trigger-by-username.tx.up.sql
+++ b/master/static/migrations/20231019155909_new-trigger-by-username.tx.up.sql
@@ -1,0 +1,16 @@
+DROP TRIGGER IF EXISTS autoupdate_users_modified_at ON users;
+
+CREATE OR REPLACE FUNCTION public.set_modified_time ()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    NEW.modified_at := now();
+    RETURN NEW;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TRIGGER autoupdate_users_modified_at
+  BEFORE INSERT OR UPDATE OF username, password_hash, admin, active, display_name, remote ON public.users
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.set_modified_time();


### PR DESCRIPTION
## Description

Responding to the error `ERROR:  control reached end of trigger procedure without RETURN` when creating new users in UI and in e2e testing (oddly, this is an issue when running e2e tests locally but not on CI)

This modifies the `users.modified_at` database trigger from #8091 and #8093 to run on INSERTs and UPDATEs

## Test Plan

As admin, visit `/det/admin/user-management`
Sort by Modified Time so you see the most recent users
Create a new user. They should appear as the first row with "Just Now" in the Modified Time column
Update an older user with a new display name or other detail. This should move up to the first row with "Just Now" in the modified column

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.