### PR TITLE
fix: prevent extra updates when observing settings store

### DIFF
--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -3,6 +3,7 @@ import { isRight, match } from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import { Map } from 'immutable';
 import * as t from 'io-ts';
+import { isEqual } from 'lodash';
 
 import { getUserSetting, resetUserSetting, updateUserSetting } from 'services/api';
 import { V1GetUserSettingResponse, V1UserWebSetting } from 'services/api-ts-sdk';
@@ -260,9 +261,9 @@ export class UserSettingsStore extends PollingStore {
 
   protected updateSettingsFromResponse(response: V1GetUserSettingResponse): void {
     this.#settings.update((loadable) => {
-      let newSettings: State = Loadable.getOrElse(Map(), loadable);
+      const oldSettings: State = Loadable.getOrElse(Map(), loadable);
 
-      newSettings = newSettings.withMutations((newSettings) => {
+      const newSettings = oldSettings.withMutations((newSettings) => {
         for (const setting of response.settings) {
           const pathKey = setting.storagePath || setting.key;
           const oldPathSettings = newSettings.get(pathKey);
@@ -280,7 +281,7 @@ export class UserSettingsStore extends PollingStore {
           }
         }
       });
-      return Loaded(newSettings);
+      return isEqual(oldSettings.toJS(), newSettings.toJS()) ? loadable : Loaded(newSettings);
     });
   }
 


### PR DESCRIPTION

## Description

This fixes a class of issues that occur when migrating a component from the `useSettings` hook to directly reading from/writing to the settings store. Previously, the settings store would update the underlying state map after each polling request. This causes issues for consumers that have object values in their settings, because those objects would then be replaced with identical objects after the settings poll finished. When passing the object value into a hook dependency, the consumer then updates along with the settings, even though the values don't change. This can cause issues when the hook is responsible for things like loading data, because it can cause extra calls and block user interaction.

We fix this by doing a deep equality check on the settings after merging with the polling results. If the two are equal, we discard the new object and return the old one, preventing downstream updates.


## Test Plan

- Visit a multi-trial experiment page (more is better)
- after seeing the page's initial load, wait 20 seconds (without having the page in the background)
- the graph and table should not have returned to the loading state.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1761


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
