### PR TITLE
fix: cifar10_tf_keras example hang

### DIFF
--- a/examples/computer_vision/cifar10_tf_keras/model_def.py
+++ b/examples/computer_vision/cifar10_tf_keras/model_def.py
@@ -80,9 +80,6 @@ class CIFARTrial(keras.TFKerasTrial):
 
         return model
 
-    def keras_callbacks(self) -> List[tf.keras.callbacks.Callback]:
-        return [keras.callbacks.TensorBoard(update_freq="batch", profile_batch=0, histogram_freq=1)]
-
     def build_training_data_loader(self) -> keras.InputData:
         hparams = self.context.get_hparams()
 

--- a/examples/computer_vision/cifar10_tf_keras/model_def.py
+++ b/examples/computer_vision/cifar10_tf_keras/model_def.py
@@ -119,7 +119,7 @@ class CIFARTrial(keras.TFKerasTrial):
 
     def build_validation_data_loader(self) -> keras.InputData:
         def val_generator():
-            xs, ys = self.train_np
+            xs, ys = self.test_np
             n = xs.shape[0]
             for i in range(n):
                 yield xs[i], ys[i]


### PR DESCRIPTION
## Description

Remove an unnecessary callback for tensorboard.


## Test Plan

Create experiments based on `const.yaml` and a `distributed.yaml`.
Look at logs.
As logs are returning metrics, pause the experiment. Wait 10 seconds. Resume the experiment.


## Commentary (optional)

This example has been causing issues for a while now... Maybe it's time to replace it with a better one?


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1111