### PR TITLE
fix: pin ruamel.yaml<0.18.0

### DIFF
--- a/harness/setup.py
+++ b/harness/setup.py
@@ -44,7 +44,8 @@ setuptools.setup(
         "pytz",
         "tabulate>=0.8.3",
         # det preview-search "pretty-dumps" a sub-yaml with an API added in 0.15.29
-        "ruamel.yaml>=0.15.29",
+        # 0.18.0 has a breaking change that we haven't reacted to yet.
+        "ruamel.yaml>=0.15.29,<0.18.0",
         # Deploy
         "docker[ssh]>=3.7.3",
         "google-api-python-client>=1.12.1",


### PR DESCRIPTION
There was a breaking change in the ruamel.yaml API, which has the unfortunate effect on our cli of causing commands like `det e config` to emit absolutely no error message, just exit 1 silently.

The fix is too big to squeeze into the release so we will use a pin until the real fix is ready.