### PR TITLE
fix: GetTasks doesn't respect rbac [DET-9914]

### DIFF
--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -38,6 +38,7 @@ import (
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	modelauth "github.com/determined-ai/determined/master/internal/model"
+	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -88,10 +89,12 @@ var (
 )
 
 // pgdb can be nil to use the singleton database for testing.
-func setupExpAuthTest(t *testing.T, pgdb *db.PgDB) (
+func setupExpAuthTest(t *testing.T, pgdb *db.PgDB,
+	actorFunc ...func(context *actor.Context) error,
+) (
 	*apiServer, *mocks.ExperimentAuthZ, *mocks.ProjectAuthZ, model.User, context.Context,
 ) {
-	api, projectAuthZ, _, user, ctx := setupProjectAuthZTest(t, pgdb)
+	api, projectAuthZ, _, user, ctx := setupProjectAuthZTest(t, pgdb, actorFunc...)
 	if authZExp == nil {
 		authZExp = &mocks.ExperimentAuthZ{}
 		expauth.AuthZProvider.Register("mock", authZExp)

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/project"
+	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -39,8 +40,9 @@ func isMockAuthZ() bool {
 // pgdb can be nil to use the singleton database for testing.
 func setupProjectAuthZTest(
 	t *testing.T, pgdb *db.PgDB,
+	actorFunc ...func(context *actor.Context) error,
 ) (*apiServer, *mocks.ProjectAuthZ, *mocks.WorkspaceAuthZ, model.User, context.Context) {
-	api, workspaceAuthZ, curUser, ctx := setupWorkspaceAuthZTest(t, pgdb)
+	api, workspaceAuthZ, curUser, ctx := setupWorkspaceAuthZTest(t, pgdb, actorFunc...)
 
 	if pAuthZ == nil {
 		pAuthZ = &mocks.ProjectAuthZ{}

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -496,17 +496,18 @@ func (a *apiServer) GetTasks(
 			return nil, err
 		}
 
-		var ok bool
 		if !isExp {
-			ok, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
+			_, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
-		if !authz.IsPermissionDenied(err) || !ok {
-			pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
+		if authz.IsPermissionDenied(err) {
+			continue
 		} else if err != nil {
 			return nil, err
 		}
+
+		pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 	}
 
 	return &apiv1.GetTasksResponse{AllocationIdToSummary: pbAllocationIDToSummary}, nil

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -44,23 +44,30 @@ var (
 )
 
 // pgdb can be nil to use the singleton database for testing.
-func setupAPITest(t *testing.T, pgdb *db.PgDB) (*apiServer, model.User, context.Context) {
+func setupAPITest(t *testing.T, pgdb *db.PgDB,
+	actorFunc ...func(context *actor.Context) error,
+) (*apiServer, model.User, context.Context) {
+	system = actor.NewSystem("mock")
+	require.LessOrEqual(t, len(actorFunc), 1)
+	if len(actorFunc) == 0 {
+		actorFunc = append(actorFunc, func(context *actor.Context) error {
+			switch context.Message().(type) {
+			case sproto.DeleteJob:
+				context.Respond(sproto.EmptyDeleteJobResponse())
+			}
+			return nil
+		})
+	}
+
+	system = actor.NewSystem(uuid.New().String())
+	ref, _ := system.ActorOf(sproto.K8sRMAddr, actor.ActorFunc(actorFunc[0]))
+	mockRM = actorrm.Wrap(ref)
+
 	if pgdb == nil {
 		if thePgDB == nil {
 			thePgDB = db.MustResolveTestPostgres(t)
 			db.MustMigrateTestPostgres(t, thePgDB, "file://../static/migrations")
 			require.NoError(t, etc.SetRootPath("../static/srv"))
-
-			system = actor.NewSystem("mock")
-			ref, _ := system.ActorOf(sproto.K8sRMAddr, actor.ActorFunc(
-				func(context *actor.Context) error {
-					switch context.Message().(type) {
-					case sproto.DeleteJob:
-						context.Respond(sproto.EmptyDeleteJobResponse())
-					}
-					return nil
-				}))
-			mockRM = actorrm.Wrap(ref)
 		}
 		pgdb = thePgDB
 	} else {
@@ -368,8 +375,9 @@ func TestRenameUserThenReuseName(t *testing.T) {
 // pgdb can be nil to use the singleton database for testing.
 func setupUserAuthzTest(
 	t *testing.T, pgdb *db.PgDB,
+	actorFunc ...func(context *actor.Context) error,
 ) (*apiServer, *mocks.UserAuthZ, model.User, context.Context) {
-	api, curUser, ctx := setupAPITest(t, pgdb)
+	api, curUser, ctx := setupAPITest(t, pgdb, actorFunc...)
 
 	if authzUser == nil {
 		authzUser = &mocks.UserAuthZ{}

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/workspace"
+	"github.com/determined-ai/determined/master/pkg/actor"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -214,8 +215,9 @@ var wAuthZ *mocks.WorkspaceAuthZ
 // pgdb can be nil to use the singleton database for testing.
 func setupWorkspaceAuthZTest(
 	t *testing.T, pgdb *db.PgDB,
+	actorFunc ...func(context *actor.Context) error,
 ) (*apiServer, *mocks.WorkspaceAuthZ, model.User, context.Context) {
-	api, _, curUser, ctx := setupUserAuthzTest(t, pgdb)
+	api, _, curUser, ctx := setupUserAuthzTest(t, pgdb, actorFunc...)
 
 	if wAuthZ == nil {
 		wAuthZ = &mocks.WorkspaceAuthZ{}


### PR DESCRIPTION
## Description

Get tasks had a regression making it not respect RBAC.

## Test Plan

Run a task on an RBAC cluster, then on a user with no permission check they can't see any in ```det task ls````


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
