### PR TITLE
fix: support ruamel.yaml>=0.18.0 [DET-9913]

### DIFF
--- a/e2e_tests/tests/cluster/test_checkpoints.py
+++ b/e2e_tests/tests/cluster/test_checkpoints.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Set, Tuple
 import pytest
 
 from determined import errors
-from determined.common import api, storage, yaml
+from determined.common import api, storage, util
 from determined.common.api import authentication, bindings, certs
 from determined.common.api.bindings import checkpointv1State
 from tests import api_utils
@@ -256,7 +256,7 @@ def run_gc_checkpoints_test(checkpoint_storage: Dict[str, str]) -> None:
 
         with tempfile.NamedTemporaryFile() as tf:
             with open(tf.name, "w") as f:
-                yaml.dump(config, f)
+                util.yaml_safe_dump(config, f)
 
             experiment_id = exp.create_experiment(tf.name, conf.fixtures_path("no_op"))
 

--- a/e2e_tests/tests/cluster/test_exp_continue.py
+++ b/e2e_tests/tests/cluster/test_exp_continue.py
@@ -4,7 +4,7 @@ from typing import Any, List, Tuple
 
 import pytest
 
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import bindings
 from tests import api_utils
 from tests import config as conf
@@ -32,7 +32,7 @@ def test_continue_config_file_cli() -> None:
 
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump({"hyperparameters": {"metrics_sigma": 1.0}}, f)
+            util.yaml_safe_dump({"hyperparameters": {"metrics_sigma": 1.0}}, f)
         det_cmd(["e", "continue", str(exp_id), "--config-file", tf.name], check=True)
 
     exp.wait_for_experiment_state(exp_id, bindings.experimentv1State.COMPLETED)
@@ -50,7 +50,9 @@ def test_continue_config_file_and_args_cli() -> None:
     expected_name = "checkThis"
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump({"name": expected_name, "hyperparameters": {"metrics_sigma": -1.0}}, f)
+            util.yaml_safe_dump(
+                {"name": expected_name, "hyperparameters": {"metrics_sigma": -1.0}}, f
+            )
 
         stdout = det_cmd(
             [

--- a/e2e_tests/tests/cluster/test_resource_manager.py
+++ b/e2e_tests/tests/cluster/test_resource_manager.py
@@ -6,7 +6,7 @@ from typing import List
 
 import pytest
 
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import bindings
 from determined.common.api.bindings import experimentv1State
 from tests import api_utils
@@ -42,7 +42,7 @@ def test_allocation_resources_incremental_release() -> None:
                 **config_obj.get("hyperparameters", {}),
                 **{"non_chief_exit_immediately": True},
             }
-            yaml.dump(config_obj, config_file)
+            util.yaml_safe_dump(config_obj, config_file)
 
             shutil.copy(
                 conf.fixtures_path("no_op/model_def.py"), os.path.join(context_dir, "model_def.py")

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -15,7 +15,7 @@ import pexpect
 import pytest
 from pexpect import spawn
 
-from determined.common import api, constants, yaml
+from determined.common import api, constants, util
 from determined.common.api import authentication, bindings, certs, errors
 from determined.experimental import Determined
 from tests import api_utils, command
@@ -862,7 +862,7 @@ def test_non_root_experiment(clean_auth: None, login_admin: None, tmp_path: path
             model_def_content = f.read()
 
         with open(conf.fixtures_path("no_op/single-one-short-step.yaml")) as f:
-            config = yaml.safe_load(f)
+            config = util.yaml_safe_load(f)
 
         # Use a user-owned path to ensure shared_fs uses the container_path and not host_path.
         with non_tmp_shared_fs_path() as host_path:
@@ -876,7 +876,7 @@ def test_non_root_experiment(clean_auth: None, login_admin: None, tmp_path: path
                 tmp_path,
                 {
                     "startup-hook.sh": "det --version || exit 77",
-                    "const.yaml": yaml.dump(config),  # type: ignore
+                    "const.yaml": util.yaml_safe_dump(config),
                     "model_def.py": model_def_content,
                 },
             ) as tree:

--- a/e2e_tests/tests/command/test_run.py
+++ b/e2e_tests/tests/command/test_run.py
@@ -10,7 +10,7 @@ import docker
 import docker.errors
 import pytest
 
-from determined.common import yaml
+from determined.common import util
 from tests import command as cmd
 from tests import config as conf
 from tests.filetree import FileTree
@@ -55,7 +55,7 @@ def _run_cmd_with_config_expecting_success(
 ) -> None:
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
 
         command = ["det", "-m", conf.make_master_url(), "cmd", "run", "--config-file", tf.name]
         if context_path:
@@ -70,7 +70,7 @@ def _run_cmd_with_config_expecting_failure(
 ) -> None:
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
 
         with pytest.raises(subprocess.CalledProcessError):
             _run_and_verify_failure(
@@ -639,7 +639,7 @@ def test_log_wait_timeout(tmp_path: Path, secrets: Dict[str, str]) -> None:
     config = {"environment": {"environment_variables": ["DET_LOG_WAIT_TIME=10"]}}
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
 
         cli = ["det", "-m", conf.make_master_url(), "cmd", "run", "--config-file", tf.name, cmd]
         p = subprocess.run(cli, stdout=subprocess.PIPE, check=True)

--- a/e2e_tests/tests/command/test_tensorboard.py
+++ b/e2e_tests/tests/command/test_tensorboard.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 import pytest
 
-from determined.common import api, yaml
+from determined.common import api, util
 from tests import command as cmd
 from tests import config as conf
 from tests import experiment as exp
@@ -55,7 +55,7 @@ def s3_config(num_trials: int, secrets: Dict[str, str], prefix: Optional[str] = 
     if prefix is not None:
         config_dict["checkpoint_storage"]["prefix"] = prefix  # type: ignore
 
-    return str(yaml.dump(config_dict))
+    return str(util.yaml_safe_dump(config_dict))
 
 
 @pytest.mark.slow
@@ -180,7 +180,7 @@ def test_start_tensorboard_with_custom_image(tmp_path: Path) -> None:
     t_id = res.stdout.strip("\n")
     command = ["det", "-m", conf.make_master_url(), "tensorboard", "config", t_id]
     res = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
-    config = yaml.safe_load(res.stdout)
+    config = util.yaml_safe_load(res.stdout)
     assert (
         config["environment"]["image"]["cpu"] == "python:3.8.16"
         and config["environment"]["image"]["cuda"] == "python:3.8.16"
@@ -214,7 +214,7 @@ def test_tensorboard_inherit_image_pull_secrets(tmp_path: Path) -> None:
     t_id = res.stdout.strip("\n")
     command = ["det", "-m", conf.make_master_url(), "tensorboard", "config", t_id]
     res = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
-    config = yaml.safe_load(res.stdout)
+    config = util.yaml_safe_load(res.stdout)
 
     ips = config["environment"]["pod_spec"]["spec"]["imagePullSecrets"]
 

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pytest
 
-from determined.common import api, yaml
+from determined.common import api, util
 from determined.common.api import authentication, bindings, certs
 from determined.common.api.bindings import experimentv1State, trialv1State
 from tests import api_utils
@@ -954,7 +954,7 @@ def run_basic_test_with_temp_config(
 ) -> int:
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         experiment_id = run_basic_test(
             tf.name,
             model_def_path,
@@ -972,7 +972,7 @@ def run_failure_test_with_temp_config(
 ) -> int:
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         return run_failure_test(tf.name, model_def_path, error_str=error_str)
 
 

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -4,7 +4,7 @@ import tempfile
 
 import pytest
 
-from determined.common import api, yaml
+from determined.common import api, util
 from determined.common.api import bindings
 from determined.experimental import Determined
 from tests import api_utils
@@ -350,7 +350,7 @@ def test_max_concurrent_trials(name: str, searcher_cfg: str) -> None:
 
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(tf.name, conf.fixtures_path("no_op"), [])
 
     try:

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -9,7 +9,7 @@ import pytest
 from urllib3 import connectionpool
 
 from determined import searcher
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import bindings
 from determined.experimental import client
 from tests import api_utils
@@ -196,7 +196,7 @@ def test_pause_multi_trial_random_searcher_core_api() -> None:
 
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
 
         searcher_exp_id = exp.create_experiment(tf.name, model_def_path, None)
         exp.wait_for_experiment_state(

--- a/e2e_tests/tests/experiment/test_noop.py
+++ b/e2e_tests/tests/experiment/test_noop.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from determined.common import check, yaml
+from determined.common import check, util
 from determined.common.api import bindings
 from determined.experimental import Determined
 from tests import config as conf
@@ -93,7 +93,7 @@ def test_noop_pause_of_experiment_without_trials() -> None:
     config_obj["resources"] = {"slots_per_trial": impossibly_large}
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(tf.name, conf.fixtures_path("no_op"), None)
     exp.pause_experiment(experiment_id)
     exp.wait_for_experiment_state(experiment_id, bindings.experimentv1State.PAUSED)
@@ -120,7 +120,7 @@ def test_noop_pause_with_multiexperiment() -> None:
     config_obj["resources"] = {"slots_per_trial": impossibly_large}
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(tf.name, conf.fixtures_path("no_op"), None)
     exp.pause_experiments([experiment_id])
     exp.wait_for_experiment_state(experiment_id, bindings.experimentv1State.PAUSED)
@@ -143,7 +143,7 @@ def test_noop_pause_with_multiexperiment_filter() -> None:
     with tempfile.NamedTemporaryFile() as tf:
         config_obj["name"] = tf.name
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(tf.name, conf.fixtures_path("no_op"), None)
     exp.pause_experiments([], name=tf.name)
     exp.wait_for_experiment_state(experiment_id, bindings.experimentv1State.PAUSED)
@@ -203,7 +203,7 @@ def test_noop_single_warm_start() -> None:
 
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
 
         experiment_id3 = exp.run_basic_test(tf.name, conf.fixtures_path("no_op"), 1)
 
@@ -326,7 +326,7 @@ def test_noop_experiment_config_override() -> None:
     config_obj = conf.load_config(conf.fixtures_path("no_op/single-one-short-step.yaml"))
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(
             tf.name,
             conf.fixtures_path("no_op"),

--- a/e2e_tests/tests/experiment/test_profiling.py
+++ b/e2e_tests/tests/experiment/test_profiling.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 
 import pytest
 
-from determined.common import api, yaml
+from determined.common import api, util
 from determined.common.api import authentication, bindings, certs
 from tests import config as conf
 from tests import experiment as exp
@@ -31,7 +31,7 @@ def test_streaming_observability_metrics_apis(model_def: str, timings_enabled: b
     config_obj = conf.set_profiling_enabled(config_obj)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config_obj, f)
+            util.yaml_safe_dump(config_obj, f)
         experiment_id = exp.create_experiment(tf.name, model_def)
 
     exp.wait_for_experiment_state(experiment_id, bindings.experimentv1State.COMPLETED)

--- a/e2e_tests/tests/nightly/test_distributed.py
+++ b/e2e_tests/tests/nightly/test_distributed.py
@@ -4,8 +4,8 @@ import tempfile
 import warnings
 
 import pytest
-import yaml
 
+from determined.common import util
 from tests import config as conf
 from tests import experiment as exp
 
@@ -152,7 +152,7 @@ def test_hf_trainer_image_classification_deepspeed_autotuning() -> None:
     config = conf.load_config(config_path)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         _ = exp.run_basic_autotuning_test(
             tf.name,
             conf.hf_trainer_examples_path(test_dir),
@@ -169,7 +169,7 @@ def test_hf_trainer_language_modeling_deepspeed_autotuning() -> None:
     config = conf.load_config(config_path)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         _ = exp.run_basic_autotuning_test(
             tf.name,
             conf.hf_trainer_examples_path(test_dir),
@@ -186,7 +186,7 @@ def test_torchvision_core_api_deepspeed_autotuning() -> None:
     config = conf.load_config(config_path)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         _ = exp.run_basic_autotuning_test(
             tf.name,
             conf.deepspeed_autotune_examples_path(test_dir),
@@ -203,7 +203,7 @@ def test_torchvision_deepspeed_trial_deepspeed_autotuning() -> None:
     config = conf.load_config(config_path)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, "w") as f:
-            yaml.dump(config, f)
+            util.yaml_safe_dump(config, f)
         _ = exp.run_basic_autotuning_test(
             tf.name,
             conf.deepspeed_autotune_examples_path(test_dir),

--- a/e2e_tests/tests/template/test_template.py
+++ b/e2e_tests/tests/template/test_template.py
@@ -2,7 +2,7 @@ from typing import Optional, Tuple
 
 import pytest
 
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import Session, bindings, errors
 from tests import api_utils
 from tests import command as cmd
@@ -15,7 +15,7 @@ def test_set_template() -> None:
     template_name = "test_set_template"
     template_path = conf.fixtures_path("templates/template.yaml")
     tpl.set_template(template_name, template_path)
-    config = yaml.safe_load(tpl.describe_template(template_name))
+    config = util.yaml_safe_load(tpl.describe_template(template_name))
     assert config == conf.load_config(template_path)
 
 

--- a/e2e_tests/tests/test_sdk.py
+++ b/e2e_tests/tests/test_sdk.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import bindings, errors
 from determined.common.experimental import resource_pool
 from determined.common.experimental.metrics import TrialMetrics
@@ -17,7 +17,7 @@ from tests import config as conf
 @pytest.mark.e2e_cpu
 def test_completed_experiment_and_checkpoint_apis(client: _client.Determined) -> None:
     with open(conf.fixtures_path("no_op/single-one-short-step.yaml")) as f:
-        config = yaml.safe_load(f)
+        config = util.yaml_safe_load(f)
     config["hyperparameters"]["num_validation_metrics"] = 2
     # Test the use of the includes parameter, by feeding the model definition file via includes.
     emptydir = tempfile.mkdtemp()
@@ -89,7 +89,7 @@ def test_completed_experiment_and_checkpoint_apis(client: _client.Determined) ->
 @pytest.mark.e2e_cpu
 def test_checkpoint_apis(client: _client.Determined) -> None:
     with open(conf.fixtures_path("no_op/single-default-ckpt.yaml")) as f:
-        config = yaml.safe_load(f)
+        config = util.yaml_safe_load(f)
 
     # Test for 100 batches/checkpoint every 10 = 10 checkpoints.
     config["min_checkpoint_period"]["batches"] = 10
@@ -238,7 +238,7 @@ def test_checkpoint_apis(client: _client.Determined) -> None:
 def _make_live_experiment(client: _client.Determined) -> _client.Experiment:
     # Create an experiment that takes a long time to run
     with open(conf.fixtures_path("no_op/single-very-many-long-steps.yaml")) as f:
-        config = yaml.safe_load(f)
+        config = util.yaml_safe_load(f)
 
     exp = client.create_experiment(config, conf.fixtures_path("no_op"))
     # Wait for a trial to actually start.
@@ -346,7 +346,7 @@ def test_models(client: _client.Determined) -> None:
 @pytest.mark.e2e_cpu
 def test_stream_metrics(client: _client.Determined) -> None:
     with open(conf.fixtures_path("no_op/single-one-short-step.yaml")) as f:
-        config = yaml.safe_load(f)
+        config = util.yaml_safe_load(f)
     config["hyperparameters"]["num_validation_metrics"] = 2
     exp = client.create_experiment(config, conf.fixtures_path("no_op"))
     assert exp.wait() == _client.ExperimentState.COMPLETED
@@ -392,7 +392,7 @@ def test_stream_metrics(client: _client.Determined) -> None:
 @pytest.mark.e2e_cpu
 def test_model_versions(client: _client.Determined) -> None:
     with open(conf.fixtures_path("no_op/single-one-short-step.yaml")) as f:
-        config = yaml.safe_load(f)
+        config = util.yaml_safe_load(f)
     exp = client.create_experiment(config, conf.fixtures_path("no_op"))
     assert exp.wait() == _client.ExperimentState.COMPLETED
     ckpt = exp.top_checkpoint()

--- a/examples/legacy/gan/pix2pix_tf_keras/data.py
+++ b/examples/legacy/gan/pix2pix_tf_keras/data.py
@@ -126,7 +126,7 @@ def main():
     import matplotlib.pyplot as plt
     import yaml
 
-    config = yaml.load(open("const.yaml", "r"), Loader=yaml.BaseLoader)
+    config = yaml.safe_load(open("const.yaml", "r"), Loader=yaml.BaseLoader)
     path, dataset_name = config["data"]["base"], config["data"]["dataset"]
     path = download(path, dataset_name)
 

--- a/examples/legacy/gan/pix2pix_tf_keras/fit.py
+++ b/examples/legacy/gan/pix2pix_tf_keras/fit.py
@@ -56,7 +56,7 @@ def fit(train_ds, test_ds, steps, preview=0):
 def main():
     import yaml
 
-    config = yaml.load(open("const.yaml", "r"), Loader=yaml.BaseLoader)
+    config = yaml.safe_load(open("const.yaml", "r"), Loader=yaml.BaseLoader)
     path, dataset_name = config["data"]["base"], config["data"]["dataset"]
     path = download(path, dataset_name)
 

--- a/harness/determined/cli/command.py
+++ b/harness/determined/cli/command.py
@@ -12,12 +12,9 @@ from termcolor import colored
 import determined.cli.render
 from determined import cli
 from determined.cli import render
-from determined.common import api, context, util, yaml
+from determined.common import api, context, util
 from determined.common.api import authentication
 from determined.util import merge_dicts
-
-yaml = yaml.YAML(typ="safe", pure=True)  # type: ignore
-
 
 CONFIG_DESC = """
 Additional configuration arguments for setting up a command.
@@ -328,15 +325,15 @@ def parse_config_overrides(config: Dict[str, Any], overrides: Iterable[str]) -> 
             # Certain configurations keys are expected to have list values.
             # Convert a single value to a singleton list if needed.
             if key in _CONFIG_PATHS_COERCE_TO_LIST and value.startswith("{"):
-                value = [yaml.load(value)]
+                value = [util.yaml_safe_load(value)]
             else:
-                value = yaml.load(value)
-        # Separate values if a comma exists. Use yaml.load() to cast
+                value = util.yaml_safe_load(value)
+        # Separate values if a comma exists. Use yaml_safe_load() to cast
         # the value(s) to the type YAML would use, e.g., "4" -> 4.
         elif "," in value:
-            value = [yaml.load(v) for v in value.split(",")]
+            value = [util.yaml_safe_load(v) for v in value.split(",")]
         else:
-            value = yaml.load(value)
+            value = util.yaml_safe_load(value)
             # Certain configurations keys are expected to have list values.
             # Convert a single value to a singleton list if needed.
             if key in _CONFIG_PATHS_COERCE_TO_LIST:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -21,7 +21,7 @@ from determined import cli
 from determined.cli import checkpoint, render
 from determined.cli.command import CONFIG_DESC, parse_config_overrides
 from determined.cli.errors import CliError
-from determined.common import api, context, set_logger, util, yaml
+from determined.common import api, context, set_logger, util
 from determined.common.api import authentication, bindings, logs
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.experimental import client
@@ -243,7 +243,7 @@ def submit_experiment(args: Namespace) -> None:
         # The user provided tweaks as cli args, so we have to reserialize the submitted experiment
         # config.  This will unfortunately remove comments they had in the yaml, so we only do it
         # when we have to.
-        yaml_dump = yaml.dump(experiment_config)
+        yaml_dump = util.yaml_safe_dump(experiment_config)
         assert yaml_dump is not None
         config_text = yaml_dump
 
@@ -272,7 +272,7 @@ def submit_experiment(args: Namespace) -> None:
         print(termcolor.colored("Creating test experiment...", "yellow"), end="\r")
         req.validateOnly = False
         test_config = det._make_test_experiment_config(experiment_config)
-        req.config = yaml.dump(test_config)
+        req.config = util.yaml_safe_dump(test_config)
         resp = bindings.post_CreateExperiment(sess, body=req)
         print(termcolor.colored(f"Created test experiment {resp.experiment.id}", "green"))
 
@@ -308,7 +308,7 @@ def continue_experiment(args: Namespace) -> None:
     else:
         experiment_config = parse_config_overrides({}, args.config)
 
-    config_text = yaml.dump(experiment_config)
+    config_text = util.yaml_safe_dump(experiment_config)
 
     sess = cli.setup_session(args)
     req = bindings.v1ContinueExperimentRequest(
@@ -654,7 +654,7 @@ def config(args: Namespace) -> None:
     result = bindings.get_GetExperiment(
         cli.setup_session(args), experimentId=args.experiment_id
     ).experiment.config
-    yaml.safe_dump(result, stream=sys.stdout, default_flow_style=False)
+    util.yaml_safe_dump(result, stream=sys.stdout, default_flow_style=False)
 
 
 @authentication.required

--- a/harness/determined/cli/job.py
+++ b/harness/determined/cli/job.py
@@ -4,7 +4,7 @@ from typing import Any, List, Union
 
 from determined import cli
 from determined.cli import render
-from determined.common import api, yaml
+from determined.common import api, util
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd, Group
 from determined.common.util import parse_protobuf_timestamp
@@ -46,7 +46,7 @@ def ls(args: Namespace) -> None:
             "jobs": [v.to_json() for v in jobs],
         }
         if args.yaml:
-            print(yaml.safe_dump(data, default_flow_style=False))
+            print(util.yaml_safe_dump(data, default_flow_style=False))
         elif args.json:
             render.print_json(data)
         return

--- a/harness/determined/cli/master.py
+++ b/harness/determined/cli/master.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 import determined.cli.render
 from determined import cli
 from determined.cli.errors import CliError
-from determined.common import yaml
+from determined.common import util
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
@@ -62,7 +62,7 @@ def config(args: Namespace) -> None:
     if args.json:
         determined.cli.render.print_json(resp)
     else:
-        print(yaml.safe_dump(resp, default_flow_style=False))
+        print(util.yaml_safe_dump(resp, default_flow_style=False))
 
 
 def get_master(args: Namespace) -> None:
@@ -70,7 +70,7 @@ def get_master(args: Namespace) -> None:
     if args.json:
         determined.cli.render.print_json(resp.to_json())
     else:
-        print(yaml.safe_dump(resp.to_json(), default_flow_style=False))
+        print(util.yaml_safe_dump(resp.to_json(), default_flow_style=False))
 
 
 def format_log_entry(log: bindings.v1LogEntry) -> str:

--- a/harness/determined/cli/render.py
+++ b/harness/determined/cli/render.py
@@ -10,7 +10,6 @@ For example, the following two lines of pseudocode return similar objects:
 * bindings.v1Model.to_json()
 * _render.model_to_json(model.Model)
 """
-import base64
 import csv
 import inspect
 import json
@@ -25,7 +24,7 @@ import tabulate
 import termcolor
 
 from determined import util as det_util
-from determined.common import util, yaml
+from determined.common import util
 from determined.experimental import Model, Project
 
 # Avoid reporting BrokenPipeError when piping `tabulate` output through
@@ -114,16 +113,8 @@ def render_objects(
     print(tabulate.tabulate(values, headers, tablefmt=table_fmt), flush=False)
 
 
-def format_base64_as_yaml(source: str) -> str:
-    s = yaml.safe_dump(yaml.safe_load(base64.b64decode(source)), default_flow_style=False)
-
-    if not isinstance(s, str):
-        raise AssertionError("cannot format base64 string to yaml")
-    return s
-
-
 def format_object_as_yaml(source: Dict[str, Any]) -> str:
-    s = yaml.safe_dump(source, default_flow_style=False)
+    s = util.yaml_safe_dump(source, default_flow_style=False)
     if not isinstance(s, str):
         raise AssertionError("cannot format object to yaml")
     return s

--- a/harness/determined/cli/template.py
+++ b/harness/determined/cli/template.py
@@ -7,7 +7,7 @@ from termcolor import colored
 from determined import cli
 from determined.cli import render
 from determined.cli.workspace import get_workspace_id_from_args, workspace_arg
-from determined.common import api, util, yaml
+from determined.common import api, util
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, Cmd
 
@@ -17,7 +17,7 @@ TemplateAll = namedtuple("TemplateAll", ["name", "workspace", "config"])
 
 def _parse_config(data: Dict[str, Any]) -> Any:
     # Pretty print the config field.
-    return yaml.safe_dump(data, default_flow_style=False)
+    return util.yaml_safe_dump(data, default_flow_style=False)
 
 
 @authentication.required

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -5,7 +5,7 @@ import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 import determined as det
-from determined.common import api, context, util, yaml
+from determined.common import api, context, util
 from determined.common.api import authentication, bindings, certs, errors
 from determined.common.experimental import (
     checkpoint,
@@ -164,7 +164,7 @@ class Determined:
                 config_text = f.read()
             _ = util.safe_load_yaml_with_exceptions(config_text)
         elif isinstance(config, Dict):
-            yaml_dump = yaml.dump(config)
+            yaml_dump = util.yaml_safe_dump(config)
             assert yaml_dump is not None
             config_text = yaml_dump
         else:

--- a/harness/determined/deploy/aws/gen_vcpu_mapping.py
+++ b/harness/determined/deploy/aws/gen_vcpu_mapping.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, List, Tuple
 
 import boto3
 
-from determined.common import yaml
+from determined.common import util
 
 
 def _fetch_vcpu_mapping() -> Iterable[Tuple[str, Dict]]:
@@ -36,7 +36,7 @@ def fetch_vcpu_mapping() -> List[Dict]:
 def main(args: argparse.Namespace) -> None:
     data = fetch_vcpu_mapping()
     with args.output_fn.open("w") as fout:
-        yaml.safe_dump(data, fout)
+        util.yaml_safe_dump(data, fout)
 
 
 if __name__ == "__main__":

--- a/harness/determined/deploy/gcp/gcp.py
+++ b/harness/determined/deploy/gcp/gcp.py
@@ -11,13 +11,13 @@ import googleapiclient.discovery
 from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import storage
 from googleapiclient.errors import HttpError
-from ruamel import yaml
 from tabulate import tabulate
 from termcolor import colored
 
 from determined import util
 from determined.cli import render
 from determined.cli.errors import CliError
+from determined.common import util as common_util
 from determined.deploy import healthcheck
 
 from .preflight import check_quota
@@ -398,7 +398,7 @@ def list_clusters(bucket_name: str, project_id: str, print_format: str = "table"
     if print_format == "json":
         render.print_json(cluster_json)
     elif print_format == "yaml":
-        cluster_yaml = yaml.dump(cluster_json)
+        cluster_yaml = common_util.yaml_safe_dump(cluster_json)
         print(cluster_yaml)
     else:
         print(tabulate(cluster_list, headers="firstrow"))

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -13,7 +13,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Typ
 import appdirs
 import docker
 
-from determined.common import yaml
+from determined.common import util
 from determined.deploy.errors import MasterTimeoutExpired
 from determined.deploy.healthcheck import wait_for_master
 
@@ -158,7 +158,7 @@ def master_up(
 
     if master_config_path is not None:
         with master_config_path.open() as f:
-            master_conf = yaml.safe_load(f)
+            master_conf = util.yaml_safe_load(f)
     else:
         master_conf = MASTER_CONF_DEFAULT
         make_temp_conf = True
@@ -188,7 +188,7 @@ def master_up(
     if make_temp_conf:
         fd, temp_path = tempfile.mkstemp(prefix="det-deploy-local-master-config-")
         with open(fd, "w") as f:
-            yaml.dump(master_conf, f)
+            util.yaml_safe_dump(master_conf, f)
         master_config_path = pathlib.Path(temp_path)
 
     # This is always true by now, but mypy needs help.
@@ -423,7 +423,7 @@ def agent_up(
     volumes = ["/var/run/docker.sock:/var/run/docker.sock"]
     if agent_config_path is not None:
         with agent_config_path.open() as f:
-            agent_conf = yaml.safe_load(f)
+            agent_conf = util.yaml_safe_load(f)
         volumes += [f"{os.path.abspath(agent_config_path)}:/etc/determined/agent.yaml"]
 
     # Fallback on agent config for options not specified as flags.

--- a/harness/determined/experimental/core_v2/_core_v2.py
+++ b/harness/determined/experimental/core_v2/_core_v2.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import determined
 from determined import core, experimental
-from determined.common import yaml
+from determined.common import util
 from determined.experimental import core_v2
 
 logger = logging.getLogger("determined.experimental.core_v2")
@@ -166,7 +166,7 @@ def _init_context(
         "project": unmanaged_config.project,
     }
 
-    config_text = yaml.dump(config)
+    config_text = util.yaml_safe_dump(config)
     assert config_text is not None
 
     unmanaged_info = core_v2._get_or_create_experiment_and_trial(

--- a/harness/determined/experimental/core_v2/_unmanaged.py
+++ b/harness/determined/experimental/core_v2/_unmanaged.py
@@ -1,10 +1,9 @@
-import io
 import logging
 from typing import Callable, Optional, Tuple, TypeVar, Union
 
 import determined as det
 from determined import core, experimental
-from determined.common import api, yaml
+from determined.common import api, util
 from determined.common.api import bindings
 
 logger = logging.getLogger("determined.experimental.unmanaged")
@@ -237,7 +236,7 @@ def _build_unmanaged_trial_cluster_info(
             experiment_id=exp_id,
             trial_seed=0,
             hparams=hparams or {},
-            config=yaml.safe_load(io.StringIO(config_text)),
+            config=util.yaml_safe_load(config_text),
             steps_completed=resp.stepsCompleted,
             trial_run_id=resp.trialRunId,
             debug=False,

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -43,9 +43,7 @@ setuptools.setup(
         "python-dateutil",
         "pytz",
         "tabulate>=0.8.3",
-        # det preview-search "pretty-dumps" a sub-yaml with an API added in 0.15.29
-        # 0.18.0 has a breaking change that we haven't reacted to yet.
-        "ruamel.yaml>=0.15.29,<0.18.0",
+        "ruamel.yaml",
         # Deploy
         "docker[ssh]>=3.7.3",
         "google-api-python-client>=1.12.1",

--- a/harness/tests/common/test_yaml.py
+++ b/harness/tests/common/test_yaml.py
@@ -1,0 +1,48 @@
+import pathlib
+import shutil
+import tempfile
+
+from determined.common import util
+
+
+def test_yaml_safe_load_strings() -> None:
+    input_text = "asdf: 1\n"
+    expect = {"asdf": 1}
+
+    assert util.yaml_safe_load(input_text) == expect
+
+
+def test_yaml_safe_load_files() -> None:
+    input_text = "asdf: 1\n"
+    expect = {"asdf": 1}
+
+    d = pathlib.Path(tempfile.mkdtemp())
+    try:
+        path = d / "temp"
+        path.write_text(input_text)
+        with path.open() as f:
+            assert util.yaml_safe_load(f) == expect
+    finally:
+        shutil.rmtree(d)
+
+
+def test_yaml_safe_dump_strings() -> None:
+    input_obj = {"asdf": 1}
+    expect = "asdf: 1\n"
+
+    assert util.yaml_safe_dump(input_obj, default_flow_style=False) == expect
+
+
+def test_yaml_safe_dump_files() -> None:
+    input_obj = {"asdf": 1}
+    expect = "asdf: 1\n"
+
+    d = pathlib.Path(tempfile.mkdtemp())
+    try:
+        path = d / "temp"
+        with path.open("w") as f:
+            util.yaml_safe_dump(input_obj, stream=f, default_flow_style=False)
+        got_text = path.read_text()
+        assert got_text == expect
+    finally:
+        shutil.rmtree(d)

--- a/harness/tests/experiment/fixtures/pytorch_onevar_model.py
+++ b/harness/tests/experiment/fixtures/pytorch_onevar_model.py
@@ -38,8 +38,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, cast
 import numpy as np
 import torch
 
-from determined import experimental, pytorch
-from determined.common import yaml
+from determined import pytorch
 from determined.pytorch import samplers
 from tests.experiment.fixtures import pytorch_counter_callback
 
@@ -668,23 +667,3 @@ class OneVarTrialCallbacks(OneVarTrial):
 
     def build_callbacks(self) -> Dict[str, pytorch.PyTorchCallback]:
         return {"counter": self.counter, "legacyCounter": self.legacy_counter}
-
-
-if __name__ == "__main__":
-    conf = yaml.safe_load(
-        """
-    description: test-native-api-local-test-mode
-    hyperparameters:
-      global_batch_size: 32
-      dataloader_type: determined
-    scheduling_unit: 1
-    searcher:
-      name: single
-      metric: val_loss
-      max_length:
-        batches: 1
-      smaller_is_better: true
-    max_restarts: 0
-    """
-    )
-    experimental.create(OneVarTrial, conf, context_dir=".", local=True, test=True)

--- a/tools/scripts/bumpenvs.py
+++ b/tools/scripts/bumpenvs.py
@@ -51,7 +51,7 @@ def replace_tags(path: str, old_tag: str, new_tag: str) -> None:
 
 def main(config_file: str) -> None:
     with open(config_file) as f:
-        config = yaml.safe_load(f)
+        config = yaml.YAML(typ="safe", pure=True).load(f)
 
     for image_type, tag_pair in config.items():
         if "old" not in tag_pair:

--- a/tools/scripts/refresh-ubuntu-amis.py
+++ b/tools/scripts/refresh-ubuntu-amis.py
@@ -54,7 +54,7 @@ def update_tag_for_image_type(subconf: Dict[str, str], new_tag: str) -> bool:
 
 def update_bumpenvs_yaml(table: List[List[str]], path: str) -> None:
     with open(path) as f:
-        bumpenvs_conf = yaml.safe_load(f)
+        bumpenvs_conf = yaml.YAML(typ="safe", pure=True).load(f)
 
     # All master-amis and bastion-amis in bumpenvs.yaml are updated.
     # The agent-amis are updated after each rebuild of the environments repo.
@@ -74,7 +74,7 @@ def update_bumpenvs_yaml(table: List[List[str]], path: str) -> None:
                 update_tag_for_image_type(subconf, new_ami)
 
     with open(path, "w") as f:
-        yaml.dump(bumpenvs_conf, f)
+        yaml.YAML(typ="safe", pure=True).dump(bumpenvs_conf, f)
 
 
 def update_packer_json(table: List[List[str]], path: str) -> None:

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -234,19 +234,17 @@ if __name__ == "__main__":
     commit = args.commit
 
     with open(path) as f:
-        conf = yaml.safe_load(f)
+        conf = yaml.YAML(typ="safe", pure=True).load(f)
 
     builds = get_all_builds(commit, args.dev, args.cloud_images)
     artifacts = get_all_artifacts(builds, args.cloud_images)
 
     tag_list = [
-        *(yaml.safe_load(artifacts[artifact]) for artifact in DOCKER_ARTIFACTS),
+        yaml.YAML(typ="safe", pure=True).load(artifacts[artifact]) for artifact in DOCKER_ARTIFACTS
     ]
 
     if args.cloud_images:
-        tag_list += [
-            *(parse_packer_log(artifacts[artifact]) for artifact in PACKER_ARTIFACTS),
-        ]
+        tag_list += [parse_packer_log(artifacts[artifact]) for artifact in PACKER_ARTIFACTS]
 
     # Flatten tag_list dicts into one dict.
     new_tags = {k: v for d in tag_list for (k, v) in d.items()}
@@ -267,6 +265,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     with open(path, "w") as f:
-        yaml.dump(conf, f)
+        yaml.YAML(typ="safe", pure=True).dump(conf, f)
 
     print(f"done, {path} has been updated", file=sys.stderr)


### PR DESCRIPTION
We pinned the ruamel.yaml<0.18.0 in a recent release as a hotfix, but this is the real fix.

## Test Plan

- [x] I manually executed every affected harness/determined/ codepath to make sure things looked right
- [x] grepped the code for all instances of `yaml\.(safe|dump|load)`
- [x] added unit tests for `util.yaml_safe_load` and `util.yaml_safe_dump`

## Commentary

This is a continuation of the mistakenly-merged #8228.