### PR TITLE
Create a link to mldes

### DIFF
--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -49,6 +49,20 @@ resources. Compatible with on-prem clusters and cloud auto-scaling (AWS and GCP)
 
 -  :ref:`topic_guide_gcp`
 
+***********************************
+ Bring Your Own Cloud (Evaluation)
+***********************************
+
+Get access to AI clusters running Determined without having to provision or configure the hardware
+yourself.
+
+-  `Trial sign-up page <http://mldes.ext.hpe.com/trial>`_
+-  `Documentation <https://mldes.ext.hpe.com/docs/index.html>`_
+
+.. attention::
+
+   This method is only available on Determined Enterprise Edition.
+
 ************
  Kubernetes
 ************


### PR DESCRIPTION
Do not merge until the sign up page is available.

## Description

Make users aware of the trial HPE Machine Learning Development Environment Software (MLDES) when they visit the setup page.

## Dependencies

This PR cannot be included in a release until the sign up page is available http://mldes.ext.hpe.com/trial.