### PR TITLE
fix: prevent passing login r= param to relayState

### DIFF
--- a/webui/react/src/ee/SamlAuth.test.ts
+++ b/webui/react/src/ee/SamlAuth.test.ts
@@ -12,6 +12,10 @@ describe('SamlAuth', () => {
         default: 'sortDesc=false&sortKey=SORT_BY_NAME&tags=mnist',
         encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
       },
+      {
+        default: 'sortDesc=false&r=0.123&sortKey=SORT_BY_NAME&tags=mnist',
+        encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
+      },
     ];
 
     it('should return base path only if no queries are provided', () => {

--- a/webui/react/src/ee/SamlAuth.ts
+++ b/webui/react/src/ee/SamlAuth.ts
@@ -1,6 +1,9 @@
 import router from 'router';
 
 export const samlUrl = (basePath: string, queries?: string): string => {
+  if (queries) {
+    queries = queries.replace(/r=0\.\d+[&]?/, '');
+  }
   if (!queries) return basePath;
   return `${basePath}?relayState=${encodeURIComponent(queries)}`;
 };


### PR DESCRIPTION
## Description

Previously in #5962 we added `?r=0.123` to our Login page URL to make a clean login page
This was related to some earlier PRs on login and LocalStorage such as #5911

We believe the issue in 3rd-party logins is that `r=0.123` is encoded by our state-preservation code and passed to `relayState`. This PR removes the `r=` parameter and may remove `relayState` entirely if there are no other URL variables.  We include an example of this in the test.

## Test Plan

PR testing whether this introduces problems: changes are tested and do not introduce problems

Testing for team with OIDC log in , to see if it fixes their bugs:
- successful SAML log in
- successful OIDC log in
- as admin, create a new non-admin user with no workspaces or permissions
- when logged out, a page such as `/det/workspaces` redirects to login
- can log in as admin and see workspaces, log out, then log in as non-admin and not have cached workspaces
- a failed username/password gives another chance to log in

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.