### PR TITLE
fix: Dont suggest register / delete a deleted checkpoint [WEB-1736]

### DIFF
--- a/webui/react/src/components/CheckpointModal.tsx
+++ b/webui/react/src/components/CheckpointModal.tsx
@@ -188,6 +188,7 @@ ${checkpoint?.totalBatches}. This action may complete or fail without further no
     <Modal
       cancel
       submit={{
+        disabled: checkpoint?.state === CheckpointState.Deleted,
         handleError,
         handler: handleOk,
         text: 'Register Checkpoint',

--- a/webui/react/src/utils/checkpoint.ts
+++ b/webui/react/src/utils/checkpoint.ts
@@ -7,9 +7,6 @@ import {
 
 type CheckpointChecker = (checkpoint: CoreApiGenericCheckpoint) => boolean;
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export const alwaysTrueCheckpointChecker = (checkpoint: CoreApiGenericCheckpoint): boolean => true;
-
 const CheckpointCheckers: Record<CheckpointAction, CheckpointChecker> = {
   /**
    * for internal use: the typing ensures that checkers
@@ -17,7 +14,7 @@ const CheckpointCheckers: Record<CheckpointAction, CheckpointChecker> = {
    * we expose the functions below as convenient wrappers
    */
 
-  [checkpointAction.Delete]: alwaysTrueCheckpointChecker,
+  [checkpointAction.Delete]: (checkpoint) => checkpoint.state !== CheckpointState.Deleted,
 
   [checkpointAction.Register]: (checkpoint) => checkpoint.state === CheckpointState.Completed,
 };


### PR DESCRIPTION
## Description

When an experiment checkpoint was previously deleted, we should disable the "Register Checkpoint" option. We previously partly disabled "Delete Checkpoint"

## Test Plan

On `/det/experiments/2727/checkpoints` (or another experiment with a mix of completed and deleted checkpoints):
- On the table of checkpoints, on the right is a three-dots menu. Completed checkpoints have "Register" and "Delete" options; Deleted checkpoints have both options disabled
- Click a flag of a completed checkpoint. The link to Delete and modal-finish button (Register Checkpoint) are enabled
- Click a flag of a deleted checkpoint. The link to Delete is missing and Register Checkpoint is disabled

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.