### PR TITLE
docs: check for dropped urls in PRs

### DIFF
--- a/docs/.redirects/redirects.json
+++ b/docs/.redirects/redirects.json
@@ -1,4 +1,8 @@
 {
+    "setup-cluster/internet-access": "checklists/adv-requirements.html",
+    "setup-cluster/deploy-cluster/internet-access": "../checklists/adv-requirements.html",
+    "setup-cluster/firewall-rules": "checklists/adv-requirements.html",
+    "setup-cluster/deploy-cluster/firewall-rules": "../checklists/adv-requirements.html",
     "articles/index": "../tutorials/_index.html",
     "example-solutions/examples": "../get-started/example-solutions/_index.html",
     "setup-cluster/basic": "../get-started/basic.html",

--- a/docs/redirects.py
+++ b/docs/redirects.py
@@ -290,12 +290,25 @@ if __name__ == "__main__":
         exit(1)
 
     if sys.argv[1] == "check":
+        #check for broken links
         errors = check_links(links)
         if errors:
             print("check failed, errors detected!", file=sys.stderr)
             for e in errors:
                 print(e, file=sys.stderr)
             exit(1)
+
+        #check for dropped urls
+        all_urls = set(l.src for l in links).union(all_urls_from_files())
+        dropped = published.difference(all_urls)
+        if dropped:
+            print(
+                "check failed; the following previously-published urls seem to have been "
+                "dropped and should be assigned redirects:\n    " + "\n    ".join(dropped),
+                file=sys.stderr,
+            )
+            exit(1)
+
         exit(0)
 
     if sys.argv[1] == "publish":

--- a/docs/redirects.py
+++ b/docs/redirects.py
@@ -290,13 +290,15 @@ if __name__ == "__main__":
         exit(1)
 
     if sys.argv[1] == "check":
+        return_code = 0
+
         #check for broken links
         errors = check_links(links)
         if errors:
             print("check failed, errors detected!", file=sys.stderr)
             for e in errors:
                 print(e, file=sys.stderr)
-            exit(1)
+            return_code = 1
 
         #check for dropped urls
         all_urls = set(l.src for l in links).union(all_urls_from_files())
@@ -307,9 +309,9 @@ if __name__ == "__main__":
                 "dropped and should be assigned redirects:\n    " + "\n    ".join(dropped),
                 file=sys.stderr,
             )
-            exit(1)
+            return_code = 1
 
-        exit(0)
+        exit(return_code)
 
     if sys.argv[1] == "publish":
         """


### PR DESCRIPTION
## Description

`make docs publish` requires that all previously-published URLs have a redirect, even if that redirect is to something like `_index.html`.  This PR makes sure that this condition will be checked in `redirects.py check` and consequently `make docs check` to catch this error before `redirects.py publish` is attempted.

Also add some redirects for some dropped previously-published urls.


## Test Plan

1. Navigate to `determined/docs`
2. Run `python redirects.py check`. There should be no errors.
3. Delete a file, such as `docs/integrations/prometheus/_index.rst`
4. Run `python redirects.py check`. There should be errors for broken redirects AND errors for dropped published urls. 


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1100

