### PR TITLE
docs: fix inaccuracies in `bind_mounts` docs.

### DIFF
--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -149,7 +149,7 @@ The default list of devices to pass to the Docker daemon. Ignored by resource ma
 ===============
 
 The default bind mounts to pass to the Docker container. Ignored by resource managers of type
-``kubernetes``. See :ref:`resources.devices <exp-bind-mounts>` for more details.
+``kubernetes``. See :ref:`bind_mounts <exp-bind-mounts>` for more details.
 
 ``kubernetes``
 ==============

--- a/docs/reference/training/experiment-config-reference.rst
+++ b/docs/reference/training/experiment-config-reference.rst
@@ -1170,12 +1170,12 @@ For each bind mount, the following optional fields may also be specified:
 ``read_only``
 =============
 
-Required. Whether the bind-mount should be a read-only mount. Defaults to ``false``.
+Optional. Whether the bind-mount should be a read-only mount. Defaults to ``false``.
 
 ``propagation``
 ===============
 
-Required. `Propagation behavior
+Optional. `Propagation behavior
 <https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__ for replicas of the
 bind-mount. Defaults to ``rprivate``.
 


### PR DESCRIPTION
## Description

- Link to the `bind_mount` docs from exp config had "resource.devices" text for some reason.
- Some internal `bind_mounts` fields were marked as required while in fact they are optional and have a default.

## Test Plan

N/A

## Commentary (optional)

Sometimes I read the docs.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
