### PR TITLE
fix: only train for one batch in PyTorch Trainer test mode

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -750,14 +750,14 @@ class _PyTorchTrialController:
     def _train_for_op(
         self, op: core.SearcherOperation, train_boundaries: List[_TrainBoundary]
     ) -> None:
-        if self.local_training:
+        if self.test_mode:
+            train_length = Batch(1)
+        elif self.local_training:
             train_length = self.max_length
         else:
             train_length = TrainUnit._from_searcher_unit(
                 op.length, self.searcher_unit, self.global_batch_size
             )
-        if self.test_mode:
-            train_length = Batch(1)
         assert train_length
 
         while self._steps_until_complete(train_length) > 0:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -753,11 +753,11 @@ class _PyTorchTrialController:
         if self.test_mode:
             train_length = Batch(1)
         elif self.local_training:
-            train_length = self.max_length
+            train_length = self.max_length  # type: ignore
         else:
             train_length = TrainUnit._from_searcher_unit(
                 op.length, self.searcher_unit, self.global_batch_size
-            )
+            )  # type: ignore
         assert train_length
 
         while self._steps_until_complete(train_length) > 0:

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -751,14 +751,14 @@ class _PyTorchTrialController:
         self, op: core.SearcherOperation, train_boundaries: List[_TrainBoundary]
     ) -> None:
         if self.local_training:
-            searcher_length = self.max_length
+            train_length = Batch(1) if self.test_mode else self.max_length
         else:
-            searcher_length = TrainUnit._from_searcher_unit(
+            train_length = TrainUnit._from_searcher_unit(
                 op.length, self.searcher_unit, self.global_batch_size
             )
-        assert searcher_length
+        assert train_length
 
-        while self._steps_until_complete(searcher_length) > 0:
+        while self._steps_until_complete(train_length) > 0:
             train_boundaries, training_metrics = self._train_with_boundaries(
                 self.training_enumerator, train_boundaries
             )

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -751,11 +751,13 @@ class _PyTorchTrialController:
         self, op: core.SearcherOperation, train_boundaries: List[_TrainBoundary]
     ) -> None:
         if self.local_training:
-            train_length = Batch(1) if self.test_mode else self.max_length
+            train_length = self.max_length
         else:
             train_length = TrainUnit._from_searcher_unit(
                 op.length, self.searcher_unit, self.global_batch_size
             )
+        if self.test_mode:
+            train_length = Batch(1)
         assert train_length
 
         while self._steps_until_complete(train_length) > 0:

--- a/harness/tests/experiment/pytorch/test_pytorch_trial.py
+++ b/harness/tests/experiment/pytorch/test_pytorch_trial.py
@@ -1250,6 +1250,16 @@ class TestPyTorchTrial:
         got_prog = [x.args[0] for x in mock_report_progress.call_args_list]
         assert exp_prog == got_prog
 
+    def test_test_mode(self):
+        trial, trial_controller = pytorch_utils.create_trial_and_trial_controller(
+            trial_class=pytorch_onevar_model.OneVarTrial,
+            hparams=self.hparams,
+            trial_seed=self.trial_seed,
+            test_mode=True,
+        )
+        trial_controller.run()
+        assert trial_controller.state.batches_trained == 1
+
     @pytest.mark.parametrize(
         "ckpt",
         [

--- a/harness/tests/experiment/pytorch_utils.py
+++ b/harness/tests/experiment/pytorch_utils.py
@@ -29,6 +29,7 @@ def create_trial_and_trial_controller(
     min_checkpoint_batches: int = sys.maxsize,
     min_validation_batches: int = sys.maxsize,
     aggregation_frequency: int = 1,
+    test_mode: bool = False,
 ) -> typing.Tuple[pytorch.PyTorchTrial, pytorch._PyTorchTrialController]:
     assert issubclass(
         trial_class, pytorch.PyTorchTrial
@@ -101,7 +102,7 @@ def create_trial_and_trial_controller(
         latest_checkpoint=latest_checkpoint,
         steps_completed=steps_completed,
         smaller_is_better=bool(exp_config["searcher"]["smaller_is_better"]),
-        test_mode=False,
+        test_mode=test_mode,
         checkpoint_policy=exp_config["checkpoint_policy"],
         step_zero_validation=bool(exp_config["perform_initial_validation"]),
         det_profiler=None,


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

previous change to enable training lengths longer than searcher length introduced bug where test_mode flag will train for max_length instead of just one batch.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

run a script using pytorch trainer API (example for mnist):
```
import determined as det
import yaml
import logging
from model_def import MNistTrial

def main():

    with open("const.yaml", "r") as file:
        exp_conf = yaml.safe_load(file)

    hparams = exp_conf["hyperparameters"]

    with det.pytorch.init(hparams=hparams, exp_conf=exp_conf) as train_context:
        trial = MNistTrial(train_context)
        trainer = det.pytorch.Trainer(trial, train_context)

        trainer.fit(
            max_length=det.pytorch.Epoch(1),
            test_mode=True
        )

if __name__ == "__main__":
    # Configure logging
    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
    main()
```

verify in stdout that the code trains for 1 batch only.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
