### PR TITLE
docs: Fix a 404 error

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ almost any deep learning model using Determined.
    <div class="landing">
       <div class="tiles-flex">
          <div class="tile-container">
-            <a class="tile" href="architecture/_index.html">
+            <a class="tile" href="get-started/architecture/_index.html">
                <img class="tile-icon" src="_static/images/tools.png" alt="tools icon">
                <h2 class="tile-title">How It Works</h2>
                <p class="tile-description">Learn about core concepts, key features, and system architecture.</p>


### PR DESCRIPTION
docs: Fix a 404 error

reported by external user

the link from the landing page to "how it works" produces a 404 error

this is a result of the info architecture changes and the fact that we don't have a test for raw html on our index pages (i.e., if we move/rename files, nothing tells us the index page is broken)

we won't need these tests once we transition away from raw html (i.e., we recently implemented a new css with a custom sphinx extension that allows us to use .. container:: homepage (along with :glob: patterns) see [TECHWR337](https://hpe-aiatscale.atlassian.net/jira/software/projects/TECHWR/boards/41/backlog?selectedIssue=TECHWR-337))