### PR TITLE
chore: restore set resource pool using job service

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -312,8 +312,6 @@ func (c *command) Receive(ctx *actor.Context) error {
 		if err := c.persist(); err != nil {
 			ctx.Log().WithError(err).Warnf("command persist failure")
 		}
-	case sproto.GetJob:
-		ctx.Respond(c.ToV1Job())
 
 	case actor.PostStop:
 		if err := tasklist.GroupPriorityChangeRegistry.Delete(c.jobID); err != nil {
@@ -479,9 +477,6 @@ func (c *command) Receive(ctx *actor.Context) error {
 		if ctx.ExpectingResponse() {
 			ctx.Respond(err)
 		}
-
-	case sproto.SetResourcePool:
-		ctx.Respond(fmt.Errorf("setting resource pool for job type %s is not supported", c.jobType))
 
 	default:
 		return actor.ErrUnexpectedMessage(ctx)

--- a/master/internal/command/command_job_service.go
+++ b/master/internal/command/command_job_service.go
@@ -74,3 +74,8 @@ func (c *command) SetWeight(weight float64) error {
 	c.Config.Resources.Weight = weight
 	return nil
 }
+
+// SetResourcePool is not implemented for commands.
+func (c *command) SetResourcePool(resourcePool string) error {
+	return fmt.Errorf("setting resource pool for job type %s is not supported", c.jobType)
+}

--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -74,3 +74,11 @@ func (e *experiment) SetWeight(weight float64) error {
 	}
 	return err
 }
+
+// SetResourcePool sets the experiment's resource pool.
+func (e *experiment) SetResourcePool(resourcePool string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.setRP(resourcePool)
+}

--- a/master/internal/job/jobservice/jobservice.go
+++ b/master/internal/job/jobservice/jobservice.go
@@ -22,6 +22,7 @@ type Job interface {
 	ToV1Job() *jobv1.Job
 	SetJobPriority(priority int) error
 	SetWeight(weight float64) error
+	SetResourcePool(resourcePool string) error
 }
 
 // Service manages the job service.
@@ -191,7 +192,7 @@ func (s *Service) applyUpdate(update *jobv1.QueueControl) error {
 		if action.ResourcePool == "" {
 			s.syslog.Error("resource pool must be set")
 		}
-		return fmt.Errorf("setting resource pool for job type %s is not supported", action)
+		return j.SetResourcePool(action.ResourcePool)
 	case *jobv1.QueueControl_AheadOf:
 		return s.rm.MoveJob(sproto.MoveJob{
 			ID:     jobID,

--- a/master/internal/sproto/jobs.go
+++ b/master/internal/sproto/jobs.go
@@ -34,9 +34,6 @@ type RMJobInfo struct { // rename ?
 	AllocatedSlots int
 }
 
-// GetJob requests a job representation from a job.
-type GetJob struct{}
-
 // GetJobQ is used to get all job information in one go to avoid any inconsistencies.
 type GetJobQ struct {
 	ResourcePool string
@@ -81,11 +78,6 @@ type (
 	// SetGroupPriority sets the priority of the group in the priority scheduler.
 	SetGroupPriority struct {
 		Priority     int
-		ResourcePool string
-		JobID        model.JobID
-	}
-	// SetResourcePool switches the resource pool that the job belongs to.
-	SetResourcePool struct {
 		ResourcePool string
 		JobID        model.JobID
 	}


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

Restores job queue set resource pool behavior.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Automated testing.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
DET-9923

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
