### PR TITLE
fix: dsat with all yaml formats [MLG-1156]

### DIFF
--- a/harness/determined/pytorch/dsat/_utils.py
+++ b/harness/determined/pytorch/dsat/_utils.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, Generator, List, Optional, Union
 
 import filelock
 import torch
-from ruamel import yaml
 
 import determined as det
+from determined.common import util
 from determined.pytorch.dsat import _defaults
 from determined.util import merge_dicts
 
@@ -281,7 +281,7 @@ def get_dict_from_yaml_or_json_path(
             return {}
     else:
         with open(p, "r") as f:
-            yaml_dict: Dict[Any, Any] = yaml.YAML(typ="safe").load(f)
+            yaml_dict: Dict[Any, Any] = util.yaml_safe_load(f)
         return yaml_dict
 
 


### PR DESCRIPTION
Oops, we forgot to set the "make it work" switch to the "on" position.

For a valid yaml string:

    s = "image: {gpu: image:tag}"

This innocent looking code does not work:

    yaml.YAML(typ="safe").load(s)

But this code does work:

    yaml.YAML(typ="safe", pure=True).load(s)

Setting pure=True cause ruamel.yaml to skip the C implementation, which is apparently not entirely correct.  Why not?  Who knows.

This was exposed by the recent conversion of some
`yaml.dump(config)` calls to `util.yaml_safe_dump(config)` in the e2e experiment utils.