### PR TITLE
fix: use proper default cpu env image in the helm chart.

### DIFF
--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -4,13 +4,13 @@ imageRegistry: determinedai
 # HPE Machine Learning Development Environment (MLDE), Determined Enterprise Edition, uses the HPE MSC as the image registry
 #imageRegistry: hub.myenterpriselicense.hpe.com/hpe-mlde/<SKU>
 # ATTENTION
-# Please also set: 
-#   - communicated product SKU, 
-#   - enterpriseEdition flag to true, 
+# Please also set:
+#   - communicated product SKU,
+#   - enterpriseEdition flag to true,
 # and configure the imagePullSecretName to the HPE MSC credentials K8s Secret (e.g. mlde-hpe-registry)
 #
 # To get the HPE MSC credentials go to the myenterpriselicense.hpe.com website, and along with the information provided with your order
-# create the HPE MSC credentials K8s Secret (e.g. mlde-hpe-registry) using the following command: 
+# create the HPE MSC credentials K8s Secret (e.g. mlde-hpe-registry) using the following command:
 # kubectl create secret docker-registry mlde-hpe-registry  \
 # --docker-server=hub.myenterpriselicense.hpe.com/hpe-mlde/<SKU> \
 # --docker-username=<HPE MSC user name>  \
@@ -18,10 +18,10 @@ imageRegistry: determinedai
 # --docker-email=<HPE MSC user email> \
 # -n <MLDE deployment K8s namespace, if any>
 
-# Default images used during the deployment 
+# Default images used during the deployment
 defaultImages:
   # PostgreSQL image
-  postgreSQL: "postgres:10.14" 
+  postgreSQL: "postgres:10.14"
 
   # default Kube Scheduler image
   kubeScheduler: "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9"
@@ -31,7 +31,7 @@ defaultImages:
   kubeSchedulerPreemption: "determinedai/kube-scheduler:0.17.0"
 
   # default images for CPU and GPU environments
-  cpuImage: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.8-cpu-9d07809"
+  cpuImage: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-2b7e2a1"
   gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2b7e2a1"
 
 # Install Determined enterprise edition.
@@ -42,26 +42,26 @@ enterpriseEdition: false
 imagePullSecretName:
 
 # Logger Level in master.yaml - Four severity levels: debug, info, warn, error
-logLevel: info 
+logLevel: info
 # Sets in master.yaml the output of Logger in color mode - Values: true (default), false
-logColor: true 
+logColor: true
 
 # masterPort configures the port at which the Determined master listens for connections on.
 masterPort: 8080
 
 # Enables the creation of non-namespaced objects - Default: true
 # Non-namespaced object are cluster-wide resources, such as the PriorityClasses.
-# In multiple installation on a single cluster (using different namespaces), 
-# this flag set to false avoids to recreate non-namespaced objects. In some cases (e.g., GitOps w/ArgoCD) 
+# In multiple installation on a single cluster (using different namespaces),
+# this flag set to false avoids to recreate non-namespaced objects. In some cases (e.g., GitOps w/ArgoCD)
 # creating existing cluster-wide resources could stop/hang automatic deployments.
 #
-# WARNING 
-# The first installation must run with the createNonNamespacedObjects flag set to true to ensure 
+# WARNING
+# The first installation must run with the createNonNamespacedObjects flag set to true to ensure
 # the non-namespaced objects are created.
 createNonNamespacedObjects: true
 
 # External ca.crt injection certificate/s secret name
-# Command to create the ca cert secret: 
+# Command to create the ca cert secret:
 #     kubectl create secret generic <external ca cert secret name, e.g., ext-ca-cert> --from-file=<ca.crt or ca bundle filename> -n <namespace>
 #
 # externalCaCertSecretName: <external ca cert secret name, e.g., ext-ca-cert>


### PR DESCRIPTION
## Description

- It probably went out of sync due to a concurrent helm chart refactoring and a bumpenvs upgrade.
- Also trim trailing spaces which have appeared in this file.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
