### PR TITLE
chore: stop using root logger

### DIFF
--- a/harness/determined/_execution.py
+++ b/harness/determined/_execution.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Type
 import determined as det
 from determined import constants, core, gpu, load
 
+logger = logging.getLogger("determined")
+
 
 class InvalidHP(Exception):
     def __init__(self, msg: str = "...") -> None:
@@ -145,7 +147,7 @@ def _make_local_execution_exp_config(
         # This codepath is used by checkpoint loading, where we do not want to emit any warnings,
         # so only warn if we are explicitly in --local --test mode.
         if test_mode and not managed_training:
-            logging.info(
+            logger.info(
                 f"'{key}' configuration key is not supported by local test mode and will be ignored"
             )
         del input_config[key]

--- a/harness/determined/_trial_context.py
+++ b/harness/determined/_trial_context.py
@@ -5,6 +5,8 @@ from typing import Any, Dict
 import determined as det
 from determined import core
 
+logger = logging.getLogger("determined")
+
 
 class TrialContext:
     """
@@ -110,7 +112,7 @@ class TrialContext:
                 "configuration 'hyperparameters' section.".format(name)
             )
         if name == "global_batch_size":
-            logging.warning(
+            logger.warning(
                 "Please use `context.get_per_slot_batch_size()` and "
                 "`context.get_global_batch_size()` instead of accessing "
                 "`global_batch_size` directly."
@@ -131,7 +133,7 @@ class TrialContext:
         if not isinstance(stop_requested, bool):
             raise AssertionError("stop_requested must be a boolean")
 
-        logging.info(
+        logger.info(
             "A trial stoppage has requested. The trial will be stopped "
             "at the end of the current step."
         )

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -1,6 +1,5 @@
 import contextlib
 import getpass
-import logging
 import os
 import platform
 import shutil
@@ -122,7 +121,7 @@ def _prepare_key(retention_dir: Union[Path, None]) -> Tuple[ContextManager[IO], 
                 try:
                     os.remove(path)
                 except Exception as e:
-                    logging.warning(f"failed to cleanup {path}: {e}")
+                    print(colored(f"failed to cleanup {path}: {e}", "yellow"), file=sys.stderr)
 
         return file_closer(), path
 

--- a/harness/determined/common/api/analytics.py
+++ b/harness/determined/common/api/analytics.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Type
 
 import analytics
 
+logger = logging.getLogger("determined.common")
+
 enabled = os.environ.get("DET_SEGMENT_ENABLED") == "true"
 _cluster_id = os.environ.get("DET_CLUSTER_ID")
 
@@ -45,5 +47,5 @@ def get_trial_analytics(obj: Type) -> Dict[str, Any]:
 
 def send_analytics(event: str, properties: Dict) -> None:
     if enabled and _cluster_id is not None and analytics.write_key is not None:
-        logging.debug(f"Sending analytics event {event}: {properties}.")
+        logger.debug(f"Sending analytics event {event}: {properties}.")
         analytics.track(_cluster_id, event, properties)

--- a/harness/determined/common/api/certs.py
+++ b/harness/determined/common/api/certs.py
@@ -12,6 +12,8 @@ import filelock
 
 from determined.common import api, util
 
+logger = logging.getLogger("determined.common")
+
 
 class Cert:
     def __init__(
@@ -203,7 +205,7 @@ def default_load(
             with open(env_path, "r") as f:
                 cert_pem = f.read()
         else:
-            logging.warning(
+            logger.warning(
                 f"DET_MASTER_CERT_FILE={env_path} path not found; continuing without cert"
             )
     else:

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -15,6 +15,8 @@ from determined.common.api import bindings
 from determined.common.experimental import metrics
 from determined.common.storage import shared
 
+logger = logging.getLogger("determined.client")
+
 
 class DownloadMode(enum.Enum):
     """
@@ -265,7 +267,7 @@ class Checkpoint:
             if checkpoint_storage["type"] != "s3" and checkpoint_storage["type"] != "gcs":
                 raise
 
-            logging.info("Unable to download directly, proxying download through master")
+            logger.info("Unable to download directly, proxying download through master")
             try:
                 self._download_via_master(self._session, self.uuid, local_ckpt_dir)
             except Exception as e:
@@ -415,7 +417,7 @@ class Checkpoint:
 
         delete_body = bindings.v1DeleteCheckpointsRequest(checkpointUuids=[self.uuid])
         bindings.delete_DeleteCheckpoints(self._session, body=delete_body)
-        logging.info(f"Deletion of checkpoint {self.uuid} is in progress.")
+        logger.info(f"Deletion of checkpoint {self.uuid} is in progress.")
 
     def remove_files(self, globs: List[str]) -> None:
         """
@@ -434,9 +436,9 @@ class Checkpoint:
         bindings.post_CheckpointsRemoveFiles(self._session, body=remove_body)
 
         if len(globs) == 0:
-            logging.info(f"Refresh of checkpoint {self.uuid} is in progress.")
+            logger.info(f"Refresh of checkpoint {self.uuid} is in progress.")
         else:
-            logging.info(f"Partial deletion of checkpoint {self.uuid} is in progress.")
+            logger.info(f"Partial deletion of checkpoint {self.uuid} is in progress.")
 
     def get_metrics(self, group: Optional[str] = None) -> Iterable["metrics.TrialMetrics"]:
         """

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -21,6 +21,8 @@ from determined.common.experimental import (
 # TODO (MLG-1087): move OrderBy to experimental.client namespace
 from determined.common.experimental._util import OrderBy  # noqa: I2041
 
+logger = logging.getLogger("determined.client")
+
 
 class Determined:
     """
@@ -190,7 +192,7 @@ class Determined:
 
         if resp.warnings:
             for w in resp.warnings:
-                logging.warning(api.WARNING_MESSAGE_MAP[w])
+                logger.warning(api.WARNING_MESSAGE_MAP[w])
 
         return experiment.Experiment._from_bindings(resp.experiment, self._session)
 

--- a/harness/determined/common/storage/azure.py
+++ b/harness/determined/common/storage/azure.py
@@ -9,6 +9,9 @@ from determined.common import storage, util
 import posixpath  # isort:skip
 
 
+logger = logging.getLogger("determined.common.storage.azure")
+
+
 class AzureStorageManager(storage.CloudStorageManager):
     """
     Store and load checkpoints from Azure Blob Storage.
@@ -38,7 +41,7 @@ class AzureStorageManager(storage.CloudStorageManager):
         self, src: Union[str, os.PathLike], dst: str, paths: Optional[storage.Paths] = None
     ) -> None:
         src = os.fspath(src)
-        logging.info(f"Uploading to Azure Blob Storage: {dst}")
+        logger.info(f"Uploading to Azure Blob Storage: {dst}")
         upload_paths = paths if paths is not None else self._list_directory(src)
         for rel_path in sorted(upload_paths):
             # Use posixpath so that we always use forward slashes, even on Windows.
@@ -48,11 +51,11 @@ class AzureStorageManager(storage.CloudStorageManager):
                 blob_dir, blob_base = posixpath.split(container_blob.rstrip("/"))
                 blob_base = f"{blob_base}/"
                 abs_path = "/dev/null"
-                logging.debug(f"Uploading blob empty {blob_base} to container {blob_dir}.")
+                logger.debug(f"Uploading blob empty {blob_base} to container {blob_dir}.")
             else:
                 blob_dir, blob_base = posixpath.split(container_blob)
                 abs_path = os.path.join(src, rel_path)
-                logging.debug(f"Uploading blob {blob_base} to container {blob_dir}.")
+                logger.debug(f"Uploading blob {blob_base} to container {blob_dir}.")
 
             self.client.put(blob_dir, blob_base, abs_path)
 
@@ -64,7 +67,7 @@ class AzureStorageManager(storage.CloudStorageManager):
         selector: Optional[storage.Selector] = None,
     ) -> None:
         dst = os.fspath(dst)
-        logging.info(f"Downloading {src} from Azure Blob Storage")
+        logger.info(f"Downloading {src} from Azure Blob Storage")
         found = False
         for blob in self.client.list_files(self.container, file_prefix=src):
             found = True
@@ -93,7 +96,7 @@ class AzureStorageManager(storage.CloudStorageManager):
     @util.preserve_random_state
     def delete(self, tgt: str, globs: List[str]) -> Dict[str, int]:
         storage_prefix = tgt
-        logging.info(f"Deleting {tgt} from Azure Blob Storage")
+        logger.info(f"Deleting {tgt} from Azure Blob Storage")
 
         objects = self.client.list_files(self.container, file_prefix=storage_prefix)
 

--- a/harness/determined/common/storage/azure_client.py
+++ b/harness/determined/common/storage/azure_client.py
@@ -8,6 +8,9 @@ from determined.common import util
 logging.getLogger("azure").setLevel(logging.ERROR)
 
 
+logger = logging.getLogger("determined.common.storage.azure")
+
+
 class AzureStorageClient(object):
     """Connects to an Azure Blob Storage service account."""
 
@@ -28,24 +31,24 @@ class AzureStorageClient(object):
         else:
             raise ValueError("Either 'connection_string' or 'account_url' must be specified.")
 
-        logging.info(f"Trying to create Azure Blob Storage Container: {container}.")
+        logger.info(f"Trying to create Azure Blob Storage Container: {container}.")
         try:
             self.client.create_container(container.split("/")[0])
-            logging.info(f"Successfully created container {container}.")
+            logger.info(f"Successfully created container {container}.")
         except azure.core.exceptions.ResourceExistsError:
-            logging.info(
+            logger.info(
                 f"Container {container} already exists, and will be used to store checkpoints."
             )
         except azure.core.exceptions.HttpResponseError as e:
             if e.error_code == blob.StorageErrorCode.invalid_uri:  # type: ignore
-                logging.warning(
+                logger.warning(
                     f"The storage client raised the following HttpResponseError:\n{e}\nPlease "
                     "ignore this warning if this is because the account url provided points to a "
                     "container instead of a storage account; otherwise, it may be necessary to fix "
                     "your config.yaml."
                 )
             else:
-                logging.error(f"Failed while trying to create container {container}.")
+                logger.error(f"Failed while trying to create container {container}.")
                 raise e
 
     @util.preserve_random_state

--- a/harness/determined/common/storage/boto3_credential_manager.py
+++ b/harness/determined/common/storage/boto3_credential_manager.py
@@ -15,6 +15,8 @@ from botocore.credentials import (
 )
 from botocore.session import get_session
 
+logger = logging.getLogger("determined.common.storage.s3")
+
 
 class RefreshableCredentialProvider(CredentialProvider):  # type: ignore
     """
@@ -82,7 +84,7 @@ class RefreshableSharedCredentials(Credentials):  # type: ignore
                 return
             self._check_time = now + self._check_every
             if self._refresh_needed():
-                logging.info("credential file changes detected, refreshing credentials")
+                logger.info("credential file changes detected, refreshing credentials")
                 self._load_and_set_credentials()
 
     def get_frozen_credentials(self) -> ReadOnlyCredentials:

--- a/harness/determined/common/storage/directory.py
+++ b/harness/determined/common/storage/directory.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Iterator, Optional
 from determined import errors
 from determined.common import check, storage
 
+logger = logging.getLogger("determined.common.storage.directory")
+
 
 class DirectoryStorageManager(storage.SharedFSStorageManager):
     """
@@ -44,7 +46,7 @@ class DirectoryStorageManager(storage.SharedFSStorageManager):
         configuration seems reasonable.
         """
         if selector is not None:
-            logging.warning(
+            logger.warning(
                 "Ignoring partial checkpoint download from 'directory' checkpoint storage; "
                 "all files will be directly accessible."
             )

--- a/harness/determined/common/storage/shared.py
+++ b/harness/determined/common/storage/shared.py
@@ -9,6 +9,9 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 from determined import errors, util
 from determined.common import check, storage
 
+logger = logging.getLogger("determined.common.storage.shared")
+
+
 # Based on shutil.copytree and shutil._copytree (for Python 3.8). Compared to the original
 # implementation this code delays creating new directories during traversal, such that dir
 # is created only when (1) selector(dir)==True or (2) selector(dir/subdir/path)==True.
@@ -156,7 +159,7 @@ class SharedFSStorageManager(storage.StorageManager):
         configuration seems reasonable.
         """
         if selector is not None:
-            logging.warning(
+            logger.warning(
                 "Ignoring partial checkpoint download from shared_fs; all files will be directly "
                 "accessible from shared_fs."
             )
@@ -177,7 +180,7 @@ class SharedFSStorageManager(storage.StorageManager):
         storage_dir = os.path.join(self._base_path, tgt)
 
         if not os.path.exists(storage_dir):
-            logging.info(f"Storage directory does not exist: {storage_dir}")
+            logger.info(f"Storage directory does not exist: {storage_dir}")
             return {}
         if not os.path.isdir(storage_dir):
             raise errors.CheckpointNotFound(f"Storage path is not a directory: {storage_dir}")
@@ -192,7 +195,7 @@ class SharedFSStorageManager(storage.StorageManager):
         for file_glob in globs:
             for path in glob.glob(f"{storage_dir}/{file_glob}", recursive=True):
                 if os.path.commonpath([storage_dir, os.path.normpath(path)]) != storage_dir:
-                    logging.warning(f"tried to delete path outside checkpoint dir {path}")
+                    logger.warning(f"tried to delete path outside checkpoint dir {path}")
                     continue
 
                 if os.path.isfile(path) or os.path.islink(path):

--- a/harness/determined/core/_log_shipper.py
+++ b/harness/determined/core/_log_shipper.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, TextIO, Union
 from determined import core
 from determined.common import api
 
-logger = logging.getLogger("determined.experimental.core_v2")
+logger = logging.getLogger("determined.core")
 
 
 class _LogShipper:

--- a/harness/determined/core/_preempt.py
+++ b/harness/determined/core/_preempt.py
@@ -68,12 +68,12 @@ class _PreemptionWatcher(threading.Thread):
             try:
                 self._should_preempt = self._get_preemption(0)
             except requests.Timeout:
-                logging.warning(
+                logger.warning(
                     "timeout during initial preemption API check (continuing):", exc_info=True
                 )
                 self._should_preempt = False
             except Exception:
-                logging.warning(
+                logger.warning(
                     "failure during initial preemption API check (continuing):", exc_info=True
                 )
                 self._should_preempt = False
@@ -88,11 +88,11 @@ class _PreemptionWatcher(threading.Thread):
             try:
                 self._should_preempt = self._get_preemption(60)
             except requests.Timeout:
-                logging.warning(
+                logger.warning(
                     "timeout communicating with preemption API (retrying):", exc_info=True
                 )
             except Exception:
-                logging.warning(
+                logger.warning(
                     "failure communicating with preemption API (retrying in 10s):", exc_info=True
                 )
                 time.sleep(10)

--- a/harness/determined/exec/harness.py
+++ b/harness/determined/exec/harness.py
@@ -9,6 +9,8 @@ import determined as det
 from determined import core, horovod, load
 from determined.common.api import analytics, certs
 
+logger = logging.getLogger("determined")
+
 
 @contextlib.contextmanager
 def maybe_periodic_stacktraces(debug_enabled: bool) -> Iterator[None]:
@@ -35,7 +37,7 @@ def main(train_entrypoint: str) -> int:
         try:
             analytics.send_analytics("trial_loaded", analytics.get_trial_analytics(trial_class))
         except Exception as e:
-            logging.debug(f"Cannot send analytics: {e}")
+            logger.debug(f"Cannot send analytics: {e}")
 
     # We can't import pytorch directly because if running TfKerasTrials with an image that contains
     # both torch and keras, keras will throw exceptions due to unexpected CUDNN library versions.
@@ -77,7 +79,7 @@ def main(train_entrypoint: str) -> int:
     )
 
     det.common.set_logger(env.debug)
-    logging.debug("Starting harness.")
+    logger.debug("Starting harness.")
 
     with maybe_periodic_stacktraces(env.debug):
         # Step 1: Load user code.
@@ -119,7 +121,7 @@ def main(train_entrypoint: str) -> int:
             trial_inst = trial_class(trial_context)
 
             # Step 5: Create a TrialController and execute training
-            logging.info(f"Creating {controller_class.__name__} with {trial_class.__name__}.")
+            logger.info(f"Creating {controller_class.__name__} with {trial_class.__name__}.")
             controller = controller_class.from_trial(
                 trial_inst=trial_inst,
                 context=trial_context,
@@ -139,7 +141,7 @@ def _run_pytorch_trial(
 
     det.common.set_logger(info.trial._debug)
 
-    logging.debug("Starting harness.")
+    logger.debug("Starting harness.")
 
     with maybe_periodic_stacktraces(info.trial._debug):
         with pytorch.init(
@@ -162,7 +164,7 @@ def _run_pytorch_trial(
                 log_level = logging.DEBUG if info.trial._debug else logging.WARNING
                 logging.getLogger().setLevel(log_level)
 
-            logging.info(
+            logger.info(
                 f"Creating {pytorch._PyTorchTrialController.__name__} with {trial_class.__name__}."
             )
 

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -19,6 +19,8 @@ from determined import constants, gpu
 from determined.common import api, util
 from determined.common.api import bindings, certs
 
+logger = logging.getLogger("determined")
+
 
 def is_trial(info: det.ClusterInfo) -> bool:
     return info.task_type == "TRIAL"
@@ -82,7 +84,7 @@ def do_rendezvous_slurm(
             rendezvous_ip = get_ip_from_interface(rendezvous_iface)
             break
         except ValueError as e:
-            logging.warning(f"Unable to resolve ip for {rendezvous_iface}: {str(e)}")
+            logger.warning(f"Unable to resolve ip for {rendezvous_iface}: {str(e)}")
 
     # Note, rendezvous must be sorted in rank order.
     resp = bindings.post_AllocationAllGather(
@@ -236,7 +238,7 @@ def set_proxy_address(sess: api.Session, allocation_id: str) -> None:
         except ValueError as e:
             resolution_error = e
     else:
-        logging.warning(f"falling back to naive proxy ip resolution (error={resolution_error})")
+        logger.warning(f"falling back to naive proxy ip resolution (error={resolution_error})")
         proxy_ip = socket.gethostbyname(socket.gethostname())
 
     # Right now this is just used in 'singularity-over-slurm' mode when singularity is using the
@@ -298,7 +300,7 @@ if __name__ == "__main__":
         level=logging.DEBUG if debug else logging.INFO,
         format=det.LOG_FORMAT,
     )
-    logging.debug("running prep_container")
+    logger.debug("running prep_container")
 
     if args.trial:
         warnings.warn(
@@ -338,7 +340,7 @@ if __name__ == "__main__":
         agent_id = os.environ.get("DET_AGENT_ID", "")
         container_id = os.environ.get("DET_CONTAINER_ID", "")
         _, accelerator_type = gpu.get_gpus()
-        logging.info(
+        logger.info(
             f"Running task container on agent_id={agent_id}, hostname={hostname} "
             f"with visible GPUs {resources.gpu_uuids}"
         )
@@ -358,7 +360,7 @@ if __name__ == "__main__":
             ),
         )
         for process in gpu.get_gpu_processes():
-            logging.warning(
+            logger.warning(
                 f"process {process.process_name} "
                 f"with pid {process.pid} "
                 f"is using {process.used_memory} memory "

--- a/harness/determined/exec/tensorboard.py
+++ b/harness/determined/exec/tensorboard.py
@@ -27,7 +27,7 @@ FULL_ITERATION_SLEEP_TIME = 20  # How long to wait between a full iteration run 
 NUM_FETCH_THREADS = 5  # Number of fetching threads to run concurrently
 READY_SIGNAL_DELAY = 7  # How many seconds to wait before sending the ready signal
 
-logger = logging.getLogger("determined.exec.tensorboard")
+logger = logging.getLogger("determined")
 
 
 def set_s3_region() -> None:
@@ -238,7 +238,7 @@ class TBFetchIterationThread(threading.Thread):
                 for filepath in self._fetcher.list_all_generator():
                     self._work_queue.put(filepath, block=True)
             except Exception as e:
-                logging.warning(
+                logger.warning(
                     f"Failure listing TensorBoard files from {self._fetcher}. Error: {e}"
                     f" (retrying in {FULL_ITERATION_SLEEP_TIME}s)...",
                     exc_info=True,
@@ -269,7 +269,7 @@ class TBFetchThread(threading.Thread):
                 filepath = self._work_queue.get(block=True)
                 self._fetcher._fetch(filepath, self._new_file_callback)
             except Exception as e:
-                logging.warning(
+                logger.warning(
                     f"Timeout fetching TensorBoard files from {self._fetcher}. Error: {e}"
                     f" (retrying)...",
                     exc_info=True,

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -73,6 +73,8 @@ from determined.common.experimental.trial import Trial, TrialOrderBy, TrialSortB
 from determined.common.experimental.user import User
 from determined.common.experimental.workspace import Workspace  # noqa: F401
 
+logger = logging.getLogger("determined.client")
+
 _determined = None  # type: Optional[Determined]
 
 C = TypeVar("C", bound=Callable[..., Any])
@@ -235,7 +237,7 @@ def logout() -> None:
     if _determined is not None:
         return _determined.logout()
 
-    logging.warning(
+    logger.warning(
         "client has not been logged in, either explicitly by client.login() or implicitly by any "
         "other client.* function, so client.logout() has no session to log out of and is a no-op. "
         "If you would like to log out of the default active session, try "

--- a/harness/determined/experimental/core_v2/_core_context_v2.py
+++ b/harness/determined/experimental/core_v2/_core_context_v2.py
@@ -9,7 +9,7 @@ from determined import core, experimental, tensorboard
 from determined.common import api, constants, storage, util
 from determined.common.api import certs
 
-logger = logging.getLogger("determined.experimental.core_v2")
+logger = logging.getLogger("determined.core")
 
 
 def _default_storage_manager() -> storage.SharedFSStorageManager:

--- a/harness/determined/experimental/core_v2/_core_v2.py
+++ b/harness/determined/experimental/core_v2/_core_v2.py
@@ -11,7 +11,7 @@ from determined import core, experimental
 from determined.common import util
 from determined.experimental import core_v2
 
-logger = logging.getLogger("determined.experimental.core_v2")
+logger = logging.getLogger("determined.core")
 
 
 _context = None  # type: Optional[core.Context]

--- a/harness/determined/experimental/core_v2/_unmanaged.py
+++ b/harness/determined/experimental/core_v2/_unmanaged.py
@@ -6,7 +6,7 @@ from determined import core, experimental
 from determined.common import api, util
 from determined.common.api import bindings
 
-logger = logging.getLogger("determined.experimental.unmanaged")
+logger = logging.getLogger("determined.unmanaged")
 
 
 T = TypeVar("T")

--- a/harness/determined/gpu.py
+++ b/harness/determined/gpu.py
@@ -4,6 +4,8 @@ import logging
 import subprocess
 from typing import List, NamedTuple, Tuple
 
+logger = logging.getLogger("determined")
+
 gpu_fields = [
     "index",
     "uuid",
@@ -29,7 +31,7 @@ def float_or_default(fields: dict, key: str, default: float) -> float:
     except ValueError:
         if key not in warned_fields:
             warned_fields.add(key)
-            logging.warning(f"Unable to get {key} from nvidia-smi")
+            logger.warning(f"Unable to get {key} from nvidia-smi")
         return default
 
 
@@ -41,18 +43,18 @@ def _get_nvidia_gpus() -> List[GPU]:
             universal_newlines=True,
         )
     except FileNotFoundError:
-        logging.info("detected 0 gpus (nvidia-smi not found)")
+        logger.info("detected 0 gpus (nvidia-smi not found)")
         # This case is expected if NVIDIA drivers are not available.
         return []
     except Exception as e:
-        logging.warning(f"detected 0 gpus (error with nvidia-smi: {e})")
+        logger.warning(f"detected 0 gpus (error with nvidia-smi: {e})")
         return []
 
     gpus = []
     with proc:
         for field_list in csv.reader(proc.stdout):  # type: ignore
             if len(field_list) != len(gpu_fields):
-                logging.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
+                logger.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
                 continue
             fields = dict(zip(gpu_fields, field_list))
             try:
@@ -66,11 +68,11 @@ def _get_nvidia_gpus() -> List[GPU]:
                     )
                 )
             except ValueError:
-                logging.warning(f"Ignoring GPU with unexpected nvidia-smi output: {fields}")
+                logger.warning(f"Ignoring GPU with unexpected nvidia-smi output: {fields}")
     if proc.returncode:
-        logging.warning(f"`nvidia-smi` exited with failure status code {proc.returncode}")
+        logger.warning(f"`nvidia-smi` exited with failure status code {proc.returncode}")
 
-    logging.info(f"detected {len(gpus)} gpus")
+    logger.info(f"detected {len(gpus)} gpus")
     return gpus
 
 
@@ -89,23 +91,23 @@ def _get_rocm_gpus() -> List[GPU]:
         ).stdout
 
     except FileNotFoundError:
-        logging.info("rocm-smi not found")
+        logger.info("rocm-smi not found")
         return []
     except Exception as e:
-        logging.warning(f"rocm-smi error: {e}")
+        logger.warning(f"rocm-smi error: {e}")
         return []
 
     try:
         output = json.loads(output_json)
     except Exception as e:
-        logging.warning(f"failed to parse rocm-smi json output: {e}, content: {str(output_json)}")
+        logger.warning(f"failed to parse rocm-smi json output: {e}, content: {str(output_json)}")
         return []
 
     gpus = []
     for k, v in output.items():
         gpus.append(GPU(id=int(k[len("card") :]), uuid=v["Unique ID"], load=0, memoryUtil=0))
 
-    logging.info(f"detected {len(gpus)} rocm gpus")
+    logger.info(f"detected {len(gpus)} rocm gpus")
     return gpus
 
 
@@ -147,18 +149,18 @@ def _get_nvidia_processes() -> List[GPUProcess]:
             universal_newlines=True,
         )
     except FileNotFoundError:
-        logging.info("detected 0 gpu processes (nvidia-smi not found)")
+        logger.info("detected 0 gpu processes (nvidia-smi not found)")
         # This case is expected if NVIDIA drivers are not available.
         return []
     except Exception as e:
-        logging.warning(f"detected 0 gpu processes (error with nvidia-smi: {e})")
+        logger.warning(f"detected 0 gpu processes (error with nvidia-smi: {e})")
         return []
 
     processes = []
     with proc:
         for field_list in csv.reader(proc.stdout):  # type: ignore
             if len(field_list) != len(GPUProcess._fields):
-                logging.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
+                logger.warning(f"Ignoring unexpected nvidia-smi output: {field_list}")
                 continue
             fields = dict(zip(GPUProcess._fields, field_list))
             try:
@@ -171,9 +173,9 @@ def _get_nvidia_processes() -> List[GPUProcess]:
                     )
                 )
             except ValueError:
-                logging.warning(f"Ignoring GPU process with unexpected nvidia-smi output: {fields}")
+                logger.warning(f"Ignoring GPU process with unexpected nvidia-smi output: {fields}")
     if proc.returncode:
-        logging.warning(f"nvidia-smi exited with failure status code {proc.returncode}")
+        logger.warning(f"nvidia-smi exited with failure status code {proc.returncode}")
     return processes
 
 

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import determined as det
 
+logger = logging.getLogger("determined")
+
 
 class _HelloMessage:
     pass
@@ -475,7 +477,7 @@ class PIDServer:
                         try:
                             return p.wait(timeout=10) or 78
                         except subprocess.TimeoutExpired:
-                            logging.error(f"killing worker which didn't exit after {on_fail.name}")
+                            logger.error(f"killing worker which didn't exit after {on_fail.name}")
                             p.send_signal(signal.SIGKILL)
                 return p.wait() or 79
 
@@ -487,7 +489,7 @@ class PIDServer:
                     try:
                         return p.wait(timeout=10)
                     except subprocess.TimeoutExpired:
-                        logging.error(f"killing worker which didn't exit after {on_exit.name}")
+                        logger.error(f"killing worker which didn't exit after {on_exit.name}")
                         p.send_signal(signal.SIGKILL)
             return p.wait()
 

--- a/harness/determined/keras/_load.py
+++ b/harness/determined/keras/_load.py
@@ -8,6 +8,8 @@ from tensorflow.python.training.tracking.tracking import AutoTrackable
 import determined as det
 from determined import keras
 
+logger = logging.getLogger("determined.keras")
+
 
 def load_model_from_checkpoint_path(path: str, tags: Optional[List[str]] = None) -> AutoTrackable:
     """
@@ -32,7 +34,7 @@ def load_model_from_checkpoint_path(path: str, tags: Optional[List[str]] = None)
         with load_data_path.open() as f:
             load_data = json.load(f)
         if load_data["trial_type"] != "TFKerasTrial":
-            logging.warning(
+            logger.warning(
                 "Checkpoint does not appear to be a valid TFKerasTrial checkpoint, "
                 "continuing anyway..."
             )
@@ -50,7 +52,7 @@ def load_model_from_checkpoint_path(path: str, tags: Optional[List[str]] = None)
         save_format = metadata.get("format")
         is_keras = save_format not in ("saved_weights", "h5")
         if not is_tf or not is_keras:
-            logging.warning(
+            logger.warning(
                 "Checkpoint does not appear to be a valid TFKerasTrial checkpoint, "
                 "continuing anyway..."
             )

--- a/harness/determined/keras/_tensorboard_callback.py
+++ b/harness/determined/keras/_tensorboard_callback.py
@@ -3,10 +3,12 @@ from typing import Any
 
 from determined.keras import callbacks
 
+logger = logging.getLogger("determined.keras")
+
 
 class TFKerasTensorBoard(callbacks.TensorBoard):
     def __init__(self, *args: Any, **kwargs: Any):
-        logging.warning(
+        logger.warning(
             "det.keras.TFKerasTensorBoard is a deprecated name for "
             "det.keras.callbacks.TensorBoard, please update your code."
         )

--- a/harness/determined/keras/_tf_keras_multi_gpu.py
+++ b/harness/determined/keras/_tf_keras_multi_gpu.py
@@ -7,6 +7,8 @@ from tensorflow.python.keras.engine import sequential
 
 from determined import util
 
+logger = logging.getLogger("determined.keras")
+
 
 def _check_if_aggregation_frequency_will_work(
     model: tf.keras.Model,
@@ -23,7 +25,7 @@ def _check_if_aggregation_frequency_will_work(
         return
 
     if util.is_overridden(model.train_step, tf.keras.Model):
-        logging.warning(
+        logger.warning(
             "If you subclassing tf.keras.Model in TF 2.2 or TF 2.3 and defining "
             "a custom train_step() method, in order to use aggregation_frequency > 1 "
             "you need to include the following steps in your train_step(): "

--- a/harness/determined/keras/callbacks.py
+++ b/harness/determined/keras/callbacks.py
@@ -9,6 +9,8 @@ from tensorflow.python.keras.utils import tf_utils
 
 from determined import profiler, tensorboard
 
+logger = logging.getLogger("determined.keras")
+
 
 class Callback(tf.keras.callbacks.Callback):  # type: ignore
     """
@@ -674,7 +676,7 @@ class TensorBoard(tf.keras.callbacks.TensorBoard, Callback):  # type: ignore
         self.workload_end_count = 0
         user_log_dir = kwargs.pop("log_dir", None)
         if user_log_dir is not None:
-            logging.warning(
+            logger.warning(
                 f"arg log_dir={user_log_dir} to det.keras.callbacks.TensorBoard will be ignored"
             )
         log_dir = str(tensorboard.get_base_path({}).resolve())

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -27,6 +27,8 @@ from determined.common.api import certs
 hostfile_path = None
 deepspeed_version = version.parse(deepspeed.__version__)
 
+logger = logging.getLogger("determined.launch.deepspeed")
+
 
 def is_using_cuda() -> bool:
     val = os.getenv("CUDA_VISIBLE_DEVICES")
@@ -157,7 +159,7 @@ def filter_env_vars(env: Mapping[str, str]) -> Dict[str, str]:
     def should_keep(k: str, v: str) -> bool:
         if not any(x.match(k) for x in excludes):
             return True
-        logging.debug(
+        logger.debug(
             f"Excluding environment variable {k}={v} from training script environment, "
             "since it is likely unsafe to share between workers."
         )
@@ -195,7 +197,7 @@ def create_deepspeed_env_file() -> None:
             if "\n" not in line:
                 f.write(f"{line}\n")
             else:
-                logging.warning(
+                logger.warning(
                     f"Excluding environment variable {k} because it contains a newline character."
                 )
 
@@ -299,7 +301,7 @@ def main(script: List[str]) -> int:
         # spun up by pdsh.
         pid_server_cmd = create_pid_server_cmd(info.allocation_id, len(info.slot_ids))
 
-        logging.debug(
+        logger.debug(
             f"Non-chief [{info.container_rank}] training process launch "
             f"command: {run_sshd_command}."
         )
@@ -328,7 +330,7 @@ def main(script: List[str]) -> int:
 
     harness_cmd = script
 
-    logging.debug(f"chief worker calling deepspeed with args: {cmd[1:]} ...")
+    logger.debug(f"chief worker calling deepspeed with args: {cmd[1:]} ...")
 
     full_cmd = pid_server_cmd + cmd + pid_client_cmd + log_redirect_cmd + harness_cmd
 

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -18,6 +18,8 @@ from determined.common import api
 from determined.common.api import certs
 from determined.constants import DTRAIN_SSH_PORT
 
+logger = logging.getLogger("determined.launch.horovod")
+
 
 def create_sshd_worker_cmd(
     allocation_id: str, num_slot_ids: int, debug: bool = False
@@ -140,7 +142,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
             info.allocation_id, len(info.slot_ids), debug=debug
         )
 
-        logging.debug(
+        logger.debug(
             f"Non-chief [{info.container_rank}] training process launch "
             f"command: {run_sshd_command}."
         )
@@ -184,7 +186,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
 
     worker_wrapper_cmd = create_worker_wrapper_cmd(info.allocation_id)
 
-    logging.debug(f"chief worker calling horovodrun with args: {hvd_cmd[1:]} ...")
+    logger.debug(f"chief worker calling horovodrun with args: {hvd_cmd[1:]} ...")
 
     os.environ["USE_HOROVOD"] = "1"
 

--- a/harness/determined/launch/torch_distributed.py
+++ b/harness/determined/launch/torch_distributed.py
@@ -9,6 +9,8 @@ import determined as det
 
 C10D_PORT = int(str(os.getenv("C10D_PORT", "29400")))
 
+logger = logging.getLogger("determined.launch.torch_distributed")
+
 
 def create_launch_cmd(
     num_nodes: int, proc_per_node: int, node_rank: int, master_addr: str, override_args: List[str]
@@ -97,7 +99,7 @@ def main(override_args: List[str], script: List[str]) -> int:
 
     launch_cmd = pid_server_cmd + torch_distributed_cmd + pid_client_cmd + log_redirect_cmd + script
 
-    logging.debug(f"Torch distributed launching with: {launch_cmd}")
+    logger.debug(f"Torch distributed launching with: {launch_cmd}")
 
     p = subprocess.Popen(launch_cmd)
     with det.util.forward_signals(p):

--- a/harness/determined/layers/_workload_sequencer.py
+++ b/harness/determined/layers/_workload_sequencer.py
@@ -10,6 +10,8 @@ WorkloadStreamElem = Tuple[workload.Workload, workload.ResponseFunc]
 
 WorkloadGenerator = Generator[WorkloadStreamElem, None, None]
 
+logger = logging.getLogger("determined")
+
 
 def yield_and_await_response(
     wkld: workload.Workload,
@@ -99,7 +101,7 @@ class WorkloadSequencer(workload.Source):
 
         unit = self.core_context.searcher.get_configured_units()
         if unit is None:
-            logging.warning(
+            logger.warning(
                 "The searcher configuration provided was configured without units, but the "
                 "training loop you are using (one of the Trial APIs) requires a searcher "
                 "configured with units.  Proceeding anyway, and assuming that the lengths "

--- a/harness/determined/load.py
+++ b/harness/determined/load.py
@@ -5,6 +5,8 @@ from typing import Type, cast
 
 import determined as det
 
+logger = logging.getLogger("determined")
+
 
 def trial_class_from_entrypoint(entrypoint_spec: str) -> Type[det.LegacyTrial]:
     """
@@ -36,7 +38,7 @@ def trial_class_from_entrypoint(entrypoint_spec: str) -> Type[det.LegacyTrial]:
     [1] https://packaging.python.org/specifications/entry-points/
     """
 
-    logging.info(f"Loading Trial implementation with entrypoint {entrypoint_spec}.")
+    logger.info(f"Loading Trial implementation with entrypoint {entrypoint_spec}.")
     module, qualname_separator, qualname = entrypoint_spec.partition(":")
 
     # Exporting checkpoints reliably requires instantiating models from user

--- a/harness/determined/profiler.py
+++ b/harness/determined/profiler.py
@@ -15,7 +15,8 @@ from determined.common import api, check
 from determined.common.api import TrialProfilerMetricsBatch
 
 MAX_COLLECTION_SECONDS = 300
-LOG_NAMESPACE = "determined-profiler"
+
+logger = logging.getLogger("determined.profiler")
 
 
 class PynvmlWrapperError(Exception):
@@ -49,20 +50,18 @@ class PynvmlWrapper:
                 self._pynvml = pynvml
                 self._device_count = num_gpus
             except Exception as e:
-                logging.warning(
-                    f"{LOG_NAMESPACE}: pynvml is functional, but failed to pass functionality "
+                logger.warning(
+                    "pynvml is functional, but failed to pass functionality "
                     f"test due to exception. Not collecting GPU metrics. Exception details: {e}"
                 )
         except ModuleNotFoundError:
-            logging.info(f"{LOG_NAMESPACE}: pynvml not found. Not collecting GPU metrics")
+            logger.info("pynvml not found. Not collecting GPU metrics")
         except pynvml.NVMLError_LibraryNotFound:
-            logging.info(
-                f"{LOG_NAMESPACE}: pynvml LibraryNotFound error. Not collecting GPU metrics"
-            )
+            logger.info("pynvml LibraryNotFound error. Not collecting GPU metrics")
         except Exception as e:
-            logging.error(
-                f"{LOG_NAMESPACE}: unexpected error while trying to set up pynvml. Not "
-                f"collecting GPU metrics. Please report this error to "
+            logger.error(
+                "unexpected error while trying to set up pynvml. Not "
+                "collecting GPU metrics. Please report this error to "
                 f"https://github.com/determined-ai/determined as it should not be "
                 f"encountered by users. Error details: {e}"
             )
@@ -312,10 +311,10 @@ class ProfilerAgent:
                 self.master_url, self.trial_id
             )
             if self.disabled_due_to_preexisting_metrics and self.global_rank == 0:
-                logging.warning(
-                    f"{LOG_NAMESPACE}: ProfilerAgent is disabled because profiling data for "
-                    f"this trial already exists. No additional profiling data is generated "
-                    f"after a restart."
+                logger.warning(
+                    "ProfilerAgent is disabled because profiling data for "
+                    "this trial already exists. No additional profiling data is generated "
+                    "after a restart."
                 )
 
             # Set up timer thread to stop collecting after MAX_COLLECTION_SECONDS
@@ -790,11 +789,11 @@ class MetricsBatcherThread(threading.Thread):
                         self.metrics_batch.append(msr.metric_type, msr.metric_name, msr)
                     self.accumulating_measurements = {}
                 else:
-                    logging.fatal(
-                        f"ProfilerAgent.MetricsBatcherThread received a message "
+                    logger.fatal(
+                        "ProfilerAgent.MetricsBatcherThread received a message "
                         f"of unexpected type '{type(m)}' from the "
-                        f"inbound_queue. This should never happen - there must "
-                        f"be a bug in the code."
+                        "inbound_queue. This should never happen - there must "
+                        "be a bug in the code."
                     )
 
             # Timeout met.
@@ -1024,7 +1023,7 @@ class GpuUtilCollector:
             return measurements
 
         except Exception as e:
-            logging.warning(f"{LOG_NAMESPACE}: error while measuring GPU utilization: {e}")
+            logger.warning(f"error while measuring GPU utilization: {e}")
             return {}
 
 
@@ -1051,7 +1050,7 @@ class GpuMemoryCollector:
             return measurements
 
         except Exception as e:
-            logging.warning(f"{LOG_NAMESPACE}: error while measuring GPU memory: {e}")
+            logger.warning(f"error while measuring GPU memory: {e}")
             return {}
 
 

--- a/harness/determined/pytorch/_data.py
+++ b/harness/determined/pytorch/_data.py
@@ -28,6 +28,8 @@ from torch.utils.data import (
 
 from determined.pytorch import samplers
 
+logger = logging.getLogger("determined.pytorch")
+
 _Array = Union[np.ndarray, torch.Tensor]
 _Data = Union[Dict[str, _Array], Sequence[_Array], _Array]
 TorchData = Union[Dict[str, torch.Tensor], Sequence[torch.Tensor], torch.Tensor]
@@ -377,8 +379,6 @@ def to_device(
 
     if type(data) not in warned_types:
         warned_types.add(type(data))
-        logging.warning(
-            f"Was not able to move data item of type '{type(data).__name__}' to device."
-        )
+        logger.warning(f"Was not able to move data item of type '{type(data).__name__}' to device.")
 
     return data  # type:ignore

--- a/harness/determined/pytorch/_experimental.py
+++ b/harness/determined/pytorch/_experimental.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any
 
+logger = logging.getLogger("determined.pytorch")
+
 # AMP is only available in PyTorch 1.6+
 try:
     from torch.cuda import amp
@@ -56,7 +58,7 @@ class PyTorchExperimentalContext:
         """
 
         self._data_repro_checks_disabled = True
-        logging.info("disabled dataset reproducibility checks")
+        logger.info("disabled dataset reproducibility checks")
 
     def disable_auto_to_device(self) -> None:
         """
@@ -81,4 +83,4 @@ class PyTorchExperimentalContext:
                 ...
         """
         self._auto_to_device = False
-        logging.info("disabled automatically moving data to device")
+        logger.info("disabled automatically moving data to device")

--- a/harness/determined/pytorch/_load.py
+++ b/harness/determined/pytorch/_load.py
@@ -9,6 +9,8 @@ import torch
 import determined as det
 from determined import core, errors, load, pytorch, util
 
+logger = logging.getLogger("determined.pytorch")
+
 
 class CheckpointLoadContext(pytorch.PyTorchTrialContext):
     """
@@ -121,7 +123,7 @@ def load_trial_from_checkpoint_path(
         with load_data_path.open() as f:
             load_data = json.load(f)
         if load_data["trial_type"] != "PyTorchTrial":
-            logging.warning(
+            logger.warning(
                 "Checkpoint does not appear to be a valid PyTorchTrial checkpoint, "
                 "continuing anyway..."
             )
@@ -144,7 +146,7 @@ def load_trial_from_checkpoint_path(
         # Older metadata layout contained torch_version and tensorflow_version
         # as keys. Eventually, we should drop support for the older format.
         if not is_torch and not has_torch_version:
-            logging.warning(
+            logger.warning(
                 "Checkpoint does not appear to be a valid PyTorchTrial checkpoint, "
                 "continuing anyway..."
             )
@@ -171,7 +173,7 @@ def load_trial_from_checkpoint_path(
                 "script, but the entrypoint script did not appear to be an importable module. "
                 "Define your Trial class in an importable module instead."
             )
-        logging.warning(
+        logger.warning(
             f"Importing trial class {qualname}, which was defined in the entrypoint script. "
             f"Assuming that entrypoint is importable via `import {module}`.  Otherwise, define "
             "your Trial class in an importable file."

--- a/harness/determined/pytorch/_metric_utils.py
+++ b/harness/determined/pytorch/_metric_utils.py
@@ -7,6 +7,8 @@ import torch
 import determined as det
 from determined import pytorch, util
 
+logger = logging.getLogger("determined.pytorch")
+
 
 def _process_combined_metrics_and_batches(
     combined_metrics_and_batches: List[Any],
@@ -182,11 +184,11 @@ def _log_tb_metrics(
     batch_metrics: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     if metric_type == "val":
-        logging.debug("Write validation metrics for TensorBoard")
+        logger.debug("Write validation metrics for TensorBoard")
     elif metric_type == "train":
-        logging.debug("Write training metrics for TensorBoard")
+        logger.debug("Write training metrics for TensorBoard")
     else:
-        logging.warning("Unrecognized tensorboard metric type: " + metric_type, stacklevel=2)
+        logger.warning("Unrecognized tensorboard metric type: " + metric_type, stacklevel=2)
 
     metrics_seen = set()
 

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -11,12 +11,14 @@ import determined as det
 from determined import profiler, pytorch, util
 from determined.horovod import hvd
 
+logger = logging.getLogger("determined.pytorch")
+
 # Apex is included only for GPU trials.
 try:
     import apex
 except ImportError:  # pragma: no cover
     if torch.cuda.is_available():
-        logging.warning("Failed to import apex.")
+        logger.warning("Failed to import apex.")
     pass
 
 # AMP is only available in PyTorch 1.6+
@@ -27,7 +29,7 @@ try:
 except ImportError:  # pragma: no cover
     HAVE_AMP = False
     if torch.cuda.is_available():
-        logging.warning("PyTorch AMP is unavailable.")
+        logger.warning("PyTorch AMP is unavailable.")
     pass
 
 
@@ -180,7 +182,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
                 "configuration 'hyperparameters' section.".format(name)
             )
         if name == "global_batch_size":
-            logging.warning(
+            logger.warning(
                 "Please use `context.get_per_slot_batch_size()` and "
                 "`context.get_global_batch_size()` instead of accessing "
                 "`global_batch_size` directly."
@@ -209,7 +211,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
         if not isinstance(stop_requested, bool):
             raise AssertionError("stop_requested must be a boolean")
 
-        logging.info(
+        logger.info(
             "A trial stoppage has requested. The trial will be stopped "
             "at the end of the current step."
         )
@@ -269,7 +271,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
             # should be manually wrapped in an autocast context.
             if type(output) not in warned_types:
                 warned_types.add(type(output))
-                logging.warn(
+                logger.warn(
                     f"Unexpected type '{type(output).__name__}' outputted by model in experimental "
                     "AMP mode."
                 )
@@ -362,7 +364,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
                     backward_passes_per_step=backward_passes_per_step * self._aggregation_frequency,
                     compression=hvd.Compression.fp16 if fp16_compression else hvd.Compression.none,
                 )
-                logging.debug(
+                logger.debug(
                     "Initialized optimizer for distributed and optimized parallel training."
                 )
 
@@ -667,7 +669,7 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
             else:
                 models = self._wrapped_models[models]
 
-        logging.info(f"Enabling mixed precision training with opt_level: {opt_level}.")
+        logger.info(f"Enabling mixed precision training with opt_level: {opt_level}.")
         models, optimizers = apex.amp.initialize(
             models=models,
             optimizers=optimizers,

--- a/harness/determined/pytorch/_trainer.py
+++ b/harness/determined/pytorch/_trainer.py
@@ -12,6 +12,8 @@ import determined as det
 from determined import core, gpu, horovod, profiler, pytorch
 from determined.horovod import hvd
 
+logger = logging.getLogger("determined.pytorch")
+
 
 class Trainer:
     """
@@ -124,7 +126,7 @@ class Trainer:
 
         if self._local_training:
             if checkpoint_policy == "best":
-                logging.warning(
+                logger.warning(
                     "checkpoint_policy='best' is not supported in local training mode. "
                     "Falling back to 'all'."
                 )
@@ -136,7 +138,7 @@ class Trainer:
                 raise TypeError("max_length must be configured in TrainUnit(int) types.")
 
             if self._det_profiler:
-                logging.warning("Determined profiler will be ignored in local training mode.")
+                logger.warning("Determined profiler will be ignored in local training mode.")
 
             smaller_is_better = True
             searcher_metric_name = None
@@ -147,14 +149,14 @@ class Trainer:
                 raise ValueError("test_mode is only supported in local training mode.")
 
             if max_length is not None:
-                logging.warning(
+                logger.warning(
                     "max_length is ignored when training on-cluster. Please configure the "
                     "searcher instead."
                 )
 
             assert self._info, "Unable to detect cluster info."
             if latest_checkpoint is None and self._info.latest_checkpoint is not None:
-                logging.warning(
+                logger.warning(
                     "latest_checkpoint has not been configured. Pause/resume training will not "
                     "be able to continue from latest checkpoint. Did you mean to set "
                     "`fit(latest_checkpoint=info.latest_checkpoint)'?"

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -13,6 +13,8 @@ from determined import profiler, pytorch
 from determined.pytorch import deepspeed as det_ds
 from determined.util import merge_dicts
 
+logger = logging.getLogger("determined.pytorch")
+
 
 def overwrite_deepspeed_config(
     base_ds_config: Union[str, Dict], source_ds_dict: Dict[str, Any]
@@ -77,7 +79,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         # Apex AMP and cannot be used with more complex AMP modes.
         apex_available = importlib.util.find_spec("apex") is not None
         if not apex_available:
-            logging.warning(
+            logger.warning(
                 "Missing package APEX is required for ZeRO optimizer support through DeepSpeed."
             )
 
@@ -138,7 +140,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         for opt_field, default_value in other_optimizations_default_values.items():
             opt_value = optimizations_config.get(opt_field, default_value)
             if opt_value != default_value:
-                logging.warning(
+                logger.warning(
                     f"{opt_field}={opt_value} ignored since the setting does not apply "
                     "to DeepSpeedTrial."
                 )
@@ -188,7 +190,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
             if len(self.models) == 0:
                 self._mpu = det_ds.make_deepspeed_mpu(model.mpu)
             else:
-                logging.warning("Using the MPU corresponding to the first wrapped model engine. ")
+                logger.warning("Using the MPU corresponding to the first wrapped model engine. ")
 
         if len(self.models) == 0:
             self._train_micro_batch_size_per_gpu = int(model.train_micro_batch_size_per_gpu())
@@ -197,7 +199,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
             # If multiple model engines are wrapped, we will raise a warning if the micro batch
             # size for additional model engines does not match that of the first model engine.
             if model.train_micro_batch_size_per_gpu() != self._train_micro_batch_size_per_gpu:
-                logging.warning(
+                logger.warning(
                     f"Train micro batch size for wrapped model engine {len(self.models) + 1} does "
                     "not match that for the first wrapped engine.  Num sample reporting will only "
                     "apply to wrapped model engine 1."

--- a/harness/determined/pytorch/dsat/_utils.py
+++ b/harness/determined/pytorch/dsat/_utils.py
@@ -15,6 +15,8 @@ from determined.common import util
 from determined.pytorch.dsat import _defaults
 from determined.util import merge_dicts
 
+logger = logging.getLogger("determined.pytorch")
+
 CURR_DIR = pathlib.Path(".")
 
 
@@ -277,7 +279,7 @@ def get_dict_from_yaml_or_json_path(
                 json_dict = {try_str_to_int(k): v for k, v in json_dict.items()}
             return json_dict
         except Exception as e:
-            logging.info(f"Exception {e} raised when loading {path} with json. Attempting yaml.")
+            logger.info(f"Exception {e} raised when loading {path} with json. Attempting yaml.")
             return {}
     else:
         with open(p, "r") as f:
@@ -458,7 +460,7 @@ def update_hf_args(args: List[str], ds_config_dict: Dict[str, Any]) -> List[str]
             if not is_auto:
                 overwrite_value_str = str(overwrite_value)
                 if args[idx + 1] != overwrite_value_str:
-                    logging.warning(
+                    logger.warning(
                         f"Changing {args[idx]} from {args[idx +1]} to {overwrite_value_str}"
                         " to match the deespspeed config values."
                     )
@@ -473,7 +475,7 @@ def update_hf_args(args: List[str], ds_config_dict: Dict[str, Any]) -> List[str]
         if not is_auto:
             hf_flag_value_str = str(hf_flag_value)
             args.extend([hf_flag, hf_flag_value_str])
-            logging.warning(
+            logger.warning(
                 f"Adding {hf_flag} {hf_flag_value_str} to HF CLI args to reflect overwrite values."
             )
     return args
@@ -498,7 +500,7 @@ def get_hf_args_with_overwrites(args: List[str], hparams: Dict[str, Any]) -> Lis
         args: updated HF CLI arguments
     """
     if _defaults.OVERWRITE_KEY not in hparams:
-        logging.info(
+        logger.info(
             f"{_defaults.OVERWRITE_KEY} key not found in hparams, `get_hf_args_with_overwrites` "
             "is a no-op"
         )

--- a/harness/determined/searcher/_remote_search_runner.py
+++ b/harness/determined/searcher/_remote_search_runner.py
@@ -90,9 +90,9 @@ class RemoteSearchRunner(searcher.SearchRunner):
                 pickle.dump(operations, ops_file)
 
     def _show_experiment_paused_msg(self) -> None:
-        logging.warning(
+        logger.warning(
             f"Experiment {self.state.experiment_id} "
-            f"has been paused. If you leave searcher experiment running, "
-            f"your search method will automatically resume when the experiment "
-            f"becomes active again."
+            "has been paused. If you leave searcher experiment running, "
+            "your search method will automatically resume when the experiment "
+            "becomes active again."
         )

--- a/harness/determined/searcher/_search_runner.py
+++ b/harness/determined/searcher/_search_runner.py
@@ -211,9 +211,9 @@ class SearchRunner:
                 experimentId=experiment_id,
             )
         except errors.APIException as e:
-            logging.warning(f"Catching errors.APIException: {str(e)}")
+            logger.warning(f"Catching errors.APIException: {str(e)}")
             close_op_in_operations = any((isinstance(o, searcher.Close) for o in operations))
-            logging.warning(f"operations: {operations}")
+            logger.warning(f"operations: {operations}")
             if close_op_in_operations and "could not be found" in str(e):
                 pass
             else:

--- a/harness/determined/tensorboard/azure.py
+++ b/harness/determined/tensorboard/azure.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 
 from determined.tensorboard import base
 
-logger = logging.getLogger("determined.tensorboard")
+logger = logging.getLogger("determined.tensorboard.azure")
 
 
 class AzureTensorboardManager(base.TensorboardManager):

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -10,6 +10,8 @@ from typing import Any, Callable, List
 from determined import tensorboard
 from determined.common import util
 
+logger = logging.getLogger("determined.tensorboard")
+
 
 @dataclass
 class PathUploadInfo:
@@ -134,7 +136,7 @@ def get_metric_writer() -> tensorboard.BatchMetricWriter:
         writer: tensorboard.MetricWriter = tensorflow.TFWriter()
 
     except ModuleNotFoundError:
-        logging.warning("TensorFlow writer not found")
+        logger.warning("TensorFlow writer not found")
         from determined.tensorboard.metric_writers import pytorch
 
         writer = pytorch._TorchWriter()
@@ -168,7 +170,7 @@ class _TensorboardUploadThread(threading.Thread):
             try:
                 self._upload_function(path_info_list)
             except Exception as e:
-                logging.warning(f"Sync of Tensorboard files failed with error: {e}")
+                logger.warning(f"Sync of Tensorboard files failed with error: {e}")
 
     def upload(self, path_info_list: List[PathUploadInfo]) -> None:
         self._work_queue.put(path_info_list)
@@ -179,7 +181,7 @@ class _TensorboardUploadThread(threading.Thread):
         was_waiting = False
         while self.is_alive():
             was_waiting = True
-            logging.info("Waiting for Tensorboard files to finish uploading")
+            logger.info("Waiting for Tensorboard files to finish uploading")
             self.join(10)
         if was_waiting:
-            logging.info("Tensorboard upload completed")
+            logger.info("Tensorboard upload completed")

--- a/harness/determined/tensorboard/fetchers/azure.py
+++ b/harness/determined/tensorboard/fetchers/azure.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Generator, List
 
 from .base import Fetcher
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("determined.tensorboard.azure")
 
 
 class AzureFetcher(Fetcher):

--- a/harness/determined/tensorboard/fetchers/gcs.py
+++ b/harness/determined/tensorboard/fetchers/gcs.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Generator, List
 
 from .base import Fetcher
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("determined.tensorboard.gcs")
 
 
 class GCSFetcher(Fetcher):

--- a/harness/determined/tensorboard/fetchers/s3.py
+++ b/harness/determined/tensorboard/fetchers/s3.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Dict, Generator, List
 
 from .base import Fetcher
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("determined.tensorboard.s3")
 
 
 class S3Fetcher(Fetcher):

--- a/harness/determined/tensorboard/fetchers/shared.py
+++ b/harness/determined/tensorboard/fetchers/shared.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Generator, List
 
 from .base import Fetcher
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("determined.tensorboard.shared")
 
 
 class SharedFSFetcher(Fetcher):

--- a/harness/determined/tensorboard/gcs.py
+++ b/harness/determined/tensorboard/gcs.py
@@ -9,7 +9,7 @@ import urllib3.exceptions
 from determined.common.storage.s3 import normalize_prefix
 from determined.tensorboard import base
 
-logger = logging.getLogger("determined.tensorboard")
+logger = logging.getLogger("determined.tensorboard.gcs")
 
 
 class GCSTensorboardManager(base.TensorboardManager):

--- a/harness/determined/tensorboard/metric_writers/callback.py
+++ b/harness/determined/tensorboard/metric_writers/callback.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from determined import util
 
+logger = logging.getLogger("determined.tensorboard")
+
 if TYPE_CHECKING:
     import numpy as np
 
@@ -35,7 +37,7 @@ class BatchMetricWriter:
         metrics: Dict[str, Any],
         batch_metrics: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
-        logging.debug("Write training metrics for TensorBoard")
+        logger.debug("Write training metrics for TensorBoard")
         metrics_seen = set()
 
         # Log all batch metrics.
@@ -55,7 +57,7 @@ class BatchMetricWriter:
         self.writer.reset()
 
     def on_validation_step_end(self, steps_completed: int, metrics: Dict[str, Any]) -> None:
-        logging.debug("Write validation metrics for TensorBoard")
+        logger.debug("Write validation metrics for TensorBoard")
         for name, value in metrics.items():
             if not name.startswith("val"):
                 name = "val_" + name

--- a/harness/determined/tensorboard/s3.py
+++ b/harness/determined/tensorboard/s3.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional
 from determined.common.storage.s3 import normalize_prefix
 from determined.tensorboard import base
 
-logger = logging.getLogger("determined.tensorboard")
+logger = logging.getLogger("determined.tensorboard.s3")
 
 
 class S3TensorboardManager(base.TensorboardManager):

--- a/harness/determined/tensorboard/shared.py
+++ b/harness/determined/tensorboard/shared.py
@@ -7,7 +7,7 @@ from typing import Any, List
 from determined import util
 from determined.tensorboard import base
 
-logger = logging.getLogger("determined.tensorboard")
+logger = logging.getLogger("determined.tensorboard.shared")
 
 
 class SharedFSTensorboardManager(base.TensorboardManager):

--- a/harness/determined/tensorboard/util.py
+++ b/harness/determined/tensorboard/util.py
@@ -3,6 +3,8 @@ import pathlib
 import re
 from typing import List, Optional
 
+logger = logging.getLogger("determined.tensorboard")
+
 tb_file_types = [
     "*tfevents*",
     "*.trace.json.gz",
@@ -47,7 +49,7 @@ def find_tb_files(base_dir: pathlib.Path) -> List[pathlib.Path]:
     """
 
     if not base_dir.exists():
-        logging.warning(f"{base_dir} directory does not exist.")
+        logger.warning(f"{base_dir} directory does not exist.")
         return []
 
     return [file for filetype in tb_file_types for file in base_dir.rglob(filetype)]

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -40,6 +40,8 @@ import determined as det
 from determined import constants
 from determined.common import check, util
 
+logger = logging.getLogger("determined")
+
 
 def rmtree_nfs_safe(
     path: Union[str, os.PathLike],
@@ -58,7 +60,7 @@ def rmtree_nfs_safe(
             if e.errno != errno.ENOTEMPTY or tries == max_tries:
                 raise
             # This should not be possible, since rmtree empties directories before rmdir'ing them.
-            logging.debug(f"rmtree() failed ({e}), is this NFS?  Retrying (tries={tries})...")
+            logger.debug(f"rmtree() failed ({e}), is this NFS?  Retrying (tries={tries})...")
             # All 5 tries should take on the order of half a second.
             time.sleep(2**tries / 100)
 
@@ -331,7 +333,7 @@ def calculate_batch_sizes(
     per_gpu_batch_size = global_batch_size // slots_per_trial
     effective_batch_size = per_gpu_batch_size * slots_per_trial
     if effective_batch_size != global_batch_size:
-        logging.warning(
+        logger.warning(
             f"`global_batch_size` changed from {global_batch_size} to {effective_batch_size} "
             f"to divide equally across {slots_per_trial} slots."
         )
@@ -405,7 +407,7 @@ def force_create_symlink(src: str, dst: str) -> None:
                 pass
 
         except PermissionError as err:
-            logging.warning(f"{err} trying to remove {dst}")
+            logger.warning(f"{err} trying to remove {dst}")
 
 
 def signal_process_tree(p: subprocess.Popen, signum: Any) -> None:
@@ -420,7 +422,7 @@ def signal_process_tree(p: subprocess.Popen, signum: Any) -> None:
         for cp in children:
             cp.send_signal(signum)
     except Exception as err:
-        logging.error(f"{err} trying to forward signal {signum} to children")
+        logger.error(f"{err} trying to forward signal {signum} to children")
         pass
 
 


### PR DESCRIPTION
By default, group logs into larger log namespaces, such as:
- determined.core
- determined.pytorch
- determined.common

For most log messages, carrying the log namespace all the way to the
file that emitted it is just noise and wasted logviewer screen space.

But where logging is especially important, or more likely to be turned
on and off by an end user, log namespaces can be more specific:
- determined.common.storage.{s3,gcs,shared}
- determined.tensorboard.{s3,gcs,shared}