### PR TITLE
fix: prevent settings store from triggering rerenders on poll

### DIFF
--- a/webui/react/src/stores/userSettings.tsx
+++ b/webui/react/src/stores/userSettings.tsx
@@ -249,12 +249,8 @@ export class UserSettingsStore extends PollingStore {
       });
     } finally {
       this.#settings.update((settings) =>
-        Loadable.match(settings, {
-          // If we are unable to load settings just notify the user and unblock them.
-          _: () => Loaded(Map()),
-
-          Loaded: (settings) => Loaded(settings),
-        }),
+        // If we are unable to load settings just notify the user and unblock them.
+        settings.isLoaded ? settings : Loaded(Map()),
       );
     }
   }


### PR DESCRIPTION
## Description

this fixes an issue where components that used the settings store would rerender on poll even if the polling function returned identical data. This is slightly different from #8212 -- there, the entire settings object was recreated, causing anything that relied on objects within the settings to refresh. This fixes the issue where each render returned the same object reference in a new Loadable.

## Test Plan

covered in unit testing, no manual testing required


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1787


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
