### PR TITLE
ci: update wrapper config to run on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,23 @@ parameters:
     type: string
     default: params.json
 
+all-filters: &all-filters
+  branches:
+    only:
+      - /.*/
+  tags:
+    only:
+      - /.*/
+
 workflows:
   determined_ai:
     jobs:
       - set_up_param_file:
+          filters: *all-filters
           context:
             - github-read
       - exec_config:
+          filters: *all-filters
           requires:
             - set_up_param_file
 


### PR DESCRIPTION
## Description

By default, jobs run only on branches, so nothing was happening on tags without this.

## Test Plan

- [x] push a test tag and see that something happens