### PR TITLE
fix: check externalConfig is enabled before setting det_jwt as auth header

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -193,7 +193,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 
 	extConfig := mconfig.GetMasterConfig().InternalConfig.ExternalSessions
 	var token string
-	if extConfig.JwtKey != "" {
+	if extConfig.Enabled() {
 		token, err = grpcutil.GetUserExternalToken(ctx)
 		if err != nil {
 			return nil, launchWarnings, status.Errorf(codes.Internal,

--- a/master/internal/grpcutil/api.go
+++ b/master/internal/grpcutil/api.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -120,9 +121,10 @@ func RegisterHTTPProxy(ctx context.Context, e *echo.Echo, port int, cert *tls.Ce
 	if err != nil {
 		return err
 	}
+	extConfig := config.GetMasterConfig().InternalConfig.ExternalSessions
 	handler := func(c echo.Context) error {
 		request := c.Request()
-		if cookie, err := c.Cookie("det_jwt"); err == nil {
+		if cookie, err := c.Cookie("det_jwt"); extConfig.Enabled() && err == nil {
 			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cookie.Value))
 		}
 		if c.Request().Header.Get("Authorization") == "" {

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -122,7 +122,7 @@ func (s *Service) extractToken(r *http.Request) (string, error) {
 			return "", echo.ErrUnauthorized
 		}
 		return strings.TrimPrefix(authRaw, "Bearer "), nil
-	} else if cookie, err := r.Cookie("det_jwt"); err == nil {
+	} else if cookie, err := r.Cookie("det_jwt"); s.extConfig.Enabled() && err == nil {
 		return cookie.Value, nil
 	} else if cookie, err := r.Cookie("auth"); err == nil {
 		return cookie.Value, nil


### PR DESCRIPTION
## Description

This PR fixes a bug in authentication so that the `det_jwt` cookie will only get set in the Authorization header if external sessions authentication is enabled

## Test Plan

On login screen, set cookie `det_jwt=test` and ensure that login still succeeds with default credentials.

## Commentary (optional)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1165
