### PR TITLE
docs: quick fix for version dropdown

### DIFF
--- a/docs/_static/version-switcher/versions.json
+++ b/docs/_static/version-switcher/versions.json
@@ -4,6 +4,10 @@
         "url": "https://docs.determined.ai/latest/"
     },
     {
+        "version": "0.26.2",
+        "url": "https://docs.determined.ai/0.26.2/"
+    },
+    {
         "version": "0.26.1",
         "url": "https://docs.determined.ai/0.26.1/"
     },


### PR DESCRIPTION
The long-term fix is still ticketed, but hasn't happened yet.