### PR TITLE
chore: deployment's --dry-run option doesn't print template

### DIFF
--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -255,7 +255,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
         check_quotas(det_configs, deployment_object)
 
     if args.dry_run:
-        deployment_object.print()
+        print("Dry run complete. Exiting.")
         return
 
     print("Starting Determined Deployment")
@@ -518,7 +518,7 @@ args_description = Cmd(
                 Arg(
                     "--dry-run",
                     action="store_true",
-                    help="print deployment template",
+                    help="only validate flags and check quota. Do not deploy.",
                 ),
                 Arg(
                     "--cpu-env-image",

--- a/harness/determined/deploy/aws/deployment_types/base.py
+++ b/harness/determined/deploy/aws/deployment_types/base.py
@@ -73,10 +73,6 @@ class DeterminedDeployment(metaclass=abc.ABCMeta):
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:
         pass
 
-    def print(self) -> None:
-        with open(self.template_path) as f:
-            print(f.read())
-
     def wait_for_master(self, timeout: int = 5 * 60) -> None:
         cert = None
         if self.parameters[constants.cloudformation.MASTER_TLS_CERT]:


### PR DESCRIPTION
Pre-patch, --dry-run:
1. validates flags
2. checks quotas (unless otherwise suppressed)
3. prints a CF template

This patch removes the 3rd step.

It was easy to confuse the template printed by --dry-run with the parameters that would be actually used when deploying a cluster (https://github.com/determined-ai/determined/issues/7978 for one such bug report).

It's tempting to remove the --dry-run flag entirely. This patch takes the stance that it's helpful to have an option that at least validates flags without doing something that's hard to undo, and so even a restricted --dry-run still has some use.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Run a `det deploy aws up` with `--dry-run` passed.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
