### PR TITLE
fix: Metric group charts have more than one color

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -16,6 +16,7 @@ import {
   TrialDetails,
   XAxisDomain,
 } from 'types';
+import { glasbeyColor } from 'utils/color';
 import handleError from 'utils/error';
 import { metricSorter, metricToKey } from 'utils/metric';
 
@@ -146,7 +147,7 @@ const TrialDetailsMetrics: React.FC<Props> = ({ experiment, trial }: Props) => {
               return '<div>⬦ Best Checkpoint <em>(click to view details)</em> </div>';
             },
             isShownEmptyVal: false,
-            seriesColors: series.map((s) => s.color ?? '#009BDE'),
+            seriesColors: series.map((s, idx) => s.color ?? glasbeyColor(idx)),
           }),
         ],
         series,

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -80,11 +80,12 @@ const summarizedMetricToSeries = (
     if (rawBatchEpochMap[metricKey]) data[XAxisDomain.Epochs] = rawBatchEpochMap[metricKey];
 
     const series: Serie = {
-      color:
-        metric.group === MetricType.Validation ? VALIDATION_SERIES_COLOR : TRAINING_SERIES_COLOR,
       data,
       name: `${metric.group}.${metric.name}`,
     };
+    if (metric.group === MetricType.Validation) series.color = VALIDATION_SERIES_COLOR;
+    if (metric.group === MetricType.Training) series.color = TRAINING_SERIES_COLOR;
+
     trialData[metricToKey(metric)] = series;
   });
   const xAxisOptions = Object.values(XAxisDomain);


### PR DESCRIPTION
## Description

We discussed how the trial's Metrics tab group-by-name feature is coloring lines the same unless the group is specifically named "Validation"

<img width="569" alt="Screen Shot 2023-11-02 at 11 33 05 AM" src="https://github.com/determined-ai/determined/assets/643918/58d8d472-4dbf-463b-8876-fc82dd302290">

The PR uses training=blue/validation=orange colors, but otherwise uses glasbeyColor

<img width="484" alt="Screen Shot 2023-11-02 at 11 35 03 AM" src="https://github.com/determined-ai/determined/assets/643918/5ea151f5-ba65-4635-9da3-6ce568249101">
<img width="476" alt="Screen Shot 2023-11-02 at 11 34 46 AM" src="https://github.com/determined-ai/determined/assets/643918/ad0f0bc4-c4e1-4130-8164-a12258e3ba07">


## Test Plan

Review charts and tooltip key where there are training/validation metrics with the same name. On gcloud this is `/det/experiments/2736/metrics`
;;; on latest-main use `/det/experiments/4951/metrics`

Review charts and tooltip key where there are metrics from other named groups. On gcloud this is `/det/experiments/2713/trials/40852/metrics`
;;; on latest-main use `/det/experiments/4754/metrics`


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.