### PR TITLE
fix: NTSC task and slot viewing obscured for RBAC users with no Viewer Permissions

### DIFF
--- a/harness/determined/cli/task.py
+++ b/harness/determined/cli/task.py
@@ -11,6 +11,8 @@ from determined.common.api import authentication, bindings
 from determined.common.api.bindings import v1AllocationSummary
 from determined.common.declarative_argparse import Arg, Cmd, Group
 
+NO_PERMISSIONS = "NO PERMISSIONS"
+
 
 def render_tasks(args: Namespace, tasks: Dict[str, v1AllocationSummary]) -> None:
     """Render tasks for JSON, tabulate or csv output.
@@ -45,9 +47,9 @@ def render_tasks(args: Namespace, tasks: Dict[str, v1AllocationSummary]) -> None
     ]
     values = [
         [
-            task.taskId,
-            task.allocationId,
-            task.name,
+            task.taskId if task.name else NO_PERMISSIONS,
+            task.allocationId if task.name else NO_PERMISSIONS,
+            task.name if task.name else NO_PERMISSIONS,
             task.slotsNeeded,
             render.format_time(task.registeredTime),
             agent_info(task),

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -534,12 +534,20 @@ func (a *apiServer) GetTasks(
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
 		if authz.IsPermissionDenied(err) {
-			continue
+			obfuscatedSummary, err := authz.ObfuscateNTSCTask(allocationSummary)
+			if err != nil {
+				return nil, err
+			}
+			if !isExp {
+				pbAllocationIDToSummary[string(authz.HiddenString)] = obfuscatedSummary.Proto()
+			} else {
+				pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
+			}
 		} else if err != nil {
 			return nil, err
+		} else {
+			pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 		}
-
-		pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 	}
 
 	return &apiv1.GetTasksResponse{AllocationIdToSummary: pbAllocationIDToSummary}, nil

--- a/master/internal/authz/obfuscate.go
+++ b/master/internal/authz/obfuscate.go
@@ -4,6 +4,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/cproto"
+	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/proto/pkg/agentv1"
 	"github.com/determined-ai/determined/proto/pkg/containerv1"
 	"github.com/determined-ai/determined/proto/pkg/devicev1"
@@ -11,8 +15,9 @@ import (
 )
 
 const (
-	hiddenString = "********"
-	hiddenInt    = -1
+	HiddenString = "********"
+	HiddenInt    = -1
+	HiddenBool   = false
 )
 
 // ObfuscateDevice obfuscates sensitive information in given Device.
@@ -20,8 +25,8 @@ func ObfuscateDevice(device *devicev1.Device) error {
 	if device == nil {
 		return errors.New("device must be defined")
 	}
-	device.Id = hiddenInt
-	device.Uuid = hiddenString
+	device.Id = HiddenInt
+	device.Uuid = HiddenString
 	return nil
 }
 
@@ -30,8 +35,8 @@ func ObfuscateContainer(container *containerv1.Container) error {
 	if container == nil {
 		return errors.New("container must be defined")
 	}
-	container.Id = hiddenString
-	container.Parent = hiddenString
+	container.Id = HiddenString
+	container.Parent = HiddenString
 	for _, device := range container.Devices {
 		if err := ObfuscateDevice(device); err != nil {
 			return err
@@ -61,7 +66,8 @@ func ObfuscateAgent(agent *agentv1.Agent) error {
 	if agent == nil {
 		return errors.New("agent must be defined")
 	}
-	agent.Addresses = []string{hiddenString}
+	agent.Addresses = []string{HiddenString}
+	agent.Id = ""
 
 	if agent.Containers != nil {
 		obfuscatedContainers := make(map[string]*containerv1.Container)
@@ -88,6 +94,48 @@ func ObfuscateAgent(agent *agentv1.Agent) error {
 	agent.Slots = obfuscatedSlots
 
 	return nil
+}
+
+// ObfuscateNTSCTask obfuscates sensitive information about a given Notebook, Tensorboard, Shell,
+// or Command Task.
+func ObfuscateNTSCTask(ntscTask sproto.AllocationSummary) (sproto.AllocationSummary, error) {
+	obfuscatedNTSCTask := sproto.AllocationSummary{}
+
+	obfuscatedNTSCTask.TaskID = HiddenString
+	obfuscatedNTSCTask.AllocationID = HiddenString
+	obfuscatedNTSCTask.Name = ""
+
+	resSummary := sproto.ResourcesSummary{}
+
+	for _, r := range ntscTask.Resources {
+		resSummary.ResourcesID = HiddenString
+		resSummary.AllocationID = HiddenString
+		var cID cproto.ID = HiddenString
+		resSummary.ContainerID = &cID
+		resourceAgentDevices := make(map[aproto.ID][]device.Device)
+		var obfuscatedDevs []device.Device
+		for _, devs := range r.AgentDevices {
+			for _, dev := range devs {
+				dev.Brand = HiddenString
+				dev.UUID = HiddenString
+				obfuscatedDevs = append(obfuscatedDevs, dev)
+			}
+			resourceAgentDevices[aproto.ID(HiddenString)] = obfuscatedDevs
+		}
+		resSummary.AgentDevices = resourceAgentDevices
+		obfuscatedNTSCTask.Resources = append(obfuscatedNTSCTask.Resources, resSummary)
+	}
+	obfuscatedProxyPorts := make([]*sproto.ProxyPortConfig, len(ntscTask.ProxyPorts))
+	for i := range ntscTask.ProxyPorts {
+		ppConf := sproto.ProxyPortConfig{}
+		ppConf.ServiceID = HiddenString
+		ppConf.Port = HiddenInt
+		ppConf.ProxyTCP = HiddenBool
+		ppConf.Unauthenticated = HiddenBool
+		obfuscatedProxyPorts[i] = &ppConf
+	}
+	obfuscatedNTSCTask.ProxyPorts = obfuscatedProxyPorts
+	return obfuscatedNTSCTask, nil
 }
 
 // ObfuscateJob obfuscates sensitive information in given Job.


### PR DESCRIPTION
## Description

RBAC enabled users with no viewer permissions can now run `det slot list` and `det task list` to see task allocations with all sensitive allocation information obscured. 

`det slot list` now uses the new grpc endpoint to access API tasks during the `GetTasks` request.

## Test Plan

To test the CLI display on `det slot list` and `det task list`: 

- Spin up a determined cluster in EE with RBAC enabled. 
- Run `det user login admin` and `det rbac my-permissions` to ensure that `admin` has all necessary permissions to view and create Notebooks, Tensorboards, Shells, and Commands.
- Run `det shell start` 
     - Run `exit` to exit out of the determined shell if it opens up in your terminal
- Run `det slot list` and `det task list` to ensure that you can see shell allocation and all of its details while logged in as `admin`
- Now, run `det user login determined` and `det rbac my-permissions` to ensure that your `determined` user has no RBAC permissions (if it does, create a new user with `admin` and log into that user, as newly created users should start out with no RBAC permissions). 
- Run `det slot list` and `det task list` to ensure that the task allocation is listed, but all sensitive information about the allocation (task id, allocation id, name, etc...) is obscured with an indication of "No permissions".

To test obscured task information on the `GetTasks` API request, run the `TestGetTasksAuthZ` integration test in `.../master/internal/api_tasks_intg_test.go`.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9595
