### PR TITLE
fix: prevent carriage return in env from crashing deepspeed launcher

### DIFF
--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -194,7 +194,7 @@ def create_deepspeed_env_file() -> None:
             #
             # Therefore, avoid writing any environment variables containing a
             # newline character.
-            if "\n" not in line:
+            if "\n" not in line and "\r" not in line:
                 f.write(f"{line}\n")
             else:
                 logger.warning(


### PR DESCRIPTION
## Description

The DeepSpeed runner users `readlines` to read the environment variable file and expects an equals sign on each line.  We prevent newlines from being in written environment variables, since this would break that format.  But carriage returns are also considered line  breaks by `readlines` in the default `open` mode and so also break the format (causing the runner to crash) -- so this PR omits them too.

## Test Plan

DeepSpeed CI

## Checklist

- [] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1206