### PR TITLE
fix: properly interpret flag values

### DIFF
--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -9,7 +9,7 @@ from termcolor import colored
 
 import determined.deploy
 from determined.cli.errors import CliError
-from determined.common.declarative_argparse import Arg, ArgGroup, Cmd, Group
+from determined.common.declarative_argparse import Arg, ArgGroup, Cmd, Group, string_to_bool
 from determined.deploy.errors import MasterTimeoutExpired
 from determined.deploy.gcp import constants, gcp
 
@@ -427,7 +427,7 @@ args_description = Cmd(
                         ),
                         Arg(
                             "--preemptible",
-                            type=bool,
+                            type=string_to_bool,
                             default=False,
                             help="whether to use preemptible instances for dynamic agents",
                         ),
@@ -535,7 +535,7 @@ args_description = Cmd(
                         ),
                         Arg(
                             "--preemption-enabled",
-                            type=bool,
+                            type=string_to_bool,
                             default=constants.defaults.PREEMPTION_ENABLED,
                             help="whether task preemption is supported in the scheduler "
                             "(only configurable for priority scheduler).",


### PR DESCRIPTION
Both `--preemptible` and `--preemption-enabled` cast values with the built-in `bool`, which casts to True any possible value but "0". Even "false" and "False". This is almost certainly not what users expect.

Using `string_to_bool`, "0" is still supported. But now all the strings that should evaluate to False do, too.

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
ROI on testing this might not be high, but:

Deploy a cluster to GCP with `det deploy gcp up` with different values for `--preemptible` and `--preemption-enabled`.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
