### PR TITLE
feat: Cluster historical usage charts move to UI Kit LineChart [WEB-1786] [WEB-1764]

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
@@ -1,11 +1,11 @@
 import { Space } from 'antd';
 import dayjs from 'dayjs';
 import Button from 'hew/Button';
+import { SyncProvider } from 'hew/LineChart/SyncProvider';
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import Section from 'components/Section';
-import { SyncProvider } from 'components/UPlot/SyncProvider';
 import { useSettings } from 'hooks/useSettings';
 import { getResourceAllocationAggregated } from 'services/api';
 import { V1ResourceAllocationAggregatedResponse } from 'services/api-ts-sdk';
@@ -135,6 +135,7 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
                 hoursByLabel={series.hoursTotal}
                 time={series.time}
@@ -151,9 +152,12 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
-                hoursByLabel={series.hoursByUsername}
-                hoursTotal={series?.hoursTotal?.total}
+                hoursByLabel={{
+                  ...series.hoursByUsername,
+                  total: series?.hoursTotal?.total,
+                }}
                 time={series.time}
               />
             ),
@@ -168,9 +172,12 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
-                hoursByLabel={series.hoursByExperimentLabel}
-                hoursTotal={series?.hoursTotal?.total}
+                hoursByLabel={{
+                  ...series.hoursByExperimentLabel,
+                  total: series?.hoursTotal?.total,
+                }}
                 time={series.time}
               />
             ),
@@ -185,9 +192,12 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
-                hoursByLabel={series.hoursByResourcePool}
-                hoursTotal={series?.hoursTotal?.total}
+                hoursByLabel={{
+                  ...series.hoursByResourcePool,
+                  total: series?.hoursTotal?.total,
+                }}
                 time={series.time}
               />
             ),

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsage.tsx
@@ -135,6 +135,7 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                chartKey={filters.afterDate.unix() + filters.beforeDate.unix()}
                 dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
                 hoursByLabel={series.hoursTotal}
@@ -152,6 +153,7 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                chartKey={filters.afterDate.unix() + filters.beforeDate.unix()}
                 dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
                 hoursByLabel={{
@@ -172,6 +174,7 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                chartKey={filters.afterDate.unix() + filters.beforeDate.unix()}
                 dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
                 hoursByLabel={{
@@ -192,6 +195,7 @@ const ClusterHistoricalUsage: React.FC = () => {
             Failed: () => null, // TODO inform user if chart fails to load
             Loaded: (series) => (
               <ClusterHistoricalUsageChart
+                chartKey={filters.afterDate.unix() + filters.beforeDate.unix()}
                 dateRange={[filters.afterDate.unix(), filters.beforeDate.unix()]}
                 groupBy={series.groupedBy}
                 hoursByLabel={{

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -1,5 +1,5 @@
 import LineChart from 'hew/LineChart';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { Serie, XAxisDomain } from 'types';
 import handleError from 'utils/error';
@@ -9,6 +9,7 @@ import { GroupBy } from './ClusterHistoricalUsage.settings';
 import css from './ClusterHistoricalUsageChart.module.scss';
 
 interface ClusterHistoricalUsageChartProps {
+  chartKey?: number;
   dateRange?: [start: number, end: number];
   formatValues?: (_: uPlot, arg0: number[]) => string[];
   groupBy?: GroupBy;
@@ -21,6 +22,7 @@ interface ClusterHistoricalUsageChartProps {
 const CHART_HEIGHT = 350;
 
 const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = ({
+  chartKey,
   dateRange,
   formatValues,
   groupBy,
@@ -29,12 +31,6 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
   label,
   time,
 }: ClusterHistoricalUsageChartProps) => {
-  const singlePoint = useMemo(
-    // one series, and that one series has one point
-    () => Object.keys(hoursByLabel).length === 1 && Object.values(hoursByLabel)[0].length === 1,
-    [hoursByLabel],
-  );
-
   const data: Serie[] = Object.keys(hoursByLabel).map((label) => ({
     data: {
       [XAxisDomain.Time]: hoursByLabel[label].map((pt, idx) => [Date.parse(time[idx]) / 1000, pt]),
@@ -42,28 +38,17 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
     name: label,
   }));
 
-  const adjustedDateRange: [number, number] | undefined = useMemo(() => {
-    return (
-      dateRange ??
-      (singlePoint
-        ? [
-            new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
-            new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
-          ]
-        : undefined)
-    );
-  }, [singlePoint, dateRange]);
-
   return (
     <div className={css.base}>
       <LineChart
         handleError={handleError}
         height={height}
+        key={chartKey}
         series={data}
         xAxis={XAxisDomain.Time}
         xLabel={capitalizeWord(groupBy || '')}
         xRange={{
-          [XAxisDomain.Time]: adjustedDateRange,
+          [XAxisDomain.Time]: dateRange,
           [XAxisDomain.Batches]: undefined,
           [XAxisDomain.Epochs]: undefined,
         }}

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -33,6 +33,7 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
 }: ClusterHistoricalUsageChartProps) => {
   const data: Serie[] = Object.keys(hoursByLabel).map((label) => ({
     data: {
+      // convert Unix times from milliseconds to seconds
       [XAxisDomain.Time]: hoursByLabel[label].map((pt, idx) => [Date.parse(time[idx]) / 1000, pt]),
     },
     name: label,

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -45,6 +45,7 @@ const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = 
         height={height}
         key={chartKey}
         series={data}
+        showLegend
         xAxis={XAxisDomain.Time}
         xLabel={capitalizeWord(groupBy || '')}
         xRange={{

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageChart.tsx
@@ -1,22 +1,19 @@
-import dayjs from 'dayjs';
-import Message from 'hew/Message';
+import LineChart from 'hew/LineChart';
 import React, { useMemo } from 'react';
-import uPlot, { AlignedData, Series } from 'uplot';
 
-import UPlotChart, { Options } from 'components/UPlot/UPlotChart';
-import { glasbeyColor } from 'utils/color';
+import { Serie, XAxisDomain } from 'types';
+import handleError from 'utils/error';
+import { capitalizeWord } from 'utils/string';
 
 import { GroupBy } from './ClusterHistoricalUsage.settings';
 import css from './ClusterHistoricalUsageChart.module.scss';
 
 interface ClusterHistoricalUsageChartProps {
-  chartKey?: number;
   dateRange?: [start: number, end: number];
-  formatValues?: (self: uPlot, splits: number[]) => string[];
+  formatValues?: (_: uPlot, arg0: number[]) => string[];
   groupBy?: GroupBy;
   height?: number;
   hoursByLabel: Record<string, number[]>;
-  hoursTotal?: number[];
   label?: string;
   time: string[];
 }
@@ -24,125 +21,55 @@ interface ClusterHistoricalUsageChartProps {
 const CHART_HEIGHT = 350;
 
 const ClusterHistoricalUsageChart: React.FC<ClusterHistoricalUsageChartProps> = ({
-  chartKey,
   dateRange,
   formatValues,
   groupBy,
   height = CHART_HEIGHT,
   hoursByLabel,
-  hoursTotal,
   label,
   time,
 }: ClusterHistoricalUsageChartProps) => {
-  const chartData: AlignedData = useMemo(() => {
-    const timeUnix: number[] = time.map((item) => Date.parse(item) / 1000);
-
-    const data: AlignedData = [timeUnix];
-    if (hoursTotal) {
-      data.push(hoursTotal);
-    }
-
-    Object.keys(hoursByLabel).forEach((label) => {
-      data.push(hoursByLabel[label]);
-    });
-
-    return data;
-  }, [hoursByLabel, hoursTotal, time]);
-
-  const hasData = useMemo(() => {
-    return Object.keys(hoursByLabel).reduce(
-      (agg, label) => agg || hoursByLabel[label].length > 0,
-      false,
-    );
-  }, [hoursByLabel]);
-
   const singlePoint = useMemo(
     // one series, and that one series has one point
     () => Object.keys(hoursByLabel).length === 1 && Object.values(hoursByLabel)[0].length === 1,
     [hoursByLabel],
   );
 
-  const chartOptions: Options = useMemo(() => {
-    let dateFormat = 'MM-DD';
-    let timeSeries: Series = { label: 'Day', value: '{YYYY}-{MM}-{DD}' };
-    if (groupBy === GroupBy.Month) {
-      dateFormat = 'YYYY-MM';
-      timeSeries = { label: 'Month', value: '{YYYY}-{MM}' };
-    }
+  const data: Serie[] = Object.keys(hoursByLabel).map((label) => ({
+    data: {
+      [XAxisDomain.Time]: hoursByLabel[label].map((pt, idx) => [Date.parse(time[idx]) / 1000, pt]),
+    },
+    name: label,
+  }));
 
-    const series: Series[] = [timeSeries];
-    if (hoursTotal) {
-      series.push({
-        label: 'total',
-        show: false,
-        stroke: glasbeyColor(series.length - 1),
-        width: 2,
-      });
-    }
-    Object.keys(hoursByLabel).forEach((label) => {
-      series.push({
-        label,
-        stroke: glasbeyColor(series.length - 1),
-        width: 2,
-      });
-    });
-
-    return {
-      axes: [
-        {
-          label: timeSeries.label,
-          space: (self, axisIdx, scaleMin, scaleMax, plotDim) => {
-            const rangeSecs = scaleMax - scaleMin;
-            const rangeDays = rangeSecs / (24 * 60 * 60);
-            const pxPerDay = plotDim / rangeDays;
-            return Math.max(60, pxPerDay * (groupBy === GroupBy.Month ? 28 : 1));
-          },
-          values: (self, splits) => {
-            return splits.map((i) => {
-              const date = dayjs.utc(i * 1000);
-              return date.hour() === 0 ? date.format(dateFormat) : '';
-            });
-          },
-        },
-        { label: label ? label : 'GPU Hours', values: formatValues },
-      ],
-      height,
-      key: chartKey,
-      scales: {
-        x: {
-          auto: !singlePoint,
-          range:
-            dateRange ??
-            (singlePoint
-              ? [
-                  new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
-                  new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
-                ]
-              : undefined),
-        },
-      },
-      series,
-      tzDate: (ts) => uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'),
-    };
-  }, [
-    chartKey,
-    dateRange,
-    formatValues,
-    groupBy,
-    height,
-    hoursByLabel,
-    hoursTotal,
-    label,
-    singlePoint,
-  ]);
-
-  if (!hasData) {
-    return <Message icon="warning" title="No data to plot." />;
-  }
+  const adjustedDateRange: [number, number] | undefined = useMemo(() => {
+    return (
+      dateRange ??
+      (singlePoint
+        ? [
+            new Date(`${new Date().getFullYear()}-01-01`).getTime() / 1000,
+            new Date(`${new Date().getFullYear() + 1}-01-01`).getTime() / 1000,
+          ]
+        : undefined)
+    );
+  }, [singlePoint, dateRange]);
 
   return (
     <div className={css.base}>
-      <UPlotChart data={chartData} options={chartOptions} />
+      <LineChart
+        handleError={handleError}
+        height={height}
+        series={data}
+        xAxis={XAxisDomain.Time}
+        xLabel={capitalizeWord(groupBy || '')}
+        xRange={{
+          [XAxisDomain.Time]: adjustedDateRange,
+          [XAxisDomain.Batches]: undefined,
+          [XAxisDomain.Epochs]: undefined,
+        }}
+        yLabel={label || 'GPU Hours'}
+        yTickValues={formatValues}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description

After we update the xRange / zoom interactions ( https://github.com/determined-ai/hew/pull/27 ) the LineChart component will be ready to replace the charts on Cluster Historical Usage

## Test Plan

On `/det/clusters/historical-usage`
- chart cursors are synced between charts
- click and drag on a chart; zoom is synced between charts
- click the chart legend to show and hide lines on an individual chart

Date range:
- select earlier and later start dates; the chart should update
- select earlier and later end dates; the chart should update
- toggle back and forth between month and day charts; the x-range should change
- on the monthly view, select a month in 2021 or earlier; the x-range should include the set dates even when we have no data in this year

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.