### PR TITLE
chore: remove fit-content from `TimeAgoc`

### DIFF
--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -25,6 +25,7 @@
     align-items: end;
     display: flex;
     font-size: 12px;
+    gap: 6px;
     grid-area: footer;
     justify-content: space-between;
 
@@ -36,9 +37,6 @@
         display: flex;
         gap: 4px;
       }
-    }
-    .lastExperiment {
-      margin-left: 6px;
     }
     .archivedBadge {
       background-color: var(--theme-status-inactive);

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -79,7 +79,6 @@ const ProjectCard: React.FC<Props> = ({
             ) : (
               project.lastExperimentStartedAt && (
                 <TimeAgo
-                  className={css.lastExperiment}
                   datetime={project.lastExperimentStartedAt}
                   tooltipFormat="[Last experiment started: \n]MMM D, YYYY - h:mm a"
                 />

--- a/webui/react/src/components/TimeAgo.module.scss
+++ b/webui/react/src/components/TimeAgo.module.scss
@@ -1,3 +1,0 @@
-.base {
-  width: fit-content;
-}

--- a/webui/react/src/components/TimeAgo.test.tsx
+++ b/webui/react/src/components/TimeAgo.test.tsx
@@ -44,14 +44,6 @@ describe('TimeAgo', () => {
     expect(screen.getByText(daysMatch)).toBeInTheDocument();
   });
 
-  it('should render with custom className', () => {
-    const datetime = shared.now - offsetDays;
-    const customClassName = 'customClassName';
-    const view = render(<TimeAgo className={customClassName} datetime={datetime} />);
-    const element = view.getByText(daysMatch);
-    expect(element.className).toBe(`base ${customClassName}`);
-  });
-
   it('should render "Just Now" when < 1 minute', () => {
     render(<TimeAgo datetime={shared.now - DURATION_SECOND} />);
     expect(screen.getByText(/just now/i)).toBeInTheDocument();

--- a/webui/react/src/components/TimeAgo.tsx
+++ b/webui/react/src/components/TimeAgo.tsx
@@ -14,8 +14,6 @@ import {
 } from 'utils/datetime';
 import { capitalize, capitalizeWord } from 'utils/string';
 
-import css from './TimeAgo.module.scss';
-
 export const TimeAgoCase = {
   Lower: 'lower',
   Sentence: 'sentence',
@@ -25,7 +23,6 @@ export const TimeAgoCase = {
 export type TimeAgoCase = ValueOf<typeof TimeAgoCase>;
 
 interface Props {
-  className?: string;
   dateFormat?: string;
   datetime: Dayjs | Date | number | string;
   long?: boolean;
@@ -39,7 +36,6 @@ export const JUST_NOW = 'Just Now';
 export const DEFAULT_TOOLTIP_FORMAT = 'MMM D, YYYY - h:mm a';
 
 const TimeAgo: React.FC<Props> = ({
-  className,
   dateFormat = 'MMM D, YYYY',
   datetime,
   long = false,
@@ -49,9 +45,6 @@ const TimeAgo: React.FC<Props> = ({
   units = 1,
 }: Props) => {
   const [now, setNow] = useState(() => Date.now());
-  const classes: string[] = [css.base];
-
-  if (className) classes.push(className);
 
   const milliseconds = useMemo(() => {
     if (isNumber(datetime)) {
@@ -122,7 +115,7 @@ const TimeAgo: React.FC<Props> = ({
           {dayjs(milliseconds).format(tooltipFormat).replace('\\n', '\n')}
         </div>
       }>
-      <div className={classes.join(' ')}>{durationString}</div>
+      {durationString}
     </Tooltip>
   );
 };


### PR DESCRIPTION


## Description
this cleans up the `TimeAgo` css. previously, `TimeAgo` rendered as a div with width set to fit-content in #5419. This was to fix the div stretching to fill its container as a block-level element. Now, the text renders as a span, so the width of the container fits its content naturally. While in there, we remove the classname prop, which was only used in one place in the codebase.

## Test Plan

* when viewing a model, hover over the value for the "updated" field. The tooltip should appear in the center of the text.

* when viewing an unarchived project, the "last submitted experiment" field in the lower right corner should not collide with the experiment count field in the lower left corner


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
related to WEB-1720 -- this is the only place where we pass `width: fit-content` through to a trigger element of the Tooltip component, so this should obviate the need for the prop in the first place.


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
