### PR TITLE
chore: Job/task displays Running instead of Scheduled [WEB-1615]

### DIFF
--- a/webui/react/src/constants/states.ts
+++ b/webui/react/src/constants/states.ts
@@ -157,7 +157,7 @@ export const commandTypeToLabel: { [key in CommandType]: string } = {
 };
 
 export const jobStateToLabel: { [key in JobState]: string } = {
-  [JobState.SCHEDULED]: 'Scheduled',
+  [JobState.SCHEDULED]: 'Running',
   [JobState.SCHEDULEDBACKFILLED]: 'ScheduledBackfilled',
   [JobState.QUEUED]: 'Queued',
   [JobState.UNSPECIFIED]: 'Unspecified',


### PR DESCRIPTION
## Description

A remaining state button which says "Scheduled" is replaced with "Running". This affects the Tasks page.

## Test Plan

Run a notebook in `/det/tasks`
Cycle through stages including light blue button with "Running" on it
`git grep Scheduled` shows no other labels with "Scheduled"

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.