### PR TITLE
fix: patched remote users were able to login with password

### DIFF
--- a/docs/release-notes/remote-was-able-to-login.rst
+++ b/docs/release-notes/remote-was-able-to-login.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Users: Fix an issue where if a user's remote was set to true through ``det user edit <username> --remote=true`` that user could still login through their username and password while they were expected to only be able to login through IDP integrations.

--- a/docs/release-notes/remote-was-able-to-login.rst
+++ b/docs/release-notes/remote-was-able-to-login.rst
@@ -2,4 +2,6 @@
 
 **Bug Fixes**
 
--  Users: Fix an issue where if a user's remote status was edited through ``det user edit <username> --remote=true`` that user could still login through their username and password while they were expected to only be able to login through IDP integrations.
+-  Users: Fix an issue where if a user's remote status was edited through ``det user edit <username>
+   --remote=true`` that user could still login through their username and password while they were
+   expected to only be able to login through IDP integrations.

--- a/docs/release-notes/remote-was-able-to-login.rst
+++ b/docs/release-notes/remote-was-able-to-login.rst
@@ -2,4 +2,4 @@
 
 **Bug Fixes**
 
--  Users: Fix an issue where if a user's remote was set to true through ``det user edit <username> --remote=true`` that user could still login through their username and password while they were expected to only be able to login through IDP integrations.
+-  Users: Fix an issue where if a user's remote status was edited through ``det user edit <username> --remote=true`` that user could still login through their username and password while they were expected to only be able to login through IDP integrations.

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -1114,7 +1114,7 @@ def test_user_edit(clean_auth: None, login_admin: None) -> None:
         "--username",
         new_username,
         "--active=true",
-        "--remote=true",
+        "--remote=false",
         "--admin=true",
     ]
 
@@ -1128,7 +1128,7 @@ def test_user_edit(clean_auth: None, login_admin: None) -> None:
     assert modded_user.displayName == new_display_name
     assert modded_user.username == new_username
     assert modded_user.active
-    assert modded_user.remote
+    assert not modded_user.remote
     assert modded_user.admin
 
 

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -59,6 +59,10 @@ func (a *apiServer) Login(
 		return nil, err
 	}
 
+	if userModel.Remote { // We can't return a more specific error for informational leak reasons.
+		return nil, grpcutil.ErrInvalidCredentials
+	}
+
 	var hashedPassword string
 	if req.IsHashed {
 		hashedPassword = req.Password

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -445,12 +445,15 @@ func (a *apiServer) PatchUser(
 		willBeRemote = updatedUser.Remote
 		insertColumns = append(insertColumns, "remote")
 
-		if willBeRemote {
-			updatedUser.PasswordHash = model.NoPasswordLogin
-			insertColumns = append(insertColumns, "password_hash")
-		} else if !willBeRemote && req.User.Password == nil {
-			updatedUser.PasswordHash = model.EmptyPassword
-			insertColumns = append(insertColumns, "password_hash")
+		// We changed remote status. Need to clear passwords.
+		if targetUser.Remote != willBeRemote {
+			if willBeRemote {
+				updatedUser.PasswordHash = model.NoPasswordLogin
+				insertColumns = append(insertColumns, "password_hash")
+			} else if !willBeRemote && req.User.Password == nil {
+				updatedUser.PasswordHash = model.EmptyPassword
+				insertColumns = append(insertColumns, "password_hash")
+			}
 		}
 	}
 

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -445,11 +445,11 @@ func (a *apiServer) PatchUser(
 		willBeRemote = updatedUser.Remote
 		insertColumns = append(insertColumns, "remote")
 
-		// Clear password when we convert a remote user into non remote without password specified.
-		if !updatedUser.Remote && req.User.Password == nil {
-			if err := updatedUser.UpdatePasswordHash(""); err != nil {
-				return nil, errors.Wrap(err, "error hashing password")
-			}
+		if willBeRemote {
+			updatedUser.PasswordHash = model.NoPasswordLogin
+			insertColumns = append(insertColumns, "password_hash")
+		} else if !willBeRemote && req.User.Password == nil {
+			updatedUser.PasswordHash = model.EmptyPassword
 			insertColumns = append(insertColumns, "password_hash")
 		}
 	}

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -234,6 +234,14 @@ func TestLoginRemote(t *testing.T) {
 		})
 		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
 
+		// We set the password to the unloginable hash.
+		var expectedUser model.User
+		err = db.Bun().NewSelect().Model(&expectedUser).
+			Where("username = ?", username).
+			Scan(ctx, &expectedUser)
+		require.NoError(t, err)
+		require.Equal(t, model.NoPasswordLogin, expectedUser.PasswordHash)
+
 		// Changing back to unremote unsets password to blank.
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -26,6 +26,7 @@ import (
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/logpattern"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/user"
@@ -130,6 +131,129 @@ func fetchUserIds(ctx context.Context, t *testing.T, api *apiServer, req *apiv1.
 		ids = append(ids, model.UserID(u.Id))
 	}
 	return ids
+}
+
+func TestLoginRemote(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+
+	t.Run("created with remote", func(t *testing.T) {
+		username := uuid.New().String()
+		resp, err := api.PostUser(ctx, &apiv1.PostUserRequest{
+			User: &userv1.User{
+				Username: username,
+				Remote:   true,
+				Active:   true,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+		})
+		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
+
+		// Can't change password while they are remote.
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Password: ptrs.Ptr("pass"),
+			},
+		})
+		require.ErrorContains(t, err, "Cannot set password")
+
+		// Changing back to unremote means we can login with blank password.
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote: ptrs.Ptr(false),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("created with remote changed with password", func(t *testing.T) {
+		username := uuid.New().String()
+		resp, err := api.PostUser(ctx, &apiv1.PostUserRequest{
+			User: &userv1.User{
+				Username: username,
+				Remote:   true,
+				Active:   true,
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote:   ptrs.Ptr(false),
+				Password: ptrs.Ptr("testpassword"),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+			Password: "testpassword",
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("created without remote", func(t *testing.T) {
+		username := uuid.New().String()
+		resp, err := api.PostUser(ctx, &apiv1.PostUserRequest{
+			User: &userv1.User{
+				Username: username,
+				Active:   true,
+			},
+			Password: "testpassword",
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+			Password: "testpassword",
+		})
+		require.NoError(t, err)
+
+		// Cannot login when we switch to remote.
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote: ptrs.Ptr(true),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+		})
+		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
+
+		// Changing back to unremote unsets password to blank.
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote: ptrs.Ptr(true),
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+			Password: "testpassword",
+		})
+		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+		})
+		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
+	})
 }
 
 func TestGetUsersRemote(t *testing.T) {

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -236,6 +236,10 @@ func (s *Service) postLogin(c echo.Context) (interface{}, error) {
 		return nil, err
 	}
 
+	if user.Remote { // We can't return a more specific error for informational leak reasons.
+		return nil, echo.NewHTTPError(http.StatusForbidden, "invalid credentials")
+	}
+
 	// The user must be active.
 	if !user.Active {
 		return nil, echo.NewHTTPError(http.StatusForbidden, "user not active")


### PR DESCRIPTION
## Description

Users with patched remote values were able to login. This was a bug.


## Test Plan

```
det -u admin user create testuser
det -u admin user edit testuser --remote true 
```
Should not be able to login in the webui with testuser


## Commentary (optional)

There is a somewhat of a case this PR doesn't hit which is pre this upgrade

if you start with a remote user then patch it to not remote, this user won't be able to login until you change their password. I don't think there is an easy migration path unless we assume all non remote invalid passwords can be set to blank which feels risky.

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
