### PR TITLE
ci: mypy fix for responses>=0.24.0

### DIFF
--- a/harness/tests/determined/common/experimental/test_trial.py
+++ b/harness/tests/determined/common/experimental/test_trial.py
@@ -42,6 +42,7 @@ def test_trial_logs_converts_epoch_time(make_trialref: Callable[[int], trial.Tri
     list(trialref.logs(timestamp_before=before_ts, timestamp_after=after_ts))
 
     call = responses.calls[0]
+    assert isinstance(call, responses.Call)
     assert call.request.params["timestampBefore"] == timestamp_before
     assert call.request.params["timestampAfter"] == timestamp_after
 


### PR DESCRIPTION
example failure [here](https://app.circleci.com/pipelines/github/determined-ai/determined-ee/9996/workflows/0001517d-c2db-40f2-bdcd-a4e174e556c1/jobs/476604), in the EE repo where the 0.23.3 edition of responses wasn't cached for some reason.