### PR TITLE
fix: Set group name and number columns to handle Safari [DET-9948] [DET-9949]

### DIFF
--- a/webui/react/src/pages/Admin/GroupManagement.tsx
+++ b/webui/react/src/pages/Admin/GroupManagement.tsx
@@ -264,7 +264,7 @@ const GroupManagement: React.FC = () => {
           <Nameplate icon={<Icon name="group" title="Group" />} name={r.group.name ?? ''} />
         ),
         title: 'Group',
-        width: 'fit-content',
+        width: '100%',
       },
       {
         dataIndex: 'users',
@@ -273,7 +273,7 @@ const GroupManagement: React.FC = () => {
         onCell: onRightClickableCell,
         render: (_: string, r: V1GroupSearchResult) => r.numMembers,
         title: 'Members',
-        width: 'fit-content',
+        width: '100%',
       },
       {
         className: 'fullCell',

--- a/webui/react/src/pages/Admin/index.tsx
+++ b/webui/react/src/pages/Admin/index.tsx
@@ -76,7 +76,7 @@ const SettingsContent: React.FC = () => {
           items.push({
             children: <UserManagement />,
             key: TAB_KEYS[TabType.UserManagement],
-            label: `${TabType.UserManagement} ${users.length}`,
+            label: `${TabType.UserManagement} (${users.length})`,
           });
         },
       });
@@ -86,7 +86,7 @@ const SettingsContent: React.FC = () => {
       items.push({
         children: <GroupManagement />,
         key: TAB_KEYS[TabType.GroupManagement],
-        label: `${TabType.GroupManagement} ${totalGroup ?? ''}`,
+        label: `${TabType.GroupManagement} ${totalGroup ? `(${totalGroup})` : ''}`,
       });
     }
 

--- a/webui/react/src/pages/Admin/index.tsx
+++ b/webui/react/src/pages/Admin/index.tsx
@@ -86,7 +86,7 @@ const SettingsContent: React.FC = () => {
       items.push({
         children: <GroupManagement />,
         key: TAB_KEYS[TabType.GroupManagement],
-        label: `${TabType.GroupManagement} ${totalGroup ? `(${totalGroup})` : ''}`,
+        label: `${TabType.GroupManagement} ${totalGroup !== undefined ? `(${totalGroup})` : ''}`,
       });
     }
 


### PR DESCRIPTION
## Description

On Safari, the group admin page wasn't showing group names
We researched and found Safari/WebKit uses `width: intrinsic` instead of `fit-content`

After discussion on Slack about this ticket and #8309 , best option is 100% width

We also added parentheses around the number of groups or users

## Test Plan

On `/det/admin/user-management`,

With EE backend, group name column appears on Safari without issues

Users and Groups tabs appear with a number in parentheses. (If groups is undefined, the Group parentheses and number do not appear)

<img width="470" alt="Screen Shot 2023-11-07 at 1 03 02 PM" src="https://github.com/determined-ai/determined/assets/643918/7762f274-f538-49be-aff6-e7ed1c795085">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.