### PR TITLE
chore: Update Horovod Cycle Time

### DIFF
--- a/docs/reference/training/experiment-config-reference.rst
+++ b/docs/reference/training/experiment-config-reference.rst
@@ -1442,7 +1442,7 @@ training. Defaults to ``64``.
 ============================
 
 Optional. The delay (in milliseconds) between each tensor fusion during distributed training.
-Defaults to ``5``.
+Defaults to ``1``.
 
 ``auto_tune_tensor_fusion``
 ===========================

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -6,7 +6,7 @@ from determined import constants, horovod
 @pytest.mark.parametrize("debug", [True, False])
 @pytest.mark.parametrize("auto_tune", [True, False])
 @pytest.mark.parametrize("tensor_fusion_threshold", [64, 128, 512])
-@pytest.mark.parametrize("tensor_fusion_cycle_time", [1, 5, 20])
+@pytest.mark.parametrize("tensor_fusion_cycle_time", [1, 5])
 def test_create_run_command(
     debug: bool, auto_tune: bool, tensor_fusion_threshold: int, tensor_fusion_cycle_time: int
 ) -> None:

--- a/harness/tests/test_horovod.py
+++ b/harness/tests/test_horovod.py
@@ -6,7 +6,7 @@ from determined import constants, horovod
 @pytest.mark.parametrize("debug", [True, False])
 @pytest.mark.parametrize("auto_tune", [True, False])
 @pytest.mark.parametrize("tensor_fusion_threshold", [64, 128, 512])
-@pytest.mark.parametrize("tensor_fusion_cycle_time", [5, 20])
+@pytest.mark.parametrize("tensor_fusion_cycle_time", [1, 5, 20])
 def test_create_run_command(
     debug: bool, auto_tune: bool, tensor_fusion_threshold: int, tensor_fusion_cycle_time: int
 ) -> None:

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1602,7 +1602,7 @@ var (
                 "null"
             ],
             "minimum": 0,
-            "default": 5
+            "default": 1
         },
         "tensor_fusion_threshold": {
             "type": [

--- a/schemas/expconf/v0/optimizations.json
+++ b/schemas/expconf/v0/optimizations.json
@@ -70,7 +70,7 @@
                 "null"
             ],
             "minimum": 0,
-            "default": 5
+            "default": 1
         },
         "tensor_fusion_threshold": {
             "type": [

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -91,7 +91,7 @@
       gradient_compression: false
       grad_updates_size_file: "/tmp/hi I am a size file"
       mixed_precision: O0
-      tensor_fusion_cycle_time: 5
+      tensor_fusion_cycle_time: 1
       tensor_fusion_threshold: 64
     perform_initial_validation: false
     pbs:

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -196,7 +196,7 @@
       gradient_compression: false
       grad_updates_size_file: null
       mixed_precision: O0
-      tensor_fusion_cycle_time: 5
+      tensor_fusion_cycle_time: 1
       tensor_fusion_threshold: 64
     pbs: {}
     perform_initial_validation: false


### PR DESCRIPTION
## Description

Performance Improvement. Our default Horovod `tensor_fusion_cycle_time` was set to a legacy value of 5ms. 1ms is the new `horovod` default value, so let's match that. 


## Test Plan

No Testing Required.


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1117