### PR TITLE
chore: fix nil ptr on allocation.Proto()

### DIFF
--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -223,8 +223,12 @@ func (a AcceleratorData) Proto() *apiv1.AcceleratorData {
 }
 
 // Proto returns the proto representation of the task state.
-func (s AllocationState) Proto() taskv1.State {
-	switch s {
+func (s *AllocationState) Proto() taskv1.State {
+	if s == nil {
+		return taskv1.State_STATE_UNSPECIFIED
+	}
+
+	switch *s {
 	case AllocationStateWaiting:
 		return taskv1.State_STATE_WAITING
 	case AllocationStatePulling:
@@ -244,13 +248,21 @@ func (s AllocationState) Proto() taskv1.State {
 
 // Proto returns the proto representation of the allocation state.
 func (a Allocation) Proto() *taskv1.Allocation {
-	startTime := a.StartTime.String()
-	endTime := a.EndTime.String()
+	var startTime *string
+	if a.StartTime != nil {
+		startTime = ptrs.Ptr(a.StartTime.String())
+	}
+
+	var endTime *string
+	if a.EndTime != nil {
+		endTime = ptrs.Ptr(a.EndTime.String())
+	}
+
 	return &taskv1.Allocation{
 		TaskId:       string(a.TaskID),
 		IsReady:      a.IsReady,
-		StartTime:    &startTime,
-		EndTime:      &endTime,
+		StartTime:    startTime,
+		EndTime:      endTime,
 		AllocationId: string(a.AllocationID),
 		State:        a.State.Proto(),
 		Slots:        int32(a.Slots),

--- a/master/pkg/model/task_test.go
+++ b/master/pkg/model/task_test.go
@@ -5,10 +5,43 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
 
 func TestTaskLogLevelFromLogrus(t *testing.T) {
 	for _, l := range logrus.AllLevels {
 		require.NotEqual(t, LogLevelUnspecified, TaskLogLevelFromLogrus(l), "unhandled log level")
 	}
+}
+
+func TestAllocationProto(t *testing.T) {
+	a := Allocation{
+		AllocationID: "aid",
+		TaskID:       "tid",
+		Slots:        1,
+		ResourcePool: "rp",
+		StartTime:    nil,
+		EndTime:      nil,
+		State:        nil,
+		IsReady:      nil,
+		Ports:        nil,
+		ProxyAddress: nil,
+		ExitReason:   nil,
+		ExitErr:      nil,
+		StatusCode:   nil,
+	}
+
+	expected := &taskv1.Allocation{
+		TaskId:       "tid",
+		IsReady:      nil,
+		StartTime:    nil,
+		EndTime:      nil,
+		AllocationId: "aid",
+		State:        taskv1.State_STATE_UNSPECIFIED,
+		Slots:        1,
+		ExitReason:   nil,
+		StatusCode:   nil,
+	}
+	require.Equal(t, expected, a.Proto())
 }


### PR DESCRIPTION
## Description

Our ```allocation.Proto()``` will cause a nil pr exception on in progress tasks since it assumes endTime is not nil.

Update the ```Proto()``` method to match the nilability of the Go struct.

No one uses this endpoint yet so this won't cause many issues.


## Test Plan

Unit test


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
