### PR TITLE
fix: Move modal context holders inside of Workspace/Project cards

### DIFF
--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -43,56 +43,50 @@ const ProjectCard: React.FC<Props> = ({
   if (project.archived) classnames.push(css.archived);
 
   return (
-    <>
-      <Card
-        actionMenu={!project.immutable && !hideActionMenu ? menu : undefined}
-        onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
-        onDropdown={onClick}>
-        <div className={classnames.join(' ')}>
-          <div className={css.headerContainer}>
-            <Typography.Title className={css.name} ellipsis={{ rows: 3, tooltip: true }} level={5}>
-              {project.name}
-            </Typography.Title>
-          </div>
-          <div className={css.workspaceContainer}>
-            {showWorkspace && project.workspaceId !== 1 && (
-              <Tooltip content={project.workspaceName}>
-                <div className={css.workspaceIcon}>
-                  <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
-                </div>
-              </Tooltip>
-            )}
-          </div>
-          <div className={css.footerContainer}>
-            <div className={css.experiments}>
-              <Tooltip
-                content={
-                  `${project.numExperiments.toLocaleString()}` +
-                  ` experiment${project.numExperiments === 1 ? '' : 's'}`
-                }>
-                <Icon name="experiment" size="small" title="Number of experiments" />
-                <span>{nearestCardinalNumber(project.numExperiments)}</span>
-              </Tooltip>
-            </div>
-            {project.archived ? (
-              <div className={css.archivedBadge}>Archived</div>
-            ) : (
-              project.lastExperimentStartedAt && (
-                <TimeAgo
-                  datetime={project.lastExperimentStartedAt}
-                  tooltipFormat="[Last experiment started: \n]MMM D, YYYY - h:mm a"
-                />
-              )
-            )}
-          </div>
+    <Card
+      actionMenu={!project.immutable && !hideActionMenu ? menu : undefined}
+      onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
+      onDropdown={onClick}>
+      <div className={classnames.join(' ')}>
+        <div className={css.headerContainer}>
+          <Typography.Title className={css.name} ellipsis={{ rows: 3, tooltip: true }} level={5}>
+            {project.name}
+          </Typography.Title>
         </div>
-      </Card>
-      {/*
-        contextHolders must be outside of Card component to prevent unexpected action
-        for more info, refer PR #6185
-      */}
+        <div className={css.workspaceContainer}>
+          {showWorkspace && project.workspaceId !== 1 && (
+            <Tooltip content={project.workspaceName}>
+              <div className={css.workspaceIcon}>
+                <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
+              </div>
+            </Tooltip>
+          )}
+        </div>
+        <div className={css.footerContainer}>
+          <div className={css.experiments}>
+            <Tooltip
+              content={
+                `${project.numExperiments.toLocaleString()}` +
+                ` experiment${project.numExperiments === 1 ? '' : 's'}`
+              }>
+              <Icon name="experiment" size="small" title="Number of experiments" />
+              <span>{nearestCardinalNumber(project.numExperiments)}</span>
+            </Tooltip>
+          </div>
+          {project.archived ? (
+            <div className={css.archivedBadge}>Archived</div>
+          ) : (
+            project.lastExperimentStartedAt && (
+              <TimeAgo
+                datetime={project.lastExperimentStartedAt}
+                tooltipFormat="[Last experiment started: \n]MMM D, YYYY - h:mm a"
+              />
+            )
+          )}
+        </div>
+      </div>
       {contextHolders}
-    </>
+    </Card>
   );
 };
 

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -32,46 +32,42 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
   const user = Loadable.getOrElse(undefined, loadableUser);
 
   return (
-    <>
-      <Card
-        actionMenu={!workspace.immutable ? menu : undefined}
-        size="small"
-        onClick={(e: AnyMouseEvent) =>
-          handlePath(e, { path: paths.workspaceDetails(workspace.id) })
-        }
-        onDropdown={onClick}>
-        <div className={workspace.archived ? css.archived : ''}>
-          <Columns gap={8}>
-            <div className={css.icon}>
-              <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
+    <Card
+      actionMenu={!workspace.immutable ? menu : undefined}
+      size="small"
+      onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.workspaceDetails(workspace.id) })}
+      onDropdown={onClick}>
+      <div className={workspace.archived ? css.archived : ''}>
+        <Columns gap={8}>
+          <div className={css.icon}>
+            <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
+          </div>
+          <div className={css.info}>
+            <div className={css.nameRow}>
+              <Typography.Title
+                className={css.name}
+                ellipsis={{ rows: 1, tooltip: true }}
+                level={5}>
+                {workspace.name}
+              </Typography.Title>
+              {workspace.pinned && <Icon name="pin" title="Pinned" />}
             </div>
-            <div className={css.info}>
-              <div className={css.nameRow}>
-                <Typography.Title
-                  className={css.name}
-                  ellipsis={{ rows: 1, tooltip: true }}
-                  level={5}>
-                  {workspace.name}
-                </Typography.Title>
-                {workspace.pinned && <Icon name="pin" title="Pinned" />}
+            <p className={css.projects}>
+              {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
+            </p>
+            <div className={css.avatarRow}>
+              <div className={css.avatar}>
+                <Spinner conditionalRender spinning={Loadable.isNotLoaded(loadableUser)}>
+                  {Loadable.isLoaded(loadableUser) && <UserAvatar user={user} />}
+                </Spinner>
               </div>
-              <p className={css.projects}>
-                {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
-              </p>
-              <div className={css.avatarRow}>
-                <div className={css.avatar}>
-                  <Spinner conditionalRender spinning={Loadable.isNotLoaded(loadableUser)}>
-                    {Loadable.isLoaded(loadableUser) && <UserAvatar user={user} />}
-                  </Spinner>
-                </div>
-                {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
-              </div>
+              {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
             </div>
-          </Columns>
-        </div>
-      </Card>
+          </div>
+        </Columns>
+      </div>
       {contextHolders}
-    </>
+    </Card>
   );
 };
 


### PR DESCRIPTION
## Description

We sometimes display Workspaces and Projects in a grid / cards view

This created a UI issue when https://github.com/determined-ai/hew/pull/34 added a wrapper  - `<div><AntdModal>...</AntdModal></div>` - these divs got counted as elements of the grid in a way that AntdModals were not.

![image](https://github.com/determined-ai/determined/assets/643918/dddb663d-69d5-49ee-a256-0b4a0638f28e)

This PR moves the modal context holder inside of the Card.

We moved modals outside the Card in PRs such as #6185 because the **left**-click on a Modal was propagating out to click the card and follow its link. The new wrapper div can call `e.stopPropagation` on both left and right click events.

## Test Plan

- `/det/workspaces` cards appear in an uninterrupted grid
- editing a workspace name works correctly (does not click through to navigate to the workspace)
- `/det/workspaces/105/projects` appear in a grid

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.