### PR TITLE
ci: update docs publish strategy

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -63,7 +63,7 @@ clean:
 	rm -rf site build attributions.rst
 
 .PHONY: pre-publish
-pre-publish:
+pre-publish: build/sp-html.stamp
 	cp ./swagger-ui/swagger-ui-main-deploy.js ./site/html/rest-api/swagger-ui-main.js
 
 .PHONY: publish-check

--- a/docs/deploy/Makefile
+++ b/docs/deploy/Makefile
@@ -19,7 +19,11 @@ plan: init
 
 .PHONY: publish
 publish: init
+	# Terraform controls the static cloudfront configuration.
 	terraform apply -auto-approve
+	# publish-to-s3.sh publishes the per-version content.
+	./publish-to-s3.sh --version $(shell cat ../../VERSION)
+
 
 .PHONY: check
 check: init

--- a/docs/deploy/input.tf
+++ b/docs/deploy/input.tf
@@ -1,8 +1,3 @@
-variable "det_version" {
-  type        = string
-  description = "The Determined version the docs are currently built under"
-}
-
 locals {
   domain = "docs.determined.ai"
 }

--- a/docs/deploy/main.tf
+++ b/docs/deploy/main.tf
@@ -12,7 +12,3 @@ provider "aws" {
   version = "~> 2.19.0"
   region  = "us-west-2"
 }
-
-provider "null" {
-  version = "~> 2.1.2"
-}

--- a/docs/deploy/publish-to-s3.sh
+++ b/docs/deploy/publish-to-s3.sh
@@ -1,0 +1,90 @@
+#/bin/sh
+
+set -e
+
+# The bucket to which we publish our docs.
+bucket="determined-ai-docs"
+# The cloudfront distribution ID for our docs site.
+# Can be obtained via `aws cloudfront list-distributions`.
+distribution="EXDWBK8432M1U"
+# The version we publish to.
+version=""
+# the location of the built html
+html="$(dirname "$0")/../site/html"
+dryrun=""
+
+while [ -n "$*" ] ; do
+    arg="$1"
+    shift;
+    case "$arg" in
+        --version)
+            version="$1"
+            shift
+            ;;
+
+        --bucket)
+            bucket="$1"
+            shift
+            ;;
+
+        --distribution)
+            distribution="$1"
+            shift
+            ;;
+
+        --html)
+            html="$1"
+            shift
+            ;;
+
+        --dry-run)
+            dryrun="yes"
+            ;;
+
+        --help)
+            echo "usage: $0 --version VERSION \\"
+            echo "    [--bucket BUCKET] \\"
+            echo "    [--distribution DISTRIBUTION_ID] \\"
+            echo "    [--html PATH/TO/SITE/HTML]"
+            echo "    [--dry-run]"
+            exit 1;;
+
+        *)
+            echo "unrecognized argument; try $0 --help"
+            exit 1;;
+    esac
+done
+
+# check script inputs
+ok="yes"
+if [ -z "$version" ] ; then
+    echo "missing --version"
+    ok=""
+fi
+if [ -z "$bucket" ] ; then
+    echo "missing --bucket"
+    ok=""
+fi
+if [ -z "$distribution" ] ; then
+    echo "missing --distribution"
+    ok=""
+fi
+if [ ! -e "$html/attributions.html" ] ; then
+    echo "the --html directory ($html) does not appear to be a sphinx build"
+    ok=""
+fi
+if [ -z "$ok" ] ; then
+    echo "try --help"
+    exit 1
+fi
+
+echo_do () {
+    echo "$@"
+    if [ -z "$dryrun" ] ; then
+        "$@"
+    fi
+}
+
+# Actually do the publishing.
+echo_do aws s3 sync "$build" "s3://$bucket/$version" --delete
+echo_do aws cloudfront create-invalidation --distribution-id "$distribution" --paths "/$version/*"

--- a/docs/deploy/s3.tf
+++ b/docs/deploy/s3.tf
@@ -41,29 +41,3 @@ resource "aws_s3_bucket_object" "robots" {
   content          = "User-agent: *\nSitemap: https://docs.determined.ai/latest/sitemap.xml"
   content_type     = "text"
 }
-
-resource "null_resource" "upload" {
-  triggers = {
-    version = "${var.det_version}"
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      aws s3 sync ../site/html s3://${aws_s3_bucket.docs.id}/${var.det_version} ;
-      aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.distribution.id} --paths '/${var.det_version}/*'
-    EOT
-  }
-}
-
-resource "null_resource" "upload_latest" {
-  triggers = {
-    version = "${var.det_version}"
-  }
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      aws s3 sync ../site/html s3://${aws_s3_bucket.docs.id}/latest --delete ;
-      aws cloudfront create-invalidation --distribution-id ${aws_cloudfront_distribution.distribution.id} --paths '/latest/*'
-    EOT
-  }
-}


### PR DESCRIPTION
Instead of (ab)using terraform to write dynamic content; let terraform own static configuration and call a new publish-to-s3.sh script for the aws upload.

The script should also be suitable for manual uploads, if another mishap occurs in the future.