### PR TITLE
chore: Rename show_ssh_command in CLI and add message for VSCode WSL Users

### DIFF
--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -31,19 +31,19 @@
  Addendum for Windows Users
 ############################
 
-#. On Windows, VSCode uses CMD to run its ssh command under the hood, so we have to modify a few
-   things in this config file. First, prepend the proxy command to use WSL. In a CMD shell, type
-   `where wsl` and prepend the result to the ProxyCommand entry in your config file. This should
-   lead to a ProxyCommand that looks like this:
+#. On Windows, Visual Studio Code uses CMD to run its SSH command under the hood. Therefore, we need
+   to make a few modifications to the config file. First, prepend the proxy command to use WSL. In a
+   CMD shell, type where wsl and prepend the result to the ProxyCommand entry in your config file.
+   This should lead to a ProxyCommand that looks like this:
 
    .. code::
 
       ProxyCommand C:\Windows\System32\wsl.exe /path/to/python -m determined.cli.tunnel <DET_MASTER_URL_HERE> %h
 
-#. An additional quirk of using CMD for the ssh step is that the key file needs to be moved out of
-   the WSL filesystem, otherwise there will be permission ambiguity that Windows OpenSSH won't like.
-   To circumvent this, we need to move or copy the file to the Windows filesystem. This key file can
-   be found in WSL in the directory `/home/<username>/.cache/determined/shell/<your_shell_id>/key`.
+#. An additional quirk of using CMD for the SSH step is that the key file needs to be moved out of
+   the WSL filesystem. Otherwise, there will be permission ambiguity that Windows OpenSSH won't
+   like. To work around this, move or copy the file to the Windows filesystem. This key file can be
+   found in WSL in the directory /home/<username>/.cache/determined/shell/<your_shell_id>/key.
 
    .. code::
 

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -20,49 +20,12 @@
 
       det shell show_ssh_command <SHELL UUID>
 
+   If you are using Windows with WSL, do not to run these commands in your WSL shell. Use a Windows
+   installation of `determined`.
+
 #. Copy the SSH command, then select ``Remote-SSH: Add new SSH Host...`` from the **Command
    Palette** in VS Code, and paste the copied SSH command when prompted. Finally, you'll be asked to
    pick a config file to use. The default option should work for most users.
 
 #. The remote host will now be available in the VS Code **Remote Explorer**. For further detail,
    please refer to the `official documentation <https://code.visualstudio.com/docs/remote/ssh>`__.
-
-############################
- Addendum for Windows Users
-############################
-
-#. On Windows, Visual Studio Code uses CMD to run its SSH command under the hood. Therefore, we need
-   to make a few modifications to the config file. First, prepend the proxy command to use WSL. In a
-   CMD shell, type ``where wsl`` and prepend the result to the ProxyCommand entry in your config
-   file. This should lead to a ProxyCommand that looks like this:
-
-   .. code::
-
-      ProxyCommand C:\Windows\System32\wsl.exe /path/to/python -m determined.cli.tunnel <DET_MASTER_URL_HERE> %h
-
-#. An additional quirk of using CMD for the SSH step is that the key file needs to be moved out of
-   the WSL filesystem. Otherwise, there will be permission ambiguity that Windows OpenSSH won't
-   like. To work around this, move or copy the file to the Windows filesystem. This key file can be
-   found in WSL in the directory /home/<username>/.cache/determined/shell/<your_shell_id>/key.
-
-   .. code::
-
-      cp /home/<username>/.cache/determined/shell/<your_shell_id>/key /mnt/c/path/to/your/key
-
-   Then follow this up by changing the IdentityFile field in your config with the new key path:
-
-   .. code::
-
-      IdentityFile C:\path\to\your\key
-
-#. Verify that the new config has properly updated parameters.
-
-   .. code::
-
-      Host <YOUR SHELL HOSTNAME>
-      HostName <YOUR SHELL HOSTNAME>
-      ProxyCommand C:\Windows\System32\wsl.exe /path/to/python -m determined.cli.tunnel <DET_MASTER_URL_HERE> %h
-      StrictHostKeyChecking no
-      IdentitiesOnly yes
-      IdentityFile C:\path\to\your\key
-      User root

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -33,8 +33,8 @@
 
 #. On Windows, Visual Studio Code uses CMD to run its SSH command under the hood. Therefore, we need
    to make a few modifications to the config file. First, prepend the proxy command to use WSL. In a
-   CMD shell, type `where wsl` and prepend the result to the ProxyCommand entry in your config file.
-   This should lead to a ProxyCommand that looks like this:
+   CMD shell, type ``where wsl`` and prepend the result to the ProxyCommand entry in your config
+   file. This should lead to a ProxyCommand that looks like this:
 
    .. code::
 

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -21,8 +21,49 @@
       det shell show_ssh_command <SHELL UUID>
 
 #. Copy the SSH command, then select ``Remote-SSH: Add new SSH Host...`` from the **Command
-   Palette** in VS Code, and paste the copied SSH command when prompted. Finally, you'll be asked to
-   pick a config file to use. The default option should work for most users.
+   Palette** in VS Code, and paste the copied SSH command when prompted. You'll be asked to pick a
+   config file to use. The default option should work for most users.
 
 #. The remote host will now be available in the VS Code **Remote Explorer**. For further detail,
    please refer to the `official documentation <https://code.visualstudio.com/docs/remote/ssh>`__.
+
+############################
+ Addendum for Windows Users
+############################
+
+#. VSCode uses CMD to run its ssh command under the hood, so we have to modify a few things in this
+   config file. First, prepend the proxy command to use WSL. In a CMD shell, type `where wsl` and
+   prepend the result to the ProxyCommand entry in your config file. This should lead to a
+   ProxyCommand that looks like this:
+
+   .. code::
+
+      ProxyCommand C:\Windows\System32\wsl.exe /path/to/python -m determined.cli.tunnel <DET_MASTER_URL_HERE> %h
+
+#. An additional quirk of using CMD for the ssh step is that the key file needs to be moved out of
+   the WSL filesystem, otherwise there will be permission ambiguity that Windows OpenSSH won't like.
+   To circumvent this, we need to move or copy the file to the windows filesystem. This key file can
+   be found in WSL in the directory `/home/<username>/.cache/determined/shell/<your_shell_id>/key`.
+   This file needs to be moved to the Windows Filesystem.
+
+   .. code::
+
+      cp /home/<username>/.cache/determined/shell/<your_shell_id>/key /mnt/c/path/to/your/key
+
+   Then follow this up by changing the IdentityFile field in your config with the new key path:
+
+   .. code::
+
+      IdentityFile C:\path\to\your\key
+
+#. Verify that the new config has properly updated parameters.
+
+   .. code::
+
+      Host <YOUR SHELL HOSTNAME>
+      HostName <YOUR SHELL HOSTNAME>
+      ProxyCommand C:\Windows\System32\wsl.exe /path/to/python -m determined.cli.tunnel <DET_MASTER_URL_HERE> %h
+      StrictHostKeyChecking no
+      IdentitiesOnly yes
+      IdentityFile C:\path\to\your\key
+      User root

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -20,9 +20,6 @@
 
       det shell show_ssh_command <SHELL UUID>
 
-   If you are using Windows with WSL, do not to run these commands in your WSL shell. Use a Windows
-   installation of `determined`.
-
 #. Copy the SSH command, then select ``Remote-SSH: Add new SSH Host...`` from the **Command
    Palette** in VS Code, and paste the copied SSH command when prompted. Finally, you'll be asked to
    pick a config file to use. The default option should work for most users.

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -33,7 +33,7 @@
 
 #. On Windows, Visual Studio Code uses CMD to run its SSH command under the hood. Therefore, we need
    to make a few modifications to the config file. First, prepend the proxy command to use WSL. In a
-   CMD shell, type where wsl and prepend the result to the ProxyCommand entry in your config file.
+   CMD shell, type `where wsl` and prepend the result to the ProxyCommand entry in your config file.
    This should lead to a ProxyCommand that looks like this:
 
    .. code::

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -21,8 +21,8 @@
       det shell show_ssh_command <SHELL UUID>
 
 #. Copy the SSH command, then select ``Remote-SSH: Add new SSH Host...`` from the **Command
-   Palette** in VS Code, and paste the copied SSH command when prompted. You'll be asked to pick a
-   config file to use. The default option should work for most users.
+   Palette** in VS Code, and paste the copied SSH command when prompted. Finally, you'll be asked to
+   pick a config file to use. The default option should work for most users.
 
 #. The remote host will now be available in the VS Code **Remote Explorer**. For further detail,
    please refer to the `official documentation <https://code.visualstudio.com/docs/remote/ssh>`__.

--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -31,10 +31,10 @@
  Addendum for Windows Users
 ############################
 
-#. VSCode uses CMD to run its ssh command under the hood, so we have to modify a few things in this
-   config file. First, prepend the proxy command to use WSL. In a CMD shell, type `where wsl` and
-   prepend the result to the ProxyCommand entry in your config file. This should lead to a
-   ProxyCommand that looks like this:
+#. On Windows, VSCode uses CMD to run its ssh command under the hood, so we have to modify a few
+   things in this config file. First, prepend the proxy command to use WSL. In a CMD shell, type
+   `where wsl` and prepend the result to the ProxyCommand entry in your config file. This should
+   lead to a ProxyCommand that looks like this:
 
    .. code::
 
@@ -42,9 +42,8 @@
 
 #. An additional quirk of using CMD for the ssh step is that the key file needs to be moved out of
    the WSL filesystem, otherwise there will be permission ambiguity that Windows OpenSSH won't like.
-   To circumvent this, we need to move or copy the file to the windows filesystem. This key file can
+   To circumvent this, we need to move or copy the file to the Windows filesystem. This key file can
    be found in WSL in the directory `/home/<username>/.cache/determined/shell/<your_shell_id>/key`.
-   This file needs to be moved to the Windows Filesystem.
 
    .. code::
 

--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -7,7 +7,7 @@ from determined.cli._util import (
     login_sdk_client,
     print_launch_warnings,
     wait_ntsc_ready,
-    warn
+    warn,
 )
 from determined.cli import (
     agent,

--- a/harness/determined/cli/__init__.py
+++ b/harness/determined/cli/__init__.py
@@ -5,8 +5,9 @@ from determined.cli._util import (
     setup_session,
     require_feature_flag,
     login_sdk_client,
-    print_warnings,
+    print_launch_warnings,
     wait_ntsc_ready,
+    warn
 )
 from determined.cli import (
     agent,

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -115,7 +115,7 @@ def require_feature_flag(feature_flag: str, error_message: str) -> Callable[...,
     return decorator
 
 
-def print_warnings(warnings: Sequence[bindings.v1LaunchWarning]) -> None:
+def print_launch_warnings(warnings: Sequence[bindings.v1LaunchWarning]) -> None:
     for warning in warnings:
         print(termcolor.colored(api.WARNING_MESSAGE_MAP[warning], "yellow"), file=sys.stderr)
 
@@ -131,3 +131,7 @@ def wait_ntsc_ready(session: api.Session, ntsc_type: api.NTSC_Kind, eid: str) ->
     loading_animator.clear(msg)
     if err_msg:
         raise errors.CliError(err_msg)
+
+
+def warn(message: str) -> None:
+    print(termcolor.colored(message, "yellow"), file=sys.stderr)

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -284,7 +284,7 @@ def submit_experiment(args: Namespace) -> None:
         print(f"Created experiment {resp.experiment.id}")
 
         if resp.warnings:
-            cli.print_warnings(resp.warnings)
+            cli.print_launch_warnings(resp.warnings)
 
         if not args.paused and args.follow_first_trial:
             if args.publish:

--- a/harness/determined/cli/notebook.py
+++ b/harness/determined/cli/notebook.py
@@ -43,7 +43,7 @@ def start_notebook(args: Namespace) -> None:
     render.report_job_launched("notebook", resp.notebook.id)
 
     if resp.warnings:
-        cli.print_warnings(resp.warnings)
+        cli.print_launch_warnings(resp.warnings)
     currentSlotsExceeded = (resp.warnings is not None) and (
         bindings.v1LaunchWarning.CURRENT_SLOTS_EXCEEDED in resp.warnings
     )

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -78,6 +78,13 @@ def open_shell(args: argparse.Namespace) -> None:
 
 @authentication.required
 def show_ssh_command(args: argparse.Namespace) -> None:
+    if "WSL" in os.uname().release:
+        cli.warn(
+            "WSL remote-ssh integration is not supported in VSCode, which "
+            "uses Windows openssh. For Windows VSCode integration, rerun this "
+            "command in a Windows shell. For PyCharm users, configure the Pycharm "
+            "ssh command to target the WSL ssh command."
+        )
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     _open_shell(

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import warnings
 from argparse import ONE_OR_MORE, FileType, Namespace
 from functools import partial
 from pathlib import Path
@@ -78,6 +79,11 @@ def open_shell(args: Namespace) -> None:
 
 @authentication.required
 def show_ssh_command(args: Namespace) -> None:
+    if "WSL" in os.uname().release:
+        print(
+            f"WARNING: WSL remote-ssh integration is not supported in VSCode. "
+            "For Windows VSCode integration, rerun this command in a Windows shell."
+        )
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     _open_shell(

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -1,3 +1,4 @@
+import argparse
 import contextlib
 import getpass
 import os
@@ -6,7 +7,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from argparse import ONE_OR_MORE, FileType, Namespace
 from functools import partial
 from pathlib import Path
 from typing import IO, Any, ContextManager, Dict, Iterator, List, Tuple, Union, cast
@@ -22,7 +22,7 @@ from determined.common.declarative_argparse import Arg, Cmd, Group
 
 
 @authentication.required
-def start_shell(args: Namespace) -> None:
+def start_shell(args: argparse.Namespace) -> None:
     data = {}
     if args.passphrase:
         data["passphrase"] = getpass.getpass("Enter new passphrase: ")
@@ -62,7 +62,7 @@ def start_shell(args: Namespace) -> None:
 
 
 @authentication.required
-def open_shell(args: Namespace) -> None:
+def open_shell(args: argparse.Namespace) -> None:
     shell_id = cast(str, command.expand_uuid_prefixes(args))
 
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
@@ -77,7 +77,7 @@ def open_shell(args: Namespace) -> None:
 
 
 @authentication.required
-def show_ssh_command(args: Namespace) -> None:
+def show_ssh_command(args: argparse.Namespace) -> None:
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]
     _open_shell(
@@ -90,8 +90,7 @@ def show_ssh_command(args: Namespace) -> None:
     )
 
 
-@authentication.required
-def show_ssh_cmd_legacy(args: Namespace) -> None:
+def show_ssh_cmd_legacy(args: argparse.Namespace) -> None:
     cli.warn(
         "DEPRECATION WARNING: show_ssh_command is being deprecated in favor" "of show-ssh-command"
     )
@@ -238,7 +237,7 @@ args_description = [
         ]),
         Cmd("start", start_shell, "start a new shell", [
             Arg("ssh_opts", nargs="*", help="additional SSH options when connecting to the shell"),
-            Arg("--config-file", default=None, type=FileType("r"),
+            Arg("--config-file", default=None, type=argparse.FileType("r"),
                 help="command config file (.yaml)"),
             cli.workspace.workspace_arg,
             Arg("-v", "--volume", action="append", default=[],
@@ -268,7 +267,7 @@ args_description = [
             Arg("--show-ssh-command", action="store_true",
                 help="show ssh command (e.g. for use in IDE) when starting the shell"),
         ]),
-        Cmd("show_ssh_command", show_ssh_cmd_legacy, "print the ssh command", [
+        Cmd("show_ssh_command", show_ssh_cmd_legacy, argparse.SUPPRESS, [
             Arg("shell_id", help="shell ID"),
             Arg("ssh_opts", nargs="*", help="additional SSH options when connecting to the shell"),
         ]),
@@ -282,7 +281,7 @@ args_description = [
             *task.common_log_options
         ]),
         Cmd("kill", partial(command.kill), "kill a shell", [
-            Arg("shell_id", help="shell ID", nargs=ONE_OR_MORE),
+            Arg("shell_id", help="shell ID", nargs=argparse.ONE_OR_MORE),
             Arg("-f", "--force", action="store_true", help="ignore errors"),
         ]),
         Cmd("set", None, "set shell attributes", [

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -18,7 +18,7 @@ from determined import cli
 from determined.cli import command, render, task
 from determined.common import api
 from determined.common.api import authentication, bindings, certs
-from determined.common.declarative_argparse import Arg, BoolOptArg, Cmd, Group
+from determined.common.declarative_argparse import Arg, Cmd, Group
 
 
 @authentication.required
@@ -93,8 +93,7 @@ def show_ssh_command(args: Namespace) -> None:
 @authentication.required
 def show_ssh_cmd_legacy(args: Namespace) -> None:
     cli.warn(
-        "DEPRECATION WARNING: show_ssh_command is being deprecated in favor"
-        "of show-ssh-command"
+        "DEPRECATION WARNING: show_ssh_command is being deprecated in favor" "of show-ssh-command"
     )
     show_ssh_command(args)
 

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import warnings
 from argparse import ONE_OR_MORE, FileType, Namespace
 from functools import partial
 from pathlib import Path
@@ -80,9 +79,11 @@ def open_shell(args: Namespace) -> None:
 @authentication.required
 def show_ssh_command(args: Namespace) -> None:
     if "WSL" in os.uname().release:
-        print(
-            f"WARNING: WSL remote-ssh integration is not supported in VSCode. "
-            "For Windows VSCode integration, rerun this command in a Windows shell."
+        cli.warn(
+            "WSL remote-ssh integration is not supported in VSCode, which "
+            "uses Windows openssh. For Windows VSCode integration, rerun this "
+            "command in a Windows shell. For PyCharm users, configure the Pycharm "
+            "ssh command to target the WSL ssh command."
         )
     shell_id = command.expand_uuid_prefixes(args)
     shell = api.get(args.master, f"api/v1/shells/{shell_id}").json()["shell"]

--- a/harness/determined/cli/tensorboard.py
+++ b/harness/determined/cli/tensorboard.py
@@ -40,7 +40,7 @@ def start_tensorboard(args: Namespace) -> None:
     render.report_job_launched("tensorboard", tsb.id)
 
     if resp.warnings:
-        cli.print_warnings(resp.warnings)
+        cli.print_launch_warnings(resp.warnings)
     currentSlotsExceeded = (resp.warnings is not None) and (
         bindings.v1LaunchWarning.CURRENT_SLOTS_EXCEEDED in resp.warnings
     )


### PR DESCRIPTION
## Description

Windows Users are having issues with VSCode remote-ssh integration. This is due to Windows defaulting to CMD with OpenSSH instead of using WSL bash and the proper ssh tool for the job. Adding warning to CLI and also changing `det shell show_ssh_command` to `det shell show-ssh-command`


## Test Plan

Start a remote shell.

1. Be a Windows user
2. `det shell show-ssh-command` should show a VSCode-specific warning in WSL shell.

1. Be any user
2. `det shell show_ssh_command` should show a deprecation warning.



## Commentary (optional)

This should address https://github.com/determined-ai/determined/issues/7726



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-871