### PR TITLE
fix: Update Trial Download Error Message

### DIFF
--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -14,7 +14,6 @@ from determined.cli.master import format_log_entry
 from determined.common import api
 from determined.common.api import authentication, bindings
 from determined.common.declarative_argparse import Arg, ArgsDescription, Cmd, Group, string_to_bool
-from determined.common.experimental.checkpoint import CheckpointState
 from determined.experimental import client
 
 from .checkpoint import render_checkpoint
@@ -180,10 +179,13 @@ def download(args: Namespace) -> None:
         if not checkpoints:
             raise ValueError(f"No checkpoints found for trial {args.trial_id}")
 
-        valid_states = [CheckpointState.COMPLETED, CheckpointState.PARTIALLY_DELETED]
+        downloadable_states = [
+            client.CheckpointState.COMPLETED,
+            client.CheckpointState.PARTIALLY_DELETED,
+        ]
         while len(checkpoints) > 0:
             checkpoint = checkpoints.pop()
-            if checkpoint.state in valid_states:
+            if checkpoint.state in downloadable_states:
                 break
         if len(checkpoints) == 0:
             raise errors.CliError("Download failed:  No downloadable checkpoint found")

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -185,9 +185,9 @@ def download(args: Namespace) -> None:
         path = checkpoint.download(path=args.output_dir)
     except errors.CheckpointStateException:
         print(
-            f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}. "
-            f"This checkpoint is in state {checkpoint.state}. "
-            "Please retry with a different checkpoint UUID."
+            "Failed to download checkpoint: "
+            f"Checkpoint {checkpoint.uuid} is in state {checkpoint.state}. "
+            "Try again with a different checkpoint."
         )
         return
 

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -186,7 +186,7 @@ def download(args: Namespace) -> None:
     except errors.CheckpointStateException:
         print(
             f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}.",
-            "It's checkpoint has likely been deleted. Please retry with a valid checkpoint UUID.",
+            "This checkpoint has likely been deleted. Please retry with a valid checkpoint UUID.",
             sep="\n",
         )
         return

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -187,7 +187,8 @@ def download(args: Namespace) -> None:
         print(
             "Failed to download checkpoint: "
             f"Checkpoint {checkpoint.uuid} is in state {checkpoint.state}. "
-            "Try again with a different checkpoint."
+            "Try again with a different checkpoint. "
+            "See `det trial download --help` for more download options."
         )
         return
 

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -186,7 +186,8 @@ def download(args: Namespace) -> None:
     except errors.CheckpointStateException:
         print(
             f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}.",
-            "This checkpoint has likely been deleted. Please retry with a valid checkpoint UUID.",
+            f"This checkpoint is in state {checkpoint.state}.",
+            "Please retry with a different checkpoint UUID.",
             sep="\n",
         )
         return

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -185,14 +185,11 @@ def download(args: Namespace) -> None:
         path = checkpoint.download(path=args.output_dir)
     except errors.CheckpointStateException:
         print(
-            f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}.",
-            f"This checkpoint is in state {checkpoint.state}.",
-            "Please retry with a different checkpoint UUID.",
-            sep="\n",
+            f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}. "
+            f"This checkpoint is in state {checkpoint.state}. "
+            "Please retry with a different checkpoint UUID."
         )
         return
-    except Exception as e:
-        raise e
 
     if args.quiet:
         print(path)

--- a/harness/determined/cli/trial.py
+++ b/harness/determined/cli/trial.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import tarfile
 import tempfile
 from argparse import Namespace
@@ -186,9 +185,9 @@ def download(args: Namespace) -> None:
         path = checkpoint.download(path=args.output_dir)
     except errors.CheckpointStateException:
         print(
-            f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}.\n",
-            "It's likely that this checkpoint is deleted. Please retry with a valid checkpoint UUID.",
-            sep=''
+            f"Invalid Checkpoint State for checkpoint {checkpoint.uuid}.",
+            "It's checkpoint has likely been deleted. Please retry with a valid checkpoint UUID.",
+            sep="\n",
         )
         return
     except Exception as e:

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -237,7 +237,6 @@ class Trial:
                 sortByMetric=sort_by if isinstance(sort_by, str) else None,
                 offset=offset,
                 limit=max_results,
-                states=[bindings.checkpointv1State.COMPLETED],
             )
 
         resps = api.read_paginated(

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -237,6 +237,7 @@ class Trial:
                 sortByMetric=sort_by if isinstance(sort_by, str) else None,
                 offset=offset,
                 limit=max_results,
+                states=[bindings.checkpointv1State.COMPLETED],
             )
 
         resps = api.read_paginated(


### PR DESCRIPTION
## Description

`Trial.list_checkpoints` never passed the `states` parameter, resulting in a return of STATE_DELETED checkpoints under some conditions. This is not an issue with the SDK, but rather a confusing output due to the CLI args. Updating the error message to dispel confusion.



## Test Plan

1. Find or make a trial with multiple checkpoints 
2. Get the UUID of the “best checkpoint”: det trial describe <trial_id> --json
3. Delete the checkpoint: det checkpoint delete <uuid>
4. Download the “best checkpoint”: det trial download <trial_id> --best

Expected behavior:  Another checkpoint is downloaded


## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1163