### PR TITLE
fix: lint and task listing for DET-9595

### DIFF
--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -533,19 +533,22 @@ func (a *apiServer) GetTasks(
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
-		if authz.IsPermissionDenied(err) {
+		switch {
+		case authz.IsPermissionDenied(err):
 			obfuscatedSummary, err := authz.ObfuscateNTSCTask(allocationSummary)
 			if err != nil {
 				return nil, err
 			}
 			if !isExp {
-				pbAllocationIDToSummary[string(authz.HiddenString)] = obfuscatedSummary.Proto()
+				randAllocID := uuid.New().String()
+				allocationID = *model.NewAllocationID(&randAllocID)
+				pbAllocationIDToSummary[randAllocID] = obfuscatedSummary.Proto()
 			} else {
 				pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 			}
-		} else if err != nil {
+		case err != nil:
 			return nil, err
-		} else {
+		default:
 			pbAllocationIDToSummary[string(allocationID)] = allocationSummary.Proto()
 		}
 	}

--- a/master/internal/authz/obfuscate.go
+++ b/master/internal/authz/obfuscate.go
@@ -15,9 +15,12 @@ import (
 )
 
 const (
+	// HiddenString is an obfuscated string from Determined API.
 	HiddenString = "********"
-	HiddenInt    = -1
-	HiddenBool   = false
+	// HiddenInt is an obfuscated int from Determined API.
+	HiddenInt = -1
+	// HiddenBool is an obfuscated bool from Determined API.
+	HiddenBool = false
 )
 
 // ObfuscateDevice obfuscates sensitive information in given Device.


### PR DESCRIPTION
## Description

Fix CircleCI lint failures from commit [#8311](https://github.com/determined-ai/determined/pull/8311/commits/13eef9632601f28317d19a417978216f517af766).

Fix `api/v1/tasks` endpoint so that multiple obfuscated tasks are still listed when users access API with no RBAC permissions.

## Test Plan

Ran `make -C master check` from local `determined` repo.
Added integration test to verify that when accessing `GetTasks` allocation summary for two obfuscated tasks, both tasks are returned in the allocation summary with all values obfuscated.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9595
