### PR TITLE
chore: Bumpenvs 0.26.4

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -40,7 +40,7 @@ parameters:
   # be referenced by --ee testing.
   default-pt-gpu-image:
     type: string
-    default: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-bf9480b
+    default: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-622d512
   # Some python, go, and react dependencies are cached by circleci via `save_cache`/`restore_cache`.
   # If the dependencies stay the same, but the circleci code that would produce them is changed,
   # it may be necessary to invalidate the cache by incrementing this value.
@@ -226,7 +226,7 @@ commands:
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b
+            - run: docker pull determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512
 
   login-docker:
     parameters:
@@ -1812,7 +1812,7 @@ jobs:
 
   test-unit-harness-pytorch2-gpu:
     docker:
-      - image: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-bf9480b
+      - image: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-622d512
     resource_class: determined-ai/container-runner-gpu
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -1833,7 +1833,7 @@ jobs:
 
   test-unit-harness-pytorch2-cpu:
     docker:
-      - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-bf9480b
+      - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-622d512
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
       - checkout

--- a/docs/model-dev-guide/api-guides/apis-howto/_index.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/_index.rst
@@ -82,7 +82,7 @@ respectively:
 
 We also provide lightweight CPU-only counterparts:
 
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4``
+-  ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4``
 -  ``determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-0.21.2``
 -  ``determinedai/environments:py-3.8-tf-2.8-cpu-0.26.4``
 

--- a/docs/model-dev-guide/prepare-container/custom-env.rst
+++ b/docs/model-dev-guide/prepare-container/custom-env.rst
@@ -101,7 +101,7 @@ Default Images
 +-------------+-------------------------------------------------------------------------------+
 | Environment | File Name                                                                     |
 +=============+===============================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4``          |
+| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4``          |
 +-------------+-------------------------------------------------------------------------------+
 | NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4``       |
 +-------------+-------------------------------------------------------------------------------+
@@ -195,7 +195,7 @@ environments using :ref:`custom images <custom-docker-images>`:
 .. code:: bash
 
    # Determined Image
-   FROM determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4
+   FROM determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4
 
    # Create a virtual environment
    RUN conda create -n myenv python=3.8

--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -188,7 +188,7 @@
 
    -  ``cpuImage``: Sets the default Docker image for all non-GPU tasks. If a Docker image is
       specified in the :ref:`experiment config <exp-environment-image>` this default is overriden.
-      Defaults to: ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4``.
+      Defaults to: ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4``.
 
    -  ``gpuImage``: Sets the default Docker image for all GPU tasks. If a Docker image is specified
       in the :ref:`experiment config <exp-environment-image>` this default is overriden. Defaults

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -91,7 +91,7 @@ Default values:
 
 -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4`` for NVIDIA GPUs.
 -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4`` for ROCm.
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
+-  ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
 
 ``environment_variables``
 =========================

--- a/docs/reference/job-config-reference.rst
+++ b/docs/reference/job-config-reference.rst
@@ -47,7 +47,7 @@ The following configuration settings are supported:
 
       -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4`` for NVIDIA GPUs.
       -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4`` for ROCm.
-      -  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
+      -  ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
 
    -  ``force_pull_image``: Forcibly pull the image from the Docker registry and bypass the Docker
       cache. Defaults to ``false``.

--- a/docs/reference/training/experiment-config-reference.rst
+++ b/docs/reference/training/experiment-config-reference.rst
@@ -1287,7 +1287,7 @@ container images for NVIDIA GPU tasks using ``cuda`` key (``gpu`` prior to 0.17.
 ``cpu`` key, and ROCm (AMD GPU) tasks using ``rocm`` key. Default values:
 
 -  ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4`` for NVIDIA GPUs.
--  ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
+-  ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4`` for CPUs.
 -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4`` for ROCm.
 
 When the cluster is configured with :ref:`resource_manager.type: slurm

--- a/docs/release-notes/python-39-bump.rst
+++ b/docs/release-notes/python-39-bump.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  Our default environment images have been updated to Python 3.9. (Previously Python 3.8)

--- a/docs/release-notes/python-39-bump.rst
+++ b/docs/release-notes/python-39-bump.rst
@@ -2,4 +2,4 @@
 
 **Improvements**
 
--  Our default environment images have been updated to Python 3.9. (Previously Python 3.8)
+-  Update default environment images to Python 3.9 from Python 3.8.

--- a/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
@@ -26,11 +26,11 @@ by default in this version of Determined are described below.
 +-------------+--------------------------------------------------------------------------+
 | Environment | File Name                                                                |
 +=============+==========================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b``    |
+| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512``    |
 +-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b`` |
+| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512`` |
 +-------------+--------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b``  |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
 +-------------+--------------------------------------------------------------------------+
 
 See :ref:`set-environment-images` for the images Docker Hub location, and add each tagged image

--- a/docs/setup-cluster/gcp/install-gcp.rst
+++ b/docs/setup-cluster/gcp/install-gcp.rst
@@ -407,4 +407,4 @@ This command line will spin up a cluster of up to 2 A100s in the ``us-central1-c
       --gpu-type nvidia-tesla-a100 \
       --region us-central1 --zone us-central1-c \
       --gpu-env-image determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4 \
-      --cpu-env-image determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4
+      --cpu-env-image determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4

--- a/docs/setup-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/slurm/singularity.rst
@@ -26,11 +26,11 @@ by default in this version of Determined are described below.
 +-------------+--------------------------------------------------------------------------+
 | Environment | File Name                                                                |
 +=============+==========================================================================+
-| CPUs        | ``determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b``    |
+| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512``    |
 +-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b`` |
+| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512`` |
 +-------------+--------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b``  |
+| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
 +-------------+--------------------------------------------------------------------------+
 
 See :ref:`set-environment-images` for the images Docker Hub location, and add each tagged image

--- a/docs/setup-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/slurm/slurm-requirements.rst
@@ -434,7 +434,7 @@ platform. There may be additional per-user configuration that is required.
 
    .. code:: bash
 
-      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b
+      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512
       cd /shared/enroot/images
       enroot import docker://$image
       enroot create /shared/enroot/images/${image//[\/:]/\+}.sqsh

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -15,13 +15,13 @@ MAX_TRIAL_BUILD_SECS = 90
 
 
 DEFAULT_TF1_CPU_IMAGE = "determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-6eceaca"
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512"
 DEFAULT_TF1_GPU_IMAGE = "determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-6eceaca"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
-DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.8-pytorch-1.12-cpu-bf9480b"
-DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-bf9480b"
-DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-pytorch-2.0-cpu-bf9480b"
-DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-bf9480b"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
+DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-cpu-622d512"
+DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-622d512"
+DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-pytorch-2.0-cpu-622d512"
+DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-622d512"
 
 TF1_CPU_IMAGE = os.environ.get("TF1_CPU_IMAGE") or DEFAULT_TF1_CPU_IMAGE
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
@@ -39,9 +39,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
@@ -38,9 +38,9 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b",
-        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512",
+        "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
       },
       "pod_spec": null,
       "ports": {},

--- a/harness/tests/fixtures/checkpoint.json
+++ b/harness/tests/fixtures/checkpoint.json
@@ -69,9 +69,9 @@
           },
           "force_pull_image":false,
           "image":{
-            "cpu":"determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-            "cuda":"determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b",
-            "rocm":"determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"
+            "cpu":"determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+            "cuda":"determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512",
+            "rocm":"determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
           },
           "pod_spec":null,
           "ports":{

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -31,8 +31,8 @@ defaultImages:
   kubeSchedulerPreemption: "determinedai/kube-scheduler:0.17.0"
 
   # default images for CPU and GPU environments
-  cpuImage: "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b"
-  gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
+  cpuImage: "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512"
+  gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
 
 # Install Determined enterprise edition.
 enterpriseEdition: false

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b"
-	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
-	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"
+	CPUImage  = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512"
+	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
+	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
 )

--- a/master/pkg/schemas/expconf/legacy_test.go
+++ b/master/pkg/schemas/expconf/legacy_test.go
@@ -111,7 +111,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-aaa3750"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-aaa3750"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},
@@ -245,7 +245,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.6.9-pytorch-1.4-tf-1.15-cpu-067db2b"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.0-pytorch-1.4-tf-1.15-gpu-067db2b"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"),
 					},
 					RawPodSpec: &PodSpec{
 						TypeMeta: metaV1.TypeMeta{
@@ -412,7 +412,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-6eceaca"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-6eceaca"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"),
 					},
 					RawPorts:            map[string]int{},
 					RawProxyPorts:       &ProxyPortsConfigV0{},
@@ -493,7 +493,7 @@ func TestLegacyConfig(t *testing.T) {
 					RawImage: &EnvironmentImageMap{
 						RawCPU:  ptrs.Ptr("determinedai/environments:py-3.7-pytorch-1.7-tf-1.15-cpu-6eceaca"),
 						RawCUDA: ptrs.Ptr("determinedai/environments:cuda-10.2-pytorch-1.7-tf-1.15-gpu-6eceaca"),
-						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b"),
+						RawROCM: ptrs.Ptr("determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"),
 					},
 					RawAddCapabilities:  []string{},
 					RawDropCapabilities: []string{},

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -32,9 +32,9 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b
-        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b
-        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b
+        cpu: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512
+        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512
+        rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512
       pod_spec: null
       ports:
         qwer: 1234

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -10,8 +10,8 @@ ap_southeast_1_master_ami: {new: ami-0fd1ee6c8b656f020, old: ami-09f03fa55726923
 ap_southeast_2_agent_ami: {new: ami-0d650c454c3d801a4, old: ami-04a413f9a98584ba4}
 ap_southeast_2_bastion_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
 ap_southeast_2_master_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
-deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-bf9480b,
-  old: determinedai/environments-dev:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-7875c0a}
+deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-bf9480b}
 deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-0.26.4,
   old: determinedai/environments-dev:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-0.26.4}
 deepspeed_gpu_1_hashed: {new: 
@@ -28,9 +28,8 @@ eu_west_2_agent_ami: {new: ami-09390dcffbfc1e0aa, old: ami-034e8e3daf405dd4c}
 eu_west_2_bastion_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
 eu_west_2_master_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
 gcp_env: {new: det-environments-bf9480b, old: det-environments-7875c0a}
-gpt_neox_deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-bf9480b,
-  old: 
-    determinedai/environments-dev:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-7875c0a}
+gpt_neox_deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-bf9480b}
 gpt_neox_deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.26.4,
   old: 
     determinedai/environments-dev:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.26.4}
@@ -38,40 +37,40 @@ gpt_neox_deepspeed_gpu_1_hashed: {new:
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094}
 gpt_neox_deepspeed_gpu_1_versioned: {new: 
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1}
-pt2_cpu_0_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-bf9480b,
-  old: determinedai/environments-dev:py-3.10-pytorch-2.0-cpu-7875c0a}
+pt2_cpu_0_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-622d512,
+  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-bf9480b}
 pt2_cpu_0_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-0.26.4,
   old: determinedai/environments-dev:py-3.10-pytorch-2.0-cpu-0.26.4}
-pt2_cpu_1_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-bf9480b,
-  old: determinedai/environments-dev:py-3.10-pytorch-2.0-cpu-mpi-7875c0a}
+pt2_cpu_1_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-622d512,
+  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-bf9480b}
 pt2_cpu_1_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-0.26.4,
   old: determinedai/environments-dev:py-3.10-pytorch-2.0-cpu-mpi-0.26.4}
-pt2_gpu_0_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-bf9480b,
-  old: determinedai/environments-dev:cuda-11.8-pytorch-2.0-gpu-7875c0a}
+pt2_gpu_0_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-622d512,
+  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-bf9480b}
 pt2_gpu_0_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-0.26.4,
   old: determinedai/environments-dev:cuda-11.8-pytorch-2.0-gpu-0.26.4}
-pt2_gpu_1_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-bf9480b,
-  old: determinedai/environments-dev:cuda-11.8-pytorch-2.0-gpu-mpi-7875c0a}
+pt2_gpu_1_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-622d512,
+  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-bf9480b}
 pt2_gpu_1_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-0.26.4,
   old: determinedai/environments-dev:cuda-11.8-pytorch-2.0-gpu-mpi-0.26.4}
-pt_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-bf9480b,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-cpu-7875c0a}
-pt_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.26.4,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-cpu-0.26.4}
-pt_cpu_1_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-bf9480b,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-cpu-mpi-7875c0a}
-pt_cpu_1_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.26.4,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-cpu-mpi-0.26.4}
-pt_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-bf9480b,
-  old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-gpu-7875c0a}
+pt_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-622d512,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-bf9480b}
+pt_cpu_0_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-0.26.4,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-0.26.4}
+pt_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-622d512,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-bf9480b}
+pt_cpu_1_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-0.26.4,
+  old: determinedai/environments:py-3.8-pytorch-1.12-cpu-mpi-0.26.4}
+pt_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-bf9480b}
 pt_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.26.4,
   old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-gpu-0.26.4}
-pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-bf9480b,
-  old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-gpu-mpi-7875c0a}
+pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-bf9480b}
 pt_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.26.4,
   old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-gpu-mpi-0.26.4}
-pytorch10_tf27_rocm50_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b,
-  old: determinedai/environments-dev:rocm-5.0-pytorch-1.10-tf-2.7-rocm-7875c0a}
+pytorch10_tf27_rocm50_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512,
+  old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b}
 pytorch10_tf27_rocm50_0_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4,
   old: determinedai/environments-dev:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4}
 pytorch19_tf25_rocm_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730,
@@ -157,33 +156,33 @@ tf27_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-9b5d
   old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-b785d7b}
 tf27_gpu_1_versioned: {new: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.2,
   old: determinedai/environments:cuda-11.2-tf-2.7-gpu-mpi-0.21.1}
-tf28_cpu_0_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-bf9480b, old: determinedai/environments-dev:py-3.8-tf-2.8-cpu-7875c0a}
+tf28_cpu_0_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-622d512, old: determinedai/environments:py-3.8-tf-2.8-cpu-bf9480b}
 tf28_cpu_0_versioned: {new: determinedai/environments:py-3.8-tf-2.8-cpu-0.26.4, old: determinedai/environments-dev:py-3.8-tf-2.8-cpu-0.26.4}
-tf28_cpu_1_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-bf9480b,
-  old: determinedai/environments-dev:py-3.8-tf-2.8-cpu-mpi-7875c0a}
+tf28_cpu_1_hashed: {new: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-622d512,
+  old: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-bf9480b}
 tf28_cpu_1_versioned: {new: determinedai/environments:py-3.8-tf-2.8-cpu-mpi-0.26.4,
   old: determinedai/environments-dev:py-3.8-tf-2.8-cpu-mpi-0.26.4}
-tf28_gpu_0_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-bf9480b, old: determinedai/environments-dev:cuda-11.2-tf-2.8-gpu-7875c0a}
+tf28_gpu_0_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-622d512, old: determinedai/environments:cuda-11.2-tf-2.8-gpu-bf9480b}
 tf28_gpu_0_versioned: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-0.26.4,
   old: determinedai/environments-dev:cuda-11.2-tf-2.8-gpu-0.26.4}
-tf28_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-bf9480b,
-  old: determinedai/environments-dev:cuda-11.2-tf-2.8-gpu-mpi-7875c0a}
+tf28_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-622d512,
+  old: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-bf9480b}
 tf28_gpu_1_versioned: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-0.26.4,
   old: determinedai/environments-dev:cuda-11.2-tf-2.8-gpu-mpi-0.26.4}
-tf2_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-tf-2.11-cpu-7875c0a}
-tf2_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4}
-tf2_cpu_1_hashed: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-bf9480b,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-7875c0a}
-tf2_cpu_1_versioned: {new: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-0.26.4,
-  old: determinedai/environments-dev:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-0.26.4}
-tf2_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b,
-  old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-tf-2.11-gpu-7875c0a}
+tf2_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b}
+tf2_cpu_0_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.26.4,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-0.26.4}
+tf2_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-622d512,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-bf9480b}
+tf2_cpu_1_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-0.26.4,
+  old: determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-mpi-0.26.4}
+tf2_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b}
 tf2_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4,
   old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4}
-tf2_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-bf9480b,
-  old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-7875c0a}
+tf2_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-622d512,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-bf9480b}
 tf2_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-0.26.4,
   old: determinedai/environments-dev:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-0.26.4}
 us_east_1_agent_ami: {new: ami-0d9e81a7919a8bc5d, old: ami-0df34f803fa837440}

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
+          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
+          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
         },
         "pod_spec": {
           "metadata": {

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.8-pytorch-1.12-tf-2.11-cpu-bf9480b",
-      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-bf9480b"
+      "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-622d512",
+      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-622d512"
     },
     "ports": null,
     "force_pull_image": false,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.mock.ts
@@ -69,7 +69,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512',
           },
           pod_spec: null,
           ports: {},
@@ -762,7 +762,7 @@ const RESPONSES = {
           image: {
             cpu: 'determinedai/environments:py-3.8-pytorch-1.10-tf-2.8-cpu-ecee7c1',
             cuda: 'determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpu-ecee7c1',
-            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b',
+            rocm: 'determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512',
           },
           pod_spec: null,
           ports: {},


### PR DESCRIPTION
## Description

Bumpenvs for 0.26.4. Includes all changes in environments since 0.24.0.



## Test Plan

CI passes


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
