### PR TITLE
chore: Add eslint rule for ?? expressions [WEB-1804]

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -103,6 +103,7 @@ module.exports = {
     ],
     'keyword-spacing': ['error'],
     'no-console': ['error', { allow: ['error'] }],
+    'no-constant-binary-expression': 'error',
     'no-duplicate-imports': 'error',
     'no-empty': ['error', { allowEmptyCatch: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],

--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -79,7 +79,7 @@ const FilterField = ({
 
   const onChangeColumnName = (value: SelectValue) => {
     const prevType = currentColumn?.type;
-    const newCol = columns.find((c) => c.column === value?.toString() ?? '');
+    const newCol = columns.find((c) => c.column === (value?.toString() ?? ''));
     if (newCol) {
       formStore.setFieldColumnName(field.id, newCol);
 


### PR DESCRIPTION
## Description

Adding eslint rule described in https://eslint.org/blog/2022/07/interesting-bugs-caught-by-no-constant-binary-expression/

Errors code with the operator `A ?? B` where A is a constant non-null type and B is never returned

The one line flagged here is `c.column === value?.toString() ?? ''` ; it appears to be operator precedence issue which I've solved with parentheses: `(value?.toString() ?? '')`

## Test Plan

Site builds, tests pass

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.