### PR TITLE
fix: Place modal inside of ResourcePoolCard

### DIFF
--- a/webui/react/src/components/ResourcePoolCard.tsx
+++ b/webui/react/src/components/ResourcePoolCard.tsx
@@ -163,54 +163,52 @@ const ResourcePoolCard: React.FC<Props> = ({
   );
 
   return (
-    <>
-      <Card
-        actionMenu={actionMenu}
-        size="medium"
-        onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.resourcePool(pool.name) })}
-        onDropdown={onDropdown}>
-        <div className={css.base}>
-          <div className={css.header}>
-            <div className={css.name}>{pool.name}</div>
-            <div className={css.details}>
-              <ConditionalWrapper
-                condition={!!defaultLabel && canManageResourcePoolBindings}
-                wrapper={(children) => (
-                  <Tooltip content="You cannot bind your default resource pool to a workspace.">
-                    {children}
-                  </Tooltip>
-                )}>
-                <span>{defaultLabel}</span>
-              </ConditionalWrapper>
-              {pool.description && <Icon name="info" showTooltip title={pool.description} />}
-            </div>
+    <Card
+      actionMenu={actionMenu}
+      size="medium"
+      onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.resourcePool(pool.name) })}
+      onDropdown={onDropdown}>
+      <div className={css.base}>
+        <div className={css.header}>
+          <div className={css.name}>{pool.name}</div>
+          <div className={css.details}>
+            <ConditionalWrapper
+              condition={!!defaultLabel && canManageResourcePoolBindings}
+              wrapper={(children) => (
+                <Tooltip content="You cannot bind your default resource pool to a workspace.">
+                  {children}
+                </Tooltip>
+              )}>
+              <span>{defaultLabel}</span>
+            </ConditionalWrapper>
+            {pool.description && <Icon name="info" showTooltip title={pool.description} />}
           </div>
-          <Suspense fallback={<Spinner center spinning />}>
-            <div className={css.body}>
-              <RenderAllocationBarResourcePool resourcePool={pool} size={ShirtSize.Medium} />
-              {rpBindingFlagOn && resourcePoolBindings.length > 0 && (
-                <section className={css.resoucePoolBoundContainer}>
-                  <div>Bound to:</div>
-                  <div className={css.resoucePoolBoundCount}>
-                    <Icon name="lock" title="Bound Workspaces" />
-                    {resourcePoolBindings.length}{' '}
-                    {pluralizer(resourcePoolBindings.length, 'workspace')}
-                  </div>
-                </section>
-              )}
-              <JsonGlossary alignValues="right" json={shortDetails} />
-              <div />
-            </div>
-          </Suspense>
         </div>
-      </Card>
+        <Suspense fallback={<Spinner center spinning />}>
+          <div className={css.body}>
+            <RenderAllocationBarResourcePool resourcePool={pool} size={ShirtSize.Medium} />
+            {rpBindingFlagOn && resourcePoolBindings.length > 0 && (
+              <section className={css.resoucePoolBoundContainer}>
+                <div>Bound to:</div>
+                <div className={css.resoucePoolBoundCount}>
+                  <Icon name="lock" title="Bound Workspaces" />
+                  {resourcePoolBindings.length}{' '}
+                  {pluralizer(resourcePoolBindings.length, 'workspace')}
+                </div>
+              </section>
+            )}
+            <JsonGlossary alignValues="right" json={shortDetails} />
+            <div />
+          </div>
+        </Suspense>
+      </div>
       <ResourcePoolBindingModal.Component
         bindings={workspaces.filter((w) => resourcePoolBindings.includes(w.id)).map((w) => w.name)}
         pool={pool.name}
         workspaces={workspaces.map((w) => w.name)}
         onSave={onSaveBindings}
       />
-    </>
+    </Card>
   );
 };
 


### PR DESCRIPTION
## Description

Fixes an issue where `ResourcePoolCard`s were spaced incorrectly due to modal.
As in #8378 , we can now move the modal placeholder inside of the `Card` component 

## Test Plan

- Fixes spacing on `/det/clusters`
- Did a search of where we use `Card` and `Card.Group`. For example `/det/workspaces/563/pools` is working.
- On an instance with more resource pools, hovering over the card shows the expected dropdown and modal (to simulate this on local devcluster, in pages/Cluster/ClusterOverview I made `actionMenu` always return a populated array)

<img width="783" alt="Screen Shot 2023-11-14 at 2 36 41 PM" src="https://github.com/determined-ai/determined/assets/643918/de98cd9d-db81-4549-a1c6-818aa1f7edfc">

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.