### PR TITLE
fix: allow for `model_dir` to be None when submitting experiments

### DIFF
--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -18,7 +18,7 @@ from tests.cluster import utils as cluster_utils
 
 
 def maybe_create_experiment(
-    config_file: str, model_def_file: str, create_args: Optional[List[str]] = None
+    config_file: str, model_def_file: Optional[str] = None, create_args: Optional[List[str]] = None
 ) -> subprocess.CompletedProcess:
     command = [
         "det",
@@ -27,8 +27,10 @@ def maybe_create_experiment(
         "experiment",
         "create",
         config_file,
-        model_def_file,
     ]
+
+    if model_def_file is not None:
+        command += model_def_file
 
     if create_args is not None:
         command += create_args
@@ -42,7 +44,7 @@ def maybe_create_experiment(
 
 
 def create_experiment(
-    config_file: str, model_def_file: str, create_args: Optional[List[str]] = None
+    config_file: str, model_def_file: Optional[str] = None, create_args: Optional[List[str]] = None
 ) -> int:
     completed_process = maybe_create_experiment(config_file, model_def_file, create_args)
     assert completed_process.returncode == 0, "\nstdout:\n{} \nstderr:\n{}".format(

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -30,7 +30,7 @@ def maybe_create_experiment(
     ]
 
     if model_def_file is not None:
-        command += model_def_file
+        command.append(model_def_file)
 
     if create_args is not None:
         command += create_args

--- a/e2e_tests/tests/fixtures/no_op/empty_model_dir.yaml
+++ b/e2e_tests/tests/fixtures/no_op/empty_model_dir.yaml
@@ -1,0 +1,7 @@
+
+name: experiment_with_no_model_definition
+entrypoint: ls
+searcher:
+   name: single
+   metric: a
+   max_length: 1

--- a/e2e_tests/tests/test_sdk.py
+++ b/e2e_tests/tests/test_sdk.py
@@ -85,6 +85,11 @@ def test_completed_experiment_and_checkpoint_apis(client: _client.Determined) ->
     assert ckpt.metadata
     assert "newkey" not in ckpt.metadata
 
+    # Test creation of experiment without a model definition
+    with open(conf.fixtures_path("no_op/empty_model_dir.yaml")) as f:
+        config = util.yaml_safe_load(f)
+    exp = client.create_experiment(config)
+
 
 @pytest.mark.e2e_cpu
 def test_checkpoint_apis(client: _client.Determined) -> None:

--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -34,6 +34,8 @@ from .trial import logs_args_description
 # a filter like `head`.
 FLUSH = False
 
+ZERO_OR_ONE = "?"
+
 
 @authentication.required
 def activate(args: Namespace) -> None:
@@ -1112,7 +1114,13 @@ main_cmd = Cmd(
             "create experiment",
             [
                 Arg("config_file", type=FileType("r"), help="experiment config file (.yaml)"),
-                Arg("model_def", type=Path, help="file or directory containing model definition"),
+                Arg(
+                    "model_def",
+                    nargs=ZERO_OR_ONE,
+                    default=None,
+                    type=Path,
+                    help="file or directory containing model definition",
+                ),
                 Arg(
                     "-i",
                     "--include",

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -140,7 +140,7 @@ class Determined:
     def create_experiment(
         self,
         config: Union[str, pathlib.Path, Dict],
-        model_dir: Union[str, pathlib.Path],
+        model_dir: Optional[Union[str, pathlib.Path]] = None,
         includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
     ) -> experiment.Experiment:
         """
@@ -150,7 +150,7 @@ class Determined:
         Arguments:
             config(string, pathlib.Path, dictionary): experiment config filename (.yaml)
                 or a dict.
-            model_dir(string): directory containing model definition.
+            model_dir(string, optional): directory containing model definition. (default: ``None``)
             includes (Iterable[Union[str, pathlib.Path]], optional): Additional files or
             directories to include in the model definition.  (default: ``None``)
         """
@@ -173,7 +173,10 @@ class Determined:
             model_dir = pathlib.Path(model_dir)
 
         path_includes = (pathlib.Path(i) for i in includes or [])
-        model_context = context.read_v1_context(model_dir, includes=path_includes)
+
+        model_context = None
+        if model_dir is not None:
+            model_context = context.read_v1_context(model_dir, includes=path_includes)
 
         req = bindings.v1CreateExperimentRequest(
             # TODO: add this as a param to create_experiment()

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -28,9 +28,8 @@ def is_trial(info: det.ClusterInfo) -> bool:
 
 def download_context_directory(sess: api.Session, info: det.ClusterInfo) -> None:
     b64_tgz = bindings.get_GetTaskContextDirectory(sess, taskId=info.task_id).b64Tgz
-    if not is_trial(info) and len(b64_tgz) == 0:
+    if len(b64_tgz) == 0:
         return  # Non trials can have empty model defs.
-    assert len(b64_tgz) > 0
 
     tgz = base64.b64decode(b64_tgz)
     with tarfile.open(fileobj=io.BytesIO(tgz), mode="r:gz") as context_directory:

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -160,7 +160,7 @@ def login(
 @_require_singleton
 def create_experiment(
     config: Union[str, pathlib.Path, Dict],
-    model_dir: str,
+    model_dir: Optional[str] = None,
     includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
 ) -> Experiment:
     """Create an experiment with config parameters and model directory.

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -419,9 +419,6 @@ func NewExperiment(
 	projectID int,
 	unmanaged bool,
 ) (*Experiment, error) {
-	if len(modelDefinitionBytes) == 0 && !unmanaged {
-		return nil, errors.New("empty model definition")
-	}
 	if !(gitRemote == nil && gitCommit == nil && gitCommitter == nil && gitCommitDate == nil) &&
 		!(gitRemote != nil && gitCommit != nil && gitCommitter != nil && gitCommitDate != nil) {
 		return nil, errors.New(


### PR DESCRIPTION
## Description
Triage to allow for `model_dir` to be set to none when creating experiments. 
- Removes the check on the model definition.
- Updates the CLI & SDK to allow for these types of experiment submissions
- Adds testing for this use case
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Attempt to create a new experiment through the SDK with `model_dir=None`
- `e2e_tests/tests/test_sdk.py:test_completed_experiment_and_checkpoint_apis` now also checks if an experiment can be create without a model definition (given that entrypoint is already in the container)
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
This resolves the immediate issue, but a more thought through implementation for checking for this specific case besides allowing any submission to be made without a `model_dir` or model definition specified would be ideal.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9962
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
