### PR TITLE
ci: delete broken fixture

### DIFF
--- a/e2e_tests/tests/conftest.py
+++ b/e2e_tests/tests/conftest.py
@@ -103,13 +103,6 @@ def pytest_addoption(parser: Parser) -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def instantiate_gpu() -> None:
-    command = ["det", "cmd", "--config", "resources.slots=1", "'sleep 30'"]
-
-    subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-
-@pytest.fixture(scope="session", autouse=True)
 def cluster_log_manager(request: SubRequest) -> Iterator[Optional[ClusterLogManager]]:
     master_scheme = request.config.getoption("--master-scheme")
     master_host = request.config.getoption("--master-host")


### PR DESCRIPTION
There is a fixture which runs the following command:

    det cmd --config resources.slots=1 "'sleep 30'"

It has never worked because it is missing the `run` subcommand.

Why fix a broken fixture when tests are fine without it?