### PR TITLE
fix: Wrap older modals in theme class [WEB-1824]

### DIFF
--- a/webui/react/src/components/GalleryModal.tsx
+++ b/webui/react/src/components/GalleryModal.tsx
@@ -2,6 +2,7 @@ import { Modal } from 'antd';
 import { ModalProps } from 'antd/es/modal/Modal';
 import Button from 'hew/Button';
 import Icon from 'hew/Icon';
+import { useTheme } from 'hew/Theme';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { keyEmitter, KeyEvent } from 'hooks/useKeyTracker';
@@ -28,6 +29,10 @@ const GalleryModal: React.FC<Props> = ({
   const resize = useResize();
   const [width, setWidth] = useState<number>();
   const [minHeight, setMinHeight] = useState<number>();
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const handlePrevious = useCallback(() => {
     if (onPrevious) onPrevious();
@@ -65,7 +70,7 @@ const GalleryModal: React.FC<Props> = ({
   }, [onNext, onPrevious]);
 
   return (
-    <Modal centered footer={null} open width={width} {...props}>
+    <Modal centered footer={null} open width={width} {...props} wrapClassName={themeClass}>
       <div className={css.base} style={{ minHeight }}>
         {children}
         <div className={css.prev}>

--- a/webui/react/src/components/ResourcePoolDetails.tsx
+++ b/webui/react/src/components/ResourcePoolDetails.tsx
@@ -1,4 +1,5 @@
 import { Divider, Modal } from 'antd';
+import { useTheme } from 'hew/Theme';
 import React, { Fragment } from 'react';
 
 import JsonGlossary from 'components/JsonGlossary';
@@ -17,6 +18,10 @@ interface Props {
 
 const ResourcePoolDetails: React.FC<Props> = ({ resourcePool: pool, ...props }: Props) => {
   const { details, ...mainSection } = pool;
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   for (const key in details) {
     if (details[key as keyof V1ResourcePoolDetail] === null) {
@@ -39,6 +44,7 @@ const ResourcePoolDetails: React.FC<Props> = ({ resourcePool: pool, ...props }: 
       open={props.visible}
       style={{ minWidth: '600px' }}
       title={title}
+      wrapClassName={themeClass}
       onCancel={props.finally}
       onOk={props.finally}>
       <JsonGlossary

--- a/webui/react/src/components/TaskList.tsx
+++ b/webui/react/src/components/TaskList.tsx
@@ -8,7 +8,7 @@ import {
 import Button from 'hew/Button';
 import Icon from 'hew/Icon';
 import { useModal } from 'hew/Modal';
-import { ShirtSize } from 'hew/Theme';
+import { ShirtSize, useTheme } from 'hew/Theme';
 import { Loadable } from 'hew/utils/loadable';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -109,6 +109,10 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
   const canceler = useRef(new AbortController());
 
   const BatchActionConfirmModal = useModal(BatchActionConfirmModalComponent);
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const loadedTasks = useMemo(() => tasks?.map(taskFromCommandTask) || [], [tasks]);
 
@@ -655,6 +659,7 @@ const TaskList: React.FC<Props> = ({ workspace }: Props) => {
           ${sourcesModal?.sources.length}
           TensorBoard Source${sourcesModal?.plural}
         `}
+        wrapClassName={themeClass}
         onCancel={handleSourceDismiss}>
         <div className={css.sourceLinks}>
           <Grid gap={ShirtSize.Medium} minItemWidth={120}>

--- a/webui/react/src/components/TextEditorModal.tsx
+++ b/webui/react/src/components/TextEditorModal.tsx
@@ -2,6 +2,7 @@ import { Modal } from 'antd';
 import Button from 'hew/Button';
 import Form from 'hew/Form';
 import Input from 'hew/Input';
+import { useTheme } from 'hew/Theme';
 import React, { useCallback, useId, useMemo, useState } from 'react';
 
 import css from './TextEditorModal.module.scss';
@@ -31,6 +32,10 @@ const TextEditorModal: React.FC<Props> = ({ disabled, onSave, title, placeholder
     return classList.join(' ');
   }, [value]);
 
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
+
   const onShowModal = () => {
     setIsModalOpen(true);
   };
@@ -54,6 +59,7 @@ const TextEditorModal: React.FC<Props> = ({ disabled, onSave, title, placeholder
         confirmLoading={isConfirmLoading}
         open={isModalOpen}
         title={title}
+        wrapClassName={themeClass}
         onCancel={onHideModal}
         onOk={onSubmit}>
         <Form form={form} id={idPrefix + FORM_ID} layout="vertical">

--- a/webui/react/src/hooks/useModal/useModal.tsx
+++ b/webui/react/src/hooks/useModal/useModal.tsx
@@ -2,6 +2,7 @@
 import { Modal } from 'antd';
 import { ModalFunc } from 'antd/es/modal/confirm';
 import { ModalFuncProps } from 'antd/es/modal/Modal';
+import { useTheme } from 'hew/Theme';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import usePrevious from 'hooks/usePrevious';
@@ -55,6 +56,9 @@ function useModal<T = RecordUnknown>(config: ModalConfig = {}): ModalHooks<T> {
   const [modalProps, setModalProps] = useState<ModalFuncProps>();
   const prevModalProps = usePrevious(modalProps, undefined);
   const [modal, antdContextHolder] = Modal.useModal();
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   /**
    * contextHolders have keys now, so elements that contain multiple modal
@@ -132,6 +136,7 @@ function useModal<T = RecordUnknown>(config: ModalConfig = {}): ModalHooks<T> {
       maskClosable: true,
       open: true,
       style: { minWidth: 280 },
+      wrapClassName: themeClass,
       ...modalProps,
       onCancel: config.options?.rawCancel
         ? modalProps.onCancel
@@ -147,7 +152,7 @@ function useModal<T = RecordUnknown>(config: ModalConfig = {}): ModalHooks<T> {
     } else {
       modalRef.current = modal.confirm(completeModalProps);
     }
-  }, [config, extendEventHandler, modal, modalProps, prevModalProps]);
+  }, [config, extendEventHandler, modal, modalProps, prevModalProps, themeClass]);
 
   /**
    * Sets componentUnmounting to true only when the parent component is unmounting so that the next

--- a/webui/react/src/pages/Cluster/ClusterHistoricalUsageCsvModal.tsx
+++ b/webui/react/src/pages/Cluster/ClusterHistoricalUsageCsvModal.tsx
@@ -2,6 +2,7 @@ import { Form, Modal } from 'antd';
 import dayjs, { Dayjs } from 'dayjs';
 import DatePicker from 'hew/DatePicker';
 import Select, { Option } from 'hew/Select';
+import { useTheme } from 'hew/Theme';
 import React from 'react';
 
 import { handlePath, serverAddress } from 'routes/utils';
@@ -28,6 +29,10 @@ const ClusterHistoricalUsageCsvModal: React.FC<Props> = ({
   onVisibleChange,
 }: Props) => {
   const [form] = Form.useForm();
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const handleOk = (event: React.MouseEvent): void => {
     const formAfterDate = form.getFieldValue('afterDate');
@@ -59,6 +64,7 @@ const ClusterHistoricalUsageCsvModal: React.FC<Props> = ({
       okText="Proceed to Download"
       open={true}
       title="Download Resource Usage Data in CSV"
+      wrapClassName={themeClass}
       onCancel={() => onVisibleChange(false)}
       onOk={handleOk}>
       <Form form={form} initialValues={{ afterDate, beforeDate, groupBy }} labelCol={{ span: 8 }}>

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -2,6 +2,7 @@ import { Modal, Tag, Typography } from 'antd';
 import Message from 'hew/Message';
 import Select, { Option, SelectValue } from 'hew/Select';
 import Spinner from 'hew/Spinner';
+import { useTheme } from 'hew/Theme';
 import { Loadable } from 'hew/utils/loadable';
 import usePrevious from 'hew/utils/usePrevious';
 import _ from 'lodash';
@@ -49,6 +50,9 @@ const TrialsComparisonModal: React.FC<ModalProps> = ({
   ...props
 }: ModalProps) => {
   const resize = useResize();
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   useEffect(() => {
     if (props.trialIds?.length === 0 || props.trials?.length === 0) onCancel();
@@ -66,6 +70,7 @@ const TrialsComparisonModal: React.FC<ModalProps> = ({
           : 'Trial Comparison'
       }
       width={resize.width * 0.9}
+      wrapClassName={themeClass}
       onCancel={onCancel}>
       <TrialsComparisonTable {...props} />
     </Modal>

--- a/webui/react/src/pages/JobQueue/ManageJob.tsx
+++ b/webui/react/src/pages/JobQueue/ManageJob.tsx
@@ -2,6 +2,7 @@ import { List, Modal, Typography } from 'antd';
 import Form from 'hew/Form';
 import Input from 'hew/Input';
 import Select, { Option } from 'hew/Select';
+import { useTheme } from 'hew/Theme';
 import { Loadable } from 'hew/utils/loadable';
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 
@@ -86,6 +87,10 @@ const ManageJob: React.FC<Props> = ({
   const isOrderedQ = orderedSchedulers.has(schedulerType);
   const resourcePools = Loadable.getOrElse([], useObservable(clusterStore.resourcePools)); // TODO show spinner when this is loading
   const [selectedPoolName, setSelectedPoolName] = useState(initialPool);
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const details = useMemo(() => {
     interface Item {
@@ -178,6 +183,7 @@ const ManageJob: React.FC<Props> = ({
       mask
       open={true}
       title={'Manage Job ' + truncate(job.jobId, 6, '')}
+      wrapClassName={themeClass}
       onCancel={onFinish}
       onOk={onOk}>
       {isOrderedQ && (

--- a/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
+++ b/webui/react/src/pages/ModelVersionDetails/ModelVersionHeader.tsx
@@ -8,6 +8,7 @@ import { useModal } from 'hew/Modal';
 import Nameplate from 'hew/Nameplate';
 import Spinner from 'hew/Spinner';
 import Tags, { tagsActionHelper } from 'hew/Tags';
+import { useTheme } from 'hew/Theme';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import ModelDownloadModal from 'components/ModelDownloadModal';
@@ -50,6 +51,10 @@ const ModelVersionHeader: React.FC<Props> = ({
   const modelVersionEditModal = useModal(ModelVersionEditModal);
 
   const { canDeleteModelVersion, canModifyModelVersion } = usePermissions();
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const infoRows: InfoRow[] = useMemo(
     () => [
@@ -222,6 +227,7 @@ with det.import_from_path(path + "/code"):
         footer={null}
         open={showUseInNotebook}
         title="Use in Notebook"
+        wrapClassName={themeClass}
         onCancel={() => setShowUseInNotebook(false)}>
         <div className={css.topLine}>
           <p>Reference this model in a notebook</p>

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceQuickSearch.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceQuickSearch.tsx
@@ -3,6 +3,7 @@ import Icon from 'hew/Icon';
 import Input from 'hew/Input';
 import Message from 'hew/Message';
 import Spinner from 'hew/Spinner';
+import { useTheme } from 'hew/Theme';
 import { Loadable } from 'hew/utils/loadable';
 import type { DefaultOptionType } from 'rc-tree-select/lib/TreeSelect';
 import React, { useCallback, useMemo, useState } from 'react';
@@ -30,6 +31,10 @@ const WorkspaceQuickSearch: React.FC<Props> = ({ children }: Props) => {
 
   const workspaceObservable = useObservable(workspaceStore.mutables);
   const workspaces = Loadable.getOrElse([], workspaceObservable);
+
+  const {
+    themeSettings: { className: themeClass },
+  } = useTheme();
 
   const fetchData = useCallback(async () => {
     try {
@@ -151,6 +156,7 @@ const WorkspaceQuickSearch: React.FC<Props> = ({ children }: Props) => {
           />
         }
         width={'clamp(520px, 50vw, 1000px)'}
+        wrapClassName={themeClass}
         onCancel={onHideModal}>
         <div className={css.modalBody}>
           {isLoading ? (


### PR DESCRIPTION
## Description

Applies system/light/dark theme to hyperparameter, notebook, or any old-style modal still inside `src/hooks/useModal`

## Test Plan

Switch to dark mode.
In a single-trial experiment, open the Hyperparameter tab, then click the Hyperparameter Search button
The background should be solid, and the title font-family should come from a CSS variable

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.