### PR TITLE
chore: add version dropdown url for previous release

### DIFF
--- a/docs/_static/version-switcher/versions.json
+++ b/docs/_static/version-switcher/versions.json
@@ -8,6 +8,10 @@
         "url": "https://docs.determined.ai/0.26.4/"
     },
     {
+        "version": "0.26.3",
+        "url": "https://docs.determined.ai/0.26.3/"
+    },
+    {
         "version": "0.26.2",
         "url": "https://docs.determined.ai/0.26.2/"
     },


### PR DESCRIPTION
## Description

We automated this process from this release (0.26.4) going forward but forgot to do it for last release.


## Test Plan

No testing required


## Commentary (optional)

This will never be a problem again.



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
None