### PR TITLE
fix: k8s autoscaling nodes not counted towards RP

### DIFF
--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1297,6 +1297,13 @@ func (p *pods) getNodeResourcePoolMapping(nodeSummaries map[string]model.AgentSu
 				}
 			}
 
+			// add default toleration so that autoscaling nodes will still be counted.
+			poolTolerations = append(poolTolerations, k8sV1.Toleration{
+				Key:               "DeletionCandidateOfClusterAutoscaler",
+				Operator:          "Exists",
+				Effect:            "PreferNoSchedule",
+				TolerationSeconds: nil,
+			})
 			// If all of a node's taints are tolerated by a pool, that node belongs to the pool.
 			if allTaintsTolerated(node.Spec.Taints, poolTolerations) {
 				poolsToNodes[poolName] = append(poolsToNodes[poolName], node)


### PR DESCRIPTION
## Description
K8s autoscaling nodes (on GKE) get marked with the `DeletionCandidateOfClusterAutoscaler` taint when there aren't any jobs scheduled on it. This does not prevent jobs from being scheduled on the node, but the additional taint makes it so that our resource pool toleration no longer matches. As a result, the node does not appear to be part of any resource pool. this fixes the issue by making the `DeletionCandidateOfClusterAutoscaler` tolerated automatically by all resource pools.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
**Prerequisites: gcloud CLI and gcloud access, kubectl installed, and determined installed.**

Start a GKE cluster with the following commands (copy pastable unless you want/need to change names or node locations):

1. `gcloud container clusters create k8s-autoscaling-rp-test --region us-west1 --node-locations us-west1-b --num-nodes=1 --cluster-version=latest --machine-type=n1-standard-8 --enable-ip-alias --create-subnetwork name=k8s-autoscaling-rp-test-subnet`
2. `gcloud container node-pools create k8s-autoscaling-rp-test-pool --cluster k8s-autoscaling-rp-test --accelerator type=nvidia-tesla-k80,count=1 --region=us-west1 --num-nodes=2 --machine-type=n1-standard-8 --scopes=storage-full --min-nodes=0 --max-nodes=2 --enable-autoscaling `
3. `kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml `

After that is complete, prepare helm for the latest release by modifying the following fields in the determined helm charts (determined/helm/charts/determined):
1. in `values.yaml`, find `maxSlotsPerPod:` and change it to `maxSlotsPerPod: 1`
2. in `Chart.yaml`, find `appVersion: "0.26.4-dev0"` and change it to `appVersion: "0.26.4-rc0"` or whatever the current release is. If this is not a release party, find the commit hash and supply that instead. If this doesn't work, contact Eric for help :) 

then perform `helm install <deployment name> <relative path to determined/helm/charts/determined>`
e.g. `helm install test-deployment helm/charts/determined` 

Once determined is up and running, submit a few jobs to the cluster. There should already be two nodes up, but if there aren't, just wait for the nodes to spin up. Once they are up, cancel or wait for the jobs to complete.

After the jobs are complete, wait a few seconds to a minute. Stand up, stretch, grab a snack, take a bathroom break, or get a drink :) 

Now, use `kubectl get nodes` to describe the nodes in your cluster. There should be one node with `default pool` in the name, and another pool with `k8s-autoscaling-rp-test-pool` in the name. copy the name of the latter, and get the node details with the command:
`kubectl describe node <node name here>` 

You'll get a wall of text, but you can ignore most of it and just look for the field labeled `Taint`. Check to make sure that the taint field has `DeletionCandidateOfClusterAutoscaler` as one of the taints.

After you confirm this, run `det agent list` to see active agents. Regardless of how many agents there are, look under the `Resource Pool` column. That column should NEVER be empty.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
