### PR TITLE
chore: add error check to KillNTSC

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -235,11 +235,9 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	c.exitStatus = ae
 
-	err := c.db.CompleteTask(c.taskID, time.Now().UTC())
-	if err != nil {
+	if err := c.db.CompleteTask(c.taskID, time.Now().UTC()); err != nil {
 		c.syslog.WithError(err).Error("marking task complete")
 	}
-
 	if err := user.DeleteSessionByToken(context.TODO(), c.GenericCommandSpec.Base.UserSessionToken); err != nil {
 		c.syslog.WithError(err).Errorf(
 			"failure to delete user session for task: %v", c.taskID)

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -241,7 +241,7 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 	err := c.db.CompleteTask(c.taskID, time.Now().UTC())
 	if err != nil {
 		c.syslog.WithError(err).Error("marking task complete")
-		if errors.As(err, &sErr) && sErr.Code() == codes.NotFound {
+		if errors.As(err, &sErr) && sErr.Code() != codes.NotFound {
 			return
 		}
 	}

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -11,8 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 	"golang.org/x/exp/slices"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
@@ -239,10 +237,6 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	err := c.db.CompleteTask(c.taskID, time.Now().UTC())
 	if err != nil {
-		var sErr status.Status
-		if errors.As(err, &sErr) && sErr.Code() != codes.NotFound {
-			return
-		}
 		c.syslog.WithError(err).Error("marking task complete")
 	}
 

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -237,13 +237,13 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	c.exitStatus = ae
 
-	var sErr status.Status
 	err := c.db.CompleteTask(c.taskID, time.Now().UTC())
 	if err != nil {
-		c.syslog.WithError(err).Error("marking task complete")
+		var sErr status.Status
 		if errors.As(err, &sErr) && sErr.Code() != codes.NotFound {
 			return
 		}
+		c.syslog.WithError(err).Error("marking task complete")
 	}
 
 	if err := user.DeleteSessionByToken(context.TODO(), c.GenericCommandSpec.Base.UserSessionToken); err != nil {

--- a/master/internal/command/command_service.go
+++ b/master/internal/command/command_service.go
@@ -230,10 +230,7 @@ func (cs *CommandService) KillNTSC(id string, taskType model.TaskType) (*Command
 
 	if !completed {
 		err = task.DefaultService.Signal(c.allocationID, task.KillAllocation, "user requested kill")
-		if strings.Contains(err.Error(), "not found") {
-			return nil, nil
-		}
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "not found") {
 			return nil, fmt.Errorf("failed to kill allocation: %w", err)
 		}
 	}

--- a/master/internal/command/command_service.go
+++ b/master/internal/command/command_service.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -229,6 +230,9 @@ func (cs *CommandService) KillNTSC(id string, taskType model.TaskType) (*Command
 
 	if !completed {
 		err = task.DefaultService.Signal(c.allocationID, task.KillAllocation, "user requested kill")
+		if strings.Contains(err.Error(), "not found") {
+			return nil, nil
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to kill allocation: %w", err)
 		}


### PR DESCRIPTION
## Description
In KillNTSC, if `Signal` returns a not found error, continue & don't  return an error. This fixes a potential race condition where the db says a command isn't completed yet the allocation has already exited.



## Test Plan
Pass CircleCI



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
