### PR TITLE
chore: use ResourcePool info for consistent capacity calculation [WEB-1796]

### DIFF
--- a/webui/react/src/stores/cluster.tsx
+++ b/webui/react/src/stores/cluster.tsx
@@ -10,7 +10,7 @@ import {
   getResourcePools,
   overwriteResourcePoolBindings,
 } from 'services/api';
-import { V1ResourcePoolType } from 'services/api-ts-sdk';
+import { V1ResourcePoolType, V1SchedulerType } from 'services/api-ts-sdk';
 import { Agent, ClusterOverview, ClusterOverviewResource, ResourcePool, ResourceType } from 'types';
 import handleError from 'utils/error';
 import { percent } from 'utils/number';
@@ -28,12 +28,21 @@ const initClusterOverview: ClusterOverview = {
   [ResourceType.UNSPECIFIED]: structuredClone(initResourceTally),
 };
 
+const flexSchedulers: V1SchedulerType[] = [V1SchedulerType.PBS, V1SchedulerType.SLURM];
+
 /**
- * maximum theoretcial capacity of the resource pool in terms of the advertised
+ * maximum theoretical capacity of the resource pool in terms of the advertised
  * compute slot type.
  * @param pool resource pool
  */
 export const maxPoolSlotCapacity = (pool: ResourcePool): number => {
+  if (
+    flexSchedulers.includes(pool.schedulerType) &&
+    pool.slotsAvailable &&
+    pool.slotsAvailable > 0
+  ) {
+    return pool.slotsAvailable; // The case for HPC Slurm & PBS clusters
+  }
   if (pool.maxAgents > 0 && pool.slotsPerAgent && pool.slotsPerAgent > 0)
     return pool.maxAgents * pool.slotsPerAgent;
   // on-premise deployments don't have dynamic agents and we don't know how many

--- a/webui/react/src/stores/cluster.tsx
+++ b/webui/react/src/stores/cluster.tsx
@@ -28,7 +28,7 @@ const initClusterOverview: ClusterOverview = {
   [ResourceType.UNSPECIFIED]: structuredClone(initResourceTally),
 };
 
-const flexSchedulers: V1SchedulerType[] = [V1SchedulerType.PBS, V1SchedulerType.SLURM];
+const flexSchedulers: Set<V1SchedulerType> = new Set([V1SchedulerType.PBS, V1SchedulerType.SLURM]);
 
 /**
  * maximum theoretical capacity of the resource pool in terms of the advertised
@@ -36,11 +36,7 @@ const flexSchedulers: V1SchedulerType[] = [V1SchedulerType.PBS, V1SchedulerType.
  * @param pool resource pool
  */
 export const maxPoolSlotCapacity = (pool: ResourcePool): number => {
-  if (
-    flexSchedulers.includes(pool.schedulerType) &&
-    pool.slotsAvailable &&
-    pool.slotsAvailable > 0
-  ) {
+  if (flexSchedulers.has(pool.schedulerType) && pool.slotsAvailable > 0) {
     return pool.slotsAvailable; // The case for HPC Slurm & PBS clusters
   }
   if (pool.maxAgents > 0 && pool.slotsPerAgent && pool.slotsPerAgent > 0)


### PR DESCRIPTION
## Description

In areas where we display {slotsUsed} / {slotsAvailable}; the number available comes from `maxPoolSlotCapacity`.
The function should be accurate and consistent between OSS and EE

This change will overwrite the EE-only line:
`if (pool.slotsAvailable && pool.slotsAvailable > 0) return pool.slotsAvailable; // The case for HPC Slurm & PBS clusters`
This should have no effect on local devcluster.

## Test Plan

Builds successfully
Completing discussion with backend team about whether this calculation is the best way to represent Slurm and PBS


## Checklist

- [ ] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.