### PR TITLE
fix: SDK list_checkpoints not defaulting to searcher metric sort

### DIFF
--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -483,6 +483,9 @@ class Experiment:
         if sort_by and not isinstance(sort_by, (checkpoint.CheckpointSortBy, str)):
             raise ValueError("sort_by must be of type CheckpointSortBy or str")
 
+        if not sort_by:
+            sort_by = checkpoint.CheckpointSortBy.SEARCHER_METRIC
+
         def get_with_offset(offset: int) -> bindings.v1GetExperimentCheckpointsResponse:
             return bindings.get_GetExperimentCheckpoints(
                 self._session,

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -226,6 +226,9 @@ class Trial:
         if sort_by and not isinstance(sort_by, (checkpoint.CheckpointSortBy, str)):
             raise ValueError("sort_by must be of type CheckpointSortBy or str")
 
+        if not sort_by:
+            sort_by = checkpoint.CheckpointSortBy.SEARCHER_METRIC
+
         def get_trial_checkpoints(offset: int) -> bindings.v1GetTrialCheckpointsResponse:
             return bindings.get_GetTrialCheckpoints(
                 self._session,


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

calling `list_checkpoints` without sort and order parameters is supposed to default to the experiment's searcher config, but instead falls through to sorting by ID on the backend.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Ensure that calling `list_checkpoints` without any arguments returns a list of checkpoints sorted by the experiment's searcher metric and smaller_is_better
```
client = experimental.Determined(master=DET_MASTER, user="determined", password="")
    ckpts = client.get_experiment(1).list_checkpoints()
    print(ckpts)
```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
