### PR TITLE
docs: Update CentOS to AlmaLinux in the docs

### DIFF
--- a/docs/setup-cluster/on-prem/requirements.rst
+++ b/docs/setup-cluster/on-prem/requirements.rst
@@ -15,8 +15,8 @@ A Determined cluster has the following requirements.
 Software
 ========
 
--  The Determined agent and master nodes must be configured with Ubuntu 20.04 or later, CentOS 7, or
-   macOS 10.13 or later.
+-  The Determined agent and master nodes must be configured with Ubuntu 20.04 or later, AlmaLinux 8 
+   (or compatible enterprise Linux) or later, or macOS 10.13 or later.
 
 -  The agent nodes must have :ref:`Docker installed <install-docker>`.
 
@@ -68,7 +68,7 @@ Install on Linux
       sudo systemctl reload docker
       sudo usermod -aG docker $USER
 
-   On CentOS:
+   On AlmaLinux:
 
    .. code:: bash
 
@@ -94,7 +94,7 @@ Install on Linux
       sudo apt-get install -y --no-install-recommends nvidia-container-toolkit
       sudo systemctl restart docker
 
-   On CentOS:
+   On AlmaLinux:
 
    .. code:: bash
 


### PR DESCRIPTION
## Description

CentOS is no longer the community downstream rebuild of RHEL.

The replacement, CentOS Stream, is upstream of RHEL, between RHEL and Fedora, and is debated whether it is suitable for long-term production deployments.

The community heir to CentOS is AlmaLinux, a community-backed RHEL-compatible Linux distro.

These changes also include a reference to compatible enterprise Linux distros, which would include RHEL, Oracle, Rocky, Scientific, and SUSE Liberty.


## Test Plan

Test Determined extensively on AlmaLinux 8 and 9. (pending)

## Checklist

- [ ] Changes have been manually QA'd