### PR TITLE
fix: add delete cascade to generic metrics

### DIFF
--- a/master/static/migrations/20231122090045_generic-metrics-on-del-casc.tx.down.sql
+++ b/master/static/migrations/20231122090045_generic-metrics-on-del-casc.tx.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE generic_metrics
+DROP CONSTRAINT generic_metrics_trial_id_fkey;
+
+ALTER TABLE generic_metrics
+ADD CONSTRAINT generic_metrics_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id);

--- a/master/static/migrations/20231122090045_generic-metrics-on-del-casc.tx.up.sql
+++ b/master/static/migrations/20231122090045_generic-metrics-on-del-casc.tx.up.sql
@@ -1,0 +1,11 @@
+/* 
+generic_metrics needs delete cascade added to its foreign key constraint to trials(id) since 
+trials(experiment_id) has delete cascade constraint to experiments(id).
+*/
+
+ALTER TABLE generic_metrics
+DROP CONSTRAINT generic_metrics_trial_id_fkey;
+
+ALTER TABLE generic_metrics
+ADD CONSTRAINT generic_metrics_trial_id_fkey FOREIGN KEY (trial_id) REFERENCES trials(id)
+ON DELETE CASCADE;


### PR DESCRIPTION
## Description

Fixed experiment deletion by adding delete cascade to `generic_metrics` table.  When trials are deleted due to delete cascade from experiments, generic metrics will in turn be deleted given their corresponding trial.


## Test Plan

No manual testing needed.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9981
