### PR TITLE
ci: register unit pytest marks

### DIFF
--- a/harness/pytest.ini
+++ b/harness/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+markers =
+    cloud: unit tests requring cloud access
+    gpu: tests which require a gpu
+    gpu_parallel: tests which require multiple gpus
+    cpu: tests which cannot use a gpu
+    deepspeed: tests concerning deepspeed
+    pytorch: tests involving pytorch
+    tensorflow: tests involving tensorflow
+    tf1_cpu: tests involving tensorflow v1
+


### PR DESCRIPTION
Avoid a wall of warnings every single run.