### PR TITLE
ci: unit-test login scenarios

### DIFF
--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -431,33 +431,6 @@ def test_login_as_non_existent_user(clean_auth: None, login_admin: None) -> None
 
 
 @pytest.mark.e2e_cpu
-def test_login_with_environment_variables(clean_auth: None, login_admin: None) -> None:
-    creds = api_utils.create_test_user(True)
-    # logout admin
-    log_out_user()
-
-    os.environ["DET_USER"] = creds.username
-    os.environ["DET_PASS"] = creds.password
-    try:
-        child = det_spawn(["user", "whoami"])
-        child.expect(creds.username)
-        child.read()
-        child.wait()
-        assert child.exitstatus == 0
-
-        # Can still override with -u.
-        with logged_in_user(conf.ADMIN_CREDENTIALS):
-            child = det_spawn(["-u", conf.ADMIN_CREDENTIALS.username, "user", "whoami"])
-            child.expect(conf.ADMIN_CREDENTIALS.username)
-            child.read()
-            child.wait()
-            assert child.exitstatus == 0
-    finally:
-        del os.environ["DET_USER"]
-        del os.environ["DET_PASS"]
-
-
-@pytest.mark.e2e_cpu
 def test_auth_inside_shell(clean_auth: None, login_admin: None) -> None:
     creds = api_utils.create_test_user(True)
 

--- a/e2e_tests/tests/command/test_shell.py
+++ b/e2e_tests/tests/command/test_shell.py
@@ -3,8 +3,6 @@ from pathlib import Path
 import pytest
 
 import determined as det
-import tests.config as conf
-from tests import api_utils
 from tests import command as cmd
 from tests.cluster import test_users
 
@@ -46,47 +44,4 @@ def test_open_shell() -> None:
         child.sendline("exit")
         child.read()
         child.wait()
-        assert child.exitstatus == 0
-
-
-@pytest.mark.e2e_cpu
-def test_user_flag_shell() -> None:
-    new_user_creds = api_utils.create_test_user(True)
-    new_user_username, _ = new_user_creds
-
-    with test_users.logged_in_user(new_user_creds):
-        with cmd.interactive_command("shell", "start", "--detach") as shell:
-            admin_username, admin_password = conf.ADMIN_CREDENTIALS
-            task_id = shell.task_id
-            assert task_id is not None
-
-            child = test_users.det_spawn(["shell", "open", task_id])
-            child.setecho(True)
-            child.expect(r".*Permanently added.+([0-9a-f-]{36}).+known hosts\.", timeout=180)
-
-            # Verify correct user credentials at the start of entering shell
-            child.sendline("det user whoami")
-            child.expect(f"You are logged in as user '{new_user_username}'")
-
-            # Use -u flag with logged in user and verify no password prompt.
-            child.sendline(f"det -u {new_user_username} user whoami")
-            child.expect(f"You are logged in as user '{new_user_username}'")
-
-            # Use the -u flag with logged out admin user and verify password prompt.
-            child.sendline(f"det -u {admin_username} user logout")
-            child.sendline(f"det -u {admin_username} user whoami")
-            child.expect(f"Password for user '{admin_username}'", timeout=10)
-            child.sendline(str(admin_password))
-            child.expect(f"You are logged in as user '{admin_username}'", timeout=10)
-
-            # Use -u flag with logged out user whose username and token are stored in environment
-            # and verify no password prompt.
-            child.sendline(f"det -u {new_user_username} user logout")
-            child.sendline(f"det -u {new_user_username} user whoami")
-            child.expect(f"You are logged in as user '{new_user_username}'")
-
-            child.sendline("exit")
-            child.read()
-            child.wait()
-
         assert child.exitstatus == 0

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -102,15 +102,15 @@ class Authentication:
             token = None
 
         # Special case: use token provided from the container environment if:
-        # * No token was obtained from the token store already,
-        # * No user was explicitly requested, or the requested user matches the token available
-        # in the container environment, and
-        # * There is a token available from the container environment.
+        # - No token was obtained from the token store already,
+        # - There is a token available from the container environment, and
+        # - No user was explicitly requested, or the requested user matches the token available
+        #   in the container environment.
         if (
             token is None
-            and requested_user in (None, util.get_det_username_from_env())
             and util.get_det_username_from_env() is not None
             and util.get_det_user_token_from_env() is not None
+            and requested_user in (None, util.get_det_username_from_env())
         ):
             session_user = util.get_det_username_from_env()
             assert session_user
@@ -125,8 +125,6 @@ class Authentication:
         fallback_to_default = password is None and session_user == constants.DEFAULT_DETERMINED_USER
         if fallback_to_default:
             password = constants.DEFAULT_DETERMINED_PASSWORD
-        elif session_user is None:
-            session_user = input("Username: ")
 
         if password is None:
             password = getpass.getpass("Password for user '{}': ".format(session_user))

--- a/harness/tests/cli/test_auth.py
+++ b/harness/tests/cli/test_auth.py
@@ -1,15 +1,19 @@
+import collections
 import contextlib
+import itertools
 import json
-import os
 import shutil
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Any, Iterator, List, Tuple, no_type_check
+from unittest import mock
 
 import pytest
-import requests_mock
+import responses
+from responses import matchers, registries
 
-from determined.common.api.authentication import Authentication, TokenStore
-from determined.common.api.certs import default_load as certs_default_load
+from determined.cli import cli
+from determined.common.api import authentication, certs
+from tests.cli import util
 from tests.confdir import use_test_config_dir
 
 MOCK_MASTER_URL = "http://localhost:8080"
@@ -29,74 +33,407 @@ AUTH_JSON = {
 }
 
 
-@pytest.mark.parametrize("user", [None, "bob", "determined"])
-def test_auth_with_store(requests_mock: requests_mock.Mocker, user: Optional[str]) -> None:
-    with use_test_config_dir() as config_dir:
-        auth_json_path = config_dir / "auth.json"
-        with open(auth_json_path, "w") as f:
-            json.dump(AUTH_JSON, f)
+class ScenarioSetMeta(type):
+    """
+    ScenarioSetMeta helps create "scenario sets", glob-like definitions of inputs and expectations.
 
-        expected_user = "determined" if user == "determined" else "bob"
-        expected_token = "det.token" if user == "determined" else "bob.token"
-        requests_mock.get(
-            "/api/v1/me",
-            status_code=200,
-            json={"username": expected_user},
+    Example:
+
+        MyTestSpec(metaclass=ScenarioSetMeta):
+            field_1 = {"y": True, "n": False}
+            field_2 = {"h": "hello", "b": "bye"}
+
+        # Defined dynamically by the metaclass:
+        #
+        #   scenariotype = namedtuple("MyTestSpecScenario", ["field_1", "field_2"])
+        #
+        #   def __init__(self, field_1, field_2, *expected):
+        #       self.field_1 = field_1
+        #       self.field_2 = field_2
+        #       # Note that extra args become "expected"
+        #       self.expected = expected
+        #
+        #   def scenarios(self):
+        #       for f1 in ("yn" if self.field_1 == "*" else self.field_1):
+        #           for f2 in ("hb" if self.field_2 == "*" else self.field_2):
+        #               f1_val = {"y": True, "n": False}[f1]
+        #               f2_val = {"h": "hello", "b": "bye"}[f2]
+        #               yield scenariotype(f1_val, f2_val)
+    """
+
+    @no_type_check
+    def __new__(cls: type, name: str, bases: Tuple, dct: dict) -> Any:
+        # Collect the "fields", which are dict-type attributes on the class.
+        fields = collections.OrderedDict()
+        for field, opts in dct.items():
+            if field.startswith("_"):
+                continue
+            if not isinstance(opts, dict):
+                continue
+            fields[field] = opts
+
+        # Build the namedtuple.
+        scenariotype = collections.namedtuple(  # type: ignore
+            name + "Scenario", [*fields, "expected"]
         )
-        authentication = Authentication(MOCK_MASTER_URL, user)
-        assert authentication.session.username == expected_user
-        assert authentication.session.token == expected_token
+
+        # Define the __init__ method.
+        def __init__(self, *args, **kwargs):
+            args, expected = args[: len(fields)], args[len(fields) :]
+            # Read and validate the fields passed in.
+            for (field, opts), arg in zip(fields.items(), args):
+                if arg != "*" and not all(a in opts for a in arg):
+                    raise ValueError(
+                        f"unknown option {arg!r} not in allowable set {opts!r} for field {field!r}"
+                    )
+                setattr(self, field, arg)
+            # Also track the expected.
+            self.expected = expected
+
+        # Define the scenarios() method.
+        def scenarios(self):
+            iterables = []
+            for field, opts in fields.items():
+                val = getattr(self, field)
+                if val == "*":
+                    # Yield one of every valid value for this field.
+                    iterables.append(opts.values())
+                else:
+                    # Yield the corresponding value for each field key in the val string.
+                    iterables.append([opts[v] for v in val])
+            yield from (scenariotype(*x, self.expected) for x in itertools.product(*iterables))
+
+        # Also define a __repr__ method().
+        def __repr__(self):
+            argstr = ", ".join(repr(getattr(self, field)) for field in fields)
+            return f"{name}({argstr}, expected={self.expected!r})"
+
+        # Actually construct the dynamic class.
+        dct["__init__"] = __init__
+        dct["scenarios"] = scenarios
+        dct["scenariotype"] = scenariotype
+        dct["__repr__"] = __repr__
+        return super().__new__(cls, name, bases, dct)
 
 
-@contextlib.contextmanager
-def set_container_env_vars() -> Iterator[None]:
-    try:
-        os.environ["DET_USER"] = "alice"
-        os.environ["DET_USER_TOKEN"] = "alice.token"
-        yield
-    finally:
-        del os.environ["DET_USER"]
-        del os.environ["DET_USER_TOKEN"]
+class ScenarioSet(metaclass=ScenarioSetMeta):
+    """This class just defines some things for mypy."""
+
+    expected: List
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        pass
+
+    def scenarios(self) -> Iterator:
+        pass
 
 
-@pytest.mark.parametrize("user", [None, "bob", "determined"])
-@pytest.mark.parametrize("has_token_store", [True, False])
-def test_auth_user_from_env(
-    requests_mock: requests_mock.Mocker, user: Optional[str], has_token_store: bool
+class Check:
+    """A result in a Login scenario indicating a check of a particular token is expected."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def __repr__(self) -> str:
+        return f"Check({self.token!r})"
+
+
+class DoLogin:
+    """A result in a Login scenario indicating a particular login call is expected."""
+
+    def __init__(self, username: str, password: str) -> None:
+        self.username = username
+        self.password = password
+
+    def __repr__(self) -> str:
+        return f"DoLogin({self.username!r}, {self.password!r})"
+
+
+class Use:
+    """A result in a Login scenario indicating a particular token should be returned."""
+
+    def __init__(self, user: str, token: str) -> None:
+        self.user = user
+        self.token = token
+
+    def __repr__(self) -> str:
+        return f"Use({self.user!r}, {self.token!r})"
+
+
+class Login(ScenarioSet):
+    req_user = {"y": "user", "n": None}
+    req_pass = {"y": "req_pass", "n": None}
+    env_user = {"y": "user", "e": "extra", "n": None}
+    env_pass = {"y": "env_pass", "n": None}
+    env_token = {"y": "env_token", "n": None}
+    cache = {"y": "cache", "x": "expired", "n": None}
+
+
+# Some shortcut results to save on line length.
+CheckCache = Check("cache")
+CheckExpired = Check("expired")
+UseCache = Use("user", "cache")
+UseNew = Use("user", "new")
+UseNewDetermined = Use("determined", "new")
+UseEnv = Use("user", "env_token")
+
+
+@pytest.mark.parametrize(
+    "scenario_set",
+    [
+        #     requested user
+        #      |   requested password
+        #      |    |   DET_USER env var
+        #      |    |    |   DET_PASS env var
+        #      |    |    |    |   DET_USER_TOKEN
+        #      |    |    |    |    |   token cache state
+        #      |    |    |    |    |    |   Expected results...
+        #      |    |    |    |    |    |    |
+        #
+        # Explicit user and password, no environment settings, or DET_USER is overridden by
+        # explicitly requested user.
+        Login("y", "y", "ne", "*", "*", "y", CheckCache, UseCache),
+        Login("y", "y", "ne", "*", "*", "n", DoLogin("user", "req_pass"), UseNew),
+        Login("y", "y", "ne", "*", "*", "x", CheckExpired, DoLogin("user", "req_pass"), UseNew),
+        # ---
+        # Explicit user, but password not provided.  Still no (relevant) environment settings.
+        Login("y", "n", "ne", "*", "*", "y", CheckCache, UseCache),
+        Login("y", "n", "ne", "*", "*", "n", DoLogin("user", "prompt_pass"), UseNew),
+        Login("y", "n", "ne", "*", "*", "x", CheckExpired, DoLogin("user", "prompt_pass"), UseNew),
+        # ---
+        # Explicit user and password, DET_USER set but DET_USER_TOKEN not set.  DET_PASS is ignored.
+        Login("y", "y", "y", "*", "n", "y", CheckCache, UseCache),
+        Login("y", "y", "y", "*", "n", "n", DoLogin("user", "req_pass"), UseNew),
+        Login("y", "y", "y", "*", "n", "x", CheckExpired, DoLogin("user", "req_pass"), UseNew),
+        # ---
+        # Explicit user and password, DET_USER (matches explicit user), DET_PASS, and DET_TOKEN set.
+        Login("y", "y", "y", "y", "y", "y", CheckCache, UseCache),
+        Login("y", "y", "y", "y", "y", "x", CheckExpired, UseEnv),
+        Login("y", "y", "y", "y", "y", "n", UseEnv),
+        # Explicit user but no password, DET_USER and DET_PASS set, and DET_USER_TOKEN unset.
+        # DET_PASS still ignored since DET_USER/DET_PASS are meant to be processed as a unit, and
+        # an explicitly-requested username overrides that unit.
+        Login("y", "n", "y", "y", "n", "y", CheckCache, UseCache),
+        Login("y", "n", "y", "y", "n", "n", DoLogin("user", "prompt_pass"), UseNew),
+        Login("y", "n", "y", "y", "n", "x", CheckExpired, DoLogin("user", "prompt_pass"), UseNew),
+        # ---
+        # Explicit user but no password, DET_USER set but no other env.  DET_USER is ignored.
+        Login("y", "n", "y", "n", "n", "y", CheckCache, UseCache),
+        Login("y", "n", "y", "n", "n", "n", DoLogin("user", "prompt_pass"), UseNew),
+        Login("y", "n", "y", "n", "n", "x", CheckExpired, DoLogin("user", "prompt_pass"), UseNew),
+        # ---
+        # DET_USER_TOKEN is overridden by a configured cache (the on-cluster `det user login` case).
+        Login("*", "*", "y", "*", "y", "y", CheckCache, UseCache),
+        # DET_USER_TOKEN can be used if user is explicit, so long as DET_USER matches explicit user.
+        Login("y", "*", "y", "*", "y", "n", UseEnv),
+        # No explicit user; token in env is used if cache is missing or invalid.
+        Login("n", "*", "y", "*", "y", "n", UseEnv),
+        Login("n", "*", "y", "*", "y", "x", CheckExpired, Use("user", "env_token")),
+        # No explicit user; token in env is overridden by a configured cache.
+        # (the on-cluster `det user login` case).
+        Login("n", "*", "y", "*", "y", "y", CheckCache, Use("user", "cache")),
+        Login("n", "*", "e", "n", "y", "y", CheckCache, Use("user", "cache")),
+        Login("n", "*", "e", "y", "y", "y", CheckCache, Use("extra", "cache")),
+        # ---
+        # Nothing explicit; DET_USER and DET_PASS are set, DET_USER_TOKEN is unset.
+        # Cache continues to work where it matches DET_USER, and there are no password prompts.
+        Login("n", "*", "y", "y", "n", "y", CheckCache, UseCache),
+        Login("n", "*", "y", "y", "n", "n", DoLogin("user", "env_pass"), UseNew),
+        Login("n", "*", "y", "y", "n", "x", CheckExpired, DoLogin("user", "env_pass"), UseNew),
+        # ---
+        # Nothing explicit; and DET_USER is ignored without either DET_PASS or DET_USER_TOKEN.
+        Login("n", "n", "*", "n", "n", "n", DoLogin("determined", ""), UseNewDetermined),
+        # the username is taken from the cache but password must be provided again
+        Login("n", "n", "*", "n", "n", "x", CheckExpired, DoLogin("user", "prompt_pass"), UseNew),
+        Login("n", "n", "*", "n", "n", "y", CheckCache, UseCache),
+        # ---
+        # If password is explicit but username is not, we fall back to the default username.
+        Login("n", "y", "n", "n", "n", "n", DoLogin("determined", "req_pass"), UseNewDetermined),
+        # Other pass-but-not-user cases are governed by other effects (see several earlier cases).
+        Login("n", "y", "yn", "*", "*", "y", CheckCache, UseCache),
+    ],
+)
+@mock.patch("determined.common.api.authentication._is_token_valid")
+@mock.patch("determined.common.api.authentication.do_login")
+@mock.patch("getpass.getpass")
+def test_login_scenarios(
+    mock_getpass: mock.MagicMock,
+    mock_do_login: mock.MagicMock,
+    mock_is_token_valid: mock.MagicMock,
+    scenario_set: Login,
 ) -> None:
-    with use_test_config_dir() as config_dir, set_container_env_vars():
-        if has_token_store:
-            auth_json_path = config_dir / "auth.json"
-            with open(auth_json_path, "w") as f:
-                json.dump(AUTH_JSON, f)
+    def getpass(*_: Any) -> str:
+        return "prompt_pass"
 
-        requests_mock.get("/api/v1/me", status_code=200, json={"username": "alice"})
+    def _is_token_valid(master_url: str, token: str, cert: Any) -> bool:
+        return token in ["cache", "env_token"]
 
-        if has_token_store:
-            nop_password = "user_password"
-            authentication = Authentication(MOCK_MASTER_URL, user, nop_password)
-            assert authentication.session.username == user or "determined"
-            assert authentication.session.token == (
-                "det.token" if user == "determined" else "bob.token"
+    def do_login(*_: Any) -> str:
+        return "new"
+
+    mock_getpass.side_effect = getpass
+    mock_is_token_valid.side_effect = _is_token_valid
+    mock_do_login.side_effect = do_login
+
+    for scenario in scenario_set.scenarios():
+        with contextlib.ExitStack() as es:
+            # Configure environment.
+            es.enter_context(util.setenv_optional("DET_MASTER", MOCK_MASTER_URL))
+            es.enter_context(util.setenv_optional("DET_USER", scenario.env_user))
+            es.enter_context(util.setenv_optional("DET_PASS", scenario.env_pass))
+            es.enter_context(util.setenv_optional("DET_USER_TOKEN", scenario.env_token))
+
+            # Configure allowable TokenStore calls.
+            mts = es.enter_context(util.MockTokenStore(strict=False))
+            mts.get_token("user", retval=scenario.cache)
+            mts.get_token("extra", retval=scenario.cache)
+            mts.get_token("determined", retval=scenario.cache)
+            mts.drop_user("user")
+            mts.drop_user("extra")
+            mts.set_token("user", "new")
+            mts.set_token("determined", "new")
+
+            # The cache active user is always "user".  This deserves some explanation.  Effectively,
+            # since this is only called within the `default_load_user_password()` function, that
+            # function will never show evidence that it checked the environment.  However, for the
+            # remainder of the authentication flow, it never matters again that the user came from
+            # the TokenStore.get_active_user(), so if we modeled that in the table it wouldn't
+            # actually increase code coverage for the Authentication object, which is what we are
+            # focusing on.
+            mts.get_active_user(retval=scenario.cache and "user")
+
+            try:
+                auth = authentication.Authentication(
+                    "master_url", scenario.req_user, scenario.req_pass, None
+                )
+
+                # Make sure we got the results we expected.
+                for exp in scenario_set.expected:
+                    if isinstance(exp, Check):
+                        mock_is_token_valid.assert_has_calls(
+                            [mock.call("master_url", exp.token, None)]
+                        )
+                    elif isinstance(exp, DoLogin):
+                        mock_do_login.assert_has_calls(
+                            [mock.call("master_url", exp.username, exp.password, None)]
+                        )
+                    elif isinstance(exp, Use):
+                        assert auth.session.username == exp.user
+                        assert auth.session.token == exp.token
+                    else:
+                        raise ValueError(f"unexpected result: {exp}")
+
+                # Make sure we didn't get any unexpected results.
+                if not any(isinstance(exp, Check) for exp in scenario_set.expected):
+                    mock_is_token_valid.assert_not_called()
+                if not any(isinstance(exp, DoLogin) for exp in scenario_set.expected):
+                    mock_do_login.assert_not_called()
+
+            except Exception as e:
+                raise RuntimeError(
+                    f"failed scenario_set: {scenario_set}, scenario={scenario}"
+                ) from e
+
+
+class GetToken:
+    """A possible result in a Logout scenario."""
+
+    def __init__(self, user: str) -> None:
+        self.user = user
+
+    def expect(self, rsps: responses.RequestsMock, mts: util.MockTokenStore, scenario: Any) -> None:
+        mts.get_token(self.user, retval="cache_token" if scenario.user_in_cache else None)
+
+
+class DoLogout:
+    """A possible result in a Logout scenario."""
+
+    def __init__(self, user: str) -> None:
+        self.user = user
+
+    def expect(self, rsps: responses.RequestsMock, mts: util.MockTokenStore, scenario: Any) -> None:
+        mts.drop_user(self.user)
+        rsps.post(
+            f"{MOCK_MASTER_URL}/api/v1/auth/logout",
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer cache_token"})],
+        )
+
+
+class GetActiveUser:
+    """A possible result in a Logout scenario."""
+
+    def expect(self, rsps: responses.RequestsMock, mts: util.MockTokenStore, scenario: Any) -> None:
+        mts.get_active_user(retval="cache_user" if scenario.user_in_cache else None)
+
+
+class Logout(ScenarioSet):
+    user_explicit = {"y": "req_user", "n": None}
+    user_in_env = {"y": "env_user", "n": None}
+    user_in_cache = {"y": "cache_user", "n": None}
+
+
+@pytest.mark.parametrize(
+    "scenario_set",
+    [
+        # Explicit user is logged out if present in the cache.
+        #       user_explicit
+        #       |    user_in_env
+        #       |    |    user_in_cache
+        #       |    |    |
+        Logout("y", "*", "y", GetToken("req_user"), DoLogout("req_user")),
+        Logout("y", "*", "n", GetToken("req_user")),
+        # Environment user is logged out if present in the cache.
+        Logout("n", "y", "y", GetToken("env_user"), DoLogout("env_user")),
+        Logout("n", "y", "n", GetToken("env_user")),
+        # Cache active user is logged out.
+        Logout("n", "n", "y", GetActiveUser(), GetToken("cache_user"), DoLogout("cache_user")),
+        # When no user is found, it is a noop.
+        Logout("n", "n", "n", GetActiveUser()),
+    ],
+)
+def test_logout(scenario_set: Logout) -> None:
+    for scenario in scenario_set.scenarios():
+        with contextlib.ExitStack() as es:
+            rsps = es.enter_context(
+                responses.RequestsMock(
+                    registry=registries.OrderedRegistry,
+                    assert_all_requests_are_fired=True,
+                )
             )
-        else:
-            authentication = Authentication(MOCK_MASTER_URL)
-            assert authentication.session.username == "alice"
-            assert authentication.session.token == "alice.token"
+            mts = es.enter_context(util.MockTokenStore(strict=True))
+
+            # Configure evironment variables.
+            es.enter_context(util.setenv_optional("DET_MASTER", MOCK_MASTER_URL))
+            es.enter_context(util.setenv_optional("DET_USER", scenario.user_in_env))
+            env_pass = "env_pass" if scenario.user_in_env else None
+            es.enter_context(util.setenv_optional("DET_PASS", env_pass))
+
+            util.expect_get_info(rsps)
+
+            for exp in scenario_set.expected:
+                exp.expect(rsps, mts, scenario)
+
+            # Actually call the cli.
+            if scenario.user_explicit:
+                cmd = ["-u", "req_user", "user", "logout"]
+            else:
+                cmd = ["user", "logout"]
+            cli.main(cmd)
 
 
 def test_auth_json_v0_upgrade() -> None:
     with use_test_config_dir() as config_dir:
         auth_json_path = config_dir / "auth.json"
         shutil.copy2(AUTH_V0_PATH, auth_json_path)
-        ts = TokenStore(MOCK_MASTER_URL, auth_json_path)
+        ts = authentication.TokenStore(MOCK_MASTER_URL, auth_json_path)
 
         assert ts.get_active_user() == "determined"
         assert ts.get_token("determined") == "v2.public.this.is.a.test"
 
         ts.set_token("determined", "ai")
 
-        ts2 = TokenStore(MOCK_MASTER_URL, auth_json_path)
+        ts2 = authentication.TokenStore(MOCK_MASTER_URL, auth_json_path)
         assert ts2.get_token("determined") == "ai"
 
         with auth_json_path.open() as fin:
@@ -112,7 +449,7 @@ def test_cert_v0_upgrade() -> None:
         with cert_path.open() as fin:
             cert_data = fin.read()
 
-        cert = certs_default_load(MOCK_MASTER_URL)
+        cert = certs.default_load(MOCK_MASTER_URL)
         assert isinstance(cert.bundle, str)
         with open(cert.bundle) as fin:
             loaded_cert_data = fin.read()
@@ -123,7 +460,7 @@ def test_cert_v0_upgrade() -> None:
         assert v1_certs_path.exists()
 
         # Load once again from v1.
-        cert2 = certs_default_load(MOCK_MASTER_URL)
+        cert2 = certs.default_load(MOCK_MASTER_URL)
         assert isinstance(cert2.bundle, str)
         with open(cert2.bundle) as fin:
             loaded_cert_data = fin.read()

--- a/harness/tests/cli/test_user.py
+++ b/harness/tests/cli/test_user.py
@@ -1,0 +1,49 @@
+from unittest import mock
+
+from responses import matchers
+
+from determined.cli import cli
+from determined.common import api
+from determined.common.api import bindings
+from tests.cli import util
+
+
+@mock.patch("getpass.getpass")
+def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
+    mock_getpass.side_effect = lambda *_: "newpass"
+    with util.standard_cli_rsps() as rsps:
+        userobj = bindings.v1User(active=True, admin=False, username="det-user", id=101)
+        rsps.get(
+            "http://localhost:8080/api/v1/users/tgt-user/by-username",
+            status=200,
+            json={"user": userobj.to_json()},
+        )
+
+        patchobj = bindings.v1PatchUser(isHashed=True, password=api.salt_and_hash("newpass"))
+        rsps.patch(
+            "http://localhost:8080/api/v1/users/101",
+            status=200,
+            match=[
+                matchers.json_params_matcher(patchobj.to_json(True)),
+            ],
+            json={"user": userobj.to_json()},
+        )
+
+        cli.main(["user", "change-password", "tgt-user"])
+
+
+@mock.patch("determined.cli.cli.die")
+def test_user_edit_no_fields(mock_die: mock.MagicMock) -> None:
+    with util.standard_cli_rsps() as rsps:
+        userobj = bindings.v1User(active=True, admin=False, username="det-user", id=101)
+        rsps.get(
+            "http://localhost:8080/api/v1/users/det-user/by-username",
+            status=200,
+            json={"user": userobj.to_json()},
+        )
+
+        # No edited field should result in error
+        cli.main(["user", "edit", "det-user"])
+        mock_die.assert_has_calls(
+            [mock.call("No field provided. Use 'det user edit -h' for usage.", exit_code=1)]
+        )

--- a/harness/tests/cli/util.py
+++ b/harness/tests/cli/util.py
@@ -1,0 +1,142 @@
+import contextlib
+import os
+from typing import Any, Iterator, List, Optional, cast
+
+import responses
+from responses import registries
+
+import determined as det
+from determined.common.api import authentication
+
+
+@contextlib.contextmanager
+def setenv_optional(key: str, val: Optional[str]) -> Iterator:
+    old = os.environ.get(key)
+    if val is None:
+        os.environ.pop(key, None)
+    else:
+        os.environ[key] = val
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = old
+
+
+class MockTokenStore:
+    def __init__(self, strict: bool) -> None:
+        self._mock = MockTokenStoreInstance(self)
+        self._strict = strict
+
+    def __call__(self, *_: Any) -> "MockTokenStoreInstance":
+        # For when somebody calls authentication.TokenStore().
+        return self._mock
+
+    def __enter__(self) -> "MockTokenStore":
+        self._exp_calls: List[Any] = []
+        self._retvals: List[Any] = []
+        self._ncalls = 0
+        self._real = authentication.TokenStore
+        authentication.TokenStore = self  # type: ignore
+        return self
+
+    def __exit__(self, exc_type: Any, *_: Any) -> None:
+        authentication.TokenStore = self._real  # type: ignore
+        if exc_type is not None:
+            return
+        if not self._strict:
+            return
+        if self._ncalls == len(self._exp_calls):
+            return
+        raise ValueError(f"missing expected calls: {self._exp_calls[self._ncalls:]}")
+
+    def _match_call(self, call: Any) -> Any:
+        if self._strict:
+            if self._ncalls == len(self._exp_calls):
+                raise ValueError(f"unexpected call to TokenStore: {call}")
+            assert self._exp_calls[self._ncalls] == call
+            retval = self._retvals[self._ncalls]
+            self._ncalls += 1
+            return retval
+        else:
+            try:
+                idx = self._exp_calls.index(call)
+            except ValueError:
+                raise ValueError(f"call to TokenStore has no match: {call}")
+            return self._retvals[idx]
+
+    def get_active_user(self, *, retval: Optional[str]) -> None:
+        self._exp_calls.append("get_active_user")
+        self._retvals.append(retval)
+
+    def get_all_users(self, *, retval: List[str]) -> None:
+        self._exp_calls.append("get_all_users")
+        self._retvals.append(retval)
+
+    def get_token(self, user: str, *, retval: Optional[str]) -> None:
+        self._exp_calls.append(("get_token", user))
+        self._retvals.append(retval)
+
+    def drop_user(self, username: str) -> None:
+        self._exp_calls.append(("drop_user", username))
+        self._retvals.append(None)
+
+    def set_token(self, username: str, token: str) -> None:
+        self._exp_calls.append(("set_token", username, token))
+        self._retvals.append(None)
+
+    def set_active(self, username: str) -> None:
+        self._exp_calls.append(("set_active", username))
+        self._retvals.append(None)
+
+
+class MockTokenStoreInstance:
+    def __init__(self, mts: MockTokenStore) -> None:
+        self._mts = mts
+
+    def get_active_user(self) -> Optional[str]:
+        return cast(Optional[str], self._mts._match_call("get_active_user"))
+
+    def get_all_users(self) -> Optional[str]:
+        return cast(Optional[str], self._mts._match_call("get_all_users"))
+
+    def get_token(self, user: str) -> Optional[str]:
+        return cast(Optional[str], self._mts._match_call(("get_token", user)))
+
+    def drop_user(self, username: str) -> None:
+        self._mts._match_call(("drop_user", username))
+
+    def set_token(self, username: str, token: str) -> None:
+        self._mts._match_call(("set_token", username, token))
+
+    def set_active(self, username: str) -> None:
+        self._mts._match_call(("set_active", username))
+
+
+@contextlib.contextmanager
+def standard_cli_rsps() -> Iterator[responses.RequestsMock]:
+    with contextlib.ExitStack() as es:
+        es.enter_context(setenv_optional("DET_USER", "det-user"))
+        es.enter_context(setenv_optional("DET_USER_TOKEN", "det-token"))
+        mts = es.enter_context(MockTokenStore(strict=False))
+        mts.get_active_user(retval="det-user")
+        mts.get_token("det-user", retval="det-token")
+        rsps = es.enter_context(
+            responses.RequestsMock(
+                registry=registries.OrderedRegistry, assert_all_requests_are_fired=True
+            )
+        )
+        expect_get_info(rsps)
+        rsps.get("http://localhost:8080/api/v1/me", status=200)
+        yield rsps
+
+
+def expect_get_info(
+    rsps: Optional[responses.RequestsMock] = None, master_url: str = "http://localhost:8080"
+) -> None:
+    if rsps:
+        rsps.get(f"{master_url}/info", status=200, json={"version": det.__version__})
+    else:
+        responses.get(f"{master_url}/info", status=200, json={"version": det.__version__})

--- a/harness/tests/requirements/requirements-cli.txt
+++ b/harness/tests/requirements/requirements-cli.txt
@@ -1,4 +1,6 @@
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 mypy==0.910
+# responses 0.23.2 requires urllib3>=2, which breaks several other dependencies
+responses!=0.23.2
 requests_mock


### PR DESCRIPTION
The unit test replaces two e2e tests, and then provides even more test
coverage beyond those.

The intention of this test is more "clearly document the current
behavior" rather than "enforce the current behavior forever".

There are decisions we've made, especially regarding the default login
credentials, that feel suspect to me.  I hope this test is useful for
highlighting the effects of changing any of those decisions, so we can
make those changes in an educated way.  I do not intend for this test
to force us to keep the exact implementation we have forever.