### PR TITLE
 fix: wrong skip experiment config regex for log policies 

### DIFF
--- a/docs/release-notes/fix-log-policies-match-itself.rst
+++ b/docs/release-notes/fix-log-policies-match-itself.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+- Fix an issue where ``log_policies`` would be compared against the trial log printing experiment config which could often cause patterns like ``(.*) match (.*)`` to incorrectly always match.

--- a/e2e_tests/tests/cluster/test_log_policies.py
+++ b/e2e_tests/tests/cluster/test_log_policies.py
@@ -14,7 +14,7 @@ from tests import experiment as exp
 def test_log_policy_cancel_retries(should_match: bool) -> None:
     regex = r"assert 0 <= self\.metrics_sigma"
     if not should_match:
-        regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"
+        regex = r"(.*) this should not match (.*)"
 
     config = conf.load_config(conf.fixtures_path("no_op/single-medium-train-step.yaml"))
     config["log_policies"] = [

--- a/master/internal/logpattern/logpattern.go
+++ b/master/internal/logpattern/logpattern.go
@@ -19,7 +19,7 @@ const regexCacheSize = 256
 
 var (
 	defaultSingleton       *LogPatternPolicies
-	expconfigCompiledRegex = regexp.MustCompile("(.*)(\\\"log_pattern_policies\\\":)(.*)")
+	expconfigCompiledRegex = regexp.MustCompile("(.*)(\\\"log_policies\\\":)(.*)")
 )
 
 // LogPatternPolicies performs log pattern checks.


### PR DESCRIPTION
## Description

Fix an issue where ```log_policies``` matched the experiment config line printed in trial logs. We had a check for this but the regex was based off an old version of the config.

## Test Plan

e2e test covers this



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
