### PR TITLE
fix: Overwrite omnibar antd modal with Hew standard modal [WEB-1830]

### DIFF
--- a/webui/react/src/components/HelpModal.tsx
+++ b/webui/react/src/components/HelpModal.tsx
@@ -1,0 +1,36 @@
+import { Modal } from 'hew/Modal';
+
+import root from 'omnibar/tree-extension/trees';
+import { dfsStaticRoutes } from 'omnibar/tree-extension/utils';
+
+const HelpModalComponent: React.FC = () => {
+  const commands = dfsStaticRoutes([], [], root)
+    .map((path) => path.reduce((acc, cur) => `${acc} ${cur.title}`, ''))
+    .map((addr) => addr.replace('root ', ''))
+    .sort();
+
+  const keymap = [
+    '"Enter" to select and auto complete an option.',
+    '"Tab", "Up", or "Down" arrow keys to cycle through suggestions.',
+    '"Escape" to close the bar.',
+  ];
+
+  return (
+    <Modal title="Help">
+      <p>Keyboard shortcuts:</p>
+      <ul>
+        {keymap.map((el, idx) => (
+          <li key={idx}>{el}</li>
+        ))}
+      </ul>
+      <p>Available commands:</p>
+      <ul>
+        {commands.map((el, idx) => (
+          <li key={idx}>{el}</li>
+        ))}
+      </ul>
+    </Modal>
+  );
+};
+
+export default HelpModalComponent;

--- a/webui/react/src/components/HelpModal.tsx
+++ b/webui/react/src/components/HelpModal.tsx
@@ -1,4 +1,5 @@
 import { Modal } from 'hew/Modal';
+import React from 'react';
 
 import root from 'omnibar/tree-extension/trees';
 import { dfsStaticRoutes } from 'omnibar/tree-extension/utils';

--- a/webui/react/src/omnibar/Omnibar.tsx
+++ b/webui/react/src/omnibar/Omnibar.tsx
@@ -1,8 +1,9 @@
 import { matchesShortcut } from 'hew/InputShortcut';
-import { Modal, useModal } from 'hew/Modal';
+import { useModal } from 'hew/Modal';
 import OmnibarNpm from 'omnibar';
 import React, { useCallback, useEffect, useState } from 'react';
 
+import HelpModalComponent from 'components/HelpModal';
 import shortCutSettingsConfig, {
   Settings as ShortcutSettings,
 } from 'components/UserSettings.settings';
@@ -10,7 +11,6 @@ import { KeyCode, keyEmitter, KeyEvent } from 'hooks/useKeyTracker';
 import { useSettings } from 'hooks/useSettings';
 import * as Tree from 'omnibar/tree-extension/index';
 import TreeNode from 'omnibar/tree-extension/TreeNode';
-import { helpContent } from 'omnibar/tree-extension/trees/actions';
 import { BaseNode } from 'omnibar/tree-extension/types';
 import { isTreeNode } from 'omnibar/tree-extension/utils';
 import handleError from 'utils/error';
@@ -31,8 +31,6 @@ const Omnibar: React.FC = () => {
     settings: { omnibar: omnibarShortcut },
   } = useSettings<ShortcutSettings>(shortCutSettingsConfig);
 
-  const HelpModal = useModal(() => <Modal title="Help">{helpContent()}</Modal>);
-
   useEffect(() => {
     const keyDownListener = (e: KeyboardEvent) => {
       if (matchesShortcut(e, omnibarShortcut)) {
@@ -52,6 +50,8 @@ const Omnibar: React.FC = () => {
   const hideBar = useCallback(() => {
     setShowing(false);
   }, []);
+
+  const HelpModal = useModal(HelpModalComponent);
 
   const onAction = useCallback(
     async (item: unknown, query: (inputEl: string) => void) => {

--- a/webui/react/src/omnibar/Omnibar.tsx
+++ b/webui/react/src/omnibar/Omnibar.tsx
@@ -1,4 +1,5 @@
 import { matchesShortcut } from 'hew/InputShortcut';
+import { Modal, useModal } from 'hew/Modal';
 import OmnibarNpm from 'omnibar';
 import React, { useCallback, useEffect, useState } from 'react';
 
@@ -9,6 +10,7 @@ import { KeyCode, keyEmitter, KeyEvent } from 'hooks/useKeyTracker';
 import { useSettings } from 'hooks/useSettings';
 import * as Tree from 'omnibar/tree-extension/index';
 import TreeNode from 'omnibar/tree-extension/TreeNode';
+import { helpContent } from 'omnibar/tree-extension/trees/actions';
 import { BaseNode } from 'omnibar/tree-extension/types';
 import { isTreeNode } from 'omnibar/tree-extension/utils';
 import handleError from 'utils/error';
@@ -28,6 +30,8 @@ const Omnibar: React.FC = () => {
   const {
     settings: { omnibar: omnibarShortcut },
   } = useSettings<ShortcutSettings>(shortCutSettingsConfig);
+
+  const HelpModal = useModal(() => <Modal title="Help">{helpContent()}</Modal>);
 
   useEffect(() => {
     const keyDownListener = (e: KeyboardEvent) => {
@@ -56,6 +60,10 @@ const Omnibar: React.FC = () => {
       if (!input) return;
       if (isTreeNode(item)) {
         try {
+          if (item.title === 'help') {
+            HelpModal.open();
+            return;
+          }
           await Tree.onAction(input, item, query);
           if (item.closeBar) {
             hideBar();
@@ -65,7 +73,7 @@ const Omnibar: React.FC = () => {
         }
       }
     },
-    [hideBar],
+    [hideBar, HelpModal],
   );
 
   useEffect(() => {
@@ -79,19 +87,22 @@ const Omnibar: React.FC = () => {
   }, [showing]);
 
   return (
-    <div className={css.base} style={{ display: showing ? 'unset' : 'none' }}>
-      <div className={css.backdrop} onClick={hideBar} />
-      <div className={css.bar} id="omnibar">
-        <OmnibarNpm<BaseNode>
-          autoFocus={true}
-          extensions={[Tree.extension]}
-          maxResults={7}
-          placeholder='Type a command or "help" for more info.'
-          render={TreeNode}
-          onAction={onAction}
-        />
+    <>
+      <div className={css.base} style={{ display: showing ? 'unset' : 'none' }}>
+        <div className={css.backdrop} onClick={hideBar} />
+        <div className={css.bar} id="omnibar">
+          <OmnibarNpm<BaseNode>
+            autoFocus={true}
+            extensions={[Tree.extension]}
+            maxResults={7}
+            placeholder='Type a command or "help" for more info.'
+            render={TreeNode}
+            onAction={onAction}
+          />
+        </div>
       </div>
-    </div>
+      <HelpModal.Component />
+    </>
   );
 };
 

--- a/webui/react/src/omnibar/tree-extension/trees/actions.tsx
+++ b/webui/react/src/omnibar/tree-extension/trees/actions.tsx
@@ -1,9 +1,6 @@
 import { makeToast } from 'hew/Toast';
-import { ReactElement } from 'react';
 
-import root from 'omnibar/tree-extension/trees';
 import { FinalAction } from 'omnibar/tree-extension/types';
-import { dfsStaticRoutes } from 'omnibar/tree-extension/utils';
 import { routeToReactUrl } from 'utils/routes';
 /** generates a handler that alerts when called */
 export const alertAction =
@@ -14,32 +11,3 @@ export const alertAction =
 export const visitAction = (url: string) => (): void => routeToReactUrl(url);
 export const noOp = (): void => undefined;
 export const parseIds = (input: string): number[] => input.split(',').map((i) => parseInt(i));
-
-export const helpContent = (): ReactElement => {
-  const commands = dfsStaticRoutes([], [], root)
-    .map((path) => path.reduce((acc, cur) => `${acc} ${cur.title}`, ''))
-    .map((addr) => addr.replace('root ', ''))
-    .sort();
-
-  const keymap = [
-    '"Enter" to select and auto complete an option.',
-    '"Tab", "Up", or "Down" arrow keys to cycle through suggestions.',
-    '"Escape" to close the bar.',
-  ];
-  return (
-    <>
-      <p>Keyboard shortcuts:</p>
-      <ul>
-        {keymap.map((el, idx) => (
-          <li key={idx}>{el}</li>
-        ))}
-      </ul>
-      <p>Available commands:</p>
-      <ul>
-        {commands.map((el, idx) => (
-          <li key={idx}>{el}</li>
-        ))}
-      </ul>
-    </>
-  );
-};

--- a/webui/react/src/omnibar/tree-extension/trees/actions.tsx
+++ b/webui/react/src/omnibar/tree-extension/trees/actions.tsx
@@ -1,5 +1,5 @@
-import { Modal as AntdModal } from 'antd';
 import { makeToast } from 'hew/Toast';
+import { ReactElement } from 'react';
 
 import root from 'omnibar/tree-extension/trees';
 import { FinalAction } from 'omnibar/tree-extension/types';
@@ -15,7 +15,7 @@ export const visitAction = (url: string) => (): void => routeToReactUrl(url);
 export const noOp = (): void => undefined;
 export const parseIds = (input: string): number[] => input.split(',').map((i) => parseInt(i));
 
-export const displayHelp = (): void => {
+export const helpContent = (): ReactElement => {
   const commands = dfsStaticRoutes([], [], root)
     .map((path) => path.reduce((acc, cur) => `${acc} ${cur.title}`, ''))
     .map((addr) => addr.replace('root ', ''))
@@ -26,29 +26,20 @@ export const displayHelp = (): void => {
     '"Tab", "Up", or "Down" arrow keys to cycle through suggestions.',
     '"Escape" to close the bar.',
   ];
-  /**
-   * TODO: look into converting into UI Kit Modal.
-   * Currently `displayHelp` doesn't seem to run inside React,
-   * hence will not have access to ModalContext.
-   */
-  AntdModal.info({
-    content: (
-      <>
-        <p>Keyboard shortcuts:</p>
-        <ul>
-          {keymap.map((el, idx) => (
-            <li key={idx}>{el}</li>
-          ))}
-        </ul>
-        <p>Available commands:</p>
-        <ul>
-          {commands.map((el, idx) => (
-            <li key={idx}>{el}</li>
-          ))}
-        </ul>
-      </>
-    ),
-    style: { minWidth: '700px' },
-    title: 'Help',
-  });
+  return (
+    <>
+      <p>Keyboard shortcuts:</p>
+      <ul>
+        {keymap.map((el, idx) => (
+          <li key={idx}>{el}</li>
+        ))}
+      </ul>
+      <p>Available commands:</p>
+      <ul>
+        {commands.map((el, idx) => (
+          <li key={idx}>{el}</li>
+        ))}
+      </ul>
+    </>
+  );
 };

--- a/webui/react/src/omnibar/tree-extension/trees/index.ts
+++ b/webui/react/src/omnibar/tree-extension/trees/index.ts
@@ -1,5 +1,5 @@
 import { activeRunStates, terminalCommandStates, terminalRunStatesKeys } from 'constants/states';
-import { displayHelp, parseIds, visitAction } from 'omnibar/tree-extension/trees/actions';
+import { parseIds, visitAction } from 'omnibar/tree-extension/trees/actions';
 import dev from 'omnibar/tree-extension/trees/dev';
 import locations from 'omnibar/tree-extension/trees/goto';
 import { Children, LeafNode, NonLeafNode } from 'omnibar/tree-extension/types';
@@ -187,7 +187,8 @@ const root: NonLeafNode = {
       title: 'dev',
     },
     {
-      onAction: displayHelp,
+      /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+      onAction: (): void => {},
       title: 'help',
     },
   ],


### PR DESCRIPTION
## Description

Replaces Omnibar response to `help` (opening an Antd Modal) with a Hew / UI Kit modal.

In #8432 I was unable to fix dark mode theming on this Antd Modal; it is also resolved here

## Test Plan

Put UI into Dark Mode
Ctrl/Control Space to open up the Omnibar
Type `help` and press enter
Confirm the new modal contains lists of shortcuts and commands:

<img width="1192" alt="Screen Shot 2023-11-27 at 11 29 42 AM" src="https://github.com/determined-ai/determined/assets/643918/4735446b-cec5-4a55-916e-1f06b0dace46">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.