### PR TITLE
chore: migrate detaileduser and experimentitem types to io-ts

### DIFF
--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -8,7 +8,6 @@ import {
   HyperparameterType,
   LogLevel,
   RunState,
-  ValueOf,
 } from 'types';
 import { DetError, ErrorLevel, ErrorType } from 'utils/error';
 
@@ -34,19 +33,6 @@ export const optional = (x: io.Mixed): io.Mixed | io.NullC | io.UndefinedC => {
 export const nullable = (x: io.Mixed): io.Mixed | io.NullC => {
   return io.union([x, io.null]);
 };
-
-export class ValueofType<D extends { [key: string]: unknown }> extends io.Type<ValueOf<D>> {
-  readonly _tag: 'ValueofType' = 'ValueofType' as const;
-  constructor(
-    name: string,
-    is: ValueofType<D>['is'],
-    validate: ValueofType<D>['validate'],
-    encode: ValueofType<D>['encode'],
-    readonly values: D,
-  ) {
-    super(name, is, validate, encode);
-  }
-}
 
 class Float extends io.Type<number, number | string, unknown> {
   readonly _tag: 'FloatType' = 'FloatType' as const;
@@ -84,26 +70,6 @@ class Float extends io.Type<number, number | string, unknown> {
 }
 
 export const float = new Float();
-
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ValueofC<D extends { [key: string]: unknown }> extends ValueofType<D> {}
-
-export function valueof<D extends { [key: string]: unknown }>(
-  values: D,
-  name: string = Object.values(values)
-    .map((k) => JSON.stringify(k))
-    .join(' | '),
-): ValueofC<D> {
-  const valueSet = new Set(Object.values(values));
-  const is = (u: unknown): u is ValueOf<D> => valueSet.has(u);
-  return new ValueofType(
-    name,
-    is,
-    (u, c) => (is(u) ? io.success(u) : io.failure(u, c)),
-    io.identity,
-    values,
-  );
-}
 
 /* Slot */
 

--- a/webui/react/src/pages/F_ExpList/glide-table/OptionsMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/OptionsMenu.tsx
@@ -5,7 +5,7 @@ import Toggle from 'hew/Toggle';
 import { TypeOf } from 'io-ts';
 import { useMemo } from 'react';
 
-import { valueof } from 'ioTypes';
+import { valueof } from 'utils/valueof';
 
 import { TableViewMode } from './GlideTable';
 import css from './OptionsMenu.module.scss';

--- a/webui/react/src/stores/experiments.tsx
+++ b/webui/react/src/stores/experiments.tsx
@@ -2,147 +2,14 @@ import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import { Map } from 'immutable';
 import * as t from 'io-ts';
 
-import { valueof } from 'ioTypes';
 import { getExperiments } from 'services/api';
-import { Jobv1State } from 'services/api-ts-sdk';
 import { GetExperimentsParams } from 'services/types';
-import {
-  CheckpointStorageType,
-  ExperimentItem,
-  ExperimentPagination,
-  ExperimentSearcherName,
-  HyperparameterBase,
-  Hyperparameters,
-  HyperparameterType,
-  JsonObject,
-  RunState,
-} from 'types';
+import { ExperimentItem, ExperimentPagination } from 'types';
 import asValueObject, { ValueObjectOf } from 'utils/asValueObject';
 import { immutableObservable, Observable } from 'utils/observable';
 import { encodeParams } from 'utils/store';
 
 import PollingStore from './polling';
-
-const primitivesCodec = t.union([t.boolean, t.number, t.string]);
-const searcherCodec = t.intersection([
-  t.partial({
-    max_length: t.record(
-      t.union([t.literal('batches'), t.literal('records'), t.literal('epochs')]),
-      t.number,
-    ),
-    max_trials: t.number,
-    sourceTrialId: t.number,
-  }),
-  t.type({
-    metric: t.string,
-    name: valueof(ExperimentSearcherName),
-    smallerIsBetter: t.boolean,
-  }),
-]);
-const hyperparametersTypeCodec = valueof(HyperparameterType);
-const hyperparametersCodec: t.Type<Hyperparameters> = t.recursion('Hyperparameters', () =>
-  t.record(t.string, t.union([hyperparametersCodec, hyperparameterBaseCodec])),
-);
-const hyperparameterBaseBaseCodec = t.recursion<HyperparameterBase>('HyperparametersBase', () =>
-  t.partial({
-    base: t.number,
-    count: t.number,
-    maxval: t.number,
-    minval: t.number,
-    vals: t.array(primitivesCodec),
-  }),
-);
-const hyperparameterBaseCodec = t.intersection([
-  hyperparameterBaseBaseCodec,
-  t.partial({
-    type: hyperparametersTypeCodec,
-    val: t.union([primitivesCodec, hyperparametersCodec]),
-  }),
-]);
-const hyperparameterCodec = t.intersection([
-  hyperparameterBaseBaseCodec,
-  t.partial({
-    val: primitivesCodec,
-  }),
-  t.type({
-    type: hyperparametersTypeCodec,
-  }),
-]);
-const checkpointStorageCodec = t.intersection([
-  t.partial({
-    bucket: t.string,
-    hostPath: t.string,
-    storagePath: t.string,
-    type: valueof(CheckpointStorageType),
-  }),
-  t.type({
-    saveExperimentBest: t.number,
-    saveTrialBest: t.number,
-    saveTrialLatest: t.number,
-  }),
-]);
-const experimentConfigCodec = t.intersection([
-  t.partial({
-    checkpointStorage: checkpointStorageCodec,
-    description: t.string,
-    labels: t.array(t.string),
-    profiling: t.type({
-      enabled: t.boolean,
-    }),
-  }),
-  t.type({
-    checkpointPolicy: t.string,
-    hyperparameters: hyperparametersCodec,
-    maxRestarts: t.number,
-    name: t.string,
-    resources: t.partial({
-      maxSlots: t.number,
-    }),
-    searcher: searcherCodec,
-  }),
-]);
-const jobSummaryCodec = t.type({
-  jobsAhead: t.number,
-  state: valueof(Jobv1State),
-});
-const experimentItemCodec = t.intersection([
-  t.partial({
-    checkpoints: t.number,
-    checkpointSize: t.number,
-    description: t.string,
-    duration: t.number,
-    endTime: t.string,
-    externalExperimentId: t.string,
-    externalTrialId: t.string,
-    forkedFrom: t.number,
-    jobSummary: jobSummaryCodec,
-    modelDefinitionSize: t.number,
-    notes: t.string,
-    progress: t.number,
-    projectName: t.string,
-    searcherMetricValue: t.number,
-    trialIds: t.array(t.number),
-    unmanaged: t.boolean,
-    workspaceName: t.string,
-  }),
-  t.type({
-    archived: t.boolean,
-    config: experimentConfigCodec,
-    configRaw: JsonObject,
-    hyperparameters: t.record(t.string, hyperparameterCodec),
-    id: t.number,
-    jobId: t.string,
-    labels: t.array(t.string),
-    name: t.string,
-    numTrials: t.number,
-    projectId: t.number,
-    resourcePool: t.string,
-    searcherType: t.string,
-    startTime: t.string,
-    state: t.union([valueof(RunState), valueof(Jobv1State)]),
-    userId: t.number,
-  }),
-]);
 
 const experimentCacheCodec = t.type({
   experimentIds: t.readonlyArray(t.number),
@@ -214,7 +81,7 @@ class ExperimentStore extends PollingStore {
   private updateExperimentMap(experimentItems: Readonly<ExperimentItem[]>) {
     this.#experimentMap.update((prev) =>
       prev.withMutations((map) => {
-        for (const exp of experimentItems) map.set(exp.id, asValueObject(experimentItemCodec, exp));
+        for (const exp of experimentItems) map.set(exp.id, asValueObject(ExperimentItem, exp));
       }),
     );
   }

--- a/webui/react/src/stores/users.tsx
+++ b/webui/react/src/stores/users.tsx
@@ -1,6 +1,5 @@
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import { Map } from 'immutable';
-import * as t from 'io-ts';
 import { Observable } from 'micro-observables';
 
 import { getCurrentUser, getUsers, patchUser } from 'services/api';
@@ -18,33 +17,7 @@ function compareUser(a: DetailedUser, b: DetailedUser): number {
   return aName.localeCompare(bName);
 }
 
-const asValueOfUser = asValueObjectFactory(
-  t.intersection(
-    [
-      t.partial({
-        agentUserGroup: t.partial(
-          {
-            agentGid: t.number,
-            agentGroup: t.string,
-            agentUid: t.number,
-            agentUser: t.string,
-          },
-          'AgentUserGroup',
-        ),
-        displayName: t.string,
-        lastAuthAt: t.number,
-        modifiedAt: t.number,
-      }),
-      t.type({
-        id: t.number,
-        isActive: t.boolean,
-        isAdmin: t.boolean,
-        username: t.string,
-      }),
-    ],
-    'DetailedUser',
-  ),
-);
+const asValueOfUser = asValueObjectFactory(DetailedUser);
 
 class UserStore extends PollingStore {
   // TODO: investigate replacing userIds + usersById with OrderedMap

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -350,34 +350,26 @@ export const HyperparameterType = {
   Log: 'log',
 } as const;
 
-export type HyperparameterType = ValueOf<typeof HyperparameterType>;
-
 const HyperparametersType = valueof(HyperparameterType);
+export type HyperparameterType = t.TypeOf<typeof HyperparametersType>;
 
 export type Hyperparameters = {
   [keys: string]: Hyperparameters | HyperparameterBase;
 };
-const Hyperparameters: t.Type<Hyperparameters> = t.recursion('Hyperparameters', () =>
-  t.record(t.string, t.union([Hyperparameters, HyperparameterBase])),
+const Hyperparameters: t.RecursiveType<t.Type<Hyperparameters>> = t.recursion(
+  'Hyperparameters',
+  () => t.record(t.string, t.union([Hyperparameters, HyperparameterBase])),
 );
 
 // io-ts doesn't have an Omit type, so we have to build iteratively instead
-interface HyperparameterBaseBase {
-  base?: number;
-  count?: number;
-  maxval?: number;
-  minval?: number;
-  vals?: Primitive[];
-}
-const HyperparameterBaseBase = t.recursion<HyperparameterBaseBase>('HyperparametersBase', () =>
-  t.partial({
-    base: t.number,
-    count: t.number,
-    maxval: t.number,
-    minval: t.number,
-    vals: t.array(Primitive),
-  }),
-);
+const HyperparameterBaseBase = t.partial({
+  base: t.number,
+  count: t.number,
+  maxval: t.number,
+  minval: t.number,
+  vals: t.array(Primitive),
+});
+
 export const HyperparameterBase = t.intersection([
   HyperparameterBaseBase,
   t.partial({

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -3,8 +3,9 @@ import { RouteProps } from 'react-router-dom';
 
 import * as Api from 'services/api-ts-sdk';
 import { V1AgentUserGroup, V1Group, V1LaunchWarning, V1Trigger } from 'services/api-ts-sdk';
-import valueof from 'utils/valueof';
+import { valueof, ValueOf } from 'utils/valueof';
 
+export type { ValueOf } from 'utils/valueof';
 export const Primitive = t.union([t.boolean, t.number, t.string]);
 export type Primitive = t.TypeOf<typeof Primitive>;
 export type RecordKey = string | number | symbol;
@@ -122,8 +123,6 @@ export interface SemanticVersion {
   minor: number;
   patch: number;
 }
-
-export type ValueOf<T> = T[keyof T];
 
 interface WithPagination {
   pagination: Api.V1Pagination; // probably should use this or Pagination

--- a/webui/react/src/utils/valueof.ts
+++ b/webui/react/src/utils/valueof.ts
@@ -1,0 +1,36 @@
+import { failure, identity, success, Type } from 'io-ts';
+
+export type ValueOf<T> = T[keyof T];
+export class ValueOfType<D extends { [key: string]: unknown }> extends Type<ValueOf<D>> {
+  readonly _tag = 'ValueofType' as const;
+  constructor(
+    name: string,
+    is: ValueOfType<D>['is'],
+    validate: ValueOfType<D>['validate'],
+    encode: ValueOfType<D>['encode'],
+    readonly values: D,
+  ) {
+    super(name, is, validate, encode);
+  }
+}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ValueOfC<D extends { [key: string]: unknown }> extends ValueOfType<D> {}
+
+export const valueof = <D extends { [key: string]: unknown }>(
+  values: D,
+  name: string = Object.values(values)
+    .map((k) => JSON.stringify(k))
+    .join(' | '),
+): ValueOfC<D> => {
+  const valueSet = new Set(Object.values(values));
+  const is = (u: unknown): u is ValueOf<D> => valueSet.has(u);
+  return new ValueOfType(
+    name,
+    is,
+    (u, c) => (is(u) ? success(u) : failure(u, c)),
+    identity,
+    values,
+  );
+};
+
+export default valueof;

--- a/webui/react/src/utils/valueof.ts
+++ b/webui/react/src/utils/valueof.ts
@@ -16,6 +16,10 @@ export class ValueOfType<D extends { [key: string]: unknown }> extends Type<Valu
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ValueOfC<D extends { [key: string]: unknown }> extends ValueOfType<D> {}
 
+/**
+ * Generate a codec describing a union type comprising an object's values. Like the
+ * `keyof` function from io-ts, but for values instead of keys.
+ */
 export const valueof = <D extends { [key: string]: unknown }>(
   values: D,
   name: string = Object.values(values)


### PR DESCRIPTION


## Description

This migrates the detaileduser and experimentitem types to io-ts. This is because these types are in use as codecs for the immutableobservables in the user and experiment stores respectively. To prevent the codec type from drifting away from the concrete type, we instead derive everything from the codec type. A small knock-on effect is that the helper `ValueOf` type and codec have been moved to a separate module to prevent circular imports.



## Test Plan
no testing required -- typescript checks should continue to pass.


## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1833

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
