### PR TITLE
docs: Add requirement and known issue for singularity-suid

### DIFF
--- a/docs/setup-cluster/slurm/slurm-known-issues.rst
+++ b/docs/setup-cluster/slurm/slurm-known-issues.rst
@@ -102,33 +102,39 @@ Some constraints are due to differences in behavior between Docker and Singulari
  Singularity Known Issues
 **************************
 
-Launching a PBS job with an experiment configuration that includes an embedded double quote
-character (") may cause the job to fail unless you have Singularity 3.10 or greater or Apptainer 1.1
-or greater. For example, the error might be the json.decoder.JSONDecodeError or the experiment log
-may contain ``source: /.inject-singularity-env.sh:224:1563: "export" must be followed by names or
-assignments`` and ``RuntimeError: missing environment keys [DET_MASTER, DET_CLUSTER_ID,
-DET_AGENT_ID, DET_SLOT_IDS, DET_TASK_ID, DET_ALLOCATION_ID, DET_SESSION_TOKEN, DET_TASK_TYPE], is
-this running on-cluster?``
+-  Launching a PBS job with an experiment configuration that includes an embedded double quote
+   character (") may cause the job to fail unless you have Singularity 3.10 or greater or Apptainer
+   1.1 or greater. For example, the error might be the json.decoder.JSONDecodeError or the
+   experiment log may contain ``source: /.inject-singularity-env.sh:224:1563: "export" must be
+   followed by names or assignments`` and ``RuntimeError: missing environment keys [DET_MASTER,
+   DET_CLUSTER_ID, DET_AGENT_ID, DET_SLOT_IDS, DET_TASK_ID, DET_ALLOCATION_ID, DET_SESSION_TOKEN,
+   DET_TASK_TYPE], is this running on-cluster?`` The version of Singularity is detected by the HPC
+   Launcher invoking the singularity command and checking for the ``--no-eval`` option. If the
+   singularity command is not on the path for the HPC launcher or is of an inconsistent version with
+   the compute nodes, embedded double quote characters may still not work.
 
-The version of Singularity is detected by the HPC Launcher invoking the singularity command and
-checking for the ``--no-eval`` option. If the singularity command is not on the path for the HPC
-launcher or is of an inconsistent version with the compute nodes, embedded double quote characters
-may still not work.
+-  When launching a shell or distributed experiment the ``sshd`` inside the container may log the
+   error ``chown(/dev/pts/0, 100165687, 5) failed: Invalid argument`` and the shell or experiment
+   may hang. This can be resolved by installing the ``singularity-suid`` installation package.
 
 ************************
  Apptainer Known Issues
 ************************
 
-Starting with Apptainer version 1.1.0 some changes may trigger permission problems inside of
-Determined containers for shells, TensorBoards, and experiments. For example, a TensorBoard log may
-contain ``ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device``,
-or a shell may fail to function and the shell logs contain the message ``chown(/dev/pts/1, 63200, 5)
-failed: Invalid argument``, or an experiment may fail to launch due to ``FATAL: container creation
-failed: mount /var/tmp->/var/tmp error: while mounting /var/tmp: could not mount /var/tmp: operation
-not supported``. This likely indicates an installation or configuration error for unprivileged
-containers. Review the `Installing Apptainer
-<https://apptainer.org/docs/admin/main/installation.html>`_ documentation. These errors are
-sometimes resolved by additionally installing the ``apptainer-setuid`` package.
+-  Starting with Apptainer version 1.1.0 some changes may trigger permission problems inside of
+   Determined containers for shells, TensorBoards, and experiments. For example, a TensorBoard log
+   may contain ``ERROR: Could not install packages due to an OSError: [Errno 28] No space left on
+   device``, or a shell may fail to function and the shell logs contain the message
+   ``chown(/dev/pts/1, 63200, 5) failed: Invalid argument``, or an experiment may fail to launch due
+   to ``FATAL: container creation failed: mount /var/tmp->/var/tmp error: while mounting /var/tmp:
+   could not mount /var/tmp: operation not supported``. This likely indicates an installation or
+   configuration error for unprivileged containers. Review the `Installing Apptainer
+   <https://apptainer.org/docs/admin/main/installation.html>`_ documentation. These errors are
+   sometimes resolved by additionally installing the ``apptainer-setuid`` package.
+
+-  When launching a shell or distributed experiment the ``sshd`` inside the container may log the
+   error ``chown(/dev/pts/0, 100165687, 5) failed: Invalid argument`` and the shell or experiment
+   may hang. This can be resolved by installing the ``singularity-suid`` installation package.
 
 *********************
  Podman Known Issues

--- a/docs/setup-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/slurm/slurm-requirements.rst
@@ -331,6 +331,11 @@ purposes of this documentation, you can consider all references to Singularity t
 Apptainer. The Determined launcher interacts with Apptainer/Singularity using the ``singularity``
 command.
 
+.. note::
+
+   In addition to the core Apptainer/Singularity installation package, the ``apptainer-suid`` or
+   ``singularity-suid`` component is also required for full Determined functionality.
+
 Singularity has numerous options that may be customized in the ``singularity.conf`` file. Determined
 has been verified using the default values and therefore does not require any special configuration
 on the compute nodes of the cluster.


### PR DESCRIPTION


## Description
Though the apptainer/singularity docs imply that with the proper kernel support that the *-suid installation package is not required, it doesn't seem to be the case for the MLDE usage (specifically SSHD within the container).  Add this as an explicit requirement in the docs.

## Test Plan


![image](https://github.com/determined-ai/determined/assets/84593277/92a75168-7a7a-422a-9f95-e57179e9e7d2)


![image](https://github.com/determined-ai/determined/assets/84593277/73bd6c3a-bb69-4b94-b8c1-bc4817c16868)

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
