### PR TITLE
fix(rm): tasks shouldn't hang on restore failures

### DIFF
--- a/master/internal/rm/agentrm/agent_state.go
+++ b/master/internal/rm/agentrm/agent_state.go
@@ -659,9 +659,9 @@ func (a *agentState) restoreContainersField() error {
 	if err != nil {
 		return err
 	}
-	log.WithField("agent-id", a.string()).Debugf("restored containers: %d", len(res))
 	a.containerAllocation = res
 
+	a.syslog.Debugf("restored %d/%d container to allocation mappings", len(res), len(containerIDs))
 	return nil
 }
 

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -155,7 +155,7 @@ func (rp *resourcePool) allocateRequest(msg sproto.AllocateRequest) {
 			log.WithError(err).Error("error restoring resources")
 
 			// Clear out the state / close and terminate the allocation.
-			rmevents.Publish(msg.AllocationID, &sproto.ResourcesFailureError{
+			rmevents.Publish(msg.AllocationID, &sproto.ResourcesRestoreError{
 				FailureType: sproto.RestoreError,
 				ErrMsg:      err.Error(),
 				ExitCode:    nil,

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -517,7 +517,7 @@ func (k *kubernetesResourcePool) assignResources(
 				WithField("allocation-id", req.AllocationID).
 				WithError(err).Error("unable to restore allocation")
 			unknownExit := sproto.ExitCode(-1)
-			rmevents.Publish(req.AllocationID, &sproto.ResourcesFailureError{
+			rmevents.Publish(req.AllocationID, &sproto.ResourcesRestoreError{
 				FailureType: sproto.ResourcesMissing,
 				ErrMsg:      errors.Wrap(err, "unable to restore allocation").Error(),
 				ExitCode:    &unknownExit,

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -136,7 +136,7 @@ func (*ReleaseResources) ResourcesEvent() {}
 func (*ResourcesStateChanged) ResourcesEvent() {}
 
 // ResourcesEvent implements ResourcesEvent.
-func (*ResourcesFailureError) ResourcesEvent() {}
+func (*ResourcesRestoreError) ResourcesEvent() {}
 
 // ResourcesEvent implements ResourcesEvent.
 func (*ContainerLog) ResourcesEvent() {}

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -187,6 +187,16 @@ func newAllocation(
 	return a, nil
 }
 
+// how are we getting 0 container snapshots in the first place?
+//		- sleep before we call persist() and see if that causes it
+//		- definitely peek at pre-actor code
+// either way, how does it cause a hang?
+//		- we don't send the resources released event.
+// after we finish restore, we should all the agentrm and cull all unreattached
+// containers.
+// allocation is crashing and deleting resourcemanagers_agent_containers so fast that
+// the agent can't restore them. then when the agent can't restore them
+
 // Receive implements actor.Actor for the allocation.
 // The normal flow of an allocation is to:
 //
@@ -211,17 +221,13 @@ func (a *allocation) run(ctx context.Context, sub *sproto.ResourcesSubscription)
 	defer a.recover()
 	defer sub.Close()
 	defer a.wg.Cancel() // Important if we panic, so awaitTermination can unblock.
-	for {
-		event := sub.Get()
-		if event == (sproto.ResourcesReleasedEvent{}) {
-			return
-		}
-		a.HandleRMEvent(event)
+
+	for !a.HandleRMEvent(sub.Get()) {
 	}
 }
 
 // HandleRMEvent handles downstream events from the resource manager.
-func (a *allocation) HandleRMEvent(msg sproto.ResourcesEvent) {
+func (a *allocation) HandleRMEvent(msg sproto.ResourcesEvent) (done bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -232,17 +238,22 @@ func (a *allocation) HandleRMEvent(msg sproto.ResourcesEvent) {
 		}
 	case *sproto.ResourcesStateChanged:
 		a.resourcesStateChanged(msg)
-	case *sproto.ResourcesFailureError:
-		a.restoreResourceFailure(msg)
 	case *sproto.ReleaseResources:
 		a.releaseResources(msg)
 	case *sproto.ContainerLog:
 		a.sendTaskLog(msg.ToTaskLog())
+	case *sproto.ResourcesRestoreError:
+		a.restoreResourceFailure(msg)
+		return true
 	case *sproto.InvalidResourcesRequestError:
 		a.crash(msg.Cause)
+		return true
+	case sproto.ResourcesReleasedEvent:
+		return true
 	default:
 		panic(fmt.Errorf("unexpected RM event"))
 	}
+	return false
 }
 
 // State returns a copy of the current State of the allocation.
@@ -788,7 +799,7 @@ func (a *allocation) resourcesStateChanged(msg *sproto.ResourcesStateChanged) {
 }
 
 // restoreResourceFailure handles the restored resource failures.
-func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesFailureError) {
+func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesRestoreError) {
 	a.syslog.Debugf("allocation resource failure")
 	a.setMostProgressedModelState(model.AllocationStateTerminating)
 
@@ -967,7 +978,7 @@ func (a *allocation) exitedWithoutErr() bool {
 
 func (a *allocation) SetExitStatus(exitReason string, exitErr error, statusCode *int32) {
 	switch err := exitErr.(type) {
-	case sproto.ResourcesFailureError:
+	case sproto.ResourcesRestoreError:
 		a.model.ExitErr = ptrs.Ptr(err.Error())
 		if err.ExitCode != nil {
 			a.model.StatusCode = ptrs.Ptr(int32(*err.ExitCode))
@@ -1097,7 +1108,7 @@ func (a *allocation) calculateExitStatus(reason string) (
 		return fmt.Sprintf("allocation stopped early after %s", reason), true, logrus.InfoLevel, nil
 	case a.exitErr != nil:
 		switch err := a.exitErr.(type) {
-		case sproto.ResourcesFailureError:
+		case sproto.ResourcesRestoreError:
 			switch err.FailureType {
 			case sproto.ResourcesFailed, sproto.TaskError:
 				if a.killedDaemonsGracefully {

--- a/master/internal/task/allocation_intg_test.go
+++ b/master/internal/task/allocation_intg_test.go
@@ -38,7 +38,7 @@ func (m mockTaskSpecifier) ToTaskSpec() (t tasks.TaskSpec) {
 func TestAllocation(t *testing.T) {
 	cases := []struct {
 		name  string
-		err   *sproto.ResourcesFailureError
+		err   *sproto.ResourcesRestoreError
 		acked bool
 		exit  *AllocationExited
 	}{
@@ -55,13 +55,13 @@ func TestAllocation(t *testing.T) {
 		{
 			name:  "container failed",
 			acked: false,
-			err:   &sproto.ResourcesFailureError{FailureType: sproto.ResourcesFailed},
-			exit:  &AllocationExited{Err: sproto.ResourcesFailureError{FailureType: sproto.ResourcesFailed}},
+			err:   &sproto.ResourcesRestoreError{FailureType: sproto.ResourcesFailed},
+			exit:  &AllocationExited{Err: sproto.ResourcesRestoreError{FailureType: sproto.ResourcesFailed}},
 		},
 		{
 			name:  "container failed, but acked preemption",
 			acked: true,
-			err:   &sproto.ResourcesFailureError{FailureType: sproto.ResourcesFailed},
+			err:   &sproto.ResourcesRestoreError{FailureType: sproto.ResourcesFailed},
 			exit:  &AllocationExited{},
 		},
 	}

--- a/master/internal/task/allocation_service_test.go
+++ b/master/internal/task/allocation_service_test.go
@@ -39,7 +39,7 @@ func TestRestoreFailed(t *testing.T) {
 	db, _, id, q, exitFuture := requireStarted(t)
 	defer requireKilled(t, db, id, q, exitFuture)
 
-	q.Put(&sproto.ResourcesFailureError{
+	q.Put(&sproto.ResourcesRestoreError{
 		FailureType: sproto.RestoreError,
 		ErrMsg:      "things weren't there",
 	})
@@ -538,7 +538,7 @@ func requireAssignedMany(
 				ResourcesID:    rID,
 				ResourcesState: sproto.Terminated,
 				ResourcesStopped: &sproto.ResourcesStopped{
-					Failure: &sproto.ResourcesFailureError{
+					Failure: &sproto.ResourcesRestoreError{
 						FailureType: sproto.TaskError,
 						ErrMsg:      "exit code 137",
 						ExitCode:    ptrs.Ptr(sproto.ExitCode(137)),


### PR DESCRIPTION
## Description
We had a few bugs, but the main one was that on receipt of a `ResourcesRestoreFailure` allocations
would not exit but just chill waiting on a `ResourcesReleased` event that would never come (RMs have never
sent this). The other issue was the RM was relying on allocations to cleanup their resources but if restore failed
they wouldn't be around to do this, so now we send an extra SIGKILL from the RM just in case.

I don't think these fixes are 100% optimal, I think there is some architectural change that solve all these and
similar issues, but I haven't dreamed up the best approach yet. 

I also fixed up some logging and type names to make debugging and readability better. 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Covered by automated testing. (I'm going to add more in a follow up)
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
Ended up needing to attach delve to a live devcluster to debug this, if anyone is interested in how, let me know.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9932


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
