### PR TITLE
fix: tqdm logs within wrap_rank [MLG-1236]

### DIFF
--- a/docs/release-notes/8488-tqdm.rst
+++ b/docs/release-notes/8488-tqdm.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Fixes**
+
+-  Fix an issue where the determined.launch.wrap_rank module, often used by custom launch layers,
+   was improperly buffering multiple lines separated by a carriage return, such as logs emitted from
+   the popular TQDM library. TQDM logs will pass now through without undue buffering.

--- a/harness/tests/launch/test_wrap_rank.py
+++ b/harness/tests/launch/test_wrap_rank.py
@@ -1,0 +1,42 @@
+import subprocess
+import sys
+import textwrap
+
+from determined.launch import wrap_rank
+
+
+def test_split_on_new_lines_or_carriage_returns() -> None:
+    script = textwrap.dedent(
+        r"""
+        print("line with lf", end="\n", flush=True)
+        input()
+        print("line with cr", end="\r", flush=True)
+        input()
+        """
+    )
+    cmd = [
+        sys.executable,
+        "-u",
+        wrap_rank.__file__,
+        "--no-redirect-stdio",
+        "0",
+        sys.executable,
+        "-u",
+        "-c",
+        script,
+    ]
+    p = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Just for mypy.
+    assert p.stdin and p.stdout and p.stderr
+    assert p.stdout.readline() == b"[rank=0] line with lf\n"
+    p.stdin.write(b"\n")
+    p.stdin.flush()
+    assert p.stdout.readline() == b"[rank=0] line with cr\n"
+    p.stdin.write(b"\n")
+    p.stdin.flush()
+    assert p.wait() == 0

--- a/master/static/srv/ship_logs.py
+++ b/master/static/srv/ship_logs.py
@@ -88,6 +88,7 @@ class DoneMsg(NamedTuple):
     exit_code: Optional[int] = None
 
 
+# Duplicated in wrap_rank.py.  If you find a bug here, fix it there too.
 def read_newlines_or_carriage_returns(fd: io.RawIOBase) -> Iterator[str]:
     r"""
     Read lines, delineated by either '\n' or '\r.


### PR DESCRIPTION
This has already been fixed in ship_logs.py, but since ship_logs.py isn't allowed to to have any non-stdlib dependencies (including determined) and since determined can't depend on ship_logs.py (which is only available on-cluster), the right answer is copy/paste.