### PR TITLE
fix: failing custom searcher due to ExtraEnvVars being overwritten

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -356,6 +356,10 @@ func (a *apiServer) SetCommandPriority(
 func (a *apiServer) getOIDCPachydermEnvVars(
 	session *model.UserSession,
 ) (map[string]string, error) {
+	if session == nil { // Can happen with allocation token.
+		return map[string]string{}, nil
+	}
+
 	envVars := make(map[string]string)
 
 	if val, ok := session.InheritedClaims["OIDCRawIDToken"]; ok {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -1670,10 +1671,11 @@ func (a *apiServer) CreateExperiment(
 		return nil, err
 	}
 
-	taskSpec.ExtraEnvVars, err = a.getOIDCPachydermEnvVars(session)
+	pachyEnvVars, err := a.getOIDCPachydermEnvVars(session)
 	if err != nil {
 		return nil, err
 	}
+	maps.Copy(taskSpec.ExtraEnvVars, pachyEnvVars)
 
 	if err = experiment.AuthZProvider.Get().CanCreateExperiment(ctx, *user, p); err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, err.Error())


### PR DESCRIPTION
## Description

Fix failing test here

https://app.circleci.com/pipelines/github/determined-ai/determined/48552/workflows/75ec094f-166f-4d8a-a9ca-7898a9ce660a/jobs/2094830

Caused by a regression in this PR
https://github.com/determined-ai/determined/pull/8473/files


## Test Plan

e2e tests cover this


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
