### PR TITLE
fix: use explicit e.state in bulk experiment delete query

### DIFF
--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1694,7 +1694,8 @@ func TestDeleteExperiments(t *testing.T) {
 	_, err := api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{ExperimentIds: expIDs})
 	require.NoError(t, err)
 
-	// Try delete experiments again using a filter
+	// Try delete experiments again using a filter, this tests the branch condition
+	// where we have a filter for the experiment delete request.
 	for i := 0; i < 3; i++ {
 		exp := createTestExp(t, api, curUser)
 		_, err := db.Bun().NewUpdate().Table("experiments").

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1694,8 +1694,64 @@ func TestDeleteExperiments(t *testing.T) {
 	_, err := api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{ExperimentIds: expIDs})
 	require.NoError(t, err)
 
-	// Try delete experiments again using a filter, this tests the branch condition
-	// where we have a filter for the experiment delete request.
+	var success bool
+	for i := 0; i < 15; i++ {
+		var inDeleteFailed int
+		for _, expID := range expIDs {
+			e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: expID})
+			require.NoError(t, err, "expected experiment to go to DELETE_FAILED")
+			if e.Experiment.State == experimentv1.State_STATE_DELETE_FAILED {
+				inDeleteFailed++
+			}
+		}
+		if len(expIDs) == inDeleteFailed {
+			success = true
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if !success {
+		t.Error("expected experiments to move to DELETE_FAILED after 15 seconds and they did not")
+	}
+
+	t.Log("and if the RM then succeeds, the experiments are then successfully deleted")
+	api.m.rm = MockRM()
+	_, err = api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{ExperimentIds: expIDs})
+	require.NoError(t, err)
+
+	// Delete is async so we need to retry until it completes.
+	for i := 0; i < 15; i++ {
+		var deleted int
+		for _, expID := range expIDs {
+			e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: expID})
+			if err != nil {
+				require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(expID), true), err)
+				deleted++
+				continue
+			}
+			require.NotEqual(t, experimentv1.State_STATE_DELETE_FAILED, e.Experiment.State)
+		}
+		if len(expIDs) == deleted {
+			return
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Error("expected experiments to delete after 15 seconds and they did not")
+}
+
+func TestDeleteExperimentsFiltered(t *testing.T) {
+	var mockRM mocks.ResourceManager
+	// Need _anything_ to error to check the error flow leaves things in DELETE_FAILED and that they are delete-able
+	// still after that.
+	mockRM.On("DeleteJob", mock.Anything).Return(func(sproto.DeleteJob) sproto.DeleteJobResponse {
+		errC := make(chan error, 1)
+		errC <- errors.New("something real bad")
+		return sproto.DeleteJobResponse{Err: errC}
+	}, nil)
+
+	api, curUser, ctx := setupAPITest(t, nil, &mockRM)
+
+	var expIDs []int32
 	for i := 0; i < 3; i++ {
 		exp := createTestExp(t, api, curUser)
 		_, err := db.Bun().NewUpdate().Table("experiments").
@@ -1706,7 +1762,9 @@ func TestDeleteExperiments(t *testing.T) {
 	}
 
 	t.Log("if DeleteExperiment with filter fails, all experiments become DELETE_FAILED")
-	_, err = api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{
+	// Try delete experiments using a filter, this tests the branch condition
+	// where we have a filter with the experiment delete request.
+	_, err := api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{
 		ExperimentIds: expIDs,
 		Filters:       &apiv1.BulkExperimentFilters{ProjectId: 1},
 	})

--- a/master/internal/experiment/bulk_action.go
+++ b/master/internal/experiment/bulk_action.go
@@ -377,7 +377,7 @@ func DeleteExperiments(ctx context.Context,
 		query = query.Where("e.id IN (?)", bun.In(experimentIds))
 	} else {
 		query = queryBulkExperiments(query, filters).
-			Where("state IN (?)", bun.In(model.StatesToStrings(model.TerminalStates)))
+			Where("e.state IN (?)", bun.In(model.StatesToStrings(model.TerminalStates)))
 	}
 
 	query, err = AuthZProvider.Get().


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
Fix an error where bulk delete can fail when using a filter with a message like:
`
[bun]  13:29:26.577   SELECT                  632µs  SELECT "e"."id", CASE e.state::text WHEN 'STARTING' THEN 15 WHEN 'DELETE_FAILED' THEN 11 WHEN 'QUEUED' THEN 13 WHEN 'ACTIVE' THEN 1 WHEN 'PAUSED' THEN 2 WHEN 'STOPPING_ERROR' THEN 5 WHEN 'COMPLETED' THEN 6 WHEN 'ERROR' THEN 8 WHEN 'DELETING' THEN 10 WHEN 'RUNNING' THEN 16 WHEN 'UNSPECIFIED' THEN 0 WHEN 'STOPPING_COMPLETED' THEN 3 WHEN 'STOPPING_CANCELED' THEN 4 WHEN 'CANCELED' THEN 7 WHEN 'DELETED' THEN 9 WHEN 'PULLING' THEN 14 WHEN 'STOPPING_KILLED' THEN 12 END AS state, COUNT(model_versions.id) AS versions FROM experiments as e JOIN projects p ON e.project_id = p.id LEFT JOIN checkpoints_view c ON c.experiment_id = e.id LEFT JOIN model_versions ON model_versions.checkpoint_uuid = c.uuid WHERE (project_id = 1) AND (state IN ('CANCELED', 'COMPLETED', 'ERROR')) GROUP BY "e"."id" 	  *pgconn.PgError: ERROR: column reference "state" is ambiguous (SQLSTATE 42702)
`


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Adds automated test.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
