### PR TITLE
ci: add date to python cache, fix moto linting issue

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -364,6 +364,7 @@ commands:
             fi
             echo '<<parameters.python-version>>' >> /tmp/cachefile
             echo '<<parameters.install-python>>' >> /tmp/cachefile
+            date -u '+%y/%m/%d' >> /tmp/cachefile
 
       - restore_cache:
           keys:

--- a/harness/tests/determined/common/storage/test_s3.py
+++ b/harness/tests/determined/common/storage/test_s3.py
@@ -22,8 +22,7 @@ def sample_checkpoint(standard_session: api.Session) -> checkpoint.Checkpoint:
     return checkpoint.Checkpoint._from_bindings(bindings_checkpoint, standard_session)
 
 
-# Typing directive can be removed when https://github.com/getmoto/moto/issues/4944 is resolved.
-@moto.mock_s3  # type: ignore
+@moto.mock_s3
 def test_download_simple_checkpoint(
     sample_checkpoint: checkpoint.Checkpoint, tmp_path: os.PathLike
 ) -> None:


### PR DESCRIPTION
## Description

Fixes moto linting issue that will happen when our Python cache is busted.

Adds a day expiry to the cache so that these issues will appear on main sooner.

## Test Plan

No testing needed

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
