### PR TITLE
chore: add ElementsMatch to usergroup test

### DIFF
--- a/master/internal/usergroup/group_intg_test.go
+++ b/master/internal/usergroup/group_intg_test.go
@@ -6,6 +6,7 @@ package usergroup
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -356,32 +357,41 @@ func TestUserGroups(t *testing.T) {
 	})
 
 	t.Run("test UpdateUserGroupMembership", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(1)
+
 		ctx := context.TODO()
 		tmpUser := db.RequireMockUser(t, pgDB)
 
-		// Define two existing test groups.
 		name1 := uuid.NewString()
-		_, err := AddGroupTx(ctx, db.Bun(), model.Group{Name: name1})
-		require.NoError(t, err, "failed to add %s group", name1)
-
 		name2 := uuid.NewString()
-		_, _, err = AddGroupWithMembers(ctx, model.Group{Name: name2}, tmpUser.ID)
-		require.NoError(t, err, "failed to add %s group", name2)
-
-		gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
-		require.NoError(t, err, "failed to search groups")
-		require.Equal(t, len(gps), 1, "failed to start with original group assignments.")
-		require.Equal(t, gps[0].Name, name2, "failed to start with %s group assignment.", name2)
-
 		name3 := uuid.NewString()
-		err = UpdateUserGroupMembershipTx(ctx, db.Bun(), &tmpUser, []string{name1, name3})
+
+		go func() {
+			defer wg.Done()
+
+			_, err := AddGroupTx(ctx, db.Bun(), model.Group{Name: name1})
+			require.NoError(t, err, "failed to add %s group", name1)
+
+			_, _, err = AddGroupWithMembers(ctx, model.Group{Name: name2}, tmpUser.ID)
+			require.NoError(t, err, "failed to add %s group", name2)
+
+			gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
+			require.NoError(t, err, "failed to search groups")
+			require.Equal(t, len(gps), 1, "failed to start with original group assignments.")
+			require.Equal(t, gps[0].Name, name2, "failed to start with %s group assignment.", name2)
+		}()
+
+		err := UpdateUserGroupMembershipTx(ctx, db.Bun(), &tmpUser, []string{name1, name3})
 		require.NoError(t, err, "failed to update user-group membership")
 
-		gps, err = SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
+		gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
 		require.NoError(t, err, "failed to search groups")
 		require.Equal(t, len(gps), 2, "failed to end with two group assignments.")
 		require.Equal(t, gps[0].Name, name1, "failed to end with %s group assignment.", name1)
 		require.Equal(t, gps[1].Name, name3, "failed to end with %s group assignment.", name3)
+
+		wg.Wait()
 	})
 }
 

--- a/master/internal/usergroup/group_intg_test.go
+++ b/master/internal/usergroup/group_intg_test.go
@@ -6,7 +6,6 @@ package usergroup
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -357,9 +356,6 @@ func TestUserGroups(t *testing.T) {
 	})
 
 	t.Run("test UpdateUserGroupMembership", func(t *testing.T) {
-		var wg sync.WaitGroup
-		wg.Add(1)
-
 		ctx := context.TODO()
 		tmpUser := db.RequireMockUser(t, pgDB)
 
@@ -367,31 +363,25 @@ func TestUserGroups(t *testing.T) {
 		name2 := uuid.NewString()
 		name3 := uuid.NewString()
 
-		go func() {
-			defer wg.Done()
+		_, err := AddGroupTx(ctx, db.Bun(), model.Group{Name: name1})
+		require.NoError(t, err, "failed to add %s group", name1)
 
-			_, err := AddGroupTx(ctx, db.Bun(), model.Group{Name: name1})
-			require.NoError(t, err, "failed to add %s group", name1)
-
-			_, _, err = AddGroupWithMembers(ctx, model.Group{Name: name2}, tmpUser.ID)
-			require.NoError(t, err, "failed to add %s group", name2)
-
-			gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
-			require.NoError(t, err, "failed to search groups")
-			require.Equal(t, len(gps), 1, "failed to start with original group assignments.")
-			require.Equal(t, gps[0].Name, name2, "failed to start with %s group assignment.", name2)
-		}()
-
-		err := UpdateUserGroupMembershipTx(ctx, db.Bun(), &tmpUser, []string{name1, name3})
-		require.NoError(t, err, "failed to update user-group membership")
+		_, _, err = AddGroupWithMembers(ctx, model.Group{Name: name2}, tmpUser.ID)
+		require.NoError(t, err, "failed to add %s group", name2)
 
 		gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
 		require.NoError(t, err, "failed to search groups")
-		require.Equal(t, len(gps), 2, "failed to end with two group assignments.")
-		require.Equal(t, gps[0].Name, name1, "failed to end with %s group assignment.", name1)
-		require.Equal(t, gps[1].Name, name3, "failed to end with %s group assignment.", name3)
+		require.Equal(t, len(gps), 1, "failed to start with original group assignments.")
+		require.Equal(t, gps[0].Name, name2, "failed to start with %s group assignment.", name2)
 
-		wg.Wait()
+		err = UpdateUserGroupMembershipTx(ctx, db.Bun(), &tmpUser, []string{name1, name3})
+		require.NoError(t, err, "failed to update user-group membership")
+
+		gps, err = SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
+		require.NoError(t, err, "failed to search groups")
+		require.Equal(t, len(gps), 2, "failed to end with two group assignments.")
+		require.ElementsMatch(t, []string{gps[0].Name, gps[1].Name}, []string{name1, name3},
+			"failed to end with %s group assignment.", name1)
 	})
 }
 

--- a/master/internal/usergroup/group_intg_test.go
+++ b/master/internal/usergroup/group_intg_test.go
@@ -379,7 +379,7 @@ func TestUserGroups(t *testing.T) {
 
 		gps, err = SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
 		require.NoError(t, err, "failed to search groups")
-		require.Equal(t, gps, 2, "failed to end with two group assignments.")
+		require.Len(t, gps, 2, "failed to end with two group assignments.")
 		require.ElementsMatch(t, []string{name1, name3}, []string{gps[0].Name, gps[1].Name},
 			"failed to end with %s group assignment.", name1)
 	})

--- a/master/internal/usergroup/group_intg_test.go
+++ b/master/internal/usergroup/group_intg_test.go
@@ -371,16 +371,16 @@ func TestUserGroups(t *testing.T) {
 
 		gps, err := SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
 		require.NoError(t, err, "failed to search groups")
-		require.Equal(t, len(gps), 1, "failed to start with original group assignments.")
-		require.Equal(t, gps[0].Name, name2, "failed to start with %s group assignment.", name2)
+		require.Len(t, gps, 1, "failed to start with original group assignments.")
+		require.Equal(t, name2, gps[0].Name, "failed to start with %s group assignment.", name2)
 
 		err = UpdateUserGroupMembershipTx(ctx, db.Bun(), &tmpUser, []string{name1, name3})
 		require.NoError(t, err, "failed to update user-group membership")
 
 		gps, err = SearchGroupsWithoutPersonalGroupsTx(ctx, db.Bun(), "", tmpUser.ID)
 		require.NoError(t, err, "failed to search groups")
-		require.Equal(t, len(gps), 2, "failed to end with two group assignments.")
-		require.ElementsMatch(t, []string{gps[0].Name, gps[1].Name}, []string{name1, name3},
+		require.Equal(t, gps, 2, "failed to end with two group assignments.")
+		require.ElementsMatch(t, []string{name1, name3}, []string{gps[0].Name, gps[1].Name},
 			"failed to end with %s group assignment.", name1)
 	})
 }


### PR DESCRIPTION
## Description
Solve https://app.circleci.com/pipelines/github/determined-ai/determined/48642/workflows/c2da444e-9db2-476f-b44b-e23ddd6809f1/jobs/2100987 flake -- switched to `require.ElementsMatch(...)`

## Test Plan
Pass circleCI


## Commentary (optional)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->