### PR TITLE
refactor: replace resource pool looping with direct call

### DIFF
--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -268,8 +268,9 @@ func (c *Command) garbageCollect() {
 func (c *Command) setNTSCPriority(priority int, forward bool) error {
 	if forward {
 		switch err := c.rm.SetGroupPriority(sproto.SetGroupPriority{
-			Priority: priority,
-			JobID:    c.jobID,
+			Priority:     priority,
+			ResourcePool: c.Config.Resources.ResourcePool,
+			JobID:        c.jobID,
 		}).(type) {
 		case nil:
 		case rmerrors.UnsupportedError:

--- a/master/internal/command/command_job_service.go
+++ b/master/internal/command/command_job_service.go
@@ -60,8 +60,9 @@ func (c *Command) SetWeight(weight float64) error {
 	defer c.mu.Unlock()
 
 	switch err := c.rm.SetGroupWeight(sproto.SetGroupWeight{
-		Weight: weight,
-		JobID:  c.jobID,
+		Weight:       weight,
+		ResourcePool: c.Config.Resources.ResourcePool,
+		JobID:        c.jobID,
 	}).(type) {
 	case nil:
 	case rmerrors.UnsupportedError:
@@ -77,4 +78,9 @@ func (c *Command) SetWeight(weight float64) error {
 // SetResourcePool is not implemented for commands.
 func (c *Command) SetResourcePool(resourcePool string) error {
 	return fmt.Errorf("setting resource pool for job type %s is not supported", c.jobType)
+}
+
+// ResourcePool gets the command's resource pool.
+func (c *Command) ResourcePool() string {
+	return c.Config.Resources.ResourcePool
 }

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -252,8 +252,9 @@ func (e *internalExperiment) start() error {
 	}
 
 	e.rm.SetGroupMaxSlots(sproto.SetGroupMaxSlots{
-		MaxSlots: e.activeConfig.Resources().MaxSlots(),
-		JobID:    e.JobID,
+		MaxSlots:     e.activeConfig.Resources().MaxSlots(),
+		ResourcePool: e.activeConfig.Resources().ResourcePool(),
+		JobID:        e.JobID,
 	})
 	if err := e.setWeight(e.activeConfig.Resources().Weight()); err != nil {
 		e.updateState(model.StateWithReason{
@@ -403,6 +404,7 @@ func (e *internalExperiment) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	resources.SetMaxSlots(msg.MaxSlots)
 	e.activeConfig.SetResources(resources)
 	msg.JobID = e.JobID
+	msg.ResourcePool = e.activeConfig.Resources().ResourcePool()
 	e.rm.SetGroupMaxSlots(msg)
 }
 
@@ -1033,8 +1035,9 @@ func (e *internalExperiment) setPriority(priority *int, forward bool) (err error
 
 	if forward {
 		switch err := e.rm.SetGroupPriority(sproto.SetGroupPriority{
-			Priority: *priority,
-			JobID:    e.JobID,
+			Priority:     *priority,
+			ResourcePool: e.activeConfig.Resources().ResourcePool(),
+			JobID:        e.JobID,
 		}).(type) {
 		case nil:
 		case rmerrors.UnsupportedError:
@@ -1059,8 +1062,9 @@ func (e *internalExperiment) setWeight(weight float64) error {
 	}
 
 	switch err := e.rm.SetGroupWeight(sproto.SetGroupWeight{
-		Weight: weight,
-		JobID:  e.JobID,
+		Weight:       weight,
+		ResourcePool: e.activeConfig.Resources().ResourcePool(),
+		JobID:        e.JobID,
 	}).(type) {
 	case nil:
 	case rmerrors.UnsupportedError:

--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -79,3 +79,11 @@ func (e *internalExperiment) SetResourcePool(resourcePool string) error {
 
 	return e.setRP(resourcePool)
 }
+
+// ResourcePool gets the experiment's resource pool.
+func (e *internalExperiment) ResourcePool() string {
+	e.mu.Lock()
+	defer e.mu.Lock()
+
+	return e.activeConfig.Resources().ResourcePool()
+}

--- a/master/internal/job/jobservice/jobservice.go
+++ b/master/internal/job/jobservice/jobservice.go
@@ -25,6 +25,7 @@ type Job interface {
 	SetJobPriority(priority int) error
 	SetWeight(weight float64) error
 	SetResourcePool(resourcePool string) error
+	ResourcePool() string
 }
 
 // Service manages the job service.
@@ -208,15 +209,17 @@ func (s *Service) applyUpdate(update *jobv1.QueueControl) error {
 		return j.SetResourcePool(action.ResourcePool)
 	case *jobv1.QueueControl_AheadOf:
 		return s.rm.MoveJob(sproto.MoveJob{
-			ID:     jobID,
-			Anchor: model.JobID(action.AheadOf),
-			Ahead:  true,
+			ID:           jobID,
+			Anchor:       model.JobID(action.AheadOf),
+			Ahead:        true,
+			ResourcePool: j.ResourcePool(),
 		})
 	case *jobv1.QueueControl_BehindOf:
 		return s.rm.MoveJob(sproto.MoveJob{
-			ID:     jobID,
-			Anchor: model.JobID(action.BehindOf),
-			Ahead:  false,
+			ID:           jobID,
+			Anchor:       model.JobID(action.BehindOf),
+			Ahead:        false,
+			ResourcePool: j.ResourcePool(),
 		})
 	default:
 		return fmt.Errorf("unexpected action: %v", action)

--- a/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
+++ b/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
@@ -135,15 +135,29 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	)
 
 	// Let the CPU task actors release resources.
-	agentRM.Release(sproto.ResourcesReleased{AllocationID: cpuTask1.ID})
-	agentRM.Release(sproto.ResourcesReleased{AllocationID: cpuTask2.ID})
+	agentRM.Release(
+		sproto.ResourcesReleased{
+			AllocationID: cpuTask1.ID,
+			ResourcePool: taskSummaries[cpuTask1.ID].ResourcePool,
+		},
+	)
+	agentRM.Release(sproto.ResourcesReleased{
+		AllocationID: cpuTask2.ID,
+		ResourcePool: taskSummaries[cpuTask2.ID].ResourcePool,
+	})
 	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	require.NoError(t, err)
 	assert.Equal(t, len(taskSummaries), 2)
 
 	// Let the GPU task actors release resources.
-	agentRM.Release(sproto.ResourcesReleased{AllocationID: gpuTask1.ID})
-	agentRM.Release(sproto.ResourcesReleased{AllocationID: gpuTask2.ID})
+	agentRM.Release(sproto.ResourcesReleased{
+		AllocationID: gpuTask1.ID,
+		ResourcePool: taskSummaries[gpuTask1.ID].ResourcePool,
+	})
+	agentRM.Release(sproto.ResourcesReleased{
+		AllocationID: gpuTask2.ID,
+		ResourcePool: taskSummaries[gpuTask2.ID].ResourcePool,
+	})
 	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	require.NoError(t, err)
 	assert.Equal(t, len(taskSummaries), 0)

--- a/master/internal/rm/agentrm/resource_pool_test.go
+++ b/master/internal/rm/agentrm/resource_pool_test.go
@@ -28,7 +28,10 @@ func TestCleanUpTaskWhenTaskActorStopsWithError(t *testing.T) {
 	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	assert.Equal(t, len(taskSummaries), 1)
 
-	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: tasks[0].ID})
+	rp.ResourcesReleased(sproto.ResourcesReleased{
+		AllocationID: tasks[0].ID,
+		ResourcePool: tasks[0].ResourcePool,
+	})
 
 	for _, n := range rp.notifications {
 		<-n
@@ -47,7 +50,10 @@ func TestCleanUpTaskWhenTaskActorPanics(t *testing.T) {
 	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	assert.Equal(t, len(taskSummaries), 1)
 
-	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: tasks[0].ID})
+	rp.ResourcesReleased(sproto.ResourcesReleased{
+		AllocationID: tasks[0].ID,
+		ResourcePool: tasks[0].ResourcePool,
+	})
 
 	for _, n := range rp.notifications {
 		<-n
@@ -66,7 +72,10 @@ func TestCleanUpTaskWhenTaskActorStopsNormally(t *testing.T) {
 	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	assert.Equal(t, len(taskSummaries), 1)
 
-	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: tasks[0].ID})
+	rp.ResourcesReleased(sproto.ResourcesReleased{
+		AllocationID: tasks[0].ID,
+		ResourcePool: tasks[0].ResourcePool,
+	})
 
 	for _, n := range rp.notifications {
 		<-n
@@ -85,7 +94,10 @@ func TestCleanUpTaskWhenTaskActorReleaseResources(t *testing.T) {
 	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
 	assert.Equal(t, len(taskSummaries), 1)
 
-	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: tasks[0].ID})
+	rp.ResourcesReleased(sproto.ResourcesReleased{
+		AllocationID: tasks[0].ID,
+		ResourcePool: tasks[0].ResourcePool,
+	})
 
 	rp.stop()
 	assert.Equal(t, len(rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})), 0)

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -305,15 +305,12 @@ func (ResourceManager) GetSlots(*apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse
 }
 
 // MoveJob implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) MoveJob(msg sproto.MoveJob) error {
-	for _, rp := range k.pools {
-		err := rp.MoveJob(msg)
-		if err != nil {
-			return err
-		}
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		return fmt.Errorf("move job found no resource pool with name %s: %w", msg.ResourcePool, err)
 	}
-	return nil
+	return rp.MoveJob(msg)
 }
 
 // RecoverJobPosition implements rm.ResourceManager.
@@ -327,51 +324,56 @@ func (k *ResourceManager) RecoverJobPosition(msg sproto.RecoverJobPosition) {
 }
 
 // Release implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) Release(msg sproto.ResourcesReleased) {
-	for _, rp := range k.pools {
-		rp.ResourcesReleased(msg)
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		k.syslog.WithError(err).Warnf("release found no resource pool with name %s",
+			msg.ResourcePool)
+		return
 	}
+	rp.ResourcesReleased(msg)
 }
 
 // SetAllocationName implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) SetAllocationName(msg sproto.SetAllocationName) {
-	for _, rp := range k.pools {
-		rp.SetAllocationName(msg)
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		k.syslog.WithError(err).Warnf("set allocation name found no resource pool with name %s",
+			msg.ResourcePool)
+		return
 	}
+	rp.SetAllocationName(msg)
 }
 
 // SetGroupMaxSlots implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
-	for _, rp := range k.pools {
-		rp.SetGroupMaxSlots(msg)
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		k.syslog.WithError(err).Warnf("set group max slots found no resource pool with name %s",
+			msg.ResourcePool)
+		return
 	}
+	rp.SetGroupMaxSlots(msg)
 }
 
 // SetGroupPriority implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) SetGroupPriority(msg sproto.SetGroupPriority) error {
-	for _, rp := range k.pools {
-		err := rp.SetGroupPriority(msg)
-		if err != nil {
-			return err
-		}
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		return fmt.Errorf("set group priority found no resource pool with name %s: %w",
+			msg.ResourcePool, err)
 	}
-	return nil
+	return rp.SetGroupPriority(msg)
 }
 
 // SetGroupWeight implements rm.ResourceManager.
-// TODO(DET-9920): This should know which pool it wants.
 func (k *ResourceManager) SetGroupWeight(msg sproto.SetGroupWeight) error {
-	for _, rp := range k.pools {
-		err := rp.SetGroupWeight(msg)
-		if err != nil {
-			return err
-		}
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		return fmt.Errorf("set group weight found no resource pool with name %s: %w",
+			msg.ResourcePool, err)
 	}
-	return nil
+	return rp.SetGroupWeight(msg)
 }
 
 // ValidateCommandResources implements rm.ResourceManager.
@@ -526,6 +528,9 @@ func (k *ResourceManager) podStatusUpdateCallback(msg sproto.UpdatePodStatus) {
 }
 
 func (k *ResourceManager) poolByName(resourcePool string) (*kubernetesResourcePool, error) {
+	if resourcePool == "" {
+		return nil, errors.New("invalid call: cannot get a resource pool with no name")
+	}
 	rp, ok := k.pools[resourcePool]
 	if !ok {
 		return nil, fmt.Errorf("cannot find resource pool %s", resourcePool)

--- a/master/internal/sproto/jobs.go
+++ b/master/internal/sproto/jobs.go
@@ -83,9 +83,10 @@ type (
 	}
 	// MoveJob requests the job to be moved within a priority queue relative to another job.
 	MoveJob struct {
-		ID     model.JobID
-		Anchor model.JobID
-		Ahead  bool
+		ID           model.JobID
+		Anchor       model.JobID
+		Ahead        bool
+		ResourcePool string
 	}
 )
 

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -73,6 +73,7 @@ type (
 	ResourcesReleased struct {
 		AllocationID model.AllocationID
 		ResourcesID  *ResourcesID
+		ResourcePool string
 	}
 	// GetAllocationSummary returns the summary of the specified task.
 	GetAllocationSummary struct{ ID model.AllocationID }
@@ -95,6 +96,7 @@ type (
 	SetAllocationName struct {
 		Name         string
 		AllocationID model.AllocationID
+		ResourcePool string
 	}
 
 	// ValidateCommandResourcesRequest is a message asking resource manager whether the given

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -522,7 +522,10 @@ func (a *allocation) finalize(
 	severity logrus.Level,
 	exitErr error,
 ) {
-	defer a.rm.Release(sproto.ResourcesReleased{AllocationID: a.req.AllocationID})
+	defer a.rm.Release(sproto.ResourcesReleased{
+		AllocationID: a.req.AllocationID,
+		ResourcePool: a.req.ResourcePool,
+	})
 	for _, cl := range a.closers {
 		defer cl()
 	}
@@ -745,6 +748,7 @@ func (a *allocation) resourcesStateChanged(msg *sproto.ResourcesStateChanged) {
 		a.rm.Release(sproto.ResourcesReleased{
 			AllocationID: a.req.AllocationID,
 			ResourcesID:  &msg.ResourcesID,
+			ResourcePool: a.req.ResourcePool,
 		})
 
 		if err := a.resources[msg.ResourcesID].Persist(); err != nil {


### PR DESCRIPTION
## Description

Removed `for` loops from the following methods for K8s and determined (agent) resource managers: 

- `MoveJob`
- `Release`
- `SetAllocationName`
- `SetGroupMaxSlots`
- `SetGroupPriority`
- `SetGroupWeight`

In all of the above referenced files, added `ResourcePool` field to API request literals if it wasn't previously there.

Now, the functions listed above make a direct call to the resource pool provided in the API request.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9920