### PR TITLE
fix: Model delete redirect only needed if inside the model [WEB-1867]

### DIFF
--- a/webui/react/src/components/DeleteModelModal.tsx
+++ b/webui/react/src/components/DeleteModelModal.tsx
@@ -1,20 +1,27 @@
 import { Modal } from 'hew/Modal';
 
+import { paths } from 'routes/utils';
 import { deleteModel } from 'services/api';
 import { ModelItem } from 'types';
 import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 import { routeToReactUrl } from 'utils/routes';
 
 interface Props {
-  listPath?: string;
   model: ModelItem;
+  redirectOnDelete?: boolean;
 }
 
-const DeleteModelModal = ({ listPath, model }: Props): JSX.Element => {
+const DeleteModelModal = ({ model, redirectOnDelete = false }: Props): JSX.Element => {
   const handleOk = async () => {
     try {
       await deleteModel({ modelName: model.name });
-      if (listPath) routeToReactUrl(listPath);
+      if (redirectOnDelete) {
+        routeToReactUrl(
+          model.workspaceId
+            ? paths.workspaceDetails(model.workspaceId, 'models')
+            : paths.modelList(),
+        );
+      }
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,

--- a/webui/react/src/components/DeleteModelModal.tsx
+++ b/webui/react/src/components/DeleteModelModal.tsx
@@ -1,20 +1,20 @@
 import { Modal } from 'hew/Modal';
 
-import { paths } from 'routes/utils';
 import { deleteModel } from 'services/api';
 import { ModelItem } from 'types';
 import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 import { routeToReactUrl } from 'utils/routes';
 
 interface Props {
+  listPath?: string;
   model: ModelItem;
 }
 
-const DeleteModelModal = ({ model }: Props): JSX.Element => {
+const DeleteModelModal = ({ listPath, model }: Props): JSX.Element => {
   const handleOk = async () => {
     try {
       await deleteModel({ modelName: model.name });
-      routeToReactUrl(paths.modelList());
+      if (listPath) routeToReactUrl(listPath);
     } catch (e) {
       handleError(e, {
         level: ErrorLevel.Error,

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -16,6 +16,7 @@ import ModelMoveModal from 'components/ModelMoveModal';
 import TimeAgo from 'components/TimeAgo';
 import Avatar from 'components/UserAvatar';
 import usePermissions from 'hooks/usePermissions';
+import { paths } from 'routes/utils';
 import userStore from 'stores/users';
 import { ModelItem, Workspace } from 'types';
 import { formatDatetime } from 'utils/datetime';
@@ -148,6 +149,12 @@ const ModelHeader: React.FC<Props> = ({
     [deleteModelModal, modelEditModal, modelMoveModal, onSwitchArchive],
   );
 
+  const listPath = useMemo(
+    () =>
+      model.workspaceId ? paths.workspaceDetails(model.workspaceId, 'models') : paths.modelList(),
+    [model.workspaceId],
+  );
+
   return (
     <header className={css.base}>
       {model.archived && (
@@ -173,7 +180,7 @@ const ModelHeader: React.FC<Props> = ({
         </div>
         <Glossary content={infoRows} />
       </div>
-      <deleteModelModal.Component model={model} />
+      <deleteModelModal.Component listPath={listPath} model={model} />
       <modelMoveModal.Component model={model} />
       <modelEditModal.Component fetchModel={fetchModel} model={model} />
     </header>

--- a/webui/react/src/pages/ModelDetails/ModelHeader.tsx
+++ b/webui/react/src/pages/ModelDetails/ModelHeader.tsx
@@ -16,7 +16,6 @@ import ModelMoveModal from 'components/ModelMoveModal';
 import TimeAgo from 'components/TimeAgo';
 import Avatar from 'components/UserAvatar';
 import usePermissions from 'hooks/usePermissions';
-import { paths } from 'routes/utils';
 import userStore from 'stores/users';
 import { ModelItem, Workspace } from 'types';
 import { formatDatetime } from 'utils/datetime';
@@ -149,12 +148,6 @@ const ModelHeader: React.FC<Props> = ({
     [deleteModelModal, modelEditModal, modelMoveModal, onSwitchArchive],
   );
 
-  const listPath = useMemo(
-    () =>
-      model.workspaceId ? paths.workspaceDetails(model.workspaceId, 'models') : paths.modelList(),
-    [model.workspaceId],
-  );
-
   return (
     <header className={css.base}>
       {model.archived && (
@@ -180,7 +173,7 @@ const ModelHeader: React.FC<Props> = ({
         </div>
         <Glossary content={infoRows} />
       </div>
-      <deleteModelModal.Component listPath={listPath} model={model} />
+      <deleteModelModal.Component model={model} redirectOnDelete />
       <modelMoveModal.Component model={model} />
       <modelEditModal.Component fetchModel={fetchModel} model={model} />
     </header>


### PR DESCRIPTION
## Description

Bug: deleting a model from a Workspace's Model Registry tab redirects us to the wrong place (general `/det/models` page)

Solution: a redirect is only needed if the user is requesting delete from the Model Details page, where I will pass a `listPath` prop. Actions on the model registry tables will no longer trigger a redirect.

Note: we don't use the store in models, so the registry takes a few seconds to update

Alternatives: I considered always passing a workspace to the delete modal, and redirecting by default. The issue was that ModelActionDropdown is wrapped by InteractiveTable/ContextMenu and cannot pass new props

## Test Plan

- Create two models within a workspace
- Click into one model's details page. Delete the model from this page, and you will be redirected back to the workspace's registry tab
- Delete the other model from the workspace tab / table view. There is no redirect

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.