### PR TITLE
fix: antd.Typography with expansion tooltips moved to hew [WEB-1862]

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.15",
+        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.17",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -6587,8 +6587,8 @@
       }
     },
     "node_modules/hew": {
-      "version": "0.6.15",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#bd4ef7688d2227da2f813616cdb82e83984c16d2",
+      "version": "0.6.17",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#4ec9decb8311c126961b63b96525bc130ae9bde5",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -6587,9 +6587,8 @@
       }
     },
     "node_modules/hew": {
-      "version": "0.6.14",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#e93d03e6caf946d7861ad04d6c999e33b6ef40f7",
-      "integrity": "sha512-UCfz9BMQgxDeljrgdGF0Q693L/9uaEDEffXG06DCy1XdQc8oHU0hZX7/kt9aXsoP27g2k5gby+MX+D5OIlnWhw==",
+      "version": "0.6.15",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#bd4ef7688d2227da2f813616cdb82e83984c16d2",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.15",
+    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.17",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",

--- a/webui/react/src/App.module.scss
+++ b/webui/react/src/App.module.scss
@@ -5,3 +5,6 @@
   height: 100%;
   width: 100%;
 }
+:global(.ant-typography.ant-typography-ellipsis-single-line) {
+  margin-bottom: 0;
+}

--- a/webui/react/src/App.module.scss
+++ b/webui/react/src/App.module.scss
@@ -5,6 +5,3 @@
   height: 100%;
   width: 100%;
 }
-:global(.ant-typography.ant-typography-ellipsis-single-line) {
-  margin-bottom: 0;
-}

--- a/webui/react/src/components/ExperimentMoveModal.tsx
+++ b/webui/react/src/components/ExperimentMoveModal.tsx
@@ -1,10 +1,10 @@
-import { Typography } from 'antd';
 import Form from 'hew/Form';
 import Icon from 'hew/Icon';
 import { Modal } from 'hew/Modal';
 import Select, { Option } from 'hew/Select';
 import Spinner from 'hew/Spinner';
 import { useToast } from 'hew/Toast';
+import { Title, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import { useObservable } from 'micro-observables';
 import React, { useEffect, useId, useState } from 'react';
@@ -174,7 +174,7 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                   title={workspace.name}
                   value={workspace.id}>
                   <div>
-                    <Typography.Text ellipsis={true}>{workspace.name}</Typography.Text>
+                    <Title truncate={{tooltip: true}}>{workspace.name}</Title>
                     {workspace.archived && <Icon name="archive" title="Archived" />}
                   </div>
                 </Option>
@@ -202,7 +202,9 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                       title={project.name}
                       value={project.id}>
                       <div>
-                        <Typography.Text ellipsis={true}>{project.name}</Typography.Text>
+                        <Title size={TypographySize.S} truncate={{ tooltip: true }}>
+                          {project.name}
+                        </Title>
                         {project.archived && <Icon name="archive" title="Archived" />}
                       </div>
                     </Option>

--- a/webui/react/src/components/ExperimentMoveModal.tsx
+++ b/webui/react/src/components/ExperimentMoveModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from 'hew/Modal';
 import Select, { Option } from 'hew/Select';
 import Spinner from 'hew/Spinner';
 import { useToast } from 'hew/Toast';
-import { Title, TypographySize } from 'hew/Typography';
+import { Label } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import { useObservable } from 'micro-observables';
 import React, { useEffect, useId, useState } from 'react';
@@ -174,7 +174,7 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                   title={workspace.name}
                   value={workspace.id}>
                   <div>
-                    <Title size={TypographySize.XS} truncate={{ tooltip: true }}>{workspace.name}</Title>
+                    <Label truncate={{ tooltip: true }}>{workspace.name}</Label>
                     {workspace.archived && <Icon name="archive" title="Archived" />}
                   </div>
                 </Option>
@@ -202,9 +202,7 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                       title={project.name}
                       value={project.id}>
                       <div>
-                        <Title size={TypographySize.XS} truncate={{ tooltip: true }}>
-                          {project.name}
-                        </Title>
+                        <Label truncate={{ tooltip: true }}>{project.name}</Label>
                         {project.archived && <Icon name="archive" title="Archived" />}
                       </div>
                     </Option>

--- a/webui/react/src/components/ExperimentMoveModal.tsx
+++ b/webui/react/src/components/ExperimentMoveModal.tsx
@@ -174,7 +174,7 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                   title={workspace.name}
                   value={workspace.id}>
                   <div>
-                    <Title truncate={{tooltip: true}}>{workspace.name}</Title>
+                    <Title size={TypographySize.XS} truncate={{ tooltip: true }}>{workspace.name}</Title>
                     {workspace.archived && <Icon name="archive" title="Archived" />}
                   </div>
                 </Option>
@@ -202,7 +202,7 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
                       title={project.name}
                       value={project.id}>
                       <div>
-                        <Title size={TypographySize.S} truncate={{ tooltip: true }}>
+                        <Title size={TypographySize.XS} truncate={{ tooltip: true }}>
                           {project.name}
                         </Title>
                         {project.archived && <Icon name="archive" title="Archived" />}

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -1,4 +1,4 @@
-import { Space, Typography } from 'antd';
+import { Space } from 'antd';
 import {
   FilterDropdownProps,
   FilterValue,
@@ -15,6 +15,7 @@ import { useModal } from 'hew/Modal';
 import Tags, { tagsActionHelper } from 'hew/Tags';
 import Toggle from 'hew/Toggle';
 import Tooltip from 'hew/Tooltip';
+import { Label } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -418,8 +419,8 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
   const columns = useMemo(() => {
     const tagsRenderer = (_CHART_HEIGHTvalue: string, record: ModelItem) => (
       <div className={css.tagsRenderer}>
-        <Typography.Text
-          ellipsis={{
+        <Label
+          truncate={{
             tooltip: <Tags disabled tags={record.labels ?? []} />,
           }}>
           <div>
@@ -432,7 +433,7 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
               )}
             />
           </div>
-        </Typography.Text>
+        </Label>
       </div>
     );
 

--- a/webui/react/src/components/OverviewStats.module.scss
+++ b/webui/react/src/components/OverviewStats.module.scss
@@ -3,9 +3,8 @@
   flex-direction: column;
   justify-content: space-between;
 
-  .title * {
-    font-size: 12px;
-    font-weight: normal;
+  .title {
+    margin-bottom: 6px;
   }
   .info {
     font-size: 13px;

--- a/webui/react/src/components/OverviewStats.module.scss
+++ b/webui/react/src/components/OverviewStats.module.scss
@@ -1,3 +1,0 @@
-.clickable {
-  color: var(--theme-ix-on-active);
-}

--- a/webui/react/src/components/OverviewStats.module.scss
+++ b/webui/react/src/components/OverviewStats.module.scss
@@ -1,23 +1,7 @@
-.base {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+.info {
+  font-size: 13px;
 
-  .title {
-    margin-bottom: 6px;
-  }
-  .info {
-    font-size: 13px;
-
-    & > :global(.ant-typography) {
-      margin: 0;
-
-      & small {
-        font-size: 12px;
-      }
-    }
-    &.clickable > :global(.ant-typography) {
-      color: var(--theme-ix-on-active);
-    }
+  &.clickable > :global(.ant-typography) {
+    color: var(--theme-ix-on-active);
   }
 }

--- a/webui/react/src/components/OverviewStats.module.scss
+++ b/webui/react/src/components/OverviewStats.module.scss
@@ -1,7 +1,3 @@
-.info {
-  font-size: 13px;
-
-  &.clickable > :global(.ant-typography) {
-    color: var(--theme-ix-on-active);
-  }
+.clickable {
+  color: var(--theme-ix-on-active);
 }

--- a/webui/react/src/components/OverviewStats.module.scss
+++ b/webui/react/src/components/OverviewStats.module.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   justify-content: space-between;
 
-  .title {
+  .title * {
     font-size: 12px;
     font-weight: normal;
   }

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -1,5 +1,5 @@
-import { Typography } from 'antd';
 import Card from 'hew/Card';
+import { Body, Label } from 'hew/Typography';
 import React from 'react';
 
 import css from './OverviewStats.module.scss';
@@ -18,13 +18,11 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
   return (
     <Card onClick={props.onClick}>
       <div className={css.base}>
-        <Typography.Title className={css.title} ellipsis={{ rows: 1, tooltip: true }} level={5}>
-          {props.title}
-        </Typography.Title>
+        <div className={css.title}>
+          <Label truncate={{ rows: 1, tooltip: true }}>{props.title}</Label>
+        </div>
         <strong className={childClasses.join(' ')}>
-          <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
-            {props.children}
-          </Typography.Paragraph>
+          <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>
         </strong>
       </div>
     </Card>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -1,5 +1,5 @@
 import Card from 'hew/Card';
-import { Body, Label } from 'hew/Typography';
+import { Body, Title, TypographySize } from 'hew/Typography';
 import React from 'react';
 
 import css from './OverviewStats.module.scss';
@@ -19,7 +19,7 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
     <Card onClick={props.onClick}>
       <div className={css.base}>
         <div className={css.title}>
-          <Label truncate={{ rows: 1, tooltip: true }}>{props.title}</Label>
+          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>{props.title}</Title>
         </div>
         <strong className={childClasses.join(' ')}>
           <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -1,5 +1,5 @@
 import Card from 'hew/Card';
-import { Body, Title, TypographySize } from 'hew/Typography';
+import { Body, Label, TypographySize } from 'hew/Typography';
 import React from 'react';
 
 import css from './OverviewStats.module.scss';
@@ -19,9 +19,9 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
     <Card onClick={props.onClick}>
       <div className={css.base}>
         <div className={css.title}>
-          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+          <Label size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
             {props.title}
-          </Title>
+          </Label>
         </div>
         <strong className={childClasses.join(' ')}>
           <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -1,4 +1,6 @@
 import Card from 'hew/Card';
+import Column from 'hew/Column';
+import Row from 'hew/Row';
 import { Body, Label, TypographySize } from 'hew/Typography';
 import React from 'react';
 
@@ -17,16 +19,18 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
 
   return (
     <Card onClick={props.onClick}>
-      <div className={css.base}>
-        <div className={css.title}>
+      <Column>
+        <Row>
           <Label size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
             {props.title}
           </Label>
-        </div>
-        <strong className={childClasses.join(' ')}>
-          <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>
-        </strong>
-      </div>
+        </Row>
+        <Row>
+          <strong className={childClasses.join(' ')}>
+            <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>
+          </strong>
+        </Row>
+      </Column>
     </Card>
   );
 };

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -19,7 +19,9 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
     <Card onClick={props.onClick}>
       <div className={css.base}>
         <div className={css.title}>
-          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>{props.title}</Title>
+          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+            {props.title}
+          </Title>
         </div>
         <strong className={childClasses.join(' ')}>
           <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -1,10 +1,9 @@
 import Card from 'hew/Card';
 import Column from 'hew/Column';
+import Link from 'hew/Link';
 import Row from 'hew/Row';
 import { Body, Label, TypographySize } from 'hew/Typography';
 import React from 'react';
-
-import css from './OverviewStats.module.scss';
 
 interface Props {
   children: React.ReactNode;
@@ -14,25 +13,21 @@ interface Props {
 }
 
 const OverviewStats: React.FC<Props> = (props: Props) => {
-  const childClasses = [];
-  if (props.onClick) childClasses.push(css.clickable);
-
-  return (
-    <Card onClick={props.onClick}>
-      <Column>
-        <Row>
-          <Label size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
-            {props.title}
-          </Label>
-        </Row>
-        <Row>
-          <strong className={childClasses.join(' ')}>
-            <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>
-          </strong>
-        </Row>
-      </Column>
-    </Card>
+  const column = (
+    <Column>
+      <Row>
+        <Label size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+          {props.title}
+        </Label>
+      </Row>
+      <Row>
+        <strong>
+          <Body truncate={{ rows: 1, tooltip: true }}>{props.children}</Body>
+        </strong>
+      </Row>
+    </Column>
   );
+  return <Card>{props.onClick ? <Link onClick={props.onClick}>{column}</Link> : column}</Card>;
 };
 
 export default OverviewStats;

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const OverviewStats: React.FC<Props> = (props: Props) => {
-  const childClasses = [css.info];
+  const childClasses = [];
   if (props.onClick) childClasses.push(css.clickable);
 
   return (

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -1,37 +1,32 @@
-.base {
+.uncategorized .workspaceContainer {
+  visibility: hidden;
+}
+.footerContainer {
+  align-items: end;
   display: flex;
-  gap: 16px;
+  flex-grow: 1;
+  font-size: 12px;
+  gap: var(spacing-sm);
+  justify-content: space-between;
 
-  &.uncategorized .workspaceContainer {
-    visibility: hidden;
-  }
-  .footerContainer {
-    align-items: end;
-    display: flex;
-    flex-grow: 1;
-    font-size: 12px;
-    gap: var(spacing-sm);
-    justify-content: space-between;
+  .experiments {
+    align-self: end;
 
-    .experiments {
-      align-self: end;
-
-      & > span {
-        align-items: center;
-        display: flex;
-        gap: 4px;
-      }
-    }
-    .archivedBadge {
-      background-color: var(--theme-status-inactive);
-      border-radius: var(--theme-border-radius);
-      color: var(--theme-status-warning-on);
-      opacity: 1;
-      padding: 2px 4px;
+    & > span {
+      align-items: center;
+      display: flex;
+      gap: 4px;
     }
   }
-  &.archived .name,
-  &.archived .experiments {
-    opacity: 0.55;
+  .archivedBadge {
+    background-color: var(--theme-status-inactive);
+    border-radius: var(--theme-border-radius);
+    color: var(--theme-status-warning-on);
+    opacity: 1;
+    padding: 2px 4px;
   }
+}
+.archived .name,
+.archived .experiments {
+  opacity: 0.55;
 }

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -2,15 +2,15 @@
   display: flex;
   gap: 16px;
 
-  .workspaceIcon {
-    width: fit-content;
+  &.uncategorized .workspaceContainer {
+    visibility: hidden;
   }
   .footerContainer {
     align-items: end;
     display: flex;
+    flex-grow: 1;
     font-size: 12px;
     gap: 6px;
-    grid-area: footer;
     justify-content: space-between;
 
     .experiments {

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -10,7 +10,7 @@
     display: flex;
     flex-grow: 1;
     font-size: 12px;
-    gap: 6px;
+    gap: var(spacing-sm);
     justify-content: space-between;
 
     .experiments {

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -10,9 +10,8 @@
   .headerContainer {
     grid-area: header;
 
-    & > h1 {
-      margin-bottom: 0;
-      width: fit-content;
+    * {
+      margin-block-end: 0;
     }
   }
   .workspaceContainer {

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -2,17 +2,14 @@
   display: grid;
   gap: 16px;
   grid-template:
-    'header  header' auto
+    'header header' auto
     'workspace workspace' 20px
     'footer footer' 20px / auto auto;
   height: 100%;
 
-  .headerContainer {
+  h1 {
     grid-area: header;
-
-    * {
-      margin-block-end: 0;
-    }
+    max-width: 100%;
   }
   .workspaceContainer {
     grid-area: workspace;

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -7,7 +7,7 @@
     'footer footer' 20px / auto auto;
   height: 100%;
 
-  h1 {
+  :global(.ant-typography-single-line) {
     grid-area: header;
     max-width: 100%;
   }

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -9,11 +9,11 @@
 
   .headerContainer {
     grid-area: header;
-  }
-  .name {
-    font-size: 13px;
-    margin-bottom: 0;
-    width: fit-content;
+
+    & > h1 {
+      margin-bottom: 0;
+      width: fit-content;
+    }
   }
   .workspaceContainer {
     grid-area: workspace;

--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -1,19 +1,7 @@
 .base {
-  display: grid;
+  display: flex;
   gap: 16px;
-  grid-template:
-    'header header' auto
-    'workspace workspace' 20px
-    'footer footer' 20px / auto auto;
-  height: 100%;
 
-  :global(.ant-typography-single-line) {
-    grid-area: header;
-    max-width: 100%;
-  }
-  .workspaceContainer {
-    grid-area: workspace;
-  }
   .workspaceIcon {
     width: fit-content;
   }

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -1,8 +1,8 @@
-import { Typography } from 'antd';
 import Avatar, { Size } from 'hew/Avatar';
 import Card from 'hew/Card';
 import Icon from 'hew/Icon';
 import Tooltip from 'hew/Tooltip';
+import { Title, TypographySize } from 'hew/Typography';
 import React from 'react';
 
 import TimeAgo from 'components/TimeAgo';
@@ -48,10 +48,10 @@ const ProjectCard: React.FC<Props> = ({
       onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
-        <div className={css.headerContainer}>
-          <Typography.Title className={css.name} ellipsis={{ rows: 3, tooltip: true }} level={5}>
+        <div className={`${css.headerContainer} ${css.name}`}>
+          <Title size={TypographySize.S} truncate={{ rows: 3, tooltip: true }}>
             {project.name}
-          </Typography.Title>
+          </Title>
         </div>
         <div className={css.workspaceContainer}>
           {showWorkspace && project.workspaceId !== 1 && (

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -48,11 +48,9 @@ const ProjectCard: React.FC<Props> = ({
       onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
-        <div className={css.headerContainer}>
-          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
-            {project.name}
-          </Title>
-        </div>
+        <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+          {project.name}
+        </Title>
         <div className={css.workspaceContainer}>
           {showWorkspace && project.workspaceId !== 1 && (
             <Tooltip content={project.workspaceName}>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -41,7 +41,7 @@ const ProjectCard: React.FC<Props> = ({
     workspaceArchived,
   });
 
-  const classnames = [css.base];
+  const classnames = [];
   if (project.archived) classnames.push(css.archived);
   if (project.workspaceId === 1) classnames.push(css.uncategorized);
 

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -1,6 +1,8 @@
 import Avatar, { Size } from 'hew/Avatar';
 import Card from 'hew/Card';
+import Column from 'hew/Column';
 import Icon from 'hew/Icon';
+import Row from 'hew/Row';
 import Tooltip from 'hew/Tooltip';
 import { Title, TypographySize } from 'hew/Typography';
 import React from 'react';
@@ -48,40 +50,48 @@ const ProjectCard: React.FC<Props> = ({
       onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
-        <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
-          {project.name}
-        </Title>
-        <div className={css.workspaceContainer}>
-          {showWorkspace && project.workspaceId !== 1 && (
-            <Tooltip content={project.workspaceName}>
-              <div className={css.workspaceIcon}>
-                <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
+        <Column>
+          <Row width={125}>
+            <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+              {project.name}
+            </Title>
+          </Row>
+          <Row>
+            <div className={css.workspaceContainer}>
+              {showWorkspace && project.workspaceId !== 1 && (
+                <Tooltip content={project.workspaceName}>
+                  <div className={css.workspaceIcon}>
+                    <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
+                  </div>
+                </Tooltip>
+              )}
+            </div>
+          </Row>
+          <Row>
+            <div className={css.footerContainer}>
+              <div className={css.experiments}>
+                <Tooltip
+                  content={
+                    `${project.numExperiments.toLocaleString()}` +
+                    ` experiment${project.numExperiments === 1 ? '' : 's'}`
+                  }>
+                  <Icon name="experiment" size="small" title="Number of experiments" />
+                  <span>{nearestCardinalNumber(project.numExperiments)}</span>
+                </Tooltip>
               </div>
-            </Tooltip>
-          )}
-        </div>
-        <div className={css.footerContainer}>
-          <div className={css.experiments}>
-            <Tooltip
-              content={
-                `${project.numExperiments.toLocaleString()}` +
-                ` experiment${project.numExperiments === 1 ? '' : 's'}`
-              }>
-              <Icon name="experiment" size="small" title="Number of experiments" />
-              <span>{nearestCardinalNumber(project.numExperiments)}</span>
-            </Tooltip>
-          </div>
-          {project.archived ? (
-            <div className={css.archivedBadge}>Archived</div>
-          ) : (
-            project.lastExperimentStartedAt && (
-              <TimeAgo
-                datetime={project.lastExperimentStartedAt}
-                tooltipFormat="[Last experiment started: \n]MMM D, YYYY - h:mm a"
-              />
-            )
-          )}
-        </div>
+              {project.archived ? (
+                <div className={css.archivedBadge}>Archived</div>
+              ) : (
+                project.lastExperimentStartedAt && (
+                  <TimeAgo
+                    datetime={project.lastExperimentStartedAt}
+                    tooltipFormat="[Last experiment started: \n]MMM D, YYYY - h:mm a"
+                  />
+                )
+              )}
+            </div>
+          </Row>
+        </Column>
       </div>
       {contextHolders}
     </Card>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -49,7 +49,7 @@ const ProjectCard: React.FC<Props> = ({
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
         <div className={css.headerContainer}>
-          <Title size={TypographySize.XS} truncate={{ rows: 3, tooltip: true }}>
+          <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
             {project.name}
           </Title>
         </div>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -43,6 +43,7 @@ const ProjectCard: React.FC<Props> = ({
 
   const classnames = [css.base];
   if (project.archived) classnames.push(css.archived);
+  if (project.workspaceId === 1) classnames.push(css.uncategorized);
 
   return (
     <Card
@@ -58,7 +59,7 @@ const ProjectCard: React.FC<Props> = ({
           </Row>
           <Row>
             <div className={css.workspaceContainer}>
-              {showWorkspace && project.workspaceId !== 1 && (
+              {showWorkspace && (
                 <Tooltip content={project.workspaceName}>
                   <div className={css.workspaceIcon}>
                     <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
@@ -67,7 +68,7 @@ const ProjectCard: React.FC<Props> = ({
               )}
             </div>
           </Row>
-          <Row>
+          <Row justifyContent="space-between" width="fill">
             <div className={css.footerContainer}>
               <div className={css.experiments}>
                 <Tooltip

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -48,7 +48,7 @@ const ProjectCard: React.FC<Props> = ({
       onClick={(e: AnyMouseEvent) => handlePath(e, { path: paths.projectDetails(project.id) })}
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
-        <div className={`${css.headerContainer} ${css.name}`}>
+        <div className={css.headerContainer}>
           <Title size={TypographySize.XS} truncate={{ rows: 3, tooltip: true }}>
             {project.name}
           </Title>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -51,7 +51,7 @@ const ProjectCard: React.FC<Props> = ({
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
         <Column>
-          <Row width={125}>
+          <Row justifyContent="space-between" width={125}>
             <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
               {project.name}
             </Title>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -49,7 +49,7 @@ const ProjectCard: React.FC<Props> = ({
       onDropdown={onClick}>
       <div className={classnames.join(' ')}>
         <div className={`${css.headerContainer} ${css.name}`}>
-          <Title size={TypographySize.S} truncate={{ rows: 3, tooltip: true }}>
+          <Title size={TypographySize.XS} truncate={{ rows: 3, tooltip: true }}>
             {project.name}
           </Title>
         </div>

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -60,11 +60,9 @@ const ProjectCard: React.FC<Props> = ({
           <Row>
             <div className={css.workspaceContainer}>
               {showWorkspace && (
-                <Tooltip content={project.workspaceName}>
-                  <div className={css.workspaceIcon}>
-                    <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
-                  </div>
-                </Tooltip>
+                <div className={css.workspaceIcon}>
+                  <Avatar palette="muted" size={Size.Small} square text={project.workspaceName} />
+                </div>
               )}
             </div>
           </Row>

--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -1,9 +1,9 @@
-import { Typography } from 'antd';
 import { SelectValue } from 'antd/lib/select';
 import Icon from 'hew/Icon';
 import { Modal } from 'hew/Modal';
 import Select, { Option } from 'hew/Select';
 import { useToast } from 'hew/Toast';
+import { Title, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import React, { useCallback, useState } from 'react';
 
@@ -91,7 +91,9 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onMove, project }: Props) 
           return (
             <Option disabled={disabled} key={workspace.id} value={workspace.id}>
               <div className={disabled ? css.workspaceOptionDisabled : ''}>
-                <Typography.Text ellipsis={true}>{workspace.name}</Typography.Text>
+                <Title size={TypographySize.S} truncate={{ tooltip: true }}>
+                  {workspace.name}
+                </Title>
                 {workspace.archived && <Icon name="archive" title="Archived" />}
                 {workspace.id === project.workspaceId && (
                   <Icon name="checkmark" title="Project's current workspace" />

--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -3,7 +3,7 @@ import Icon from 'hew/Icon';
 import { Modal } from 'hew/Modal';
 import Select, { Option } from 'hew/Select';
 import { useToast } from 'hew/Toast';
-import { Title, TypographySize } from 'hew/Typography';
+import { Label } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import React, { useCallback, useState } from 'react';
 
@@ -91,9 +91,7 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onMove, project }: Props) 
           return (
             <Option disabled={disabled} key={workspace.id} value={workspace.id}>
               <div className={disabled ? css.workspaceOptionDisabled : ''}>
-                <Title size={TypographySize.S} truncate={{ tooltip: true }}>
-                  {workspace.name}
-                </Title>
+                <Label truncate={{ tooltip: true }}>{workspace.name}</Label>
                 {workspace.archived && <Icon name="archive" title="Archived" />}
                 {workspace.id === project.workspaceId && (
                   <Icon name="checkmark" title="Project's current workspace" />

--- a/webui/react/src/components/Table/Table.tsx
+++ b/webui/react/src/components/Table/Table.tsx
@@ -1,9 +1,10 @@
-import { Space, Typography } from 'antd';
+import { Space } from 'antd';
 import Avatar from 'hew/Avatar';
 import Icon from 'hew/Icon';
 import Spinner from 'hew/Spinner';
 import { StateOfUnion } from 'hew/Theme';
 import Tooltip from 'hew/Tooltip';
+import { Label } from 'hew/Typography';
 import React from 'react';
 
 import Badge, { BadgeType } from 'components/Badge';
@@ -208,7 +209,7 @@ export const experimentNameRenderer = (
   value: string | number | undefined,
   record: ExperimentItem,
 ): React.ReactNode => (
-  <Typography.Text ellipsis={{ tooltip: true }}>
+  <Label truncate={{ tooltip: true }}>
     <Link path={paths.experimentDetails(record.id)}>
       {value === undefined ? '' : value}&nbsp;&nbsp;
       {record.unmanaged && (
@@ -217,7 +218,7 @@ export const experimentNameRenderer = (
         </Badge>
       )}
     </Link>
-  </Typography.Text>
+  </Label>
 );
 
 /* Model Table Column Renderers */

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -1,12 +1,13 @@
-import { Space } from 'antd';
 import Accordion from 'hew/Accordion';
 import Button from 'hew/Button';
+import Column from 'hew/Column';
 import Drawer from 'hew/Drawer';
 import Icon from 'hew/Icon';
 import InlineForm from 'hew/InlineForm';
 import Input from 'hew/Input';
 import InputShortcut, { KeyboardShortcut, shortcutToString } from 'hew/InputShortcut';
 import { useModal } from 'hew/Modal';
+import Row from 'hew/Row';
 import Select, { Option } from 'hew/Select';
 import Spinner from 'hew/Spinner';
 import { ShirtSize } from 'hew/Theme';
@@ -328,10 +329,10 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                     }
                     key={feature}
                     label={
-                      <Space>
+                      <Row>
                         {description.friendlyName}
                         <Icon name="info" showTooltip title={description.description} />
-                      </Space>
+                      </Row>
                     }
                     valueFormatter={(value) => (value ? 'On' : 'Off')}
                     onSubmit={(val) => {
@@ -354,7 +355,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                   reset your user settings if you make a mistake.
                 </Body>
                 <Accordion title="I know what I'm doing">
-                  <Space>
+                  <Column>
                     <Button
                       danger
                       type="primary"
@@ -376,7 +377,7 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
                       Edit Raw Settings (JSON)
                     </Button>
                     <UserSettingsModal.Component />
-                  </Space>
+                  </Column>
                 </Accordion>
               </Grid>
             </Section>

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -9,12 +9,14 @@ import InputShortcut, { KeyboardShortcut, shortcutToString } from 'hew/InputShor
 import { useModal } from 'hew/Modal';
 import Select, { Option } from 'hew/Select';
 import Spinner from 'hew/Spinner';
+import { ShirtSize } from 'hew/Theme';
 import { useToast } from 'hew/Toast';
 import { Body } from 'hew/Typography';
 import useConfirm from 'hew/useConfirm';
 import { Loadable } from 'hew/utils/loadable';
 import React, { useCallback, useState } from 'react';
 
+import Grid from 'components/Grid';
 import PasswordChangeModalComponent from 'components/PasswordChangeModal';
 import Section from 'components/Section';
 import useUI, { Mode } from 'components/ThemeProvider';
@@ -346,33 +348,37 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
               </div>
             </Section>
             <Section title="Advanced">
-              <Body>
-                Advanced features are potentially dangerous and could require you to completely
-                reset your user settings if you make a mistake.
-              </Body>
-              <Accordion title="I know what I'm doing">
-                <Space>
-                  <Button
-                    danger
-                    type="primary"
-                    onClick={() =>
-                      confirm({
-                        content:
-                          'Are you sure you want to reset all user settings to their default values?',
-                        onConfirm: () => {
-                          setMode(Mode.System);
-                          userSettings.clear();
-                        },
-                        onError: handleError,
-                        title: 'Reset User Settings',
-                      })
-                    }>
-                    Reset to Default
-                  </Button>
-                  <Button onClick={() => UserSettingsModal.open()}>Edit Raw Settings (JSON)</Button>
-                  <UserSettingsModal.Component />
-                </Space>
-              </Accordion>
+              <Grid gap={ShirtSize.Medium} minItemWidth={400}>
+                <Body>
+                  Advanced features are potentially dangerous and could require you to completely
+                  reset your user settings if you make a mistake.
+                </Body>
+                <Accordion title="I know what I'm doing">
+                  <Space>
+                    <Button
+                      danger
+                      type="primary"
+                      onClick={() =>
+                        confirm({
+                          content:
+                            'Are you sure you want to reset all user settings to their default values?',
+                          onConfirm: () => {
+                            setMode(Mode.System);
+                            userSettings.clear();
+                          },
+                          onError: handleError,
+                          title: 'Reset User Settings',
+                        })
+                      }>
+                      Reset to Default
+                    </Button>
+                    <Button onClick={() => UserSettingsModal.open()}>
+                      Edit Raw Settings (JSON)
+                    </Button>
+                    <UserSettingsModal.Component />
+                  </Space>
+                </Accordion>
+              </Grid>
             </Section>
           </Drawer>
         );

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -1,4 +1,4 @@
-import { ModalFuncProps, Radio, Space, Typography } from 'antd';
+import { ModalFuncProps, Radio, Space } from 'antd';
 import { RefSelectProps } from 'antd/lib/select';
 import Button from 'hew/Button';
 import Checkbox from 'hew/Checkbox';
@@ -8,6 +8,7 @@ import Input from 'hew/Input';
 import InputNumber from 'hew/InputNumber';
 import Message from 'hew/Message';
 import Select, { Option, SelectValue } from 'hew/Select';
+import { Title, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import yaml from 'js-yaml';
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
@@ -716,9 +717,9 @@ const HyperparameterRow: React.FC<RowProps> = ({ hyperparameter, name, searcher 
   return (
     <>
       <div className={css.hyperparameterName}>
-        <Typography.Title ellipsis={{ rows: 1, tooltip: true }} level={3}>
+        <Title size={TypographySize.S} truncate={{ rows: 1, tooltip: true }}>
           {name}
-        </Typography.Title>
+        </Title>
       </div>
       <Form.Item initialValue={hyperparameter.type} name={[name, 'type']} noStyle>
         <Select aria-labelledby="type" ref={typeRef} width={'100%'} onChange={handleTypeChange}>

--- a/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
+++ b/webui/react/src/hooks/useModal/HyperparameterSearch/useModalHyperparameterSearch.tsx
@@ -8,7 +8,7 @@ import Input from 'hew/Input';
 import InputNumber from 'hew/InputNumber';
 import Message from 'hew/Message';
 import Select, { Option, SelectValue } from 'hew/Select';
-import { Title, TypographySize } from 'hew/Typography';
+import { Label, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import yaml from 'js-yaml';
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
@@ -717,9 +717,9 @@ const HyperparameterRow: React.FC<RowProps> = ({ hyperparameter, name, searcher 
   return (
     <>
       <div className={css.hyperparameterName}>
-        <Title size={TypographySize.S} truncate={{ rows: 1, tooltip: true }}>
+        <Label size={TypographySize.L} truncate={{ rows: 1, tooltip: true }}>
           {name}
-        </Title>
+        </Label>
       </div>
       <Form.Item initialValue={hyperparameter.type} name={[name, 'type']} noStyle>
         <Select aria-labelledby="type" ref={typeRef} width={'100%'} onChange={handleTypeChange}>

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Button as AntdButton, Space, Typography } from 'antd';
+import { Button as AntdButton, Space } from 'antd';
 import Button from 'hew/Button';
 import Dropdown from 'hew/Dropdown';
 import Glossary, { InfoRow } from 'hew/Glossary';
@@ -8,6 +8,7 @@ import Spinner from 'hew/Spinner';
 import Tags from 'hew/Tags';
 import { useTheme } from 'hew/Theme';
 import Tooltip from 'hew/Tooltip';
+import { Body } from 'hew/Typography';
 import useConfirm from 'hew/useConfirm';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -584,12 +585,11 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
       {
         label: 'Description',
         value: (
-          <Typography.Paragraph
-            disabled={!experiment.description}
-            ellipsis={{ rows: 1, tooltip: true }}
-            style={{ margin: 0 }}>
+          <Body
+            // disabled={!experiment.description}
+            truncate={{ rows: 1, tooltip: true }}>
             {experiment.description || 'N/A'}
-          </Typography.Paragraph>
+          </Body>
         ),
       },
     ];

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -584,11 +584,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
     const rows = [
       {
         label: 'Description',
-        value: (
-          <div className={css.nomargin}>
-            <Body truncate={{ rows: 1, tooltip: true }}>{experiment.description || 'N/A'}</Body>
-          </div>
-        ),
+        value: <Body truncate={{ rows: 1, tooltip: true }}>{experiment.description || 'N/A'}</Body>,
       },
     ];
     if (experiment.forkedFrom && experiment.config.searcher.sourceTrialId) {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -585,11 +585,9 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
       {
         label: 'Description',
         value: (
-          <Body
-            // disabled={!experiment.description}
-            truncate={{ rows: 1, tooltip: true }}>
-            {experiment.description || 'N/A'}
-          </Body>
+          <div className={css.nomargin}>
+            <Body truncate={{ rows: 1, tooltip: true }}>{experiment.description || 'N/A'}</Body>
+          </div>
         ),
       },
     ];

--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpTrialTable.tsx
@@ -1,5 +1,5 @@
-import { Typography } from 'antd';
 import { TablePaginationConfig } from 'antd/es/table/interface';
+import { Body } from 'hew/Typography';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import HumanReadableNumber from 'components/HumanReadableNumber';
@@ -115,11 +115,7 @@ const HpTrialTable: React.FC<Props> = ({
         if (isNumber(value) && isValidType) {
           return <HumanReadableNumber num={value} />;
         }
-        return (
-          <Typography.Paragraph ellipsis={{ rows: 1, tooltip: true }}>
-            {JSON.stringify(value)}
-          </Typography.Paragraph>
-        );
+        return <Body truncate={{ rows: 1, tooltip: true }}>{JSON.stringify(value)}</Body>;
       };
     };
     const hpColumnSorter = (key: string) => {

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -1,8 +1,10 @@
-import { Tag, Typography } from 'antd';
+import { Tag } from 'antd';
 import Message from 'hew/Message';
 import { Modal } from 'hew/Modal';
 import Select, { Option, SelectValue } from 'hew/Select';
 import Spinner from 'hew/Spinner';
+import { useTheme } from 'hew/Theme';
+import { Label } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import usePrevious from 'hew/utils/usePrevious';
 import _ from 'lodash';
@@ -238,9 +240,9 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                       onClose={() => handleTrialUnselect(trial.id)}>
                       <Link path={paths.trialDetails(trial.id, trial.experimentId)}>
                         {Array.isArray(experiment) ? (
-                          <Typography.Text ellipsis={{ tooltip: true }}>
+                          <Label truncate={{ tooltip: true }}>
                             {experimentMap[trial.experimentId]?.name}
-                          </Typography.Text>
+                          </Label>
                         ) : (
                           `Trial ${trial.id}`
                         )}
@@ -265,9 +267,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                     <th scope="row">Experiment ID</th>
                     {trialsDetails.map((trial) => (
                       <td key={trial.id}>
-                        <Typography.Text ellipsis={{ tooltip: true }}>
-                          {trial.experimentId}
-                        </Typography.Text>
+                        <Label truncate={{ tooltip: true }}>{trial.experimentId}</Label>
                       </td>
                     ))}
                   </tr>
@@ -275,7 +275,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                     <th scope="row">Trial ID</th>
                     {trialsDetails.map((trial) => (
                       <td key={trial.id}>
-                        <Typography.Text ellipsis={{ tooltip: true }}>{trial.id}</Typography.Text>
+                        <Label truncate={{ tooltip: true }}>{trial.id}</Label>
                       </td>
                     ))}
                   </tr>
@@ -285,9 +285,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                 <th scope="row">Batched Processed</th>
                 {trialsDetails.map((trial) => (
                   <td key={trial.id}>
-                    <Typography.Text ellipsis={{ tooltip: true }}>
-                      {trial.totalBatchesProcessed}
-                    </Typography.Text>
+                    <Label truncate={{ tooltip: true }}>{trial.totalBatchesProcessed}</Label>
                   </td>
                 ))}
               </tr>
@@ -295,9 +293,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                 <th scope="row">Total Checkpoint Size</th>
                 {trialsDetails.map((trial) => (
                   <td key={trial.id}>
-                    <Typography.Text ellipsis={{ tooltip: true }}>
-                      {totalCheckpointsSizes[trial.id]}
-                    </Typography.Text>
+                    <Label truncate={{ tooltip: true }}>{totalCheckpointsSizes[trial.id]}</Label>
                   </td>
                 ))}
               </tr>
@@ -358,7 +354,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
               {selectedHyperparameters.map((hp) => (
                 <tr key={hp}>
                   <th scope="row">
-                    <Typography.Text ellipsis={{ tooltip: true }}>{hp}</Typography.Text>
+                    <Label truncate={{ tooltip: true }}>{hp}</Label>
                   </th>
                   {trialsDetails.map((trial) => {
                     const hpValue = trial.hyperparameters[hp];
@@ -368,9 +364,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                         {isNumber(hpValue) ? (
                           <HumanReadableNumber num={hpValue} />
                         ) : (
-                          <Typography.Text ellipsis={{ tooltip: true }}>
-                            {stringValue}
-                          </Typography.Text>
+                          <Label truncate={{ tooltip: true }}>{stringValue}</Label>
                         )}
                       </td>
                     );

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -3,7 +3,6 @@ import Message from 'hew/Message';
 import { Modal } from 'hew/Modal';
 import Select, { Option, SelectValue } from 'hew/Select';
 import Spinner from 'hew/Spinner';
-import { useTheme } from 'hew/Theme';
 import { Label } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import usePrevious from 'hew/utils/usePrevious';

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -1,4 +1,4 @@
-import { Space, Typography } from 'antd';
+import { Space } from 'antd';
 import { FilterDropdownProps } from 'antd/lib/table/interface';
 import Button from 'hew/Button';
 import Dropdown, { MenuItem } from 'hew/Dropdown';
@@ -9,6 +9,7 @@ import Progress from 'hew/Progress';
 import Tags from 'hew/Tags';
 import { useTheme } from 'hew/Theme';
 import Toggle from 'hew/Toggle';
+import { Body } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
@@ -406,8 +407,8 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
   const columns = useMemo(() => {
     const tagsRenderer = (_value: string, record: ExperimentItem) => (
       <div className={css.tagsRenderer}>
-        <Typography.Text
-          ellipsis={{
+        <Body
+          truncate={{
             tooltip: <Tags disabled tags={record.labels} />,
           }}>
           <div>
@@ -418,7 +419,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
               onAction={experimentTags.handleTagListChange(record.id, record.labels)}
             />
           </div>
-        </Typography.Text>
+        </Body>
       </div>
     );
 

--- a/webui/react/src/pages/ModelDetails.tsx
+++ b/webui/react/src/pages/ModelDetails.tsx
@@ -1,10 +1,10 @@
-import { Typography } from 'antd';
 import { FilterValue, SorterResult, TablePaginationConfig } from 'antd/lib/table/interface';
 import Input from 'hew/Input';
 import Message from 'hew/Message';
 import Notes from 'hew/RichTextEditor';
 import Spinner from 'hew/Spinner';
 import Tags, { tagsActionHelper } from 'hew/Tags';
+import { Label } from 'hew/Typography';
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -168,8 +168,8 @@ const ModelDetails: React.FC = () => {
   const columns = useMemo(() => {
     const tagsRenderer = (_value: string, record: ModelVersion) => (
       <div className={css.tagsRenderer}>
-        <Typography.Text
-          ellipsis={{
+        <Label
+          truncate={{
             tooltip: <Tags disabled tags={record.labels ?? []} />,
           }}>
           <div>
@@ -182,7 +182,7 @@ const ModelDetails: React.FC = () => {
               )}
             />
           </div>
-        </Typography.Text>
+        </Label>
       </div>
     );
 

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -10,8 +10,12 @@
 .info {
   display: flex;
   flex-direction: column;
-  font-size: 11px;
   justify-content: space-between;
   overflow: hidden;
   width: 100%;
+
+  > div:first-child {
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -1,5 +1,11 @@
-.base {
-  margin-top: auto;
+.archived {
+  opacity: 0.55;
+}
+.archivedBadge {
+  background-color: var(--theme-status-inactive);
+  border-radius: var(--theme-border-radius);
+  color: var(--theme-status-warning-on);
+  padding: 2px 4px;
 }
 .info {
   display: flex;
@@ -8,43 +14,4 @@
   justify-content: space-between;
   overflow: hidden;
   width: 100%;
-
-  .nameRow {
-    align-items: center;
-    display: flex;
-    gap: 6px;
-    height: min-content;
-    justify-content: space-between;
-    min-width: 0;
-
-    * {
-      margin-block-end: 0;
-    }
-  }
-  .projects {
-    margin: 8px 0;
-  }
-}
-.pinned {
-  font-size: 20px;
-  height: min-content;
-  width: min-content;
-}
-.avatarRow {
-  display: flex;
-  justify-content: space-between;
-
-  .archivedBadge {
-    background-color: var(--theme-status-inactive);
-    border-radius: var(--theme-border-radius);
-    color: var(--theme-status-warning-on);
-    opacity: 1;
-    padding: 2px 4px;
-  }
-}
-.archived .icon,
-.archived .nameRow,
-.archived .projects,
-.archived .avatar {
-  opacity: 0.55;
 }

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -11,20 +11,15 @@
 
   .nameRow {
     align-items: center;
+    color: var(--theme-surface-on-strong);
     display: flex;
     gap: 6px;
     height: min-content;
     justify-content: space-between;
     min-width: 0;
 
-    .name {
-      color: var(--theme-surface-on-strong);
-      font-size: 14px;
+    & .ant-typography-ellipsis-single-line {
       margin: 0;
-
-      & * {
-        margin: 0;
-      }
     }
   }
   .projects {

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -11,15 +11,14 @@
 
   .nameRow {
     align-items: center;
-    color: var(--theme-surface-on-strong);
     display: flex;
     gap: 6px;
     height: min-content;
     justify-content: space-between;
     min-width: 0;
 
-    & .ant-typography-ellipsis-single-line {
-      margin: 0;
+    h1 {
+      margin-bottom: 10px;
     }
   }
   .projects {

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -17,12 +17,12 @@
     justify-content: space-between;
     min-width: 0;
 
-    h1 {
-      margin-bottom: 10px;
+    * {
+      margin-block-end: 0;
     }
   }
   .projects {
-    margin: 0;
+    margin: 8px 0;
   }
 }
 .pinned {

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -8,14 +8,8 @@
   padding: 2px 4px;
 }
 .info {
-  display: flex;
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
   width: 100%;
-
-  > div:first-child {
-    display: flex;
-    justify-content: space-between;
-  }
 }

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -1,9 +1,9 @@
-import { Typography } from 'antd';
 import Avatar, { Size } from 'hew/Avatar';
 import Card from 'hew/Card';
 import Icon from 'hew/Icon';
 import Row from 'hew/Row';
 import Spinner from 'hew/Spinner';
+import { Title, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import React from 'react';
 
@@ -43,13 +43,10 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
             <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
           </div>
           <div className={css.info}>
-            <div className={css.nameRow}>
-              <Typography.Title
-                className={css.name}
-                ellipsis={{ rows: 1, tooltip: true }}
-                level={5}>
+            <div className={`${css.nameRow} ${css.name}`}>
+              <Title size={TypographySize.S} truncate={{ rows: 1, tooltip: true }}>
                 {workspace.name}
-              </Typography.Title>
+              </Title>
               {workspace.pinned && <Icon name="pin" title="Pinned" />}
             </div>
             <p className={css.projects}>

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -43,27 +43,27 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
           <Column width="hug">
             <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
           </Column>
-          <Column>
-            <div className={css.info}>
-              <Row width={215}>
+          <div className={css.info}>
+            <Column width={225}>
+              <Row justifyContent="space-between" width="fill">
                 <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
                   {workspace.name}
                 </Title>
                 {workspace.pinned && <Icon name="pin" title="Pinned" />}
               </Row>
               <Row>
-                <Label size={TypographySize.XS}>
+                <Label size="small">
                   {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
                 </Label>
               </Row>
-              <Row>
+              <Row justifyContent="space-between" width="fill">
                 <Spinner conditionalRender spinning={Loadable.isNotLoaded(loadableUser)}>
                   {Loadable.isLoaded(loadableUser) && <UserAvatar user={user} />}
                 </Spinner>
                 {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
               </Row>
-            </div>
-          </Column>
+            </Column>
+          </div>
         </Row>
       </div>
       {contextHolders}

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -1,9 +1,10 @@
 import Avatar, { Size } from 'hew/Avatar';
 import Card from 'hew/Card';
+import Column from 'hew/Column';
 import Icon from 'hew/Icon';
 import Row from 'hew/Row';
 import Spinner from 'hew/Spinner';
-import { Title, TypographySize } from 'hew/Typography';
+import { Label, Title, TypographySize } from 'hew/Typography';
 import { Loadable } from 'hew/utils/loadable';
 import React from 'react';
 
@@ -39,28 +40,30 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
       onDropdown={onClick}>
       <div className={workspace.archived ? css.archived : ''}>
         <Row>
-          <div className={css.icon}>
+          <Column width="hug">
             <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
-          </div>
-          <div className={css.info}>
-            <div className={css.nameRow}>
-              <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
-                {workspace.name}
-              </Title>
-              {workspace.pinned && <Icon name="pin" title="Pinned" />}
-            </div>
-            <p className={css.projects}>
-              {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
-            </p>
-            <div className={css.avatarRow}>
-              <div className={css.avatar}>
+          </Column>
+          <Column>
+            <div className={css.info}>
+              <Row width={215}>
+                <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+                  {workspace.name}
+                </Title>
+                {workspace.pinned && <Icon name="pin" title="Pinned" />}
+              </Row>
+              <Row>
+                <Label>
+                  {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
+                </Label>
+              </Row>
+              <Row>
                 <Spinner conditionalRender spinning={Loadable.isNotLoaded(loadableUser)}>
                   {Loadable.isLoaded(loadableUser) && <UserAvatar user={user} />}
                 </Spinner>
-              </div>
-              {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
+                {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
+              </Row>
             </div>
-          </div>
+          </Column>
         </Row>
       </div>
       {contextHolders}

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -43,8 +43,8 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
             <Avatar palette="muted" size={Size.ExtraLarge} square text={workspace.name} />
           </div>
           <div className={css.info}>
-            <div className={`${css.nameRow} ${css.name}`}>
-              <Title size={TypographySize.S} truncate={{ rows: 1, tooltip: true }}>
+            <div className={css.nameRow}>
+              <Title size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
                 {workspace.name}
               </Title>
               {workspace.pinned && <Icon name="pin" title="Pinned" />}

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -52,7 +52,7 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
                 {workspace.pinned && <Icon name="pin" title="Pinned" />}
               </Row>
               <Row>
-                <Label>
+                <Label size={TypographySize.XS}>
                   {workspace.numProjects} {pluralizer(workspace.numProjects, 'project')}
                 </Label>
               </Row>


### PR DESCRIPTION
## Description

Bug: If `antd.Typography` element text overflows into a tooltip, we are not seeing the theme's background/font, similar to issues which we saw with other tooltips and modals.

This PR comes from scanning for all imports of Typography. If it comes from antd and the file uses the `ellipsis` prop, then we replace it with `<Title truncate={ tooltip: true }>` or `Label` or `Body` from hew.Typography.

- Created XS size for titles

## Test Plan

Fixes this bug with hovering long names on `/det/workspaces`:

<img width="424" alt="Screen Shot 2023-11-30 at 9 39 02 AM" src="https://github.com/determined-ai/determined/assets/643918/3d2eee43-52b4-4ec0-9a96-fdd2981c43f9">

<img width="419" alt="Screen Shot 2023-11-30 at 9 31 37 AM" src="https://github.com/determined-ai/determined/assets/643918/42a7bed1-4d4f-4d21-80ba-596929155509">

Code replacement is sound across changes.

Affected components:
- ProjectCard and WorkspaceCard

<img width="403" alt="Screen Shot 2023-12-01 at 10 38 08 AM" src="https://github.com/determined-ai/determined/assets/643918/490a6832-a8ff-4a36-a4ff-137eaca29dc9">

- Stats on top of Clusters view (continues to have font-size override)

<img width="509" alt="Screen Shot 2023-12-01 at 10 40 47 AM" src="https://github.com/determined-ai/determined/assets/643918/9214d97d-810b-4065-93dc-29f30a78a9db">

- Comparing experiments -> Details tab, experiment name headers

<img width="568" alt="Screen Shot 2023-12-01 at 10 41 40 AM" src="https://github.com/determined-ai/determined/assets/643918/d66b9239-7b4d-4814-8ec7-d13e82166978">

- Long experiment descriptions in Experiment Details Header

<img width="482" alt="Screen Shot 2023-12-01 at 10 50 50 AM" src="https://github.com/determined-ai/determined/assets/643918/cfb4c98a-eb4b-4e95-b0f8-352972c41f6a">

- Text cells in a Trial Table in multi-trial experiment (such as under LearningCurve)
- Tags column when one has a longer name, such as on ModelRegistry

<img width="223" alt="Screen Shot 2023-12-01 at 11 01 08 AM" src="https://github.com/determined-ai/determined/assets/643918/2751f5de-17b9-4f6e-b76e-d1fce39ede6e">

- Dropdown options in experiment move modal, project move modal

<img width="398" alt="Screen Shot 2023-12-01 at 11 07 15 AM" src="https://github.com/determined-ai/determined/assets/643918/410c6f99-5073-4dd8-afe2-a1c23a8913dd">

- New HParam Search , 2nd page of modal

<img width="355" alt="Screen Shot 2023-12-01 at 11 10 31 AM" src="https://github.com/determined-ai/determined/assets/643918/c19bdb0e-ae67-47e4-b32d-08926e2a780a">


- "Unmanaged" label in a table which has this as a column (?)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.