### PR TITLE
fix: Properly set log viewer height

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.12",
+        "hew": "git+https://git@github.com/determined-ai/hew.git#gt/pass-height-to-logviewer",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -6588,7 +6588,7 @@
     },
     "node_modules/hew": {
       "version": "0.6.12",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#f9e31f68ed03a2a2e7973771a0cfcd23cda1e807",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#4fdca7cde4107e3aeac78cf2b48492d3a3ebf72e",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.12",
+    "hew": "git+https://git@github.com/determined-ai/hew.git#gt/pass-height-to-logviewer",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",

--- a/webui/react/src/pages/ClusterLogs.tsx
+++ b/webui/react/src/pages/ClusterLogs.tsx
@@ -1,6 +1,7 @@
 import LogViewer, { FetchConfig, FetchDirection, FetchType } from 'hew/LogViewer/LogViewer';
 import React, { useCallback } from 'react';
 
+import useResize from 'hooks/useResize';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { jsonToClusterLog } from 'services/decoder';
@@ -10,6 +11,7 @@ import handleError from 'utils/error';
 import css from './ClusterLogs.module.scss';
 
 const ClusterLogs: React.FC = () => {
+  const pageSize = useResize();
   const handleFetch = useCallback((config: FetchConfig, type: FetchType) => {
     const options = { follow: false, limit: config.limit, offset: 0 };
     const offsetId = isNumber(config.offsetLog?.id) ? config.offsetLog?.id ?? 0 : 0;
@@ -35,6 +37,7 @@ const ClusterLogs: React.FC = () => {
     <div className={css.base}>
       <LogViewer
         decoder={jsonToClusterLog}
+        height={pageSize.height - 200}
         serverAddress={serverAddress}
         sortKey="id"
         onError={handleError}

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -6,6 +6,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 
 import Page from 'components/Page';
 import { commandTypeToLabel } from 'constants/states';
+import useResize from 'hooks/useResize';
 import { useSettings } from 'hooks/useSettings';
 import { paths, serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
@@ -36,6 +37,7 @@ export const TaskLogsWrapper: React.FC = () => {
 const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerComponent }: Props) => {
   const [filterOptions, setFilterOptions] = useState<Filters>({});
   const [searchParams] = useSearchParams();
+  const pageSize = useResize();
 
   const taskTypeLabel = commandTypeToLabel[taskType as CommandType];
   const title = `${searchParams.has('id') ? `${searchParams.get('id')} ` : ''}Logs`;
@@ -159,6 +161,7 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
       <LogViewer
         decoder={mapV1LogsResponse}
         handleCloseLogs={onCloseLogs}
+        height={pageSize.height - 120}
         serverAddress={serverAddress}
         title={logFilters}
         onError={handleError}

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -7,6 +7,7 @@ import useConfirm from 'hew/useConfirm';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import useUI from 'components/ThemeProvider';
+import useResize from 'hooks/useResize';
 import { useSettings } from 'hooks/useSettings';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
@@ -29,6 +30,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
   const { ui } = useUI();
   const [filterOptions, setFilterOptions] = useState<Filters>({});
   const confirm = useConfirm();
+  const pageSize = useResize();
   const canceler = useRef(new AbortController());
 
   const trialSettingsConfig = useMemo(() => settingsConfigForTrial(trial?.id || -1), [trial?.id]);
@@ -185,6 +187,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
       <Spinner conditionalRender spinning={!trial}>
         <LogViewer
           decoder={mapV1LogsResponse}
+          height={pageSize.height - 260}
           serverAddress={serverAddress}
           title={logFilters}
           onDownload={handleDownloadLogs}


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
Since we use `LogViewer` at multiple places, we should be able to set the height for each of them individually.
Based off Hew [changes](https://github.com/determined-ai/hew/pull/67).

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
Master Log:
before:
<img width="1676" alt="Screenshot 2023-11-30 at 1 36 26 PM" src="https://github.com/determined-ai/determined/assets/40620519/cda87f1e-f667-421c-b0c8-347e63aa1917">

After:
<img width="1676" alt="Screenshot 2023-11-30 at 1 35 42 PM" src="https://github.com/determined-ai/determined/assets/40620519/95f4a3d5-3de9-4b4e-b72c-44944eab7522">


Trial Log:
before:
<img width="1678" alt="Screenshot 2023-11-30 at 1 36 14 PM" src="https://github.com/determined-ai/determined/assets/40620519/3862a329-891c-4c8d-8612-9c98c99cd5a4">

After:
<img width="1676" alt="Screenshot 2023-11-30 at 1 35 55 PM" src="https://github.com/determined-ai/determined/assets/40620519/f6fb49e9-ea46-40ad-93b3-59aa0a29130c">

Task Log:
before:
<img width="1683" alt="Screenshot 2023-11-30 at 1 36 39 PM" src="https://github.com/determined-ai/determined/assets/40620519/a4731b16-caac-4cd3-ba7a-7c85965c7a64">

After:
<img width="1675" alt="Screenshot 2023-11-30 at 1 35 33 PM" src="https://github.com/determined-ai/determined/assets/40620519/172d847b-2800-4680-9cc5-1044bd2c6653">


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
WEB-1864

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
