### PR TITLE
fix: ensure filter columns are valid when selecting special columns

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -79,11 +79,12 @@ const FilterField = ({
 
   const onChangeColumnName = (value: SelectValue) => {
     const prevType = currentColumn?.type;
-    const newCol = columns.find((c) => c.column === (value?.toString() ?? ''));
+    const newColName = value?.toString() ?? '';
+    const newCol = columns.find((c) => c.column === newColName);
     if (newCol) {
       formStore.setFieldColumnName(field.id, newCol);
 
-      if ((SpecialColumnNames as ReadonlyArray<string>).includes(field.columnName)) {
+      if ((SpecialColumnNames as ReadonlyArray<string>).includes(newColName)) {
         formStore.setFieldOperator(field.id, Operator.Eq);
         updateFieldValue(field.id, null);
       } else if (prevType !== newCol?.type) {


### PR DESCRIPTION


## Description

this fixes an issue in the experiment list where selecting a column that has specific values after selecting a column that does not causes the resulting query to be invalid. this is because the code intended to do so checked if the previous value was special, not if the value the field was turning to.



## Test Plan

- in the experiment list, open the filter menu and clear all existing filters
- add a new condition and set the column name to "name", and the value to "foo"
- change the column name of the current condition to "state"
- the experiment list should reset to show everything instead of being stuck loading.





## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

[WEB-1861]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1861]: https://hpe-aiatscale.atlassian.net/browse/WEB-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ