### PR TITLE
fix: Trial spinner [WEB-1872]

### DIFF
--- a/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.module.scss
+++ b/webui/react/src/pages/TrialDetails/Header/TrialHeaderLeft.module.scss
@@ -15,7 +15,7 @@
     }
   }
   [class*='Icon_base_'] {
-    padding: 0 8px;
+    margin: 0 8px;
   }
   .trial {
     align-items: center;


### PR DESCRIPTION
## Description

The padding property was making any icon too narrow to show the spinner for running trials, or ✔️ for completed trials:

<img width="573" alt="Screen Shot 2023-12-01 at 12 44 11 PM" src="https://github.com/determined-ai/determined/assets/643918/c61e2bb5-3db3-49b5-b854-fc0881c3c46f">

With the CSS fix:

<img width="552" alt="Screen Shot 2023-12-01 at 12 42 50 PM" src="https://github.com/determined-ai/determined/assets/643918/d0f27496-9f5f-42e7-90e5-3a0be220cb55">


<img width="558" alt="Screen Shot 2023-12-01 at 12 41 30 PM" src="https://github.com/determined-ai/determined/assets/643918/3f86962c-12d0-455d-8494-0826cdd2a880">


## Test Plan

View a trial of a multi-trial experiment such  as http://latest-main.determined.ai:8080/det/experiments/5118/trials/37884/overview

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.