### PR TITLE
chore: remove CI go unit tests and rename CI integration target

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1657,29 +1657,6 @@ jobs:
           paths:
             - "proto/build/**/*"
 
-  test-unit-go:
-    docker:
-      - image: <<pipeline.parameters.docker-image>>
-        environment:
-          GO111MODULE: "on"
-    steps:
-      - checkout
-      - skip-if-docs-only
-      - skip-if-github-only
-      - skip-if-webui-only
-      - reinstall-go
-      - go-get-deps
-      - run: make -C proto build
-      - run: make -C master test
-      - run: make -C agent test
-      - codecov/upload:
-          flags: "backend"
-          xtra_args: "-v"
-      - store_test_results:
-          path: master/test.junit.xml
-      - store_test_results:
-          path: agent/test.junit.xml
-
   test-intg-master:
     machine:
       image: <<pipeline.parameters.machine-image>>
@@ -2538,7 +2515,6 @@ workflows:
 
   test-unit:
     jobs:
-      - test-unit-go
       - test-unit-react
       - test-unit-harness-cpu
       - test-unit-harness-tf2
@@ -2581,7 +2557,7 @@ workflows:
             - test-unit-model-hub
             - test-unit-storage
 
-  test-intg:
+  test-go:
     jobs:
       # https://determined-ai.slack.com/archives/C03H5KZPU30/p1667241463073989
       # - test-intg-downstream

--- a/master/internal/logpattern/logpattern_intg_test.go
+++ b/master/internal/logpattern/logpattern_intg_test.go
@@ -1,4 +1,5 @@
 //go:build integration
+// +build integration
 
 package logpattern
 

--- a/master/internal/webhooks/shipper_test.go
+++ b/master/internal/webhooks/shipper_test.go
@@ -1,4 +1,5 @@
 //go:build integration
+// +build integration
 
 package webhooks
 


### PR DESCRIPTION
## Description

Since our Go unit tests are a subset of our Go integration tests, we don't need to run the unit test suite individually in CI.
Removed the Go unit test target from CI config and renamed 


## Test Plan

Ensure sure that all jobs in `test-go` Circle CI target run smoothly.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9992