### PR TITLE
docs: Add autoprovision release note

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -42,6 +42,10 @@ Version 0.26.4
 -  CLI: Add a new CLI command ``det e delete-tb-files [Experiment ID]`` to delete local TensorBoard
    files associated with a given experiment.
 
+-  Authentication: In the enterprise edition of Determined, add the ability to auto-provision OIDC
+   users upon their first login. To configure, set the ``oidc.auto_provision_users`` option to
+   ``True``. If SCIM is enabled as well, ``auto_provision_users`` must be False.
+
 **Improvements**
 
 -  Update default environment images to Python 3.9 from Python 3.8.


### PR DESCRIPTION
release note is for 0.26.4
see [original commit](https://github.com/determined-ai/determined-ee/blob/76f43f1ac069258d0cc955a00305ab0c5a1231e9/docs/release-notes/autoprovision-oidc-users.rst
) 