### PR TITLE
chore: run to checkpoint migration

### DIFF
--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -58,7 +58,7 @@ func createVersionTwoCheckpoint(
 			"steps_completed":    5,
 		},
 	}
-	require.NoError(t, db.AddCheckpointMetadata(ctx, checkpoint, &tr.ID))
+	require.NoError(t, db.AddCheckpointMetadata(ctx, checkpoint, tr.ID))
 
 	return checkpoint.UUID.String()
 }

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -32,7 +32,7 @@ import (
 func createVersionTwoCheckpoint(
 	ctx context.Context, t *testing.T, api *apiServer, curUser model.User, resources map[string]int64,
 ) string {
-	_, task := createTestTrial(t, api, curUser)
+	tr, task := createTestTrial(t, api, curUser)
 
 	aID := model.AllocationID(string(task.TaskID) + "-1")
 	aIn := &model.Allocation{
@@ -58,7 +58,7 @@ func createVersionTwoCheckpoint(
 			"steps_completed":    5,
 		},
 	}
-	require.NoError(t, db.AddCheckpointMetadata(ctx, checkpoint))
+	require.NoError(t, db.AddCheckpointMetadata(ctx, checkpoint, &tr.ID))
 
 	return checkpoint.UUID.String()
 }

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -1385,20 +1385,19 @@ func (a *apiServer) ReportCheckpoint(
 	default:
 	}
 
-	var runID *int
 	task, err := db.TaskByID(ctx, model.TaskID(req.Checkpoint.TaskId))
 	if err != nil {
 		return nil, fmt.Errorf("looking up task to decide if trial: %w", err)
 	}
-	if task.TaskType == model.TaskTypeTrial {
-		trial, err := db.TrialByTaskID(ctx, task.TaskID)
-		if err != nil {
-			return nil, fmt.Errorf("getting trial by task ID: %w", err)
-		}
-		runID = &trial.ID
+	if task.TaskType != model.TaskTypeTrial {
+		return nil, fmt.Errorf("can only report checkpoints on trial's tasks")
+	}
+	trial, err := db.TrialByTaskID(ctx, task.TaskID)
+	if err != nil {
+		return nil, fmt.Errorf("getting trial by task ID: %w", err)
 	}
 
-	if err := db.AddCheckpointMetadata(ctx, c, runID); err != nil {
+	if err := db.AddCheckpointMetadata(ctx, c, trial.ID); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -530,6 +530,9 @@ func TestTrialsNonNumericMetrics(t *testing.T) {
 	})
 }
 
+func TestReportCheckpoint(t *testing.T) {
+}
+
 func TestUnusualMetricNames(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
 	expectedMetricsMap := map[string]any{

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -19,6 +19,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/determined-ai/determined/master/pkg/protoutils/protoconverter"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/commonv1"
 	"github.com/determined-ai/determined/proto/pkg/trialv1"
 )
@@ -531,6 +534,83 @@ func TestTrialsNonNumericMetrics(t *testing.T) {
 }
 
 func TestReportCheckpoint(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+
+	tr, task := createTestTrial(t, api, curUser)
+
+	checkpointMeta, err := structpb.NewStruct(map[string]any{
+		"steps_completed": 1,
+	})
+	require.NoError(t, err)
+
+	checkpointID := uuid.New().String()
+	req := &apiv1.ReportCheckpointRequest{
+		Checkpoint: &checkpointv1.Checkpoint{
+			TaskId:       string(task.TaskID),
+			AllocationId: nil,
+			Uuid:         checkpointID,
+			ReportTime:   timestamppb.New(time.Now().Truncate(time.Millisecond)),
+			Resources:    nil,
+			Metadata:     checkpointMeta,
+			State:        checkpointv1.State_STATE_COMPLETED,
+		},
+	}
+	_, err = api.ReportCheckpoint(ctx, req)
+	require.NoError(t, err)
+
+	c, err := api.GetCheckpoint(ctx, &apiv1.GetCheckpointRequest{
+		CheckpointUuid: checkpointID,
+	})
+	require.NoError(t, err)
+
+	jsonActual, err := json.MarshalIndent(c.Checkpoint, "", "\t")
+	require.NoError(t, err)
+
+	getExperimentResp, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{
+		ExperimentId: int32(tr.ExperimentID),
+	})
+	require.NoError(t, err)
+
+	req.Checkpoint.Training = &checkpointv1.CheckpointTrainingMetadata{
+		TrialId:           wrapperspb.Int32(int32(tr.ID)),
+		ExperimentId:      wrapperspb.Int32(int32(tr.ExperimentID)),
+		ExperimentConfig:  getExperimentResp.Experiment.Config,
+		Hparams:           nil,
+		TrainingMetrics:   &commonv1.Metrics{},
+		ValidationMetrics: &commonv1.Metrics{},
+	}
+	jsonExpected, err := json.MarshalIndent(req.Checkpoint, "", "\t")
+	require.NoError(t, err)
+
+	require.Equal(t, string(jsonExpected), string(jsonActual))
+}
+
+// This may have worked at some point but this definitely doesn't work after
+// trial one to many tasks since we switched the fk reference for some reason.
+func TestReportCheckpointNonTrialErrors(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+
+	notebookTask := mockNotebookWithWorkspaceID(ctx, api, t, 1)
+
+	checkpointMeta, err := structpb.NewStruct(map[string]any{
+		"steps_completed": 1,
+	})
+	require.NoError(t, err)
+
+	checkpointID := uuid.New().String()
+	req := &apiv1.ReportCheckpointRequest{
+		Checkpoint: &checkpointv1.Checkpoint{
+			TaskId:       string(notebookTask),
+			AllocationId: nil,
+			Uuid:         checkpointID,
+			ReportTime:   timestamppb.New(time.Now().Truncate(time.Millisecond)),
+			Resources:    nil,
+			Metadata:     checkpointMeta,
+			State:        checkpointv1.State_STATE_COMPLETED,
+		},
+	}
+	_, err = api.ReportCheckpoint(ctx, req)
+	require.ErrorContains(t, err, "can only report checkpoints on trial's tasks")
 }
 
 func TestUnusualMetricNames(t *testing.T) {

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -134,11 +134,11 @@ func addMockCheckpointDB(t *testing.T, pgDB *db.PgDB, id uuid.UUID) {
 	user := db.RequireMockUser(t, pgDB)
 	// Using a different path than DefaultTestSrcPath since we are one level up than most db tests
 	exp := mockExperimentS3(t, pgDB, user, "../../examples/tutorials/mnist_pytorch")
-	_, task := db.RequireMockTrial(t, pgDB, exp)
+	tr, task := db.RequireMockTrial(t, pgDB, exp)
 	allocation := db.RequireMockAllocation(t, pgDB, task.TaskID)
 	// Create checkpoints
 	checkpoint := db.MockModelCheckpoint(id, allocation)
-	err := db.AddCheckpointMetadata(context.TODO(), &checkpoint)
+	err := db.AddCheckpointMetadata(context.TODO(), &checkpoint, &tr.ID)
 	require.NoError(t, err)
 }
 

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -138,7 +138,7 @@ func addMockCheckpointDB(t *testing.T, pgDB *db.PgDB, id uuid.UUID) {
 	allocation := db.RequireMockAllocation(t, pgDB, task.TaskID)
 	// Create checkpoints
 	checkpoint := db.MockModelCheckpoint(id, allocation)
-	err := db.AddCheckpointMetadata(context.TODO(), &checkpoint, &tr.ID)
+	err := db.AddCheckpointMetadata(context.TODO(), &checkpoint, tr.ID)
 	require.NoError(t, err)
 }
 

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -61,7 +61,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 
 				checkpoint := MockModelCheckpoint(ckpt, allocation)
 				checkpoint.Resources = resources[resourcesIndex]
-				err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
+				err := AddCheckpointMetadata(ctx, &checkpoint, tr.ID)
 				require.NoError(t, err)
 
 				resourcesIndex++
@@ -170,15 +170,15 @@ func TestDeleteCheckpoints(t *testing.T) {
 	// Create checkpoints
 	ckpt1 := uuid.New()
 	checkpoint1 := MockModelCheckpoint(ckpt1, allocation)
-	err := AddCheckpointMetadata(ctx, &checkpoint1, &tr.ID)
+	err := AddCheckpointMetadata(ctx, &checkpoint1, tr.ID)
 	require.NoError(t, err)
 	ckpt2 := uuid.New()
 	checkpoint2 := MockModelCheckpoint(ckpt2, allocation)
-	err = AddCheckpointMetadata(ctx, &checkpoint2, &tr.ID)
+	err = AddCheckpointMetadata(ctx, &checkpoint2, tr.ID)
 	require.NoError(t, err)
 	ckpt3 := uuid.New()
 	checkpoint3 := MockModelCheckpoint(ckpt3, allocation)
-	err = AddCheckpointMetadata(ctx, &checkpoint3, &tr.ID)
+	err = AddCheckpointMetadata(ctx, &checkpoint3, tr.ID)
 	require.NoError(t, err)
 
 	// Insert a model.
@@ -299,7 +299,7 @@ func BenchmarkUpdateCheckpointSize(b *testing.B) {
 			checkpoint := MockModelCheckpoint(ckpt, allocation)
 			checkpoint.Resources = resources
 
-			err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
+			err := AddCheckpointMetadata(ctx, &checkpoint, tr.ID)
 			require.NoError(t, err)
 		}
 	}

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -61,7 +61,7 @@ func TestUpdateCheckpointSize(t *testing.T) {
 
 				checkpoint := MockModelCheckpoint(ckpt, allocation)
 				checkpoint.Resources = resources[resourcesIndex]
-				err := AddCheckpointMetadata(ctx, &checkpoint)
+				err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
 				require.NoError(t, err)
 
 				resourcesIndex++
@@ -164,21 +164,21 @@ func TestDeleteCheckpoints(t *testing.T) {
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 	exp := RequireMockExperiment(t, db, user)
-	_, task := RequireMockTrial(t, db, exp)
+	tr, task := RequireMockTrial(t, db, exp)
 	allocation := RequireMockAllocation(t, db, task.TaskID)
 
 	// Create checkpoints
 	ckpt1 := uuid.New()
 	checkpoint1 := MockModelCheckpoint(ckpt1, allocation)
-	err := AddCheckpointMetadata(ctx, &checkpoint1)
+	err := AddCheckpointMetadata(ctx, &checkpoint1, &tr.ID)
 	require.NoError(t, err)
 	ckpt2 := uuid.New()
 	checkpoint2 := MockModelCheckpoint(ckpt2, allocation)
-	err = AddCheckpointMetadata(ctx, &checkpoint2)
+	err = AddCheckpointMetadata(ctx, &checkpoint2, &tr.ID)
 	require.NoError(t, err)
 	ckpt3 := uuid.New()
 	checkpoint3 := MockModelCheckpoint(ckpt3, allocation)
-	err = AddCheckpointMetadata(ctx, &checkpoint3)
+	err = AddCheckpointMetadata(ctx, &checkpoint3, &tr.ID)
 	require.NoError(t, err)
 
 	// Insert a model.
@@ -285,7 +285,7 @@ func BenchmarkUpdateCheckpointSize(b *testing.B) {
 	exp := RequireMockExperiment(t, db, user)
 	for j := 0; j < 10; j++ {
 		t.Logf("Adding trial #%d", j)
-		_, task := RequireMockTrial(t, db, exp)
+		tr, task := RequireMockTrial(t, db, exp)
 		allocation := RequireMockAllocation(t, db, task.TaskID)
 		for k := 0; k < 10; k++ {
 			ckpt := uuid.New()
@@ -299,7 +299,7 @@ func BenchmarkUpdateCheckpointSize(b *testing.B) {
 			checkpoint := MockModelCheckpoint(ckpt, allocation)
 			checkpoint.Resources = resources
 
-			err := AddCheckpointMetadata(ctx, &checkpoint)
+			err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
 			require.NoError(t, err)
 		}
 	}

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -258,6 +258,17 @@ func TestCheckpointMetadata(t *testing.T) {
 			err := AddCheckpointMetadata(ctx, &ckpt, tr.ID)
 			require.NoError(t, err)
 
+			// We added the checkpoint relationship row.
+			var res model.RunCheckpoints
+			require.NoError(t, Bun().NewSelect().Model(&res).
+				Where("run_id = ?", tr.ID).
+				Where("checkpoint_id = ?", ckptUUID).
+				Scan(ctx, &res))
+			require.Equal(t, model.RunCheckpoints{
+				RunID:        tr.ID,
+				CheckpointID: ckptUUID,
+			}, res)
+
 			var m *trialv1.TrialMetrics
 			const metricValue = 1.0
 			if tt.hasValidation {

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -53,7 +53,7 @@ func TestPgDB_ExperimentCheckpointsToGCRawModelRegistry(t *testing.T) {
 	for i := 1; i <= length; i++ {
 		ckptUUID := uuid.New()
 		ckpt := MockModelCheckpoint(ckptUUID, a, WithSteps(i))
-		err := AddCheckpointMetadata(ctx, &ckpt)
+		err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
 		require.NoError(t, err)
 		err = AddTrialValidationMetrics(ctx, ckptUUID, tr, int32(i), int32(i+5), db)
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestPgDB_ExperimentCheckpointsToGCRaw(t *testing.T) {
 	for i := 1; i <= length; i++ {
 		ckptUUID := uuid.New()
 		ckpt := MockModelCheckpoint(ckptUUID, a, WithSteps(i))
-		err := AddCheckpointMetadata(ctx, &ckpt)
+		err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
 		require.NoError(t, err)
 		err = AddTrialValidationMetrics(ctx, ckptUUID, tr, int32(i), int32(i+5), db)
 		require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestCheckpointMetadata(t *testing.T) {
 					"steps_completed":    float64(stepsCompleted),
 				},
 			}
-			err := AddCheckpointMetadata(ctx, &ckpt)
+			err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
 			require.NoError(t, err)
 
 			var m *trialv1.TrialMetrics
@@ -718,7 +718,7 @@ func TestDeleteExperiments(t *testing.T) {
 			for k := 0; k < numChkpts; k++ { // Create checkpoints
 				ckpt := uuid.New()
 				checkpoint := MockModelCheckpoint(ckpt, allocation)
-				err := AddCheckpointMetadata(ctx, &checkpoint)
+				err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
 				require.NoError(t, err)
 				checkpointIDs = append(checkpointIDs, checkpoint.ID)
 				checkPointIndex++

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -53,7 +53,7 @@ func TestPgDB_ExperimentCheckpointsToGCRawModelRegistry(t *testing.T) {
 	for i := 1; i <= length; i++ {
 		ckptUUID := uuid.New()
 		ckpt := MockModelCheckpoint(ckptUUID, a, WithSteps(i))
-		err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
+		err := AddCheckpointMetadata(ctx, &ckpt, tr.ID)
 		require.NoError(t, err)
 		err = AddTrialValidationMetrics(ctx, ckptUUID, tr, int32(i), int32(i+5), db)
 		require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestPgDB_ExperimentCheckpointsToGCRaw(t *testing.T) {
 	for i := 1; i <= length; i++ {
 		ckptUUID := uuid.New()
 		ckpt := MockModelCheckpoint(ckptUUID, a, WithSteps(i))
-		err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
+		err := AddCheckpointMetadata(ctx, &ckpt, tr.ID)
 		require.NoError(t, err)
 		err = AddTrialValidationMetrics(ctx, ckptUUID, tr, int32(i), int32(i+5), db)
 		require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestCheckpointMetadata(t *testing.T) {
 					"steps_completed":    float64(stepsCompleted),
 				},
 			}
-			err := AddCheckpointMetadata(ctx, &ckpt, &tr.ID)
+			err := AddCheckpointMetadata(ctx, &ckpt, tr.ID)
 			require.NoError(t, err)
 
 			var m *trialv1.TrialMetrics
@@ -718,7 +718,7 @@ func TestDeleteExperiments(t *testing.T) {
 			for k := 0; k < numChkpts; k++ { // Create checkpoints
 				ckpt := uuid.New()
 				checkpoint := MockModelCheckpoint(ckpt, allocation)
-				err := AddCheckpointMetadata(ctx, &checkpoint, &tr.ID)
+				err := AddCheckpointMetadata(ctx, &checkpoint, tr.ID)
 				require.NoError(t, err)
 				checkpointIDs = append(checkpointIDs, checkpoint.ID)
 				checkPointIndex++

--- a/master/internal/db/postgres_model_intg_test.go
+++ b/master/internal/db/postgres_model_intg_test.go
@@ -87,7 +87,7 @@ func TestModels(t *testing.T) {
 					"steps_completed":    stepsCompleted,
 				},
 			}
-			err = AddCheckpointMetadata(ctx, ckpt, &tr.ID)
+			err = AddCheckpointMetadata(ctx, ckpt, tr.ID)
 			require.NoError(t, err)
 
 			// Which maybe has some metrics.

--- a/master/internal/db/postgres_model_intg_test.go
+++ b/master/internal/db/postgres_model_intg_test.go
@@ -87,7 +87,7 @@ func TestModels(t *testing.T) {
 					"steps_completed":    stepsCompleted,
 				},
 			}
-			err = AddCheckpointMetadata(ctx, ckpt)
+			err = AddCheckpointMetadata(ctx, ckpt, &tr.ID)
 			require.NoError(t, err)
 
 			// Which maybe has some metrics.

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -646,7 +646,7 @@ func calculateNewSummaryMetrics(
 }
 
 // AddCheckpointMetadata persists metadata for a completed checkpoint to the database.
-func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2, runID *int) error {
+func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2, runID int) error {
 	var size int64
 	for _, v := range m.Resources {
 		size += v
@@ -658,13 +658,11 @@ func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2, runID *in
 			return fmt.Errorf("inserting checkpoint model: %w", err)
 		}
 
-		if runID != nil {
-			if _, err := tx.NewInsert().Model(&model.RunCheckpoints{
-				RunID:        *runID,
-				CheckpointID: m.UUID,
-			}).Exec(ctx); err != nil {
-				return fmt.Errorf("inserting checkpoint run model: %w", err)
-			}
+		if _, err := tx.NewInsert().Model(&model.RunCheckpoints{
+			RunID:        runID,
+			CheckpointID: m.UUID,
+		}).Exec(ctx); err != nil {
+			return fmt.Errorf("inserting checkpoint run model: %w", err)
 		}
 
 		if err := UpdateCheckpointSizeTx(ctx, tx, []uuid.UUID{m.UUID}); err != nil {

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -646,7 +646,7 @@ func calculateNewSummaryMetrics(
 }
 
 // AddCheckpointMetadata persists metadata for a completed checkpoint to the database.
-func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2) error {
+func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2, runID *int) error {
 	var size int64
 	for _, v := range m.Resources {
 		size += v
@@ -654,12 +654,21 @@ func AddCheckpointMetadata(ctx context.Context, m *model.CheckpointV2) error {
 	m.Size = size
 
 	err := Bun().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		if _, err := tx.NewInsert().Model(m).Exec(context.TODO()); err != nil {
-			return errors.Wrap(err, "inserting checkpoint")
+		if _, err := tx.NewInsert().Model(m).Exec(ctx); err != nil {
+			return fmt.Errorf("inserting checkpoint model: %w", err)
+		}
+
+		if runID != nil {
+			if _, err := tx.NewInsert().Model(&model.RunCheckpoints{
+				RunID:        *runID,
+				CheckpointID: m.UUID,
+			}).Exec(ctx); err != nil {
+				return fmt.Errorf("inserting checkpoint run model: %w", err)
+			}
 		}
 
 		if err := UpdateCheckpointSizeTx(ctx, tx, []uuid.UUID{m.UUID}); err != nil {
-			return errors.Wrap(err, "updating checkpoint size")
+			return fmt.Errorf("updating checkpoint size: %w", err)
 		}
 
 		return nil

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -926,7 +926,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		ReportTime:   time.Now(),
 		State:        model.ActiveState,
 		Metadata:     map[string]any{"steps_completed": 50},
-	}))
+	}, &tr.ID))
 
 	// Trial gets interrupted and starts in the future with a new trial run ID.
 	a = &model.Allocation{
@@ -968,7 +968,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		ReportTime:   time.Now(),
 		State:        model.ActiveState,
 		Metadata:     map[string]any{"steps_completed": 400},
-	}))
+	}, &tr.ID))
 	checkpoints = []*checkpointv1.Checkpoint{}
 	require.NoError(t, db.QueryProto("get_checkpoints_for_experiment", &checkpoints, exp.ID))
 	require.Len(t, checkpoints, 2)
@@ -1044,7 +1044,7 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 				ReportTime:   time.Now(),
 				State:        model.CompletedState,
 				Metadata:     map[string]any{"steps_completed": batches},
-			}))
+			}, &tr.ID))
 		default:
 			rollbacksCnts, err := db.addTrialMetrics(
 				ctx, trialMetrics, model.MetricGroup(typ),

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -926,7 +926,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		ReportTime:   time.Now(),
 		State:        model.ActiveState,
 		Metadata:     map[string]any{"steps_completed": 50},
-	}, &tr.ID))
+	}, tr.ID))
 
 	// Trial gets interrupted and starts in the future with a new trial run ID.
 	a = &model.Allocation{
@@ -968,7 +968,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		ReportTime:   time.Now(),
 		State:        model.ActiveState,
 		Metadata:     map[string]any{"steps_completed": 400},
-	}, &tr.ID))
+	}, tr.ID))
 	checkpoints = []*checkpointv1.Checkpoint{}
 	require.NoError(t, db.QueryProto("get_checkpoints_for_experiment", &checkpoints, exp.ID))
 	require.Len(t, checkpoints, 2)
@@ -1044,7 +1044,7 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 				ReportTime:   time.Now(),
 				State:        model.CompletedState,
 				Metadata:     map[string]any{"steps_completed": batches},
-			}, &tr.ID))
+			}, tr.ID))
 		default:
 			rollbacksCnts, err := db.addTrialMetrics(
 				ctx, trialMetrics, model.MetricGroup(typ),

--- a/master/internal/run/postgres_run_intg_test.go
+++ b/master/internal/run/postgres_run_intg_test.go
@@ -23,19 +23,39 @@ func TestMigrateTrials(t *testing.T) {
 
 	preTrialData := olddata.MigrateToPreRunTrialsData(t, pgDB, "file://../../static/migrations")
 
-	var currentTrialsViewData []struct {
-		TrialData map[string]any
-	}
-	require.NoError(t, db.Bun().NewSelect().Table("trials").
-		ColumnExpr("to_jsonb(trials.*) AS trial_data").
-		Order("id").
-		Scan(ctx, &currentTrialsViewData),
-	)
+	t.Run("trialView", func(t *testing.T) {
+		var currentTrialsViewData []struct {
+			TrialData map[string]any
+		}
+		require.NoError(t, db.Bun().NewSelect().Table("trials").
+			ColumnExpr("to_jsonb(trials.*) AS trial_data").
+			Order("id").
+			Scan(ctx, &currentTrialsViewData),
+		)
 
-	var actual []map[string]any
-	for _, t := range currentTrialsViewData {
-		actual = append(actual, t.TrialData)
-	}
+		var actual []map[string]any
+		for _, t := range currentTrialsViewData {
+			actual = append(actual, t.TrialData)
+		}
 
-	require.Equal(t, preTrialData.PreRunTrialsTable, actual)
+		require.Equal(t, preTrialData.PreRunTrialsTable, actual)
+	})
+
+	t.Run("checkpointsView", func(t *testing.T) {
+		var currentCheckpointViewData []struct {
+			CheckpointData map[string]any
+		}
+		require.NoError(t, db.Bun().NewSelect().Table("checkpoints_view").
+			ColumnExpr("to_jsonb(checkpoints_view.*) AS checkpoint_data").
+			Order("id").
+			Scan(ctx, &currentCheckpointViewData),
+		)
+
+		var actual []map[string]any
+		for _, t := range currentCheckpointViewData {
+			actual = append(actual, t.CheckpointData)
+		}
+
+		require.Equal(t, preTrialData.PreRunCheckpointsView, actual)
+	})
 }

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -662,6 +662,13 @@ type CheckpointV2 struct {
 	Size          int64                  `db:"size"`
 }
 
+// RunCheckpoints represents a row from the `run_checkpoints` table.
+type RunCheckpoints struct {
+	bun.BaseModel `bun:"table:run_checkpoints"`
+	RunID         int       `bun:"run_id"`
+	CheckpointID  uuid.UUID `bun:"checkpoint_id"`
+}
+
 // CheckpointTrainingMetadata is a substruct of checkpoints encapsulating training specific
 // information.
 type CheckpointTrainingMetadata struct {

--- a/master/static/migrations/20231204141901_run-checkpoints.tx.down.sql
+++ b/master/static/migrations/20231204141901_run-checkpoints.tx.down.sql
@@ -56,4 +56,3 @@ CREATE OR REPLACE VIEW proto_checkpoints_view AS
 
 -- Uncreate run_checkpoints MTM.
 DROP TABLE run_checkpoints;
-DROP TYPE relationship_type;

--- a/master/static/migrations/20231204141901_run-checkpoints.tx.down.sql
+++ b/master/static/migrations/20231204141901_run-checkpoints.tx.down.sql
@@ -1,0 +1,59 @@
+-- Update checkpoints_v2 and views.
+DROP VIEW proto_checkpoints_view;
+DROP VIEW checkpoints_view;
+
+CREATE OR REPLACE VIEW checkpoints_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        t.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        t.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        CAST(c.metadata->>'steps_completed' AS int) as steps_completed,
+        c.size
+    FROM checkpoints_v2 AS c
+    LEFT JOIN trial_id_task_id AS task ON c.task_id = task.task_id
+    LEFT JOIN trials AS t on t.id = task.trial_id
+    LEFT JOIN experiments AS e on t.experiment_id = e.id
+    LEFT JOIN raw_validations AS v on CAST(c.metadata->>'steps_completed' AS int) = v.total_batches and t.id = v.trial_id AND NOT v.archived
+    LEFT JOIN raw_steps AS s on CAST(c.metadata->>'steps_completed' AS int) = s.total_batches and t.id = s.trial_id AND NOT s.archived;
+
+CREATE OR REPLACE VIEW proto_checkpoints_view AS
+    SELECT
+        c.uuid::text AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time as report_time,
+        'STATE_' || c.state AS state,
+        c.resources,
+        c.metadata,
+        -- Build a training substruct for protobuf.
+        jsonb_build_object(
+            'trial_id', c.trial_id,
+            'experiment_id', c.experiment_id,
+            'experiment_config', c.experiment_config,
+            'hparams', c.hparams,
+            -- construct training metrics from the untyped jsonb deterministically, since older
+            -- versions may have old keys (e.g., num_inputs) and our unmarshaling is strict.
+            'training_metrics', jsonb_build_object(
+                'avg_metrics', c.training_metrics->'avg_metrics',
+                'batch_metrics', c.training_metrics->'batch_metrics'
+            ),
+            'validation_metrics', json_build_object('avg_metrics', c.validation_metrics),
+            'searcher_metric', c.searcher_metric
+        ) AS training
+    FROM checkpoints_view AS c;
+
+-- Uncreate run_checkpoints MTM.
+DROP TABLE run_checkpoints;
+DROP TYPE relationship_type;

--- a/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
+++ b/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
@@ -1,24 +1,13 @@
 -- Create run_checkpoints MTM.
-CREATE TYPE relationship_type AS ENUM (
-  'CheckpointProducedByRun',
-  'RunUsedForInference',
-  'RunUsedForWarmStart',
-  'RunUsedForDataset',
-  'VisualizationArtifactProducedByRun'
-);
-
 CREATE TABLE run_checkpoints (
   run_id integer REFERENCES runs(id) ON DELETE CASCADE NOT NULL,
-  checkpoint_id uuid REFERENCES checkpoints_v2(uuid) ON DELETE CASCADE NOT NULL UNIQUE,
-  model_id text, -- TODO?
-  model_version text, -- TODO?
-  relationship relationship_type NOT NULL,
+  checkpoint_id uuid UNIQUE REFERENCES checkpoints_v2(uuid) ON DELETE CASCADE NOT NULL UNIQUE,
   PRIMARY KEY(run_id, checkpoint_id)
 );
 CREATE INDEX idx_checkpoint_id_run_id ON run_checkpoints USING btree (checkpoint_id, run_id);
 
-INSERT INTO run_checkpoints(run_id, checkpoint_id, relationship_type)
-SELECT t.trial_id AS run_id, uuid AS checkpoint_id, 'CheckpointProducedByRun' AS relationship_type
+INSERT INTO run_checkpoints(run_id, checkpoint_id)
+SELECT t.trial_id AS run_id, uuid AS checkpoint_id
 FROM checkpoints_v2 c
 LEFT JOIN trial_id_task_id t ON c.task_id = t.task_id;
 

--- a/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
+++ b/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
@@ -12,13 +12,13 @@ CREATE TABLE run_checkpoints (
   checkpoint_id uuid REFERENCES checkpoints_v2(uuid) ON DELETE CASCADE NOT NULL UNIQUE,
   model_id text, -- TODO?
   model_version text, -- TODO?
-  relationship relationship_type,
+  relationship relationship_type NOT NULL,
   PRIMARY KEY(run_id, checkpoint_id)
 );
 CREATE INDEX idx_checkpoint_id_run_id ON run_checkpoints USING btree (checkpoint_id, run_id);
 
-INSERT INTO run_checkpoints(run_id, checkpoint_id)
-SELECT t.trial_id AS run_id, uuid AS checkpoint_id
+INSERT INTO run_checkpoints(run_id, checkpoint_id, relationship_type)
+SELECT t.trial_id AS run_id, uuid AS checkpoint_id, 'CheckpointProducedByRun' AS relationship_type
 FROM checkpoints_v2 c
 LEFT JOIN trial_id_task_id t ON c.task_id = t.task_id;
 

--- a/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
+++ b/master/static/migrations/20231204141901_run-checkpoints.tx.up.sql
@@ -1,0 +1,79 @@
+-- Create run_checkpoints MTM.
+CREATE TYPE relationship_type AS ENUM (
+  'CheckpointProducedByRun',
+  'RunUsedForInference',
+  'RunUsedForWarmStart',
+  'RunUsedForDataset',
+  'VisualizationArtifactProducedByRun'
+);
+
+CREATE TABLE run_checkpoints (
+  run_id integer REFERENCES runs(id) ON DELETE CASCADE NOT NULL,
+  checkpoint_id uuid REFERENCES checkpoints_v2(uuid) ON DELETE CASCADE NOT NULL UNIQUE,
+  model_id text, -- TODO?
+  model_version text, -- TODO?
+  relationship relationship_type,
+  PRIMARY KEY(run_id, checkpoint_id)
+);
+CREATE INDEX idx_checkpoint_id_run_id ON run_checkpoints USING btree (checkpoint_id, run_id);
+
+INSERT INTO run_checkpoints(run_id, checkpoint_id)
+SELECT t.trial_id AS run_id, uuid AS checkpoint_id
+FROM checkpoints_v2 c
+LEFT JOIN trial_id_task_id t ON c.task_id = t.task_id;
+
+-- Update checkpoints_v2 and views.
+DROP VIEW proto_checkpoints_view;
+DROP VIEW checkpoints_view;
+
+CREATE OR REPLACE VIEW checkpoints_view AS
+    SELECT
+        c.id AS id,
+        c.uuid AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time,
+        c.state,
+        c.resources,
+        c.metadata,
+        r.id AS trial_id,
+        e.id AS experiment_id,
+        e.config AS experiment_config,
+        r.hparams AS hparams,
+        s.metrics AS training_metrics,
+        v.metrics->'validation_metrics' AS validation_metrics,
+        (v.metrics->'validation_metrics'->>(e.config->'searcher'->>'metric'))::float8 AS searcher_metric,
+        CAST(c.metadata->>'steps_completed' AS int) as steps_completed,
+        c.size
+    FROM checkpoints_v2 AS c
+    LEFT JOIN run_checkpoints AS rc on rc.checkpoint_id = c.uuid
+    LEFT JOIN runs AS r on r.id = rc.run_id
+    LEFT JOIN experiments AS e on r.experiment_id = e.id
+    LEFT JOIN raw_validations AS v on CAST(c.metadata->>'steps_completed' AS int) = v.total_batches and r.id = v.trial_id AND NOT v.archived
+    LEFT JOIN raw_steps AS s on CAST(c.metadata->>'steps_completed' AS int) = s.total_batches and r.id = s.trial_id AND NOT s.archived;
+
+CREATE OR REPLACE VIEW proto_checkpoints_view AS
+    SELECT
+        c.uuid::text AS uuid,
+        c.task_id,
+        c.allocation_id,
+        c.report_time as report_time,
+        'STATE_' || c.state AS state,
+        c.resources,
+        c.metadata,
+        -- Build a training substruct for protobuf.
+        jsonb_build_object(
+            'trial_id', c.trial_id,
+            'experiment_id', c.experiment_id,
+            'experiment_config', c.experiment_config,
+            'hparams', c.hparams,
+            -- construct training metrics from the untyped jsonb deterministically, since older
+            -- versions may have old keys (e.g., num_inputs) and our unmarshaling is strict.
+            'training_metrics', jsonb_build_object(
+                'avg_metrics', c.training_metrics->'avg_metrics',
+                'batch_metrics', c.training_metrics->'batch_metrics'
+            ),
+            'validation_metrics', json_build_object('avg_metrics', c.validation_metrics),
+            'searcher_metric', c.searcher_metric
+        ) AS training
+    FROM checkpoints_view AS c;

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -116,7 +116,7 @@ func testGetCheckpoint(
 					"determined_version": "1.0.0",
 				},
 			}
-			err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
+			err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, trial.ID)
 
 			assert.NilError(t, err, "failed to add checkpoint meta")
 
@@ -179,7 +179,7 @@ func testGetExperimentCheckpoints(
 			},
 		}
 
-		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
+		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, trial.ID)
 		assert.NilError(t, err, "failed to add checkpoint meta")
 
 		trialMetrics := trialv1.TrialMetrics{
@@ -299,7 +299,7 @@ func testGetTrialCheckpoints(
 				"determined_version": "1.0.0",
 			},
 		}
-		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
+		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, trial.ID)
 		assert.NilError(t, err, "failed to add checkpoint meta")
 	}
 

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -116,7 +116,7 @@ func testGetCheckpoint(
 					"determined_version": "1.0.0",
 				},
 			}
-			err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta)
+			err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
 
 			assert.NilError(t, err, "failed to add checkpoint meta")
 
@@ -179,7 +179,7 @@ func testGetExperimentCheckpoints(
 			},
 		}
 
-		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta)
+		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
 		assert.NilError(t, err, "failed to add checkpoint meta")
 
 		trialMetrics := trialv1.TrialMetrics{
@@ -299,7 +299,7 @@ func testGetTrialCheckpoints(
 				"determined_version": "1.0.0",
 			},
 		}
-		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta)
+		err := db.AddCheckpointMetadata(context.Background(), &checkpointMeta, &trial.ID)
 		assert.NilError(t, err, "failed to add checkpoint meta")
 	}
 


### PR DESCRIPTION
## Description

Adds a one run to many checkpoint relationship table. Didn't just add a field so in the future if we want to make the relationship many to many we can just drop the unique constraint on the relationship table.


## Test Plan


should be covered by integration tests


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
