### PR TITLE
fix: update user table / all useAsync updates [WEB-1876]

### DIFF
--- a/webui/react/src/hooks/useAsync.ts
+++ b/webui/react/src/hooks/useAsync.ts
@@ -1,4 +1,5 @@
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
+import { isEqual } from 'lodash';
 import { useCallback, useEffect, useInsertionEffect, useRef, useState } from 'react';
 
 type LoadablePromiser<T> = (canceler: AbortController) => Promise<T | Loadable<T>>;
@@ -38,10 +39,12 @@ export const useAsync = <T>(
   useEffect(() => {
     const internalCanceler = new AbortController();
     (async () => {
-      setState(NotLoaded);
       const retVal = await callFunc(internalCanceler);
       if (!internalCanceler.signal.aborted) {
-        setState(Loadable.isLoadable(retVal) ? retVal : Loaded(retVal));
+        const loaded = Loadable.isLoadable(retVal) ? retVal : Loaded(retVal);
+        if (!isEqual(loaded, state)) {
+          setState(loaded);
+        }
       }
     })();
     return () => {


### PR DESCRIPTION
## Description

Ticket + Slack report that the users table excessively refreshes and jumps to top of table. One reply is that this only happens when they have the name filter.

I believe this involves `useAsync` and this motivates two suggested changes:
- calling the function should not reset to `NotLoaded` before `Loaded(response)`; it's sufficient for state to begin as `NotLoaded` and be replaced on new responses. The downside is going to the next page would not show the loading state
- lodash `isEqual` prevents replacing an unchanged array with a "new" array by reference

## Test Plan

On `/det/admin/user-management`, interact with the users table with no filters, a name filter with multiple pages such as "a", different page counts, etc.
In each case the users table should not refresh / jump window back to the top of the table

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.