### PR TITLE
chore: update model_hub requirements

### DIFF
--- a/model_hub/setup.py
+++ b/model_hub/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     # libraries that are guaranteed to work with our code.  Other versions
     # may work with model-hub as well but are not officially supported.
     install_requires=[
-        "attrdict",
+        "attrdict3",
         "determined>=0.13.11",  # We require custom reducers for PyTorchTrial.
     ],
 )


### PR DESCRIPTION
## Description

`attrdict` is a deprecated module since Python 3.9. It is backwards compatible with Python 3.8. Having this pip install here breaks attrdict3 in our images, and uninstalling it doesn't fix the problem. Updating this requirement.



## Test Plan

On a clean system, i.e. in any of our latest docker images via:

docker run -v /path/to/determined:/src/proj/determined -it determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.26.4

1. `cd path/to/determined/model_hub`
2. pip install .
3. python
4. import model_hub

Expected behavior:
model_hub imports successfully.



## Commentary (optional)

Don't give 2 packages the same import structure when developing your python project.



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1440