### PR TITLE
fix: Helm master-service clusterip mngt. openshift

### DIFF
--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -1,3 +1,4 @@
+{{- $clusterip := false -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,6 +12,15 @@ spec:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
+{{- if .Values.openshiftRoute }}
+{{- if .Values.openshiftRoute.enabled  }}
+{{- $clusterip =  true }}
+{{- end }}
+{{- end }}
+{{- if $clusterip }}
+  type: ClusterIP
+{{- else }}
   type: {{ if (.Values.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
+{{- end }}
   selector:
     app: determined-master-{{ .Release.Name }}

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -12,14 +12,13 @@ spec:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
-{{- if .Values.openshiftRoute }}
-{{- if .Values.openshiftRoute.enabled  }}
-{{- $clusterip =  true }}
-{{- end }}
-{{- end }}
-{{- if $clusterip }}
+{{- if ((.Values.openshiftRoute).enabled | default false) }}
   type: ClusterIP
+{{- else if (.Values.useNodePortForMaster | default false) }}
+  type: NodePort
 {{- else }}
+  type: LoadBalancer
+{{- end }}
   type: {{ if (.Values.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
 {{- end }}
   selector:

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -23,3 +23,4 @@ spec:
 {{- end }}
   selector:
     app: determined-master-{{ .Release.Name }}
+

--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -1,4 +1,3 @@
-{{- $clusterip := false -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,15 +11,12 @@ spec:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
+
 {{- if ((.Values.openshiftRoute).enabled | default false) }}
   type: ClusterIP
-{{- else if (.Values.useNodePortForMaster | default false) }}
-  type: NodePort
 {{- else }}
-  type: LoadBalancer
-{{- end }}
   type: {{ if (.Values.useNodePortForMaster | default false) }}NodePort{{ else }}LoadBalancer{{ end }}
 {{- end }}
   selector:
     app: determined-master-{{ .Release.Name }}
-
+    


### PR DESCRIPTION
## Description

Changes regarding: Helm chart - `master-service.yaml ` template file

On OPENSHIFT clusters, if the parameter` .Values.openshiftRoute.enabled` is set to true, to request the creation of the **Route HAProxy**, the related master service must have type **ClusterIP**; this because using the the **Haproxy** route the IP traffic goes though the **Load Balancer** (LB) already present in the **Haproxy** itself, hence nor the **LoadBalancer** neither the **NodePort** are needed.

Previously the chart created a master service that depends on the param. `useNodePortForMaster`, so it creartes **NodePort** or **LoadBalancer** (as in this case) that is not needed.

Template `master-service.yaml` change practically works this way: if an route openshift is requested the service type will be ClusterIP independently on the useNodePortForMaster value.

Customer Intesa Sanpaolo Bank
https://hpe-aiatscale.atlassian.net/browse/HELP-381


## Test Plan

Tested on both, OpenShift enviroment and GCP cluster. 



## Commentary (optional)

N/A


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

HELP-381

