### PR TITLE
Mention det python sdk demo

### DIFF
--- a/docs/reference/python-sdk.rst
+++ b/docs/reference/python-sdk.rst
@@ -65,13 +65,8 @@ with an object-oriented interface.
       **Run and Administer Experiments**
 
       Visit the `det-python-sdk-demo
-      <https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__ to
-      learn how to run and administer experiments using the Python SDK.
-
-      .. note::
-
-         Note: This repository contains a variety of Determined examples that are not actively
-         maintained by the Determined team. Results may vary.
+      <https://github.com/determined-ai/determined-examples/tree/e499000d92a0a973d1f40a419934f393957a3296/blog/python_sdk_demo>`__
+      to learn how to run and administer experiments using the Python SDK.
 
 .. _python-sdk-reference:
 

--- a/docs/reference/python-sdk.rst
+++ b/docs/reference/python-sdk.rst
@@ -14,168 +14,159 @@ of the broader Determined Python library, is designed to perform tasks such as:
 The client module exposes many of the same capabilities as the det CLI tool directly to Python code
 with an object-oriented interface.
 
-*****************************************
- Example: Run and Administer Experiments
-*****************************************
+.. tabs::
 
-This `demo <https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__
-describes how to run a script that shows an example of running and administering experiments. This
-example uses MedMNIST datasets and demos the following:
+   .. tab::
 
--  Archiving existing experiments with the same names as the datasets being train on.
--  Creating models for each dataset and registering them in the Determined model registry.
--  Training a model for each dataset by creating an experiment.
--  Registering the best checkpoint for each experiment in the Determined model registry.
+      Basic Example
 
-For instructions on running this example, visit `det-python-sdk-demo
-<https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__ in the
-`Determined GitHub repo <https://github.com/determined-ai/determined/tree/master/examples>`__.
+      **Find the Top Performing Checkpoint**
 
-*********************************************
- Example: Find the Top Performing Checkpoint
-*********************************************
+      In this example, we'll walk through the most basic workflow for creating an experiment,
+      waiting for it to complete, and finding the top-performing checkpoint.
 
-In this example, we'll walk through the most basic workflow for creating an experiment, waiting for
-it to complete, and finding the top-performing checkpoint.
+      The first step is to import the client module and possibly to call login():
 
-The first step is to import the client module and possibly to call login():
+      .. code:: python
 
-.. code:: python
+         from determined.experimental import client
 
-   from determined.experimental import client
+         # We will assume that you have called `det user login`, so this is unnecessary:
+         # client.login(master=..., user=..., password=...)
 
-   # We will assume that you have called `det user login`, so this is unnecessary:
-   # client.login(master=..., user=..., password=...)
+      The next step is to call create_experiment():
 
-The next step is to call create_experiment():
+      .. code:: python
 
-.. code:: python
+         # Config can be a path to a config file or a Python dict of the config.
+         exp = client.create_experiment(config="my_config.yaml", model_dir=".")
+         print(f"started experiment {exp.id}")
 
-   # Config can be a path to a config file or a Python dict of the config.
-   exp = client.create_experiment(config="my_config.yaml", model_dir=".")
-   print(f"started experiment {exp.id}")
+      The returned object is an ``Experiment`` object, which offers methods to manage the
+      experiment's lifecycle. In the following example, we simply await the experiment's completion.
 
-The returned object is an ``Experiment`` object, which offers methods to manage the experiment's
-lifecycle. In the following example, we simply await the experiment's completion.
+      .. code:: python
 
-.. code:: python
+         exit_status = exp.wait()
+         print(f"experiment completed with status {exit_status}")
 
-   exit_status = exp.wait()
-   print(f"experiment completed with status {exit_status}")
+      Now that the experiment has completed, you can grab the top-performing checkpoint from
+      training:
 
-Now that the experiment has completed, you can grab the top-performing checkpoint from training:
+      .. code:: python
 
-.. code:: python
+         best_checkpoint = exp.list_checkpoints()[0]
+         print(f"best checkpoint was {best_checkpoint.uuid}")
 
-   best_checkpoint = exp.list_checkpoints()[0]
-   print(f"best checkpoint was {best_checkpoint.uuid}")
+   .. tab::
+
+      Advanced Example
+
+      **Run and Administer Experiments**
+
+      Visit the `det-python-sdk-demo
+      <https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__ to
+      learn how to run and administer experiments using the Python SDK.
+
+      .. note::
+
+         Note: This repository contains a variety of Determined examples that are not actively
+         maintained by the Determined team. Results may vary.
 
 .. _python-sdk-reference:
 
-Python SDK Reference
-====================
+**********************
+ Python SDK Reference
+**********************
 
-************
- ``Client``
-************
+``Client``
+==========
 
 .. automodule:: determined.experimental.client
    :members: login, create_experiment, get_experiment, get_trial, get_checkpoint, create_model, get_model, get_models, iter_trials_metrics
    :member-order: bysource
 
-*************
- ``OrderBy``
-*************
+``OrderBy``
+===========
 
 .. autoclass:: determined.experimental.client.OrderBy
    :members:
    :member-order: bysource
 
-****************
- ``Checkpoint``
-****************
+``Checkpoint``
+==============
 
 .. autoclass:: determined.experimental.client.Checkpoint
    :members:
    :member-order: bysource
 
-****************
- ``Determined``
-****************
+``Determined``
+==============
 
 .. autoclass:: determined.experimental.client.Determined
    :members:
    :exclude-members: stream_trials_metrics, stream_trials_training_metrics, stream_trials_validation_metrics
    :member-order: bysource
 
-****************
- ``Experiment``
-****************
+``Experiment``
+==============
 
 .. autoclass:: determined.experimental.client.Experiment
    :members:
    :exclude-members: get_trials
    :member-order: bysource
 
-******************
- ``DownloadMode``
-******************
+``DownloadMode``
+================
 
 .. autoclass:: determined.experimental.client.DownloadMode
    :members:
    :member-order: bysource
 
-***********
- ``Model``
-***********
+``Model``
+=========
 
 .. autoclass:: determined.experimental.client.Model
    :members:
    :exclude-members: get_metrics
    :member-order: bysource
 
-*****************
- ``ModelSortBy``
-*****************
+``ModelSortBy``
+===============
 
 .. autoclass:: determined.experimental.client.ModelSortBy
    :members:
    :member-order: bysource
 
-******************
- ``ModelVersion``
-******************
+``ModelVersion``
+================
 
 .. autoclass:: determined.experimental.model.ModelVersion
    :members:
    :member-order: bysource
 
-*************
- ``Project``
-*************
+``Project``
+===========
 
 .. autoclass:: determined.experimental.client.Project
    :members:
    :member-order: bysource
 
-***********
- ``Trial``
-***********
+``Trial``
+=========
 
 .. autoclass:: determined.experimental.client.Trial
    :members:
    :exclude-members: stream_metrics, stream_training_metrics, stream_validation_metrics
    :member-order: bysource
 
-******************
- ``TrialMetrics``
-******************
+``TrialMetrics``
+================
 
 .. autoclass:: determined.experimental.client.TrialMetrics
 
-***************
- ``Workspace``
-***************
+``Workspace``
+=============
 
 .. autoclass:: determined.experimental.client.Workspace
    :members:

--- a/docs/reference/python-sdk.rst
+++ b/docs/reference/python-sdk.rst
@@ -4,17 +4,39 @@
  Python SDK
 ############
 
-You can interact with a Determined cluster with the Python SDK.
+You can interact with a Determined cluster using the Python SDK. The Determined Python SDK, a part
+of the broader Determined Python library, is designed to perform tasks such as:
+
+-  Creating and organizing experiments
+-  Downloading model checkpoints, and adding them to the model registry
+-  Retrieving trial metrics
 
 The client module exposes many of the same capabilities as the det CLI tool directly to Python code
 with an object-oriented interface.
 
-*****************************
- Experiment Workflow Example
-*****************************
+*****************************************
+ Example: Run and Administer Experiments
+*****************************************
 
-As a simple example, let’s walk through the most basic workflow for creating an experiment, waiting
-for it to complete, and finding the top-performing checkpoint.
+This `demo <https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__
+describes how to run a script that shows an example of running and administering experiments. This
+example uses MedMNIST datasets and demos the following:
+
+-  Archiving existing experiments with the same names as the datasets being train on.
+-  Creating models for each dataset and registering them in the Determined model registry.
+-  Training a model for each dataset by creating an experiment.
+-  Registering the best checkpoint for each experiment in the Determined model registry.
+
+For instructions on running this example, visit `det-python-sdk-demo
+<https://github.com/determined-ai/determined-examples/tree/main/blog/python_sdk_demo>`__ in the
+`Determined GitHub repo <https://github.com/determined-ai/determined/tree/master/examples>`__.
+
+*********************************************
+ Example: Find the Top Performing Checkpoint
+*********************************************
+
+In this example, we'll walk through the most basic workflow for creating an experiment, waiting for
+it to complete, and finding the top-performing checkpoint.
 
 The first step is to import the client module and possibly to call login():
 
@@ -50,98 +72,110 @@ Now that the experiment has completed, you can grab the top-performing checkpoin
 
 .. _python-sdk-reference:
 
-**********************
- Python SDK Reference
-**********************
+Python SDK Reference
+====================
 
-``Client``
-==========
+************
+ ``Client``
+************
 
 .. automodule:: determined.experimental.client
    :members: login, create_experiment, get_experiment, get_trial, get_checkpoint, create_model, get_model, get_models, iter_trials_metrics
    :member-order: bysource
 
-``OrderBy``
-===========
+*************
+ ``OrderBy``
+*************
 
 .. autoclass:: determined.experimental.client.OrderBy
    :members:
    :member-order: bysource
 
-``Checkpoint``
-==============
+****************
+ ``Checkpoint``
+****************
 
 .. autoclass:: determined.experimental.client.Checkpoint
    :members:
    :member-order: bysource
 
-``Determined``
-==============
+****************
+ ``Determined``
+****************
 
 .. autoclass:: determined.experimental.client.Determined
    :members:
    :exclude-members: stream_trials_metrics, stream_trials_training_metrics, stream_trials_validation_metrics
    :member-order: bysource
 
-``Experiment``
-==============
+****************
+ ``Experiment``
+****************
 
 .. autoclass:: determined.experimental.client.Experiment
    :members:
    :exclude-members: get_trials
    :member-order: bysource
 
-``DownloadMode``
-================
+******************
+ ``DownloadMode``
+******************
 
 .. autoclass:: determined.experimental.client.DownloadMode
    :members:
    :member-order: bysource
 
-``Model``
-=========
+***********
+ ``Model``
+***********
 
 .. autoclass:: determined.experimental.client.Model
    :members:
    :exclude-members: get_metrics
    :member-order: bysource
 
-``ModelSortBy``
-===============
+*****************
+ ``ModelSortBy``
+*****************
 
 .. autoclass:: determined.experimental.client.ModelSortBy
    :members:
    :member-order: bysource
 
-``ModelVersion``
-================
+******************
+ ``ModelVersion``
+******************
 
 .. autoclass:: determined.experimental.model.ModelVersion
    :members:
    :member-order: bysource
 
-``Project``
-===========
+*************
+ ``Project``
+*************
 
 .. autoclass:: determined.experimental.client.Project
    :members:
    :member-order: bysource
 
-``Trial``
-=========
+***********
+ ``Trial``
+***********
 
 .. autoclass:: determined.experimental.client.Trial
    :members:
    :exclude-members: stream_metrics, stream_training_metrics, stream_validation_metrics
    :member-order: bysource
 
-``TrialMetrics``
-================
+******************
+ ``TrialMetrics``
+******************
 
 .. autoclass:: determined.experimental.client.TrialMetrics
 
-``Workspace``
-=============
+***************
+ ``Workspace``
+***************
 
 .. autoclass:: determined.experimental.client.Workspace
    :members:


### PR DESCRIPTION
Help evangelize the python sdk by updating the documentation. Specifically, by describing a specific version of the [det-python-sdk-demo](https://github.com/determined-ai/determined-examples/tree/e499000d92a0a973d1f40a419934f393957a3296/blog/python_sdk_demo) example and applying the latest standards.