### PR TITLE
chore: Remove attrdict from model hub

### DIFF
--- a/model_hub/docker/Dockerfile.transformers
+++ b/model_hub/docker/Dockerfile.transformers
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 ARG TRANSFORMERS_VERSION
 ARG DATASETS_VERSION
-RUN pip install transformers==${TRANSFORMERS_VERSION} datasets==${DATASETS_VERSION} attrdict
+RUN pip install transformers==${TRANSFORMERS_VERSION} datasets==${DATASETS_VERSION}
 RUN pip install sentencepiece!=0.1.92 protobuf scikit-learn conllu seqeval
 
 

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -1,7 +1,8 @@
 import dataclasses
+import types
 from typing import Any, Dict, Optional, Tuple, Union
 
-import attrdict
+from model_hub import utils
 
 
 class FlexibleDataclass:
@@ -272,7 +273,7 @@ class LRSchedulerKwargs:
 
 def parse_dict_to_dataclasses(
     dataclass_types: Tuple[Any, ...],
-    args: Union[Dict[str, Any], attrdict.AttrDict],
+    args: Union[Dict[str, Any], types.SimpleNamespace],
     as_dict: bool = False,
 ) -> Tuple[Any, ...]:
     """
@@ -283,7 +284,7 @@ def parse_dict_to_dataclasses(
     Args:
         dataclass_types: dataclasses with expected attributes.
         args: arguments that will be parsed to each of the dataclass_types.
-        as_dict: if true will return dictionary instead of AttrDict
+        as_dict: if true will return dictionary instead of SimpleNamespace
 
     Returns:
         One dictionary for each dataclass with keys filled in from args if found.
@@ -295,15 +296,15 @@ def parse_dict_to_dataclasses(
         obj = dtype(**inputs)
         if as_dict:
             try:
-                obj = attrdict.AttrDict(obj.as_dict())
+                obj = utils.attribute_dict(obj.as_dict())
             except AttributeError:
-                obj = attrdict.AttrDict(dataclasses.asdict(obj))
+                obj = utils.attribute_dict(dataclasses.asdict(obj))
         outputs.append(obj)
     return (*outputs,)
 
 
 def default_parse_config_tokenizer_model_kwargs(
-    hparams: Union[Dict, attrdict.AttrDict]
+    hparams: Union[Dict, types.SimpleNamespace]
 ) -> Tuple[Dict, Dict, Dict]:
     """
     This function will provided hparams into fields for the transformers config, tokenizer,
@@ -316,8 +317,8 @@ def default_parse_config_tokenizer_model_kwargs(
     Returns:
         One dictionary each for the config, tokenizer, and model.
     """
-    if not isinstance(hparams, attrdict.AttrDict):
-        hparams = attrdict.AttrDict(hparams)
+    if not isinstance(hparams, types.SimpleNamespace):
+        hparams = utils.attribute_dict(hparams)
     config_args, tokenizer_args, model_args = parse_dict_to_dataclasses(
         (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, as_dict=True
     )
@@ -340,7 +341,7 @@ def default_parse_config_tokenizer_model_kwargs(
 
 
 def default_parse_optimizer_lr_scheduler_kwargs(
-    hparams: Union[Dict, attrdict.AttrDict]
+    hparams: Union[Dict, types.SimpleNamespace]
 ) -> Tuple[OptimizerKwargs, LRSchedulerKwargs]:
     """
     Parse hparams relevant for the optimizer and lr_scheduler and fills in with

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -315,7 +315,7 @@ def default_parse_config_tokenizer_model_kwargs(
         hparams: hyperparameters to parse.
 
     Returns:
-        One dictionary each for the config, tokenizer, and model.
+        One SimpleNamespace each for the config, tokenizer, and model.
     """
     if not isinstance(hparams, types.SimpleNamespace):
         hparams = utils.to_namespace(hparams)

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -302,9 +302,11 @@ def parse_dict_to_dataclasses(
     return (*outputs,)
 
 
-def default_parse_config_tokenizer_model_kwargs(hparams: Dict) -> Tuple[Dict, Dict, Dict]:
+def default_parse_config_tokenizer_model_kwargs(
+    hparams: Union[Dict, utils.AttrDict],
+) -> Tuple[utils.AttrDict, utils.AttrDict, utils.AttrDict]:
     """
-    This function will provided hparams into fields for the transformers config, tokenizer,
+    This function converts hparams into fields for the transformers config, tokenizer,
     and model. See the defined dataclasses ConfigKwargs, TokenizerKwargs, and ModelKwargs for
     expected fields and defaults.
 

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -274,7 +274,6 @@ class LRSchedulerKwargs:
 def parse_dict_to_dataclasses(
     dataclass_types: Tuple[Any, ...],
     args: Union[Dict[str, Any], types.SimpleNamespace],
-    as_dict: bool = False,
 ) -> Tuple[Any, ...]:
     """
     This function will fill in values for a dataclass if the target key is found

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -340,7 +340,7 @@ def default_parse_config_tokenizer_model_kwargs(
 
 
 def default_parse_optimizer_lr_scheduler_kwargs(
-    hparams: Union[Dict, utils.AttrDict],
+    hparams: Union[Dict, utils.AttrDict]
 ) -> Tuple[OptimizerKwargs, LRSchedulerKwargs]:
     """
     Parse hparams relevant for the optimizer and lr_scheduler and fills in with

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -272,7 +272,7 @@ class LRSchedulerKwargs:
 
 def parse_dict_to_dataclasses(
     dataclass_types: Tuple[Any, ...],
-    args: Union[Dict[str, Any]],
+    args: Union[Dict[str, Any], utils.AttrDict],
     as_dict: bool = False,
 ) -> Tuple[Any, ...]:
     """
@@ -283,7 +283,7 @@ def parse_dict_to_dataclasses(
     Args:
         dataclass_types: dataclasses with expected attributes.
         args: arguments that will be parsed to each of the dataclass_types.
-        as_dict: if true will return AttrDict instead of dict
+        as_dict: if true will return dictionary instead of AttrDict
 
     Returns:
         One dictionary for each dataclass with keys filled in from args if found.

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -286,7 +286,7 @@ def parse_dict_to_dataclasses(
         as_dict: if true will return AttrDict instead of dict
 
     Returns:
-        One namespace for each dataclass with keys filled in from args if found.
+        One dictionary for each dataclass with keys filled in from args if found.
     """
     outputs = []
     for dtype in dataclass_types:
@@ -323,11 +323,11 @@ def default_parse_config_tokenizer_model_kwargs(hparams: Dict) -> Tuple[Dict, Di
     # If a pretrained_model_name_or_path is provided it will be parsed to the
     # arguments for config, tokenizer, and model.  Then, if specific names are
     # provided for config, tokenizer, or model we will override it.
-    if hasattr(hparams, "config_name"):
+    if "config_name" in hparams:
         config_args.pretrained_model_name_or_path = hparams.config_name
-    if hasattr(hparams, "tokenizer_name"):
+    if "tokenizer_name" in hparams:
         tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name
-    if hasattr(hparams, "tokenizer_name"):
+    if "model_name" in hparams:
         model_args.pretrained_model_name_or_path = hparams.model_name
     assert (
         config_args.pretrained_model_name_or_path is not None

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -296,9 +296,9 @@ def parse_dict_to_dataclasses(
         obj = dtype(**inputs)
         if as_dict:
             try:
-                obj = utils.attribute_dict(obj.as_dict())
+                obj = utils.to_namespace(obj.as_dict())
             except AttributeError:
-                obj = utils.attribute_dict(dataclasses.asdict(obj))
+                obj = utils.to_namespace(dataclasses.asdict(obj))
         outputs.append(obj)
     return (*outputs,)
 
@@ -318,7 +318,7 @@ def default_parse_config_tokenizer_model_kwargs(
         One dictionary each for the config, tokenizer, and model.
     """
     if not isinstance(hparams, types.SimpleNamespace):
-        hparams = utils.attribute_dict(hparams)
+        hparams = utils.to_namespace(hparams)
     config_args, tokenizer_args, model_args = parse_dict_to_dataclasses(
         (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, as_dict=True
     )

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -340,7 +340,7 @@ def default_parse_config_tokenizer_model_kwargs(
 
 
 def default_parse_optimizer_lr_scheduler_kwargs(
-    hparams: Dict,
+    hparams: Union[Dict, utils.AttrDict],
 ) -> Tuple[OptimizerKwargs, LRSchedulerKwargs]:
     """
     Parse hparams relevant for the optimizer and lr_scheduler and fills in with

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -273,7 +273,7 @@ class LRSchedulerKwargs:
 def parse_dict_to_dataclasses(
     dataclass_types: Tuple[Any, ...],
     args: Union[Dict[str, Any]],
-    output_as_dict: bool = False,
+    as_dict: bool = False,
 ) -> Tuple[Any, ...]:
     """
     This function will fill in values for a dataclass if the target key is found
@@ -283,7 +283,7 @@ def parse_dict_to_dataclasses(
     Args:
         dataclass_types: dataclasses with expected attributes.
         args: arguments that will be parsed to each of the dataclass_types.
-        output_as_dict: if true will return AttrDict instead of dict
+        as_dict: if true will return AttrDict instead of dict
 
     Returns:
         One namespace for each dataclass with keys filled in from args if found.
@@ -293,7 +293,7 @@ def parse_dict_to_dataclasses(
         keys = {f.name for f in dataclasses.fields(dtype) if f.init}
         inputs = {k: v for k, v in args.items() if k in keys}
         obj = dtype(**inputs)
-        if output_as_dict:
+        if as_dict:
             try:
                 obj = utils.AttrDict(obj.as_dict())
             except AttributeError:
@@ -317,7 +317,7 @@ def default_parse_config_tokenizer_model_kwargs(hparams: Dict) -> Tuple[Dict, Di
     if not isinstance(hparams, utils.AttrDict):
         hparams = utils.AttrDict(hparams)
     config_args, tokenizer_args, model_args = parse_dict_to_dataclasses(
-        (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, output_as_dict=True
+        (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, as_dict=True
     )
 
     # If a pretrained_model_name_or_path is provided it will be parsed to the

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -324,11 +324,11 @@ def default_parse_config_tokenizer_model_kwargs(hparams: Dict) -> Tuple[Dict, Di
     # arguments for config, tokenizer, and model.  Then, if specific names are
     # provided for config, tokenizer, or model we will override it.
     if hasattr(hparams, "config_name"):
-        config_args.pretrained_model_name_or_path = hparams.config_name  # type: ignore
+        config_args.pretrained_model_name_or_path = hparams.config_name
     if hasattr(hparams, "tokenizer_name"):
-        tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name  # type: ignore
+        tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name
     if hasattr(hparams, "tokenizer_name"):
-        model_args.pretrained_model_name_or_path = hparams.model_name  # type: ignore
+        model_args.pretrained_model_name_or_path = hparams.model_name
     assert (
         config_args.pretrained_model_name_or_path is not None
         and tokenizer_args.pretrained_model_name_or_path is not None

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -274,6 +274,7 @@ class LRSchedulerKwargs:
 def parse_dict_to_dataclasses(
     dataclass_types: Tuple[Any, ...],
     args: Union[Dict[str, Any], types.SimpleNamespace],
+    output_as_namespace: bool = False,
 ) -> Tuple[Any, ...]:
     """
     This function will fill in values for a dataclass if the target key is found
@@ -283,17 +284,17 @@ def parse_dict_to_dataclasses(
     Args:
         dataclass_types: dataclasses with expected attributes.
         args: arguments that will be parsed to each of the dataclass_types.
-        as_dict: if true will return dictionary instead of SimpleNamespace
+        output_as_namespace: if true will return SimpleNamespace instead of dict
 
     Returns:
-        One dictionary for each dataclass with keys filled in from args if found.
+        One namespace for each dataclass with keys filled in from args if found.
     """
     outputs = []
     for dtype in dataclass_types:
         keys = {f.name for f in dataclasses.fields(dtype) if f.init}
         inputs = {k: v for k, v in args.items() if k in keys}
         obj = dtype(**inputs)
-        if as_dict:
+        if output_as_namespace:
             try:
                 obj = utils.to_namespace(obj.as_dict())
             except AttributeError:
@@ -319,7 +320,7 @@ def default_parse_config_tokenizer_model_kwargs(
     if not isinstance(hparams, types.SimpleNamespace):
         hparams = utils.to_namespace(hparams)
     config_args, tokenizer_args, model_args = parse_dict_to_dataclasses(
-        (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, as_dict=True
+        (ConfigKwargs, TokenizerKwargs, ModelKwargs), hparams, output_as_namespace=True
     )
 
     # If a pretrained_model_name_or_path is provided it will be parsed to the

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -326,11 +326,11 @@ def default_parse_config_tokenizer_model_kwargs(
     # If a pretrained_model_name_or_path is provided it will be parsed to the
     # arguments for config, tokenizer, and model.  Then, if specific names are
     # provided for config, tokenizer, or model we will override it.
-    if "config_name" in hparams:
+    if hasattr(hparams, "config_name"):
         config_args.pretrained_model_name_or_path = hparams.config_name
-    if "tokenizer_name" in hparams:
+    if hasattr(hparams, "tokenizer_name"):
         tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name
-    if "model_name" in hparams:
+    if hasattr(hparams, "tokenizer_name"):
         model_args.pretrained_model_name_or_path = hparams.model_name
     assert (
         config_args.pretrained_model_name_or_path is not None

--- a/model_hub/model_hub/huggingface/_config_parser.py
+++ b/model_hub/model_hub/huggingface/_config_parser.py
@@ -324,11 +324,11 @@ def default_parse_config_tokenizer_model_kwargs(hparams: Dict) -> Tuple[Dict, Di
     # arguments for config, tokenizer, and model.  Then, if specific names are
     # provided for config, tokenizer, or model we will override it.
     if hasattr(hparams, "config_name"):
-        config_args.pretrained_model_name_or_path = hparams.config_name
+        config_args.pretrained_model_name_or_path = hparams.config_name  # type: ignore
     if hasattr(hparams, "tokenizer_name"):
-        tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name
+        tokenizer_args.pretrained_model_name_or_path = hparams.tokenizer_name  # type: ignore
     if hasattr(hparams, "tokenizer_name"):
-        model_args.pretrained_model_name_or_path = hparams.model_name
+        model_args.pretrained_model_name_or_path = hparams.model_name  # type: ignore
     assert (
         config_args.pretrained_model_name_or_path is not None
         and tokenizer_args.pretrained_model_name_or_path is not None

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -1,12 +1,12 @@
 import dataclasses
 import logging
+import types
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import datasets as hf_datasets
 import torch
 import transformers
 import transformers.optimization as hf_opt
-import types
 
 import determined.pytorch as det_torch
 from model_hub import utils
@@ -285,8 +285,8 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
 
         required_hps = ("use_apex_amp", "model_mode", "num_training_steps")
         for hp in required_hps:
-            assert (
-                hasattr(self.hparams, hp)
+            assert hasattr(
+                self.hparams, hp
             ), "{} is a required hyperparameter for BaseTransformerTrial".format(hp)
 
     def train_batch(self, batch: Any, epoch_idx: int, batch_idx: int) -> Any:

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -146,7 +146,7 @@ def build_default_lr_scheduler(
 
 
 def default_load_dataset(
-    data_config: types.SimpleNamespace
+    data_config: Dict[Any, Any]
 ) -> Union[
     hf_datasets.Dataset,
     hf_datasets.IterableDataset,
@@ -165,10 +165,10 @@ def default_load_dataset(
     """
     (data_config,) = hf_parse.parse_dict_to_dataclasses((hf_parse.DatasetKwargs,), data_config)
     # This method is common in nearly all main HF examples.
-    if data_config.dataset_name is not None:
+    if data_config["dataset_name"] is not None:
         # Downloading and loading a dataset from the hub.
         datasets = hf_datasets.load_dataset(
-            data_config.dataset_name, data_config.dataset_config_name
+            data_config["dataset_name"], data_config["dataset_config_name"]
         )
         assert hasattr(datasets, "keys"), "Expected a dictionary of datasets."
         datasets = cast(Union[hf_datasets.DatasetDict, hf_datasets.IterableDatasetDict], datasets)
@@ -179,22 +179,22 @@ def default_load_dataset(
             ), "Validation split not provided by this huggingface dataset. Please specify "
             "validation_split_percentage in data_config for use to create validation set"
             datasets["validation"] = hf_datasets.load_dataset(
-                data_config.dataset_name,
-                data_config.dataset_config_name,
-                split=f"train[:{data_config.validation_split_percentage}%]",
+                data_config.data_config["dataset_name"],
+                data_config.data_config["dataset_config_name"],
+                split=f"train[:{data_config['validation_split_percentage']}%]",
             )
             datasets["train"] = hf_datasets.load_dataset(
-                data_config.dataset_name,
-                data_config.dataset_config_name,
-                split=f"train[{data_config.validation_split_percentage}%:]",
+                data_config.data_config["dataset_name"],
+                data_config.data_config["dataset_config_name"],
+                split=f"train[:{data_config['validation_split_percentage']}%]",
             )
     else:
         data_files = {}
-        if data_config.train_file is not None:
+        if data_config["train_file"] is not None:
             data_files["train"] = data_config.train_file
-        if data_config.validation_file is not None:
+        if data_config["validation_file"] is not None:
             data_files["validation"] = data_config.validation_file
-        extension = data_config.train_file.split(".")[-1]
+        extension = data_config["train_file"].split(".")[-1]
         if extension == "txt":
             extension = "text"
         datasets = hf_datasets.load_dataset(extension, data_files=data_files)

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -216,11 +216,11 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         # A subclass of BaseTransformerTrial may have already set hparams and data_config
         # attributes so we only reset them if they do not exist.
         if not hasattr(self, "hparams"):
-            self.hparams = utils.AttrDict(context.get_hparams())  # type: ignore
+            self.hparams = utils.AttrDict(context.get_hparams())
         if not hasattr(self, "data_config"):
-            self.data_config = utils.AttrDict(context.get_data_config())  # type: ignore
+            self.data_config = utils.AttrDict(context.get_data_config())
         if not hasattr(self, "exp_config"):
-            self.exp_config = utils.AttrDict(context.get_experiment_config())  # type: ignore
+            self.exp_config = utils.AttrDict(context.get_experiment_config())
         # Check to make sure all expected hyperparameters are set.
         self.check_hparams()
 
@@ -260,7 +260,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
 
         self.grad_clip_fn = None
 
-        if optimizer_kwargs.max_grad_norm > 0:  # type: ignore
+        if optimizer_kwargs.max_grad_norm > 0:
             self.grad_clip_fn = lambda x: torch.nn.utils.clip_grad_norm_(
                 x, optimizer_kwargs.max_grad_norm
             )

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -182,12 +182,12 @@ def default_load_dataset(
             datasets["validation"] = hf_datasets.load_dataset(
                 data_config.dataset_name,
                 data_config.dataset_config_name,
-                split=f"train[{data_config.validation_split_percentage}%:]",
+                split=f"train[:{data_config.validation_split_percentage}%]",
             )
             datasets["train"] = hf_datasets.load_dataset(
                 data_config.dataset_name,
                 data_config.dataset_config_name,
-                split=f"train[:{data_config.validation_split_percentage}%]",
+                split=f"train[{data_config.validation_split_percentage}%:]",
             )
     else:
         data_files = {}
@@ -266,7 +266,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
             )
 
     def check_hparams(self) -> None:
-        # We require hparams to be a AttrDict.
+        # We require hparams to be an AttrDict.
         if not isinstance(self.hparams, utils.AttrDict):
             self.hparams = utils.AttrDict(self.hparams)
 

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -260,7 +260,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
 
         self.grad_clip_fn = None
 
-        if optimizer_kwargs.max_grad_norm > 0:
+        if optimizer_kwargs.max_grad_norm > 0:  # type: ignore
             self.grad_clip_fn = lambda x: torch.nn.utils.clip_grad_norm_(
                 x, optimizer_kwargs.max_grad_norm
             )

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -145,7 +145,7 @@ def build_default_lr_scheduler(
 
 
 def default_load_dataset(
-    data_config: dict,
+    data_config_input: Union[Dict, utils.AttrDict],
 ) -> Union[
     hf_datasets.Dataset,
     hf_datasets.IterableDataset,
@@ -154,7 +154,7 @@ def default_load_dataset(
 ]:
     """
     Creates the dataset using HuggingFace datasets' load_dataset method.
-    If a dataset_name is provided, we will use that long with the dataset_config_name.
+    If a dataset_name is provided, we will use that along with the dataset_config_name.
     Otherwise, we will create the dataset using provided train_file and validation_file.
 
     Args:
@@ -163,7 +163,7 @@ def default_load_dataset(
         Dataset returned from hf_datasets.load_dataset.
     """
     (data_config,) = hf_parse.parse_dict_to_dataclasses(
-        (hf_parse.DatasetKwargs,), data_config, as_dict=True
+        (hf_parse.DatasetKwargs,), data_config_input
     )
     # This method is common in nearly all main HF examples.
     if data_config.dataset_name is not None:

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -26,10 +26,10 @@ MODEL_MODES = {
 
 
 def build_using_auto(
-    config_kwargs: Dict,
-    tokenizer_kwargs: Dict,
+    config_kwargs: Union[Dict, utils.AttrDict],
+    tokenizer_kwargs: Union[Dict, utils.AttrDict],
     model_mode: str,
-    model_kwargs: Dict,
+    model_kwargs: Union[Dict, utils.AttrDict],
     use_pretrained_weights: bool = True,
 ) -> Tuple[
     transformers.PretrainedConfig,  # This is how it's named in transformers
@@ -182,7 +182,7 @@ def default_load_dataset(
             datasets["validation"] = hf_datasets.load_dataset(
                 data_config.dataset_name,
                 data_config.dataset_config_name,
-                split=f"train[:{data_config.validation_split_percentage}%]",
+                split=f"train[{data_config.validation_split_percentage}%:]",
             )
             datasets["train"] = hf_datasets.load_dataset(
                 data_config.dataset_name,
@@ -286,8 +286,8 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
 
         required_hps = ("use_apex_amp", "model_mode", "num_training_steps")
         for hp in required_hps:
-            assert hasattr(
-                self.hparams, hp
+            assert (
+                hp in self.hparams
             ), "{} is a required hyperparameter for BaseTransformerTrial".format(hp)
 
     def train_batch(self, batch: Any, epoch_idx: int, batch_idx: int) -> Any:

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -269,13 +269,13 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         if not isinstance(self.hparams, types.SimpleNamespace):
             self.hparams = utils.to_namespace(self.hparams)
 
-        if "num_training_steps" not in self.hparams:
+        if not hasattr(self.hparams, "num_training_steps"):
             # Compute the total number of training iterations used to configure the
             # learning rate scheduler.
             self.hparams.num_training_steps = model_hub.utils.compute_num_training_steps(
                 self.context.get_experiment_config(), self.context.get_global_batch_size()
             )
-        if "use_pretrained_weights" not in self.hparams:
+        if not hasattr(self.hparams, "use_pretrained_weights"):
             logging.warning(
                 "We will be using pretrained weights for the model by default."
                 "If you want to train the model from scratch, you can set a hyperparameter "
@@ -286,7 +286,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         required_hps = ("use_apex_amp", "model_mode", "num_training_steps")
         for hp in required_hps:
             assert (
-                hp in self.hparams
+                hasattr(self.hparams, hp)
             ), "{} is a required hyperparameter for BaseTransformerTrial".format(hp)
 
     def train_batch(self, batch: Any, epoch_idx: int, batch_idx: int) -> Any:

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -146,7 +146,7 @@ def build_default_lr_scheduler(
 
 
 def default_load_dataset(
-    data_config: Union[Dict, types.SimpleNamespace]
+    data_config: types.SimpleNamespace
 ) -> Union[
     hf_datasets.Dataset,
     hf_datasets.IterableDataset,

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
 import types
+import typing
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import datasets as hf_datasets
@@ -145,8 +146,9 @@ def build_default_lr_scheduler(
     )
 
 
+@typing.no_type_check
 def default_load_dataset(
-    data_config: dict
+    data_config: dict,
 ) -> Union[
     hf_datasets.Dataset,
     hf_datasets.IterableDataset,
@@ -163,7 +165,9 @@ def default_load_dataset(
     Returns:
         Dataset returned from hf_datasets.load_dataset.
     """
-    (data_config,) = hf_parse.parse_dict_to_dataclasses((hf_parse.DatasetKwargs,), data_config)
+    (data_config,) = hf_parse.parse_dict_to_dataclasses(
+        (hf_parse.DatasetKwargs,), data_config, output_as_namespace=True
+    )
     # This method is common in nearly all main HF examples.
     if data_config.dataset_name is not None:
         # Downloading and loading a dataset from the hub.

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -146,7 +146,7 @@ def build_default_lr_scheduler(
 
 
 def default_load_dataset(
-    data_config: Dict[Any, Any]
+    data_config: dict
 ) -> Union[
     hf_datasets.Dataset,
     hf_datasets.IterableDataset,
@@ -165,10 +165,10 @@ def default_load_dataset(
     """
     (data_config,) = hf_parse.parse_dict_to_dataclasses((hf_parse.DatasetKwargs,), data_config)
     # This method is common in nearly all main HF examples.
-    if data_config["dataset_name"] is not None:
+    if data_config.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
         datasets = hf_datasets.load_dataset(
-            data_config["dataset_name"], data_config["dataset_config_name"]
+            data_config.dataset_name, data_config.dataset_config_name
         )
         assert hasattr(datasets, "keys"), "Expected a dictionary of datasets."
         datasets = cast(Union[hf_datasets.DatasetDict, hf_datasets.IterableDatasetDict], datasets)
@@ -179,22 +179,22 @@ def default_load_dataset(
             ), "Validation split not provided by this huggingface dataset. Please specify "
             "validation_split_percentage in data_config for use to create validation set"
             datasets["validation"] = hf_datasets.load_dataset(
-                data_config.data_config["dataset_name"],
-                data_config.data_config["dataset_config_name"],
-                split=f"train[:{data_config['validation_split_percentage']}%]",
+                data_config.dataset_name,
+                data_config.dataset_config_name,
+                split=f"train[:{data_config.validation_split_percentage}%]",
             )
             datasets["train"] = hf_datasets.load_dataset(
-                data_config.data_config["dataset_name"],
-                data_config.data_config["dataset_config_name"],
-                split=f"train[:{data_config['validation_split_percentage']}%]",
+                data_config.dataset_name,
+                data_config.dataset_config_name,
+                split=f"train[{data_config.validation_split_percentage}%:]",
             )
     else:
         data_files = {}
-        if data_config["train_file"] is not None:
+        if data_config.train_file is not None:
             data_files["train"] = data_config.train_file
-        if data_config["validation_file"] is not None:
+        if data_config.validation_file is not None:
             data_files["validation"] = data_config.validation_file
-        extension = data_config["train_file"].split(".")[-1]
+        extension = data_config.train_file.split(".")[-1]
         if extension == "txt":
             extension = "text"
         datasets = hf_datasets.load_dataset(extension, data_files=data_files)

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -272,7 +272,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         if not hasattr(self.hparams, "num_training_steps"):
             # Compute the total number of training iterations used to configure the
             # learning rate scheduler.
-            self.hparams.num_training_steps = model_hub.utils.compute_num_training_steps(
+            self.hparams.num_training_steps = utils.compute_num_training_steps(
                 self.context.get_experiment_config(), self.context.get_global_batch_size()
             )
         if not hasattr(self.hparams, "use_pretrained_weights"):

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -215,11 +215,11 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         # A subclass of BaseTransformerTrial may have already set hparams and data_config
         # attributes so we only reset them if they do not exist.
         if not hasattr(self, "hparams"):
-            self.hparams = utils.attribute_dict(context.get_hparams())
+            self.hparams = utils.to_namespace(context.get_hparams())
         if not hasattr(self, "data_config"):
-            self.data_config = utils.attribute_dict(context.get_data_config())
+            self.data_config = utils.to_namespace(context.get_data_config())
         if not hasattr(self, "exp_config"):
-            self.exp_config = utils.attribute_dict(context.get_experiment_config())
+            self.exp_config = utils.to_namespace(context.get_experiment_config())
         # Check to make sure all expected hyperparameters are set.
         self.check_hparams()
 
@@ -267,7 +267,7 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
     def check_hparams(self) -> None:
         # We require hparams to be a SimpleNamespace.
         if not isinstance(self.hparams, types.SimpleNamespace):
-            self.hparams = utils.attribute_dict(self.hparams)
+            self.hparams = utils.to_namespace(self.hparams)
 
         if "num_training_steps" not in self.hparams:
             # Compute the total number of training iterations used to configure the

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -216,11 +216,11 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         # A subclass of BaseTransformerTrial may have already set hparams and data_config
         # attributes so we only reset them if they do not exist.
         if not hasattr(self, "hparams"):
-            self.hparams = utils.AttrDict(context.get_hparams())
+            self.hparams = utils.AttrDict(context.get_hparams())  # type: ignore
         if not hasattr(self, "data_config"):
-            self.data_config = utils.AttrDict(context.get_data_config())
+            self.data_config = utils.AttrDict(context.get_data_config())  # type: ignore
         if not hasattr(self, "exp_config"):
-            self.exp_config = utils.AttrDict(context.get_experiment_config())
+            self.exp_config = utils.AttrDict(context.get_experiment_config())  # type: ignore
         # Check to make sure all expected hyperparameters are set.
         self.check_hparams()
 

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -166,10 +166,10 @@ def default_load_dataset(
         (hf_parse.DatasetKwargs,), data_config, as_dict=True
     )
     # This method is common in nearly all main HF examples.
-    if data_config["dataset_name"] is not None:
+    if data_config.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
         datasets = hf_datasets.load_dataset(
-            data_config["dataset_name"], data_config["dataset_config_name"]
+            data_config.dataset_name, data_config.dataset_config_name
         )
         assert hasattr(datasets, "keys"), "Expected a dictionary of datasets."
         datasets = cast(Union[hf_datasets.DatasetDict, hf_datasets.IterableDatasetDict], datasets)
@@ -180,22 +180,22 @@ def default_load_dataset(
             ), "Validation split not provided by this huggingface dataset. Please specify "
             "validation_split_percentage in data_config for use to create validation set"
             datasets["validation"] = hf_datasets.load_dataset(
-                data_config["dataset_name"],
-                data_config["dataset_config_name"],
-                split=f"train[:{data_config['validation_split_percentage']}%]",
+                data_config.dataset_name,
+                data_config.dataset_config_name,
+                split=f"train[:{data_config.validation_split_percentage}%]",
             )
             datasets["train"] = hf_datasets.load_dataset(
-                data_config["dataset_name"],
-                data_config["dataset_config_name"],
-                split=f"train[:{data_config['validation_split_percentage']}%]",
+                data_config.dataset_name,
+                data_config.dataset_config_name,
+                split=f"train[:{data_config.validation_split_percentage}%]",
             )
     else:
         data_files = {}
-        if data_config["train_file"] is not None:
-            data_files["train"] = data_config["train_file"]
-        if data_config["validation_file"] is not None:
-            data_files["validation"] = data_config["validation_file"]
-        extension = data_config["train_file"].split(".")[-1]
+        if data_config.train_file is not None:
+            data_files["train"] = data_config.train_file
+        if data_config.validation_file is not None:
+            data_files["validation"] = data_config.validation_file
+        extension = data_config.train_file.split(".")[-1]
         if extension == "txt":
             extension = "text"
         datasets = hf_datasets.load_dataset(extension, data_files=data_files)
@@ -270,13 +270,13 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
         if not isinstance(self.hparams, utils.AttrDict):
             self.hparams = utils.AttrDict(self.hparams)
 
-        if not hasattr(self.hparams, "num_training_steps"):
+        if "num_training_steps" not in self.hparams:
             # Compute the total number of training iterations used to configure the
             # learning rate scheduler.
             self.hparams.num_training_steps = utils.compute_num_training_steps(
                 self.context.get_experiment_config(), self.context.get_global_batch_size()
             )
-        if not hasattr(self.hparams, "use_pretrained_weights"):
+        if "use_pretrained_weights" not in self.hparams:
             logging.warning(
                 "We will be using pretrained weights for the model by default."
                 "If you want to train the model from scratch, you can set a hyperparameter "

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -163,7 +163,7 @@ def default_load_dataset(
         Dataset returned from hf_datasets.load_dataset.
     """
     (data_config,) = hf_parse.parse_dict_to_dataclasses(
-        (hf_parse.DatasetKwargs,), data_config, output_as_dict=True
+        (hf_parse.DatasetKwargs,), data_config, as_dict=True
     )
     # This method is common in nearly all main HF examples.
     if data_config["dataset_name"] is not None:

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -123,21 +123,21 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         # If a backend is specified, we will the backend used in all occurrences of
         # LoadImageFromFile in the mmdet config.
-        if hasattr(self.data_config, "file_client_args") is not None:
+        if self.data_config.file_client_args is not None:
             data_backends.sub_backend(self.data_config.file_client_args, cfg)
         if self.hparams.merge_config is not None:
             override_config = mmcv.Config.fromfile(self.hparams.merge_config)
             new_config = mmcv.Config._merge_a_into_b(override_config, cfg._cfg_dict)
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
-        if hasattr(self.hparams, "override_mmdet_config"):
+        if "override_mmdet_config" in self.hparams:
             cfg.merge_from_dict(self.hparams.override_mmdet_config)
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)
 
         # Save and log the resulting config.
-        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:
-            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"
+        if "save_cfg" in self.hparams and self.hparams.save_cfg:
+            save_dir = self.hparams.save_dir if "save_dir" in self.hparams else "/tmp"
             extension = cfg._filename.split(".")[-1]
             cfg.dump(os.path.join(save_dir, f"final_config.{extension}"))
         logging.info(cfg)
@@ -157,7 +157,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
     def build_callbacks(self) -> Dict[str, det_torch.PyTorchCallback]:
         self.lr_updater = None
         hooks = {}  # type: Dict[str, det_torch.PyTorchCallback]
-        if hasattr(self.cfg, "lr_config"):
+        if "lr_config" in self.cfg:
             logging.info("Adding lr updater callback.")
             self.lr_updater = callbacks.LrUpdaterCallback(
                 self.context, lr_config=self.cfg.lr_config

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -55,8 +55,8 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
         self.context = context
-        self.hparams = utils.to_namespace(context.get_hparams())
-        self.data_config = utils.to_namespace(context.get_data_config())
+        self.hparams = utils.AttrDict(context.get_hparams())
+        self.data_config = utils.AttrDict(context.get_data_config())
         self.cfg = self.build_mmdet_config()
         # We will control how data is moved to GPU.
         self.context.experimental.disable_auto_to_device()
@@ -131,8 +131,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            cfg.merge_from_dict(
-                utils.from_namespace(utils.from_namespace(self.hparams.override_mmdet_config)))
+            cfg.merge_from_dict(self.hparams.override_mmdet_config)
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -131,7 +131,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            cfg.merge_from_dict(self.hparams.override_mmdet_config)
+            cfg.merge_from_dict(self.hparams.override_mmdet_config.__dict__)
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -131,6 +131,8 @@ class MMDetTrial(det_torch.PyTorchTrial):
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
+            print(self.hparams.override_mmdet_config)
+            print(self.hparams.override_mmdet_config.__dict__)
             cfg.merge_from_dict(self.hparams.override_mmdet_config.__dict__)
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -117,14 +117,14 @@ class MMDetTrial(det_torch.PyTorchTrial):
             if config_dir is not None:
                 config_file = os.path.join(config_dir, config_file)
             if config_dir is None or not os.path.exists(config_file):
-                raise OSError(f"Config file {self.hparams.config_file} not found.")
+                raise OSError(f"Config file {self.hparams['config_file']} not found.")
         cfg = mmcv.Config.fromfile(config_file)
         cfg.data.val.test_mode = True
 
         # If a backend is specified, we will the backend used in all occurrences of
         # LoadImageFromFile in the mmdet config.
-        if self.data_config.file_client_args is not None:
-            data_backends.sub_backend(self.data_config.file_client_args, cfg)
+        if self.data_config["file_client_args"] is not None:
+            data_backends.sub_backend(self.data_config["file_client_args"], cfg)
         if self.hparams["merge_config"] is not None:
             override_config = mmcv.Config.fromfile(self.hparams["merge_config"])
             new_config = mmcv.Config._merge_a_into_b(override_config, cfg._cfg_dict)
@@ -138,7 +138,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         # Save and log the resulting config.
         if "save_cfg" in self.hparams and self.hparams["save_cfg"]:
-            save_dir = self.hparams.save_dir if "save_dir" in self.hparams else "/tmp"
+            save_dir = self.hparams["save_dir"] if "save_dir" in self.hparams else "/tmp"
             extension = cfg._filename.split(".")[-1]
             cfg.dump(os.path.join(save_dir, f"final_config.{extension}"))
         logging.info(cfg)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -69,7 +69,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         # If use_pretrained, try loading pretrained weights for the mmcv config if available.
         if hasattr(self.hparams, "use_pretrained"):
-            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams.config_file)  # type: ignore
+            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams.config_file)
             if ckpt_path is not None:
                 logging.info("Loading from pretrained weights.")
                 if "state_dict" in ckpt:
@@ -111,7 +111,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
         Returns:
             overridden mmdet config
         """
-        config_file = self.hparams.config_file  # type: ignore
+        config_file = self.hparams.config_file
         if not os.path.exists(config_file):
             config_dir = os.getenv("MMDETECTION_CONFIG_DIR")
             if config_dir is not None:
@@ -124,21 +124,20 @@ class MMDetTrial(det_torch.PyTorchTrial):
         # If a backend is specified, we will the backend used in all occurrences of
         # LoadImageFromFile in the mmdet config.
         if hasattr(self.data_config, "file_client_args") is not None:
-            data_backends.sub_backend(self.data_config.file_client_args, cfg)  # type: ignore
-        if self.hparams.merge_config is not None:  # type: ignore
-            override_config = mmcv.Config.fromfile(self.hparams.merge_config)  # type: ignore
+            data_backends.sub_backend(self.data_config.file_client_args, cfg)
+        if self.hparams.merge_config is not None:
+            override_config = mmcv.Config.fromfile(self.hparams.merge_config)
             new_config = mmcv.Config._merge_a_into_b(override_config, cfg._cfg_dict)
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            cfg.merge_from_dict(self.hparams.override_mmdet_config)  # type: ignore
-
+            cfg.merge_from_dict(self.hparams.override_mmdet_config)
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)
 
         # Save and log the resulting config.
-        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:  # type: ignore
-            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"  # type: ignore
+        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:
+            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"
             extension = cfg._filename.split(".")[-1]
             cfg.dump(os.path.join(save_dir, f"final_config.{extension}"))
         logging.info(cfg)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -131,9 +131,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            print(self.hparams.override_mmdet_config)
-            print(self.hparams.override_mmdet_config.__dict__)
-            cfg.merge_from_dict(self.hparams.override_mmdet_config.__dict__)
+            cfg.merge_from_dict(utils.from_namespace(self.hparams.override_mmdet_config))
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -39,7 +39,6 @@ from model_hub.mmdetection import _callbacks as callbacks
 from model_hub.mmdetection import _data as data
 from model_hub.mmdetection import _data_backends as data_backends
 from model_hub.mmdetection import utils as mmdetutils
-from model_hub import utils
 
 
 class MMDetTrial(det_torch.PyTorchTrial):
@@ -69,7 +68,9 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         # If use_pretrained, try loading pretrained weights for the mmcv config if available.
         if "use_pretrained" in self.hparams:
-            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams["config_file"])
+            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path(
+                "/tmp", self.hparams["config_file"]
+            )
             if ckpt_path is not None:
                 logging.info("Loading from pretrained weights.")
                 if "state_dict" in ckpt:

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -131,7 +131,8 @@ class MMDetTrial(det_torch.PyTorchTrial):
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            cfg.merge_from_dict(utils.from_namespace(self.hparams.override_mmdet_config))
+            cfg.merge_from_dict(
+                utils.from_namespace(utils.from_namespace(self.hparams.override_mmdet_config)))
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -132,6 +132,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         if "override_mmdet_config" in self.hparams:
             cfg.merge_from_dict(self.hparams.override_mmdet_config)
+
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)
 

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -55,8 +55,8 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
         self.context = context
-        self.hparams = utils.attribute_dict(context.get_hparams())
-        self.data_config = utils.attribute_dict(context.get_data_config())
+        self.hparams = utils.to_namespace(context.get_hparams())
+        self.data_config = utils.to_namespace(context.get_data_config())
         self.cfg = self.build_mmdet_config()
         # We will control how data is moved to GPU.
         self.context.experimental.disable_auto_to_device()

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -68,7 +68,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
         self.model.init_weights()
 
         # If use_pretrained, try loading pretrained weights for the mmcv config if available.
-        if hasattr(self.hparams, "use_pretrained"):
+        if self.hparams.use_pretrained:
             ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams.config_file)
             if ckpt_path is not None:
                 logging.info("Loading from pretrained weights.")
@@ -91,7 +91,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         self.clip_grads_fn = None
         if self.cfg.optimizer_config.grad_clip is not None:
-            self.clip_grads_fn = lambda x: torch.nn.mmdetutils.clip_grad_norm_(
+            self.clip_grads_fn = lambda x: torch.nn.utils.clip_grad_norm_(
                 x,
                 self.cfg.optimizer_config.grad_clip.max_norm,
                 self.cfg.optimizer_config.grad_clip.norm_type,

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -69,7 +69,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
 
         # If use_pretrained, try loading pretrained weights for the mmcv config if available.
         if hasattr(self.hparams, "use_pretrained"):
-            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams.config_file)
+            ckpt_path, ckpt = mmdetutils.get_pretrained_ckpt_path("/tmp", self.hparams.config_file)  # type: ignore
             if ckpt_path is not None:
                 logging.info("Loading from pretrained weights.")
                 if "state_dict" in ckpt:
@@ -111,7 +111,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
         Returns:
             overridden mmdet config
         """
-        config_file = self.hparams.config_file
+        config_file = self.hparams.config_file  # type: ignore
         if not os.path.exists(config_file):
             config_dir = os.getenv("MMDETECTION_CONFIG_DIR")
             if config_dir is not None:
@@ -124,21 +124,21 @@ class MMDetTrial(det_torch.PyTorchTrial):
         # If a backend is specified, we will the backend used in all occurrences of
         # LoadImageFromFile in the mmdet config.
         if hasattr(self.data_config, "file_client_args") is not None:
-            data_backends.sub_backend(self.data_config.file_client_args, cfg)
-        if self.hparams.merge_config is not None:
-            override_config = mmcv.Config.fromfile(self.hparams.merge_config)
+            data_backends.sub_backend(self.data_config.file_client_args, cfg)  # type: ignore
+        if self.hparams.merge_config is not None:  # type: ignore
+            override_config = mmcv.Config.fromfile(self.hparams.merge_config)  # type: ignore
             new_config = mmcv.Config._merge_a_into_b(override_config, cfg._cfg_dict)
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
         if hasattr(self.hparams, "override_mmdet_config"):
-            cfg.merge_from_dict(self.hparams.override_mmdet_config)
+            cfg.merge_from_dict(self.hparams.override_mmdet_config)  # type: ignore
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)
 
         # Save and log the resulting config.
-        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:
-            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"
+        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:  # type: ignore
+            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"  # type: ignore
             extension = cfg._filename.split(".")[-1]
             cfg.dump(os.path.join(save_dir, f"final_config.{extension}"))
         logging.info(cfg)

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -130,15 +130,15 @@ class MMDetTrial(det_torch.PyTorchTrial):
             new_config = mmcv.Config._merge_a_into_b(override_config, cfg._cfg_dict)
             cfg = mmcv.Config(new_config, cfg._text, cfg._filename)
 
-        if "override_mmdet_config" in self.hparams:
+        if hasattr(self.hparams,"override_mmdet_config"):
             cfg.merge_from_dict(self.hparams.override_mmdet_config)
 
         cfg.data.val.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.val.pipeline)
         cfg.data.test.pipeline = mmdet.datasets.replace_ImageToTensor(cfg.data.test.pipeline)
 
         # Save and log the resulting config.
-        if "save_cfg" in self.hparams and self.hparams.save_cfg:
-            save_dir = self.hparams.save_dir if "save_dir" in self.hparams else "/tmp"
+        if hasattr(self.hparams, "save_cfg") and self.hparams.save_cfg:
+            save_dir = self.hparams.save_dir if hasattr(self.hparams, "save_dir") else "/tmp"
             extension = cfg._filename.split(".")[-1]
             cfg.dump(os.path.join(save_dir, f"final_config.{extension}"))
         logging.info(cfg)
@@ -158,7 +158,7 @@ class MMDetTrial(det_torch.PyTorchTrial):
     def build_callbacks(self) -> Dict[str, det_torch.PyTorchCallback]:
         self.lr_updater = None
         hooks = {}  # type: Dict[str, det_torch.PyTorchCallback]
-        if "lr_config" in self.cfg:
+        if hasattr(self.cfg, "lr_config"):
             logging.info("Adding lr updater callback.")
             self.lr_updater = callbacks.LrUpdaterCallback(
                 self.context, lr_config=self.cfg.lr_config

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -91,9 +91,9 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
 class AttrDict(dict):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        for key, val in self.items():
-            if isinstance(key, dict):
-                self.key = AttrDict(val)
+        for key in self.keys():
+            if isinstance(self[key], dict):
+                self[key] = AttrDict(self[key])
 
     def __getattr__(self, name: str, default: Any = None) -> Any:
         return self.get(name, default)

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -1,8 +1,7 @@
 import logging
 import os
-import types
 import urllib.parse
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import filelock
 import numpy as np
@@ -89,20 +88,12 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
     return int(max_length / global_batch_size)
 
 
-def to_namespace(input_dict: dict) -> types.SimpleNamespace:
-    namespace = types.SimpleNamespace()
-    for key, value in input_dict.items():
-        if isinstance(value, dict):
-            setattr(namespace, key, to_namespace(value))
-        else:
-            setattr(namespace, key, value)
-    return namespace
+class AttrDict(dict):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
+    def __getattr__(self, name: str, default: Any = None) -> Any:
+        return self.get(name, default)
 
-def from_namespace(input_namespace: types.SimpleNamespace) -> dict:
-    output_dict = input_namespace.__dict__
-    for key, val in output_dict.items():
-        if isinstance(val, types.SimpleNamespace):
-            output_dict[key] = from_namespace(val)
-
-    return output_dict
+    def __setattr__(self, name: str, val: Any) -> None:
+        self[name] = val

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import urllib.parse
 import typing
+import urllib.parse
 from typing import Any, Dict, List, Union
 
 import filelock
@@ -98,8 +98,9 @@ class AttrDict(dict):
                 self[key] = AttrDict(self[key])
 
     if typing.TYPE_CHECKING:
-        def __getattr__(self, item):
+
+        def __getattr__(self, item: Any) -> Any:
             return True
 
-        def __setattr__(self, item, value):
+        def __setattr__(self, item: Any, value: Any) -> None:
             return None

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -97,3 +97,12 @@ def to_namespace(input_dict: dict) -> types.SimpleNamespace:
         else:
             setattr(namespace, key, value)
     return namespace
+
+
+def from_namespace(input_namespace: types.SimpleNamespace) -> dict:
+    output_dict = input_namespace.__dict__
+    for key, val in output_dict.items():
+        if isinstance(val, types.SimpleNamespace):
+            output_dict[key] = from_namespace(val)
+
+    return output_dict

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -89,13 +89,11 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
     return int(max_length / global_batch_size)
 
 
-def to_namespace(input_dict: [dict, list]) -> types.SimpleNamespace:
+def to_namespace(input_dict: dict) -> types.SimpleNamespace:
     namespace = types.SimpleNamespace()
     for key, value in input_dict.items():
         if isinstance(value, dict):
             setattr(namespace, key, to_namespace(value))
-        elif isinstance(value, list):
-            _ = [setattr(namespace, key, to_namespace(item)) for item in value]
         else:
             setattr(namespace, key, value)
     return namespace

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import urllib.parse
+import typing
 from typing import Any, Dict, List, Union
 
 import filelock
@@ -96,3 +97,10 @@ class AttrDict(dict):
             if isinstance(self[key], dict):
                 self[key] = AttrDict(self[key])
             super().__setattr__(key, self[key])
+
+    if typing.TYPE_CHECKING:
+        def __getattr__(self, item):
+            return True
+
+        def __setattr__(self, item, value):
+            return None

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -91,14 +91,8 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
 class AttrDict(dict):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self.__dict__ = self
         for key in self.keys():
             if isinstance(self[key], dict):
                 self[key] = AttrDict(self[key])
             super().__setattr__(key, self[key])
-
-    def __setattr__(self, name: str, val: Any) -> None:
-        super().__setattr__(name, val)
-        super().__setitem__(name, val)
-
-    def __setitem__(self, name: str, val: Any) -> None:
-        setattr(self, name, val)

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -88,6 +88,13 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
     # Otherwise, max_length_unit=='records'
     return int(max_length / global_batch_size)
 
-def attribute_dict(input_dict: dict) -> types.SimpleNamespace:
-    dictionary = types.SimpleNamespace(input_dict)
-    return dictionary
+def to_namespace(input_dict: [dict, list]) -> types.SimpleNamespace:
+    namespace = types.SimpleNamespace()
+    for key, value in input_dict.items():
+        if isinstance(value, dict):
+            setattr(namespace, key, to_namespace(value))
+        elif isinstance(value, list):
+            _ = [setattr(namespace, key, to_namespace(item)) for item in value]
+        else:
+            setattr(namespace, key, value)
+    return namespace

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -7,6 +7,7 @@ import filelock
 import numpy as np
 import requests
 import torch
+import types
 
 
 def expand_like(arrays: List[np.ndarray], fill: float = -100) -> np.ndarray:
@@ -86,3 +87,7 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
         )
     # Otherwise, max_length_unit=='records'
     return int(max_length / global_batch_size)
+
+def attribute_dict(input_dict: dict) -> types.SimpleNamespace:
+    dictionary = types.SimpleNamespace(input_dict)
+    return dictionary

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -96,7 +96,6 @@ class AttrDict(dict):
         for key in self.keys():
             if isinstance(self[key], dict):
                 self[key] = AttrDict(self[key])
-            super().__setattr__(key, self[key])
 
     if typing.TYPE_CHECKING:
         def __getattr__(self, item):

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import types
 import urllib.parse
 from typing import Dict, List, Union
 
@@ -7,7 +8,6 @@ import filelock
 import numpy as np
 import requests
 import torch
-import types
 
 
 def expand_like(arrays: List[np.ndarray], fill: float = -100) -> np.ndarray:
@@ -87,6 +87,7 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
         )
     # Otherwise, max_length_unit=='records'
     return int(max_length / global_batch_size)
+
 
 def to_namespace(input_dict: [dict, list]) -> types.SimpleNamespace:
     namespace = types.SimpleNamespace()

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -94,9 +94,11 @@ class AttrDict(dict):
         for key in self.keys():
             if isinstance(self[key], dict):
                 self[key] = AttrDict(self[key])
-
-    def __getattr__(self, name: str, default: Any = None) -> Any:
-        return self.get(name, default)
+            super().__setattr__(key, self[key])
 
     def __setattr__(self, name: str, val: Any) -> None:
-        self[name] = val
+        super().__setattr__(name, val)
+        super().__setitem__(name, val)
+
+    def __setitem__(self, name: str, val: Any) -> None:
+        setattr(self, name, val)

--- a/model_hub/model_hub/utils.py
+++ b/model_hub/model_hub/utils.py
@@ -91,6 +91,9 @@ def compute_num_training_steps(experiment_config: Dict, global_batch_size: int) 
 class AttrDict(dict):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        for key, val in self.items():
+            if isinstance(key, dict):
+                self.key = AttrDict(val)
 
     def __getattr__(self, name: str, default: Any = None) -> Any:
         return self.get(name, default)

--- a/model_hub/mypy.ini
+++ b/model_hub/mypy.ini
@@ -6,6 +6,7 @@ ignore_missing_imports = True
 
 # All strict checks.
 check_untyped_defs = True
+diable_error_code = attr-defined
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True

--- a/model_hub/mypy.ini
+++ b/model_hub/mypy.ini
@@ -6,7 +6,6 @@ ignore_missing_imports = True
 
 # All strict checks.
 check_untyped_defs = True
-disable_error_code = attr-defined
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True

--- a/model_hub/mypy.ini
+++ b/model_hub/mypy.ini
@@ -6,7 +6,7 @@ ignore_missing_imports = True
 
 # All strict checks.
 check_untyped_defs = True
-diable_error_code = attr-defined
+disable_error_code = attr-defined
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True

--- a/model_hub/setup.py
+++ b/model_hub/setup.py
@@ -17,7 +17,6 @@ setuptools.setup(
     # libraries that are guaranteed to work with our code.  Other versions
     # may work with model-hub as well but are not officially supported.
     install_requires=[
-        "attrdict",
         "determined>=0.13.11",  # We require custom reducers for PyTorchTrial.
     ],
 )

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -4,7 +4,7 @@ from model_hub import utils
 
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
-    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
+    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, output_as_namespace=True)[0]
     target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",
@@ -21,7 +21,7 @@ def test_nodefault_config_parser() -> None:
     args = {
         "pretrained_model_name_or_path": "xnli",
     }
-    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
+    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, output_as_namespace=True)[0]
     target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -1,6 +1,7 @@
 import model_hub.huggingface as hf
 from model_hub import utils
 
+
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -5,7 +5,7 @@ from model_hub import utils
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = utils.to_namespace(
+    target = utils.AttrDict(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",
@@ -22,7 +22,7 @@ def test_nodefault_config_parser() -> None:
         "pretrained_model_name_or_path": "xnli",
     }
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = utils.to_namespace(
+    target = utils.AttrDict(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -4,7 +4,7 @@ from model_hub import utils
 
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
-    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, output_as_namespace=True)[0]
+    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
     target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",
@@ -21,7 +21,7 @@ def test_nodefault_config_parser() -> None:
     args = {
         "pretrained_model_name_or_path": "xnli",
     }
-    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, output_as_namespace=True)[0]
+    config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
     target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -1,12 +1,10 @@
-import attrdict
-
 import model_hub.huggingface as hf
-
+from model_hub import utils
 
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = attrdict.AttrDict(
+    target = utils.attribute_dict(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",
@@ -23,7 +21,7 @@ def test_nodefault_config_parser() -> None:
         "pretrained_model_name_or_path": "xnli",
     }
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = attrdict.AttrDict(
+    target = utils.attribute_dict(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",

--- a/model_hub/tests/test_hf.py
+++ b/model_hub/tests/test_hf.py
@@ -4,7 +4,7 @@ from model_hub import utils
 def test_config_parser() -> None:
     args = {"pretrained_model_name_or_path": "xnli", "num_labels": 4}
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = utils.attribute_dict(
+    target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",
@@ -21,7 +21,7 @@ def test_nodefault_config_parser() -> None:
         "pretrained_model_name_or_path": "xnli",
     }
     config = hf.parse_dict_to_dataclasses((hf.ConfigKwargs,), args, as_dict=True)[0]
-    target = utils.attribute_dict(
+    target = utils.to_namespace(
         {
             "pretrained_model_name_or_path": "xnli",
             "revision": "main",

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -12,7 +12,6 @@ import model_hub.mmdetection as mh_mmdet
 import model_hub.mmdetection._callbacks as callbacks
 import model_hub.utils as mh_utils
 from determined.common import util
-from model_hub import utils
 
 
 def cleanup_dir(directory: str) -> None:

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -125,9 +125,9 @@ class TestMMDetTrial:
     def test_merge_config(
         self, context: det_torch.PyTorchTrialContext, trial: mh_mmdet.MMDetTrial
     ) -> None:
-        hparams = mh_utils.AttrDict(context.get_hparams())
-        hparams.merge_config = "./tests/fixtures/merge_config.py"
-        trial.hparams = hparams
+        hparams = context.get_hparams()
+        hparams["merge_config"] = "./tests/fixtures/merge_config.py"
+        trial.hparams = mh_utils.AttrDict(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
         assert new_cfg.optimizer_config.grad_clip.max_norm == 0.1
@@ -136,15 +136,12 @@ class TestMMDetTrial:
         self, context: det_torch.PyTorchTrialContext, trial: mh_mmdet.MMDetTrial
     ) -> None:
         hparams = context.get_hparams()
-        hparams = mh_utils.AttrDict(hparams)
-        hparams["override_mmdet_config"] = mh_utils.AttrDict(
-            {
-                "optimizer_config._delete_": True,
-                "optimizer_config.grad_clip.max_norm": 35,
-                "optimizer_config.grad_clip.norm_type": 2,
-            }
-        )
-        trial.hparams = hparams
+        hparams["override_mmdet_config"] = {
+            "optimizer_config._delete_": True,
+            "optimizer_config.grad_clip.max_norm": 35,
+            "optimizer_config.grad_clip.norm_type": 2,
+        }
+        trial.hparams = mh_utils.AttrDict(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35
         assert new_cfg.optimizer_config.grad_clip.norm_type == 2

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -127,6 +127,7 @@ class TestMMDetTrial:
     ) -> None:
         hparams = context.get_hparams()
         hparams["merge_config"] = "./tests/fixtures/merge_config.py"
+        trial.hparams = hparams
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
         assert new_cfg.optimizer_config.grad_clip.max_norm == 0.1
@@ -140,6 +141,7 @@ class TestMMDetTrial:
             "optimizer_config.grad_clip.max_norm": 35,
             "optimizer_config.grad_clip.norm_type": 2,
         }
+        trial.hparams = hparams
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35
         assert new_cfg.optimizer_config.grad_clip.norm_type == 2

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -125,8 +125,8 @@ class TestMMDetTrial:
     def test_merge_config(
         self, context: det_torch.PyTorchTrialContext, trial: mh_mmdet.MMDetTrial
     ) -> None:
-        hparams = context.get_hparams()
-        hparams["merge_config"] = "./tests/fixtures/merge_config.py"
+        hparams = mh_utils.AttrDict(context.get_hparams())
+        hparams.merge_config = "./tests/fixtures/merge_config.py"
         trial.hparams = hparams
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
@@ -136,11 +136,14 @@ class TestMMDetTrial:
         self, context: det_torch.PyTorchTrialContext, trial: mh_mmdet.MMDetTrial
     ) -> None:
         hparams = context.get_hparams()
-        hparams["override_mmdet_config"] = {
-            "optimizer_config._delete_": True,
-            "optimizer_config.grad_clip.max_norm": 35,
-            "optimizer_config.grad_clip.norm_type": 2,
-        }
+        hparams = mh_utils.AttrDict(hparams)
+        hparams["override_mmdet_config"] = mh_utils.AttrDict(
+            {
+                "optimizer_config._delete_": True,
+                "optimizer_config.grad_clip.max_norm": 35,
+                "optimizer_config.grad_clip.norm_type": 2,
+            }
+        )
         trial.hparams = hparams
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -2,7 +2,6 @@ import os
 import shutil
 from typing import Generator
 
-import attrdict
 import git
 import pytest
 import torch
@@ -13,6 +12,7 @@ import model_hub.mmdetection as mh_mmdet
 import model_hub.mmdetection._callbacks as callbacks
 import model_hub.utils as mh_utils
 from determined.common import util
+from model_hub import utils
 
 
 def cleanup_dir(directory: str) -> None:
@@ -128,7 +128,7 @@ class TestMMDetTrial:
     ) -> None:
         hparams = context.get_hparams()
         hparams["merge_config"] = "./tests/fixtures/merge_config.py"
-        trial.hparams = attrdict.AttrDict(hparams)
+        trial.hparams = utils.attribute_dict(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
         assert new_cfg.optimizer_config.grad_clip.max_norm == 0.1
@@ -142,7 +142,7 @@ class TestMMDetTrial:
             "optimizer_config.grad_clip.max_norm": 35,
             "optimizer_config.grad_clip.norm_type": 2,
         }
-        trial.hparams = attrdict.AttrDict(hparams)
+        trial.hparams = utils.attribute_dict(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35
         assert new_cfg.optimizer_config.grad_clip.norm_type == 2

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -128,7 +128,7 @@ class TestMMDetTrial:
     ) -> None:
         hparams = context.get_hparams()
         hparams["merge_config"] = "./tests/fixtures/merge_config.py"
-        trial.hparams = utils.attribute_dict(hparams)
+        trial.hparams = utils.to_namespace(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
         assert new_cfg.optimizer_config.grad_clip.max_norm == 0.1
@@ -142,7 +142,7 @@ class TestMMDetTrial:
             "optimizer_config.grad_clip.max_norm": 35,
             "optimizer_config.grad_clip.norm_type": 2,
         }
-        trial.hparams = utils.attribute_dict(hparams)
+        trial.hparams = utils.to_namespace(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35
         assert new_cfg.optimizer_config.grad_clip.norm_type == 2

--- a/model_hub/tests/test_mmdetection.py
+++ b/model_hub/tests/test_mmdetection.py
@@ -128,7 +128,6 @@ class TestMMDetTrial:
     ) -> None:
         hparams = context.get_hparams()
         hparams["merge_config"] = "./tests/fixtures/merge_config.py"
-        trial.hparams = utils.to_namespace(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer.type == "AdamW"
         assert new_cfg.optimizer_config.grad_clip.max_norm == 0.1
@@ -142,7 +141,6 @@ class TestMMDetTrial:
             "optimizer_config.grad_clip.max_norm": 35,
             "optimizer_config.grad_clip.norm_type": 2,
         }
-        trial.hparams = utils.to_namespace(hparams)
         new_cfg = trial.build_mmdet_config()
         assert new_cfg.optimizer_config.grad_clip.max_norm == 35
         assert new_cfg.optimizer_config.grad_clip.norm_type == 2


### PR DESCRIPTION
## Description

`attrdict` is broken since Python 3.9.  Possible replacements do not meet our dependency requirements. This PR implements our own `AttrDict` as a utility class.

Replaces https://github.com/determined-ai/determined/pull/8541



## Test Plan

Unit tests pass. Also try any `mmdetection` and `hugginface` example.


## Checklist

- [C] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1442