### PR TITLE
chore: Model metadata sections move to Surface [WEB-1813]

### DIFF
--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -1,5 +1,6 @@
 import Form from 'hew/Form';
 import Glossary, { InfoRow } from 'hew/Glossary';
+import Surface from 'hew/Surface';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import Link from 'components/Link';
@@ -59,7 +60,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
   return (
     <Form form={form} initialValues={{ metadata: metadataList }} onValuesChange={onValuesChange}>
       {editing ? (
-        <>
+        <Surface>
           <div className={css.titleRow}>
             <span>Key</span>
             <span>Value</span>
@@ -83,7 +84,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
               </>
             )}
           </Form.List>
-        </>
+        </Surface>
       ) : (
         <Glossary content={metadataRows} />
       )}

--- a/webui/react/src/components/Metadata/EditableMetadata.tsx
+++ b/webui/react/src/components/Metadata/EditableMetadata.tsx
@@ -1,6 +1,5 @@
 import Form from 'hew/Form';
 import Glossary, { InfoRow } from 'hew/Glossary';
-import Surface from 'hew/Surface';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
 import Link from 'components/Link';
@@ -60,7 +59,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
   return (
     <Form form={form} initialValues={{ metadata: metadataList }} onValuesChange={onValuesChange}>
       {editing ? (
-        <Surface>
+        <>
           <div className={css.titleRow}>
             <span>Key</span>
             <span>Value</span>
@@ -84,7 +83,7 @@ const EditableMetadata: React.FC<Props> = ({ metadata = {}, editing, updateMetad
               </>
             )}
           </Form.List>
-        </Surface>
+        </>
       ) : (
         <Glossary content={metadataRows} />
       )}

--- a/webui/react/src/components/Metadata/MetadataCard.module.scss
+++ b/webui/react/src/components/Metadata/MetadataCard.module.scss
@@ -1,0 +1,8 @@
+.cardPadding {
+  padding: 8px;
+
+  .cardHeader {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/webui/react/src/components/Metadata/MetadataCard.tsx
+++ b/webui/react/src/components/Metadata/MetadataCard.tsx
@@ -1,7 +1,8 @@
-import { Card, Space } from 'antd';
+import { Typography } from 'antd';
 import Button from 'hew/Button';
 import Icon from 'hew/Icon';
 import Spinner from 'hew/Spinner';
+import Surface from 'hew/Surface';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { Metadata } from 'types';
@@ -56,36 +57,34 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
   }, [isEditing, metadataArray.length]);
 
   return (
-    <Card
-      bodyStyle={{ padding: '16px' }}
-      extra={
-        isEditing ? (
-          <Space size="small">
-            <Button size="small" onClick={cancelEditMetadata}>
-              Cancel
-            </Button>
-            <Button size="small" type="primary" onClick={saveMetadata}>
-              Save
-            </Button>
-          </Space>
-        ) : (
-          disabled || (
-            <Button
-              icon={<Icon name="pencil" showTooltip size="small" title="Edit" />}
-              type="text"
-              onClick={editMetadata}
-            />
-          )
+    <Surface>
+      <Typography.Title level={5}>Metadata</Typography.Title>
+      {isEditing ? (
+        <>
+          <Button size="small" onClick={cancelEditMetadata}>
+            Cancel
+          </Button>
+          <Button size="small" type="primary" onClick={saveMetadata}>
+            Save
+          </Button>
+        </>
+      ) : (
+        disabled || (
+          <Button
+            icon={<Icon name="pencil" showTooltip size="small" title="Edit" />}
+            type="text"
+            onClick={editMetadata}
+          />
         )
-      }
-      headStyle={{ paddingInline: '16px' }}
-      title={'Metadata'}>
+      )}
       {showPlaceholder ? (
-        <div
-          style={{ color: 'var(--theme-colors-monochrome-9)', fontStyle: 'italic' }}
-          onClick={editMetadata}>
-          {disabled ? 'No metadata present.' : 'Add Metadata...'}
-        </div>
+        <Surface>
+          <div
+            style={{ color: 'var(--theme-colors-monochrome-9)', fontStyle: 'italic' }}
+            onClick={editMetadata}>
+            {disabled ? 'No metadata present.' : 'Add Metadata...'}
+          </div>
+        </Surface>
       ) : (
         <Spinner spinning={isLoading}>
           <EditableMetadata
@@ -95,7 +94,7 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
           />
         </Spinner>
       )}
-    </Card>
+    </Surface>
   );
 };
 

--- a/webui/react/src/components/Metadata/MetadataCard.tsx
+++ b/webui/react/src/components/Metadata/MetadataCard.tsx
@@ -1,14 +1,15 @@
-import { Typography } from 'antd';
 import Button from 'hew/Button';
 import Icon from 'hew/Icon';
 import Spinner from 'hew/Spinner';
 import Surface from 'hew/Surface';
+import { Title, TypographySize } from 'hew/Typography';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { Metadata } from 'types';
 import handleError, { ErrorType } from 'utils/error';
 
 import EditableMetadata from './EditableMetadata';
+import css from './MetadataCard.module.scss';
 
 interface Props {
   disabled?: boolean;
@@ -58,42 +59,46 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
 
   return (
     <Surface>
-      <Typography.Title level={5}>Metadata</Typography.Title>
-      {isEditing ? (
-        <>
-          <Button size="small" onClick={cancelEditMetadata}>
-            Cancel
-          </Button>
-          <Button size="small" type="primary" onClick={saveMetadata}>
-            Save
-          </Button>
-        </>
-      ) : (
-        disabled || (
-          <Button
-            icon={<Icon name="pencil" showTooltip size="small" title="Edit" />}
-            type="text"
-            onClick={editMetadata}
-          />
-        )
-      )}
-      {showPlaceholder ? (
+      <div className={css.cardPadding}>
+        <div className={css.cardHeader}>
+          <Title size={TypographySize.S}>Metadata</Title>
+          {isEditing ? (
+            <div>
+              <Button size="small" onClick={cancelEditMetadata}>
+                Cancel
+              </Button>
+              <Button size="small" type="primary" onClick={saveMetadata}>
+                Save
+              </Button>
+            </div>
+          ) : (
+            disabled || (
+              <Button
+                icon={<Icon name="pencil" showTooltip size="small" title="Edit" />}
+                type="text"
+                onClick={editMetadata}
+              />
+            )
+          )}
+        </div>
         <Surface>
-          <div
-            style={{ color: 'var(--theme-colors-monochrome-9)', fontStyle: 'italic' }}
-            onClick={editMetadata}>
-            {disabled ? 'No metadata present.' : 'Add Metadata...'}
-          </div>
+          {showPlaceholder ? (
+            <div
+              style={{ color: 'var(--theme-colors-monochrome-9)', fontStyle: 'italic' }}
+              onClick={editMetadata}>
+              {disabled ? 'No metadata present.' : 'Add Metadata...'}
+            </div>
+          ) : (
+            <Spinner spinning={isLoading}>
+              <EditableMetadata
+                editing={isEditing}
+                metadata={editedMetadata}
+                updateMetadata={setEditedMetadata}
+              />
+            </Spinner>
+          )}
         </Surface>
-      ) : (
-        <Spinner spinning={isLoading}>
-          <EditableMetadata
-            editing={isEditing}
-            metadata={editedMetadata}
-            updateMetadata={setEditedMetadata}
-          />
-        </Spinner>
-      )}
+      </div>
     </Surface>
   );
 };

--- a/webui/react/src/components/Metadata/MetadataCard.tsx
+++ b/webui/react/src/components/Metadata/MetadataCard.tsx
@@ -58,7 +58,7 @@ const MetadataCard: React.FC<Props> = ({ disabled = false, metadata = {}, onSave
   }, [isEditing, metadataArray.length]);
 
   return (
-    <Surface>
+    <Surface elevationOverride={1}>
       <div className={css.cardPadding}>
         <div className={css.cardHeader}>
           <Title size={TypographySize.S}>Metadata</Title>


### PR DESCRIPTION
## Description

Replaces antd.Card and Typography in the MetadataCard component, affecting ModelDetails (objective of ticket) and ModelVersionDetails.

## Test Plan

View a Model from the registry, such as `/det/models/71`

Before any metadata:

<img width="609" alt="Screen Shot 2023-12-06 at 9 18 23 PM" src="https://github.com/determined-ai/determined/assets/643918/e48d54e0-b8ca-4783-8a50-f07afbb17fa2">

Editing:

<img width="600" alt="Screen Shot 2023-12-06 at 9 18 30 PM" src="https://github.com/determined-ai/determined/assets/643918/730dd5ed-3aa1-4670-ac95-60f0e8d23306">

With values:

<img width="607" alt="Screen Shot 2023-12-06 at 9 18 47 PM" src="https://github.com/determined-ai/determined/assets/643918/ddbd64d4-5ede-40d3-b60f-dd40742d0c3a">

The difference in font sizes for keys and values exists in the current version.

The MetadataCard appears inside a tab panel at ModelVersionDetails, so I've added `elevationOverride` to its Surface prevent it from looking different on that page.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.