### PR TITLE
fix: master cannot download s3 from us-east-1 

### DIFF
--- a/docs/release-notes/fix-master-download.rst
+++ b/docs/release-notes/fix-master-download.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Fix an issue where master was unable to download checkpoints from s3 on buckets in the ``us-east-1`` region.

--- a/docs/release-notes/fix-master-download.rst
+++ b/docs/release-notes/fix-master-download.rst
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Fix an issue where master was unable to download checkpoints from s3 on buckets in the ``us-east-1`` region.
+-  Fix an issue where master was unable to download checkpoints from s3 on buckets in the
+   ``us-east-1`` region.

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -197,7 +197,6 @@ func testGetCheckpointEcho(t *testing.T, bucket string) {
 			err = api.m.getCheckpoint(ctx)
 			require.NoError(t, err, "API call returns error")
 			checkTgz(t, rec.Body, id)
-
 			return err
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 		{"CanGetCheckpointZip", func() error {

--- a/master/pkg/checkpoints/s3/s3checkpoints.go
+++ b/master/pkg/checkpoints/s3/s3checkpoints.go
@@ -37,6 +37,11 @@ func (w *seqWriterAt) WriteAt(p []byte, off int64) (int, error) {
 // It does so by making an API call to AWS.
 func GetS3BucketRegion(ctx context.Context, bucket string) (string, error) {
 	// TODO this won't work on non aws s3 APIs.
+	// We can't use the AWS SDK for getting bucket region
+	// because we get a 403 when the region in the client is different
+	// than the bucket (defeating the whole point of calling bucket location).
+	// Instead just use the HEAD API since this is a lot simpler and doesn't require any auth.
+	// https://github.com/aws/aws-sdk-go/issues/720
 	url := fmt.Sprintf("https://%s.s3.amazonaws.com", bucket)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
@@ -47,7 +52,9 @@ func GetS3BucketRegion(ctx context.Context, bucket string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("getting region of s3 bucket at url %s: %w", url, err)
 	}
-	defer res.Body.Close()
+	if err := res.Body.Close(); err != nil {
+		return "", fmt.Errorf("closing s3 bucket request body: %w", err)
+	}
 
 	return res.Header.Get("X-Amz-Bucket-Region"), nil
 }

--- a/master/pkg/checkpoints/s3/s3checkpoints.go
+++ b/master/pkg/checkpoints/s3/s3checkpoints.go
@@ -49,6 +49,11 @@ func GetS3BucketRegion(ctx context.Context, bucket string) (string, error) {
 		return "", err
 	}
 
+	// Buckets in Region us-east-1 have a LocationConstraint of null.
+	if out == nil || out.LocationConstraint == nil {
+		return "us-east-1", nil
+	}
+
 	return *out.LocationConstraint, nil
 }
 


### PR DESCRIPTION
## Description

Bug in how we called the s3 API meaning we couldn't download from ```us-east-1```



## Test Plan

Integration test should cover it, manual though

manual

run ```mnist_pytorch_const``` with config
```
name: mnist_pytorch_const
hyperparameters:
  learning_rate: 1.0
  n_filters1: 32
  n_filters2: 64
  dropout1: 0.25
  dropout2: 0.5
searcher:
  name: single
  metric: validation_loss
  max_length:
      epochs: 1
  smaller_is_better: true
entrypoint: python3 train.py
checkpoint_storage:
  type: s3
  bucket: storage-unit-tests-us-east-1
  prefix: master/checkpoint-download
  access_key: EDIT
  secret_key: EDIT
```

direct download a checkpoint through ```det checkpoint download $CHECKPOINT_ID --mode master``` $CHECKPOINT_ID you can get from ```det e lc $expID```

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
