### PR TITLE
docs: Add a link to mldes trial

### DIFF
--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -49,6 +49,22 @@ resources. Compatible with on-prem clusters and cloud auto-scaling (AWS and GCP)
 
 -  :ref:`topic_guide_gcp`
 
+.. _mldes-trial:
+
+***********************************
+ Bring Your Own Cloud (Evaluation)
+***********************************
+
+Get access to AI clusters running Determined without having to provision or configure the hardware
+yourself.
+
+-  `Trial sign-up page <http://mldes.ext.hpe.com/trial>`_
+-  `Documentation <https://mldes.ext.hpe.com/docs/index.html>`_
+
+.. attention::
+
+   This method is only available on Determined Enterprise Edition.
+
 ************
  Kubernetes
 ************


### PR DESCRIPTION
Users want to be able to find the HPE MLDES Managed Service trial so that they can sign up. Users want to be able to find the HPE MLDES Managed Service documentation so that they can find out more.