### PR TITLE
docs: Fix workspaces projects left nav

### DIFF
--- a/docs/manage/workspaces.rst
+++ b/docs/manage/workspaces.rst
@@ -69,9 +69,3 @@ projects. Use the ``-h`` flag to get a list of all possible commands.
 
    det workspace -h
    det project -h
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   Binding Resource Pools to Workspaces <workspaces-rpools>


### PR DESCRIPTION
Remove the extra toctree from the `workspaces` file that was referencing the `workspaces-rpools` page. We don't need this anymore because we are catching them all at the `_index` page level.

remove
```

.. toctree::
   :maxdepth: 1
   :hidden:

   Binding Resource Pools to Workspaces <workspaces-rpools>
```

in favor of
```

.. toctree::
   :glob:
   :hidden:

   ./*
   ./*/_index
```
