### PR TITLE
docs: Introduce mldes sign up

### DIFF
--- a/docs/manage/security/_index.rst
+++ b/docs/manage/security/_index.rst
@@ -24,6 +24,8 @@ These security features apply only to Determined Enterprise Edition, except for 
 | :ref:`rbac`       | Configure Role-Based Access Control.                                       |
 +-------------------+----------------------------------------------------------------------------+
 
+See also: :ref:`remote-users`
+
 .. toctree::
    :maxdepth: 1
    :hidden:

--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -49,6 +49,23 @@ resources. Compatible with on-prem clusters and cloud auto-scaling (AWS and GCP)
 
 -  :ref:`topic_guide_gcp`
 
+.. _mldes-trial:
+
+***********************************
+ Bring Your Own Cloud (Evaluation)
+***********************************
+
+Get access to AI clusters running Determined without having to provision or configure the hardware
+yourself.
+
+-  Visit the Machine Learning Development Environment Software (MLDES) Trial `sign-up page
+   <http://mldes.ext.hpe.com/trial>`_.
+-  Visit the `documentation <https://mldes.ext.hpe.com/docs/index.html>`_.
+
+.. attention::
+
+   This method is only available on Determined Enterprise Edition.
+
 ************
  Kubernetes
 ************


### PR DESCRIPTION
## Description

Introduce users to the evaluation edition of machine learning development environment software (MLDES) and its documentation (the docs are a separate repo published via markdown).

use case: As a user, I want to be made aware of the MLDES trial and to be able to find out more information about it when I visit the usual docs site.

## Note

Do not merge before review/approval.