### PR TITLE
chore: drop raw_checkpoints table

### DIFF
--- a/master/static/migrations/20231208132223_drop-raw-checkpoints.tx.up.sql
+++ b/master/static/migrations/20231208132223_drop-raw-checkpoints.tx.up.sql
@@ -1,0 +1,24 @@
+ALTER TABLE checkpoints_v2 
+    ALTER COLUMN id DROP DEFAULT;
+
+-- We need to add `IF EXISTS` to these data drops in order to safely perform down migrations. 
+-- Since this migration does not have a corresponding down migration, we need to verify existence
+-- of the following functions, table, and sequence in order to migrate up and down from this 
+-- schema version.
+
+DROP FUNCTION IF EXISTS best_checkpoint_by_metric;
+DROP FUNCTION IF EXISTS experiments_best_checkpoints_by_metric;
+DROP TABLE IF EXISTS raw_checkpoints;
+DROP SEQUENCE IF EXISTS checkpoints_id_seq;
+
+CREATE SEQUENCE checkpoints_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+SELECT setval('checkpoints_id_seq', (SELECT MAX(id) FROM checkpoints_v2));
+
+ALTER TABLE checkpoints_v2
+    ALTER COLUMN id SET DEFAULT nextval('checkpoints_id_seq');


### PR DESCRIPTION
## Description

Remove `raw_checkpoints` table.

In case customers who upgraded determined still had checkpoints in this table, all elements from `raw_checkpoints` were copied into `checkpoints_v2` [here](https://github.com/determined-ai/determined/pull/7325). We left `raw_checkpoints` around to avoid a tricky down migration, but this PR removes the table without a down migration since we no longer insert checkpoints into `raw_checkpoints`, and instead use `checkpoints_v2`.

## Test Plan

Manual test required:

- Store some checkpoints in `checkpoints_v2` as follows:
  - Start up a local cluster with the `devcluster` command so that all migrations run except for `20231208132223`. To ignore migration `20231208132223`:
    - Either run a down migration using `determined-master -m <master instance> migrate down <older migration version>` or temporarily move the file out of `master/static/migrations` and into `master/static`.
  - In a separate terminal tab, create an experiment. 
      - You can `cd` into `examples/tutorials/mnist_pytorch` and run `det e create adaptive.yaml .` 
  - Let the experiment run for a bit, and then log into `psql` and run `SELECT * FROM checkpoints_v2` to verify that a few checkpoints have been created for your experiment. Check that the `id` column is set for each checkpoint. 
  - Go back to the tab where you started your cluster and kill it (`Control + C`).
  - Now, we want to run _all_  migrations including `20231208132223`.
    - Migrate back up to version `20231208132223` using  `determined-master -m <master instance> migrate up 20231208132223` or move the migration file back into `master/static/migrations`.
  - Create a new cluster by rerunning the `devcluster` command and navigate back to your experiments tab.
  - Once again, run `det e create adaptive.yaml .` to create a new experiment.
  - Let the experiment run for a bit, then log into `psql` and rerun `SELECT * FROM checkpoints_v2` to verify that you can still see all old checkpoints from the previous experiment, and that new checkpoints have been created with the `id` column set. Also verify that ids are sequential (starting directly after the previous experiment's checkpoint id).
    - This should ensure that users who had `raw_checkpoints` or `checkpoints_v2` checkpoints in their database should not lose any of them after performing this migration (remember that all checkpoints in `raw_checkpoints` should have already been copied into `checkpoints_v2`). 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10014