### PR TITLE
fix: Change slot number back to 2 in Keras example

### DIFF
--- a/examples/computer_vision/iris_tf_keras/distributed.yaml
+++ b/examples/computer_vision/iris_tf_keras/distributed.yaml
@@ -8,7 +8,7 @@ hyperparameters:
   layer1_dense_size: 16
   global_batch_size: 32
 resources:
-  slots_per_trial: 16 # Use 2 GPUs to train the model.
+  slots_per_trial: 2 # Use 2 GPUs to train the model.
 searcher:
   name: single
   metric: val_categorical_accuracy


### PR DESCRIPTION
## Description
Using GPU slot 16 would lead to error where sequence length < num_slots. ([link](https://gcloud.determined.ai/det/experiments/2856/overview))

Thus, change the number back to 2 as before.


## Test Plan
In `determined/examples/computer_vision/iris_tf_keras`
 `det e create distributed.yaml . --project 56`

https://gcloud.determined.ai/det/experiments/2858/logs
Completed successfully



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
