### PR TITLE
fix: prevent theme settings conflict in multi-client/window scenario

### DIFF
--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -58,7 +58,7 @@ const AppView: React.FC = () => {
   const { updateTelemetry } = useTelemetry();
   const checkAuth = useAuthCheck();
   const settings = useObservable(themeSetting);
-  const [isThemeReady, setIsThemeReady] = useState(false);
+  const [isSettingsReady, setIsSettingsReady] = useState(false);
   const { ui, actions: uiActions, theme, isDarkMode } = useUI();
 
   useEffect(() => {
@@ -134,16 +134,17 @@ const AppView: React.FC = () => {
 
   // Update setting mode when mode changes.
   useLayoutEffect(() => {
-    settings.forEach((s) => {
-      const mode = s?.mode || Mode.System;
-      setIsThemeReady(true);
-      uiActions.setMode(mode);
-    });
-  }, [settings, uiActions]);
+    !isSettingsReady &&
+      settings.forEach((s) => {
+        const mode = s?.mode || Mode.System;
+        setIsSettingsReady(true);
+        uiActions.setMode(mode);
+      });
+  }, [settings, uiActions, isSettingsReady]);
 
-  useEffect(() => {
-    isThemeReady && updateThemeSetting(ui.mode);
-  }, [isThemeReady, ui.mode]);
+  useLayoutEffect(() => {
+    isSettingsReady && updateThemeSetting(ui.mode);
+  }, [isSettingsReady, ui.mode]);
 
   // Check permissions and params for JupyterLabGlobal.
   const { canCreateNSC, canCreateWorkspaceNSC } = usePermissions();

--- a/webui/react/src/App.tsx
+++ b/webui/react/src/App.tsx
@@ -6,7 +6,7 @@ import { notification } from 'hew/Toast';
 import { ConfirmationProvider } from 'hew/useConfirm';
 import { Loadable } from 'hew/utils/loadable';
 import { useObservable } from 'micro-observables';
-import React, { useEffect, useLayoutEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { HelmetProvider } from 'react-helmet-async';
@@ -58,6 +58,7 @@ const AppView: React.FC = () => {
   const { updateTelemetry } = useTelemetry();
   const checkAuth = useAuthCheck();
   const settings = useObservable(themeSetting);
+  const [isThemeReady, setIsThemeReady] = useState(false);
   const { ui, actions: uiActions, theme, isDarkMode } = useUI();
 
   useEffect(() => {
@@ -135,13 +136,14 @@ const AppView: React.FC = () => {
   useLayoutEffect(() => {
     settings.forEach((s) => {
       const mode = s?.mode || Mode.System;
+      setIsThemeReady(true);
       uiActions.setMode(mode);
     });
   }, [settings, uiActions]);
 
-  useLayoutEffect(() => {
-    updateThemeSetting(ui.mode);
-  }, [ui.mode]);
+  useEffect(() => {
+    isThemeReady && updateThemeSetting(ui.mode);
+  }, [isThemeReady, ui.mode]);
 
   // Check permissions and params for JupyterLabGlobal.
   const { canCreateNSC, canCreateWorkspaceNSC } = usePermissions();

--- a/webui/react/src/hooks/useTheme.settings.ts
+++ b/webui/react/src/hooks/useTheme.settings.ts
@@ -1,20 +1,10 @@
-import { literal, union } from 'io-ts';
+import { type, TypeOf } from 'io-ts';
 
 import { Mode } from 'components/ThemeProvider';
-import { SettingsConfig } from 'hooks/useSettings';
+import { valueof } from 'utils/valueof';
 
-export interface Settings {
-  mode: Mode;
-}
-
-export const config: SettingsConfig<Settings> = {
-  settings: {
-    mode: {
-      defaultValue: Mode.System,
-      skipUrlEncoding: true,
-      storageKey: 'mode',
-      type: union([literal(Mode.Dark), literal(Mode.Light), literal(Mode.System)]),
-    },
-  },
-  storagePath: 'settings-theme',
-};
+export const settings = type({
+  mode: valueof(Mode),
+});
+export type Settings = TypeOf<typeof settings>;
+export const STORAGE_PATH = 'settings-theme';


### PR DESCRIPTION
## Description
This fixes an issue where the user management table appeared to refresh constantly. the user management page is set up to refresh the table when its underlying persisted settings refresh, which can happen inadvertently when multiple clients are using the same user account. The theme setting was set up to always update the settings table to the local value on conflict, which causes a conflict when one client changes the theme. To fix this, we:

1) ensure that the user settings store does not trigger refreshes when setting to an identical value. note that we aren't able to use the deep or immutable observable wrappers introduced in #8405 because the value is an immutable collection wrapped in a plain object -- immutable collections are stateful, so a simple deep check wouldn't work, and because the top value isn't an immutable collection, the immutable observer wouldn't work.

2) move themesettings out of usesettings. this prevents the updateSettings function from being marked as an effect dependency

3) ~ensure that the remote wins when the theme is in conflict~ split the effect that updates the local theme when the remote settings changes from the effect that updates the remote settings when the local theme changes.

## Test Plan

* Open two windows to the webui and log in as the same user with admin permissions on both.
* on one window, navigate to the user management page and open a user overflow menu (the three dot menu on each user row)
* on the other, change the theme and monitor the first window for 10 seconds
* you should see the user overflow menu close on as the user table temporarily shows the loading state _once_
* wait 20 seconds
* you should not see the user table go back to the loading state.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
