### PR TITLE
chore: add Go coverage ratchet to unit and integration tests

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.0.0
+  codecov: codecov/codecov@3.3.0
   gcloud: circleci/gcp-cli@2.1.0
   gh: circleci/github-cli@2.0
   helm: circleci/helm@1.2.0
@@ -1673,6 +1673,9 @@ jobs:
           executor: <<pipeline.parameters.machine-image>>
       - setup-go-intg-deps
       - run: make -C master test-intg
+      - codecov/upload:
+          flags: "backend"
+          xtra_args: "-v"
       - store_test_results:
           path: master/test-intg.junit.xml
       - persist_to_workspace:
@@ -1696,6 +1699,9 @@ jobs:
           executor: <<pipeline.parameters.machine-image>>
       - setup-go-intg-deps
       - run: make -C agent test-intg
+      - codecov/upload:
+          flags: "backend"
+          xtra_args: "-v"
       - store_test_results:
           path: agent/test-intg.junit.xml
       - persist_to_workspace:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ codecov:
   notify:
     wait_for_ci: no
 
-# Coverage of backend PRs must be at least 80% with 5% leeway.
+# Backend code coverage must be >= 37% +/- 3%. Backend PR coverage must be >= 80% +/- 5%.
 coverage:
   status:
     project:
@@ -14,7 +14,8 @@ coverage:
         threshold: 3%
         flags: 
           - backend
-    patch:
+        informational: false
+    patch: 
       default:
         informational: true
       backend: 
@@ -22,6 +23,7 @@ coverage:
         threshold: 5%
         flags: 
           - backend
+        informational: false
 
 flags:
   backend:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,35 @@
 codecov:
   require_ci_to_pass: yes
+  notify:
+    wait_for_ci: no
 
-# coverage of each PR must be at least 85% and must not be negative
+# Coverage of backend PRs must be at least 80% with 5% leeway.
 coverage:
   status:
     project:
       default:
         informational: true
+      backend:
+        target: 37%
+        threshold: 3%
+        flags: 
+          - backend
     patch:
       default:
         informational: true
+      backend: 
+        target: 80%
+        threshold: 5%
+        flags: 
+          - backend
 
+flags:
+  backend:
+    carryforward: true
+    
 github_checks:
   annotations: false
 
-comment: false
+comment: 
+  layout: "diff, flags, files"
+  behavior: default


### PR DESCRIPTION
## Description

This PR provisions Go coverage metrics through Codecov and imposes a (currently non-blocking) per-PR (`codecov/patch/backend`) and overall backend (`codecov/project/backend`) coverage ratchet.

## Test Plan

`codecov/project`,` codecov/patch`, `codecov/project/backend`, and `codecov/patch/backend` coverage checks and metrics are visibly available in Github status checks after all CI checks have completed and passed, and the "Details" page links to Codecov UI containing the dashboard for respective coverage metrics.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10037, DET-10038, DET-10039