### PR TITLE
docs: Fix mmdetection readme link

### DIFF
--- a/docs/reference/model-hub/mmdetection-api.rst
+++ b/docs/reference/model-hub/mmdetection-api.rst
@@ -10,13 +10,13 @@
 
 .. _mmdettrial:
 
-.. _readme: https://github.com/determined-ai/determined/tree/master/model_hub/examples/mmdetection/README.md
+.. _readme: https://github.com/determined-ai/determined-examples/blob/main/model_hub/mmdetection/README.md
 
 .. autoclass:: model_hub.mmdetection.MMDetTrial
 
 Simlar to using the MMDetection library directly, the main way users customize an experiment is by
-modifying the MMDetection config. We detail how to configure MMDetection through the Determined
-experiment configuration in the readme_.
+modifying the MMDetection config. To find out how to configure MMDetection using the
+:ref:`experiment configuration <experiment-configuration>` file, visit the readme_.
 
 Helper Functions
 ================


### PR DESCRIPTION
Fix broken link to `readme` that was moved as part of examples pruning.