### PR TITLE
chore: cli describe workspaces no longer also lists projects

### DIFF
--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -203,12 +203,6 @@ def describe_workspace(args: Namespace) -> None:
         determined.cli.render.print_json(w.to_json())
     else:
         render_workspaces([w])
-        print("\nAssociated Projects")
-        vars(args)["order_by"] = "asc"
-        vars(args)["sort_by"] = "id"
-        vars(args)["offset"] = 0
-        vars(args)["limit"] = 200
-        list_workspace_projects(args)
 
 
 @authentication.required


### PR DESCRIPTION
Old:
`det workspace describe <workspace>` (when executed with out `--json`) used to first print a table of information about the passed workspace and then would print another table listing all the projects that belong to the workspace.

New:
`det workspace describe <workspace>` *only* describes the passed workspace

Justification:
`det workspace list-projects <workspace>` is already a thing. If a user wants to list workspaces they can run that command. The old behavior was awkward to implement because it needed to assume parameters to list-projects that would normally be passed as flags to `det workspace list-projects`.

[MLG-1113]

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

Describe a workspace:
```
det workspace describe <workspace>
```
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MLG-1113]: https://hpe-aiatscale.atlassian.net/browse/MLG-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ