### PR TITLE
ci: fix test split for skipped tests

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -577,7 +577,7 @@ commands:
             # of the tests that would be run, along with some other stuff. Each file containing
             # any selected tests is printed on a line by itself, except for (for some reason) a
             # single trailing space.
-            pytest --setup-plan -m '<<parameters.mark>>' | egrep '\.py (ss)?$' | sed 's/ \(ss\)\{0,1\}$//' > /tmp/all-relevant-files
+            pytest --setup-plan -m '<<parameters.mark>>' | egrep '\.py s*$' | sed 's/\.py.*$/.py/' > /tmp/all-relevant-files
 
             echo 'All files with tests matching mark "<<parameters.mark>>":'
             sed 's/^/- /' </tmp/all-relevant-files


### PR DESCRIPTION
## Description

Fix failing nightly test

https://app.circleci.com/pipelines/github/determined-ai/determined/49487/workflows/f6e9c9db-7147-4ccd-9a0c-dbf1f1926536/jobs/2157980

```
tests/model_hub/test_mmdetection.py sssss                                                                                                                                                                                                                                      
SETUP    S cluster_log_manager                                                                                                                                                                                                                                                 
        SETUP    F test_start_timer                                                                                                                                                                                                                                            
        tests/model_hub/test_mmdetection.py::test_detr_distributed_fake (fixtures used: cluster_log_manager, request, test_start_timer)
        TEARDOWN F test_start_timer
TEARDOWN S cluster_log_manager


pytest --setup-plan -m 'model_hub_mmdetection'                                                                                                                                                                                      
============================================================================================================================= test session starts =============================================================================================================================
platform linux -- Python 3.8.16, pytest-7.4.4, pluggy-1.3.0                                                                                                                                                                                                                    
rootdir: /home/circleci/project/e2e_tests                                                                                                                                                                                                                                      
configfile: pytest.ini                                                                                                                                                                                                                                                         
plugins: anyio-4.2.0, timeout-2.2.0                                                                                                                                                                                                                                            
collected 403 items / 397 deselected / 6 selected                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                               
tests/model_hub/test_mmdetection.py sssss                                                                                                                                                                                                                                      
SETUP    S cluster_log_manager                                                                                                                                                                                                                                                 
        SETUP    F test_start_timer                                                                                                                                                                                                                                            
        tests/model_hub/test_mmdetection.py::test_detr_distributed_fake (fixtures used: cluster_log_manager, request, test_start_timer)
        TEARDOWN F test_start_timer
TEARDOWN S cluster_log_manager

=========================================================================================================================== short test summary info ======================================================================
```

The regex hard coded (ss) but as we skipped more tests we broke this hard coding. Basically unhardcode the amount of skipped tests.



## Test Plan

test-e2e-gpu-mmdetection passes, and other tests run


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
