### PR TITLE
fix: Trial metric chart series always have unique colors

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -20,7 +20,7 @@ import { glasbeyColor } from 'utils/color';
 import handleError from 'utils/error';
 import { metricSorter, metricToKey } from 'utils/metric';
 
-import { TRAIN_PREFIX, useTrialMetrics, VAL_PREFIX } from './useTrialMetrics';
+import { useTrialMetrics } from './useTrialMetrics';
 
 export interface Props {
   experiment: ExperimentBase;
@@ -29,6 +29,9 @@ export interface Props {
 
 type XAxisVal = number;
 export type CheckpointsDict = Record<XAxisVal, CheckpointWorkloadExtended>;
+
+const TRAIN_PREFIX = /^(t_|train_|training_)/;
+const VAL_PREFIX = /^(v_|val_|validation_)/;
 
 const stripPrefix = (metricName: string): string => {
   return metricName.replace(TRAIN_PREFIX, '').replace(VAL_PREFIX, '');

--- a/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsMetrics.tsx
@@ -20,7 +20,7 @@ import { glasbeyColor } from 'utils/color';
 import handleError from 'utils/error';
 import { metricSorter, metricToKey } from 'utils/metric';
 
-import { useTrialMetrics } from './useTrialMetrics';
+import { TRAIN_PREFIX, useTrialMetrics, VAL_PREFIX } from './useTrialMetrics';
 
 export interface Props {
   experiment: ExperimentBase;
@@ -29,9 +29,6 @@ export interface Props {
 
 type XAxisVal = number;
 export type CheckpointsDict = Record<XAxisVal, CheckpointWorkloadExtended>;
-
-const TRAIN_PREFIX = /^(t_|train_|training_)/;
-const VAL_PREFIX = /^(v_|val_|validation_)/;
 
 const stripPrefix = (metricName: string): string => {
   return metricName.replace(TRAIN_PREFIX, '').replace(VAL_PREFIX, '');

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -38,6 +38,9 @@ export interface TrialMetricData {
   selectedMetrics: Metric[];
 }
 
+export const TRAIN_PREFIX = /^(t_|train_|training_)/;
+export const VAL_PREFIX = /^(v_|val_|validation_)/;
+
 const summarizedMetricToSeries = (
   allDownsampledMetrics: MetricContainer[],
   selectedMetrics: Metric[],
@@ -83,8 +86,11 @@ const summarizedMetricToSeries = (
       data,
       name: `${metric.group}.${metric.name}`,
     };
-    if (metric.group === MetricType.Validation) series.color = VALIDATION_SERIES_COLOR;
-    if (metric.group === MetricType.Training) series.color = TRAINING_SERIES_COLOR;
+
+    if (metric.group === MetricType.Training || metric.name.match(TRAIN_PREFIX))
+      series.color = TRAINING_SERIES_COLOR;
+    if (metric.group === MetricType.Validation || metric.name.match(VAL_PREFIX))
+      series.color = VALIDATION_SERIES_COLOR;
 
     trialData[metricToKey(metric)] = series;
   });

--- a/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
+++ b/webui/react/src/pages/TrialDetails/useTrialMetrics.ts
@@ -1,4 +1,3 @@
-import { TRAINING_SERIES_COLOR, VALIDATION_SERIES_COLOR } from 'hew/LineChart';
 import { makeToast } from 'hew/Toast';
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import _ from 'lodash';
@@ -9,16 +8,7 @@ import useMetricNames from 'hooks/useMetricNames';
 import usePolling from 'hooks/usePolling';
 import usePrevious from 'hooks/usePrevious';
 import { timeSeries } from 'services/api';
-import {
-  Metric,
-  MetricContainer,
-  MetricType,
-  RunState,
-  Scale,
-  Serie,
-  TrialDetails,
-  XAxisDomain,
-} from 'types';
+import { Metric, MetricContainer, RunState, Scale, Serie, TrialDetails, XAxisDomain } from 'types';
 import handleError, { ErrorType } from 'utils/error';
 import { metricToKey } from 'utils/metric';
 
@@ -37,9 +27,6 @@ export interface TrialMetricData {
   metricHasData: Record<string, boolean>;
   selectedMetrics: Metric[];
 }
-
-export const TRAIN_PREFIX = /^(t_|train_|training_)/;
-export const VAL_PREFIX = /^(v_|val_|validation_)/;
 
 const summarizedMetricToSeries = (
   allDownsampledMetrics: MetricContainer[],
@@ -86,11 +73,6 @@ const summarizedMetricToSeries = (
       data,
       name: `${metric.group}.${metric.name}`,
     };
-
-    if (metric.group === MetricType.Training || metric.name.match(TRAIN_PREFIX))
-      series.color = TRAINING_SERIES_COLOR;
-    if (metric.group === MetricType.Validation || metric.name.match(VAL_PREFIX))
-      series.color = VALIDATION_SERIES_COLOR;
 
     trialData[metricToKey(metric)] = series;
   });


### PR DESCRIPTION
## Description

On the experiment Metrics tab, we put metrics with similar names on the same plot. Ideally training loss and validation loss would be plotted together.
In the example, loss and val_loss were plotted together but both coded in the training metric group.
~Under this change, the metric group coloring will look for prefixes, and "val_" will override the metric being in training metric group.~

**Update: Removes blue/orange coloring for training/validation special groups, instead using glasbey colors; this avoids issues with multiple series being resolved to the same chart + training group**

## Test Plan

Experiment `/det/experiments/5518/metrics` displays validation_loss and loss on the same chart

Update `/det/experiments/5522/metrics` shows multiple lines in one chart

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.