### PR TITLE
fix: Check if loading before saying no workspaces / projects [WEB-1904]

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -445,7 +445,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
           </Column>
         </Row>
       </Section>
-      <Spinner spinning={isLoading}>
+      <Spinner conditionalRender spinning={isLoading}>
         {projects.length !== 0 ? (
           projectsList
         ) : workspace.numProjects === 0 ? (
@@ -459,7 +459,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
             title="Workspace contains no projects. "
           />
         ) : (
-          !isLoading && <Message icon="warning" title="No projects matching the current filters" />
+          <Message icon="warning" title="No projects matching the current filters" />
         )}
       </Spinner>
       <ProjectCreateModal.Component workspaceId={workspace.id} />

--- a/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
+++ b/webui/react/src/pages/WorkspaceDetails/WorkspaceProjects.tsx
@@ -459,7 +459,7 @@ const WorkspaceProjects: React.FC<Props> = ({ workspace, id, pageRef }) => {
             title="Workspace contains no projects. "
           />
         ) : (
-          <Message icon="warning" title="No projects matching the current filters" />
+          !isLoading && <Message icon="warning" title="No projects matching the current filters" />
         )}
       </Spinner>
       <ProjectCreateModal.Component workspaceId={workspace.id} />

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -371,7 +371,7 @@ const WorkspaceList: React.FC = () => {
           </Column>
         </Row>
       </Section>
-      <Spinner spinning={isLoading}>
+      <Spinner conditionalRender spinning={isLoading}>
         {workspaces.length !== 0 ? (
           workspacesList
         ) : settings.whose === WhoseWorkspaces.All && settings.archived && !isLoading ? (
@@ -381,9 +381,7 @@ const WorkspaceList: React.FC = () => {
             title="No Workspaces"
           />
         ) : (
-          !isLoading && (
-            <Message icon="warning" title="No workspaces matching the current filters" />
-          )
+          <Message icon="warning" title="No workspaces matching the current filters" />
         )}
       </Spinner>
       <WorkspaceCreateModal.Component />

--- a/webui/react/src/pages/WorkspaceList.tsx
+++ b/webui/react/src/pages/WorkspaceList.tsx
@@ -381,7 +381,9 @@ const WorkspaceList: React.FC = () => {
             title="No Workspaces"
           />
         ) : (
-          <Message icon="warning" title="No workspaces matching the current filters" />
+          !isLoading && (
+            <Message icon="warning" title="No workspaces matching the current filters" />
+          )
         )}
       </Spinner>
       <WorkspaceCreateModal.Component />


### PR DESCRIPTION
## Description

Avoid showing the No Workspaces / No Projects messages until finished loading a response from API
Both of these pages use the Spinner component to show loading, so we don't need to show the message unless we finish loading and receive 0 results

## Test Plan

When you load Determined and then click Workspaces in the nav bar, it shows the loading spinner without the No Workspaces message

Workspace without projects shows No Projects message `/det/workspaces/535/projects`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.