### PR TITLE
fix: os.uname() not found on windows

### DIFF
--- a/docs/integrations/ide/vscode.rst
+++ b/docs/integrations/ide/vscode.rst
@@ -6,7 +6,7 @@
 
 #. Make sure `Visual Studio Code Remote - SSH
    <https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh>`__ extension is
-   installed.
+   installed. Windows users should run these steps in a Windows shell outside of WSL.
 
 #. Start a new shell and get its SSH command by running:
 

--- a/harness/determined/cli/shell.py
+++ b/harness/determined/cli/shell.py
@@ -78,7 +78,7 @@ def open_shell(args: argparse.Namespace) -> None:
 
 @authentication.required
 def show_ssh_command(args: argparse.Namespace) -> None:
-    if "WSL" in os.uname().release:
+    if platform.system() == "Linux" and "WSL" in os.uname().release:
         cli.warn(
             "WSL remote-ssh integration is not supported in VSCode, which "
             "uses Windows openssh. For Windows VSCode integration, rerun this "


### PR DESCRIPTION
## Description

`os.uname()` doesn't work on Windows. Use platform to identify a Linux system before warning WSL users. Also add a line in docs for Windows users.



## Test Plan

Test that `show-ssh-command` doesn't error on Windows and still shows a warning on WSL.



## Commentary (optional)

Linked issue here https://github.com/determined-ai/determined/issues/8621



## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1503