### PR TITLE
fix: Changes on jobs table trigger cluster stats [WEB-1914]

### DIFF
--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -24,16 +24,7 @@ import { paths } from 'routes/utils';
 import { cancelExperiment, getJobQ, killExperiment, killTask } from 'services/api';
 import * as Api from 'services/api-ts-sdk';
 import userStore from 'stores/users';
-import {
-  DetailedUser,
-  FullJob,
-  Job,
-  JobAction,
-  JobState,
-  JobType,
-  ResourcePool,
-  RPStats,
-} from 'types';
+import { DetailedUser, FullJob, Job, JobAction, JobState, JobType, ResourcePool } from 'types';
 import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 import {
   canManageJob,
@@ -53,7 +44,7 @@ import ManageJobModalComponent from './ManageJob';
 
 interface Props {
   jobState: JobState;
-  rpStats: RPStats[];
+  rpStats: Api.V1RPQueueStat[];
   selectedRp: ResourcePool;
 }
 

--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -81,8 +81,9 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
   const manageJobModal = useModal(ManageJobModalComponent);
   const pageRef = useRef<HTMLElement>(null);
 
-  useMemo(() => {
+  useEffect(() => {
     refreshCluster?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [total]);
 
   useEffect(() => {
@@ -129,7 +130,7 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
       // Process jobs response.
       if (firstJob && !_.isEqual(firstJob, topJob)) setTopJob(firstJob);
       setJobs(jobState ? jobs.jobs.filter((j) => j.summary.state === jobState) : jobs.jobs);
-      if (jobs.pagination.total) setTotal(jobs.pagination.total);
+      if (jobs.pagination.total !== undefined) setTotal(jobs.pagination.total);
 
       // Process job stats response.
       setRpStats(stats.results.sort((a, b) => a.resourcePool.localeCompare(b.resourcePool)));

--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -54,10 +54,11 @@ import ManageJobModalComponent from './ManageJob';
 
 interface Props {
   jobState: JobState;
+  refreshCluster?: () => void;
   selectedRp: ResourcePool;
 }
 
-const JobQueue: React.FC<Props> = ({ selectedRp, jobState }) => {
+const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => {
   const users = Loadable.getOrElse([], useObservable(userStore.getUsers()));
   const resourcePools = useObservable(clusterStore.resourcePools);
   const [managingJob, setManagingJob] = useState<Job>();
@@ -79,6 +80,10 @@ const JobQueue: React.FC<Props> = ({ selectedRp, jobState }) => {
   const [pageState, setPageState] = useState<{ isLoading: boolean }>({ isLoading: true });
   const manageJobModal = useModal(ManageJobModalComponent);
   const pageRef = useRef<HTMLElement>(null);
+
+  useMemo(() => {
+    refreshCluster?.();
+  }, [total]);
 
   useEffect(() => {
     if (managingJob) {

--- a/webui/react/src/pages/JobQueue/JobQueue.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.tsx
@@ -21,9 +21,8 @@ import usePolling from 'hooks/usePolling';
 import { useSettings } from 'hooks/useSettings';
 import { columns as defaultColumns, SCHEDULING_VAL_KEY } from 'pages/JobQueue/JobQueue.table';
 import { paths } from 'routes/utils';
-import { cancelExperiment, getJobQ, getJobQStats, killExperiment, killTask } from 'services/api';
+import { cancelExperiment, getJobQ, killExperiment, killTask } from 'services/api';
 import * as Api from 'services/api-ts-sdk';
-import clusterStore from 'stores/cluster';
 import userStore from 'stores/users';
 import {
   DetailedUser,
@@ -54,25 +53,13 @@ import ManageJobModalComponent from './ManageJob';
 
 interface Props {
   jobState: JobState;
-  refreshCluster?: () => void;
+  rpStats: RPStats[];
   selectedRp: ResourcePool;
 }
 
-const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => {
+const JobQueue: React.FC<Props> = ({ rpStats, selectedRp, jobState }) => {
   const users = Loadable.getOrElse([], useObservable(userStore.getUsers()));
-  const resourcePools = useObservable(clusterStore.resourcePools);
   const [managingJob, setManagingJob] = useState<Job>();
-  const [rpStats, setRpStats] = useState<RPStats[]>(() => {
-    if (!Loadable.isLoaded(resourcePools)) return [];
-
-    return resourcePools.data.map(
-      (rp) =>
-        ({
-          resourcePool: rp.name,
-          stats: { preemptibleCount: 0, queuedCount: 0, scheduledCount: 0 },
-        }) as RPStats,
-    );
-  });
   const [jobs, setJobs] = useState<Job[]>([]);
   const [topJob, setTopJob] = useState<Job>();
   const [total, setTotal] = useState(0);
@@ -80,11 +67,6 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
   const [pageState, setPageState] = useState<{ isLoading: boolean }>({ isLoading: true });
   const manageJobModal = useModal(ManageJobModalComponent);
   const pageRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    refreshCluster?.();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [total]);
 
   useEffect(() => {
     if (managingJob) {
@@ -98,24 +80,21 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
 
   const isJobOrderAvailable = orderedSchedulers.has(selectedRp.schedulerType);
 
-  const fetchAll = useCallback(async () => {
+  const fetchJobsTable = useCallback(async () => {
     if (!settings) return;
 
     try {
       const orderBy = settings.sortDesc ? 'ORDER_BY_DESC' : 'ORDER_BY_ASC';
-      const [jobs, stats] = await Promise.all([
-        getJobQ(
-          {
-            limit: settings.tableLimit,
-            offset: settings.tableOffset,
-            orderBy,
-            resourcePool: selectedRp.name,
-            states: jobState ? [jobState] : undefined,
-          },
-          { signal: canceler.signal },
-        ),
-        getJobQStats({}, { signal: canceler.signal }),
-      ]);
+      const jobs = await getJobQ(
+        {
+          limit: settings.tableLimit,
+          offset: settings.tableOffset,
+          orderBy,
+          resourcePool: selectedRp.name,
+          states: jobState ? [jobState] : undefined,
+        },
+        { signal: canceler.signal },
+      );
 
       const firstJobResp = await getJobQ(
         {
@@ -131,9 +110,6 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
       if (firstJob && !_.isEqual(firstJob, topJob)) setTopJob(firstJob);
       setJobs(jobState ? jobs.jobs.filter((j) => j.summary.state === jobState) : jobs.jobs);
       if (jobs.pagination.total !== undefined) setTotal(jobs.pagination.total);
-
-      // Process job stats response.
-      setRpStats(stats.results.sort((a, b) => a.resourcePool.localeCompare(b.resourcePool)));
     } catch (e) {
       if ((e as DetError)?.publicMessage === 'offset out of bounds' && settings.tableOffset !== 0) {
         updateSettings({ tableOffset: 0 });
@@ -150,7 +126,7 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
     }
   }, [canceler.signal, selectedRp.name, settings, jobState, topJob, updateSettings]);
 
-  usePolling(fetchAll, { rerunOnNewFn: true });
+  usePolling(fetchJobsTable, { rerunOnNewFn: true });
 
   const rpTotalJobCount = useCallback(
     (rpName: string) => {
@@ -206,18 +182,18 @@ const JobQueue: React.FC<Props> = ({ refreshCluster, selectedRp, jobState }) => 
         if (!fn) return;
         triggers[action] = async () => {
           await fn();
-          await fetchAll();
+          await fetchJobsTable();
         };
       });
       return triggers;
     },
-    [selectedRp, isJobOrderAvailable, topJob, fetchAll],
+    [selectedRp, isJobOrderAvailable, topJob, fetchJobsTable],
   );
 
   const onModalClose = useCallback(() => {
     setManagingJob(undefined);
-    fetchAll();
-  }, [fetchAll]);
+    fetchJobsTable();
+  }, [fetchJobsTable]);
 
   useEffect(() => {
     if (!managingJob) return;

--- a/webui/react/src/pages/JobQueue/ManageJob.tsx
+++ b/webui/react/src/pages/JobQueue/ManageJob.tsx
@@ -11,7 +11,7 @@ import { columns } from 'pages/JobQueue/JobQueue.table';
 import { getJobQ, updateJobQueue } from 'services/api';
 import * as api from 'services/api-ts-sdk';
 import clusterStore from 'stores/cluster';
-import { Job, JobType, RPStats } from 'types';
+import { Job, JobType } from 'types';
 import handleError, { ErrorType } from 'utils/error';
 import { moveJobToPositionUpdate, orderedSchedulers, unsupportedQPosSchedulers } from 'utils/job';
 import { useObservable } from 'utils/observable';
@@ -25,7 +25,7 @@ interface Props {
   /** total number of jobs */
   jobCount: number;
   onFinish?: () => void;
-  rpStats: RPStats[];
+  rpStats: api.V1RPQueueStat[];
   schedulerType: api.V1SchedulerType;
 }
 

--- a/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
@@ -166,12 +166,20 @@ const ResourcepoolDetailInner: React.FC = () => {
 
     const tabItems: PivotProps['items'] = [
       {
-        children: <JobQueue jobState={JobState.SCHEDULED} selectedRp={pool} refreshCluster={refreshCluster} />,
+        children: (
+          <JobQueue
+            jobState={JobState.SCHEDULED}
+            refreshCluster={refreshCluster}
+            selectedRp={pool}
+          />
+        ),
         key: TabType.Active,
         label: `${poolStats?.stats.scheduledCount ?? ''} Active`,
       },
       {
-        children: <JobQueue jobState={JobState.QUEUED} selectedRp={pool} refreshCluster={refreshCluster} />,
+        children: (
+          <JobQueue jobState={JobState.QUEUED} refreshCluster={refreshCluster} selectedRp={pool} />
+        ),
         key: TabType.Queued,
         label: `${poolStats?.stats.queuedCount ?? ''} Queued`,
       },
@@ -196,7 +204,14 @@ const ResourcepoolDetailInner: React.FC = () => {
     }
 
     return tabItems;
-  }, [canManageResourcePoolBindings, pool, poolStats, renderPoolConfig, rpBindingFlagOn]);
+  }, [
+    canManageResourcePoolBindings,
+    pool,
+    poolStats,
+    renderPoolConfig,
+    rpBindingFlagOn,
+    refreshCluster,
+  ]);
 
   if (!pool || Loadable.isNotLoaded(resourcePools)) {
     return <Spinner center spinning />;

--- a/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
@@ -109,6 +109,10 @@ const ResourcepoolDetailInner: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const refreshCluster = useCallback(() => {
+    fetchStats();
+  }, [fetchStats]);
+
   useEffect(() => {
     if (tab || !pool) return;
     const basePath = paths.resourcePool(pool.name);
@@ -162,12 +166,12 @@ const ResourcepoolDetailInner: React.FC = () => {
 
     const tabItems: PivotProps['items'] = [
       {
-        children: <JobQueue jobState={JobState.SCHEDULED} selectedRp={pool} />,
+        children: <JobQueue jobState={JobState.SCHEDULED} selectedRp={pool} refreshCluster={refreshCluster} />,
         key: TabType.Active,
         label: `${poolStats?.stats.scheduledCount ?? ''} Active`,
       },
       {
-        children: <JobQueue jobState={JobState.QUEUED} selectedRp={pool} />,
+        children: <JobQueue jobState={JobState.QUEUED} selectedRp={pool} refreshCluster={refreshCluster} />,
         key: TabType.Queued,
         label: `${poolStats?.stats.queuedCount ?? ''} Queued`,
       },

--- a/webui/react/src/pages/ResourcePool/Topology.tsx
+++ b/webui/react/src/pages/ResourcePool/Topology.tsx
@@ -47,8 +47,11 @@ const NodeElement: React.FC<PropsWithChildren<NodeElementProps>> = ({ name, slot
         <span className={css.nodeName}>{name}</span>
       )}
       <span className={css.nodeCluster} ref={slotsContainer}>
-        {slotsData.map(({ enabled }, idx) => (
-          <span className={`${styles.join(' ')} ${enabled ? css.active : ''}`} key={`slot${idx}`} />
+        {slotsData.map(({ container }, idx) => (
+          <span
+            className={`${styles.join(' ')} ${container ? css.active : ''}`}
+            key={`slot${idx}`}
+          />
         ))}
       </span>
     </div>

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -996,7 +996,6 @@ export const JobType = Api.Jobv1Type;
 export type JobType = Api.Jobv1Type;
 export const JobState = Api.Jobv1State;
 export type JobState = Api.Jobv1State;
-export type RPStats = Api.V1RPQueueStat;
 
 export const JobAction = {
   Cancel: 'Cancel',


### PR DESCRIPTION
## Description

Reported in a few places - we have polling on JobQueue but not ResourcepoolDetail, so you might see disagreement between the tab and the number of Active or Queued tasks:

<img width="950" alt="Screen Shot 2024-01-03 at 1 01 08 PM" src="https://github.com/determined-ai/determined/assets/643918/e1cf6a92-a6f2-4827-901c-d8800fa962bc">

**Updated fix:** this moves the polling of `getJobQStats` from JobQueue to ResourcepoolDetail.  This still requests stats from all resource pools, so that we can get that info in JobQueue's ManageJobModalComponent. JobQueue is not used anywhere else.

**Update 2:** this also fixes an issue where agents with only some slots used were rendered incorrectly in Topology

## Test Plan

- Go to `/det/resourcepool/compute-pool/queued` and see 0 queued tasks
- In another tab or window, launch two Jupyter Notebooks
- As the notebooks get ready, they will appear in Queued and the total will update
- As a notebook becomes Active, it will disappear from Queued and total will update
- Switch to Active tab to see the updated 1 Active task
- Kill the Active notebook task and observe changes

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.