### PR TITLE
chore: improve error message for continuing a completed hp search [DET-10041]

### DIFF
--- a/e2e_tests/tests/cluster/test_exp_continue.py
+++ b/e2e_tests/tests/cluster/test_exp_continue.py
@@ -378,31 +378,3 @@ def test_continue_hp_search_single_cli() -> None:
 
     trials = exp.experiment_trials(exp_id)
     assert trials[0].trial.state == bindings.trialv1State.COMPLETED
-
-
-@pytest.mark.e2e_cpu
-def test_continue_hp_search_completed_cli() -> None:
-    exp_id = exp.create_experiment(
-        conf.fixtures_path("no_op/random-short.yaml"),
-        conf.fixtures_path("no_op"),
-        [],
-    )
-    exp.wait_for_experiment_state(exp_id, bindings.experimentv1State.COMPLETED)
-
-    with pytest.raises(subprocess.CalledProcessError):
-        det_cmd(["e", "continue", str(exp_id)], check=True)
-
-
-@pytest.mark.e2e_cpu
-def test_continue_hp_search_provided_config() -> None:
-    exp_id = exp.create_experiment(
-        conf.fixtures_path("no_op/random-short.yaml"),
-        conf.fixtures_path("no_op"),
-    )
-    exp.wait_for_experiment_state(exp_id, bindings.experimentv1State.COMPLETED)
-
-    with pytest.raises(subprocess.CalledProcessError):
-        det_cmd(
-            ["e", "continue", str(exp_id), "--config", "hyperparameters.metrics_sigma=1.0"],
-            check=True,
-        )

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1479,6 +1479,9 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 	return bytes.([]byte), isSingle, nil
 }
 
+var errHPSearchAllTriesCompleted = status.Error(codes.FailedPrecondition,
+	"experiment has been completed, cannot continue this experiment")
+
 func (a *apiServer) ContinueExperiment(
 	ctx context.Context, req *apiv1.ContinueExperimentRequest,
 ) (*apiv1.ContinueExperimentResponse, error) {
@@ -1538,14 +1541,13 @@ func (a *apiServer) ContinueExperiment(
 		if expState == model.CompletedState && !isSingle {
 			hasIncompleteTrials := false
 			for _, trial := range trialsResp.Trials {
-				if model.StateFromProto(experimentv1.State(trial.State)) != model.CompletedState {
+				if trial.State != trialv1.State_STATE_COMPLETED {
 					hasIncompleteTrials = true
 					break
 				}
 			}
 			if !hasIncompleteTrials {
-				return status.Error(codes.FailedPrecondition,
-					"experiment has been completed, cannot continue this experiment")
+				return errHPSearchAllTriesCompleted
 			}
 		} else if isSingle && len(trialsResp.Trials) > 0 {
 			if _, err := tx.NewUpdate().Table("runs"). // TODO(nick-runs) call runs package.

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1479,7 +1479,7 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 	return bytes.([]byte), isSingle, nil
 }
 
-var errHPSearchAllTriesCompleted = status.Error(codes.FailedPrecondition,
+var errContinueHPSearchCompleted = status.Error(codes.FailedPrecondition,
 	"experiment has been completed, cannot continue this experiment")
 
 func (a *apiServer) ContinueExperiment(
@@ -1547,7 +1547,7 @@ func (a *apiServer) ContinueExperiment(
 				}
 			}
 			if !hasIncompleteTrials {
-				return errHPSearchAllTriesCompleted
+				return errContinueHPSearchCompleted
 			}
 		} else if isSingle && len(trialsResp.Trials) > 0 {
 			if _, err := tx.NewUpdate().Table("runs"). // TODO(nick-runs) call runs package.

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -252,6 +252,48 @@ func TestDeleteExperimentWithoutCheckpoints(t *testing.T) {
 	t.Error("expected experiment to delete after 1 minute and it did not")
 }
 
+func TestHPSearchContinueProvideConfigError(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+	trial, _ := createTestTrial(t, api, curUser)
+
+	_, err := db.Bun().NewUpdate().Table("experiments").
+		Set("state = ?", model.CompletedState).
+		Set("config = jsonb_set(config, '{searcher}', "+
+			`'{"name": "random", "metric": "loss", "max_trials": 5, "max_length": 5}', false)`).
+		Where("id = ?", trial.ExperimentID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = api.ContinueExperiment(ctx, &apiv1.ContinueExperimentRequest{
+		Id:             int32(trial.ExperimentID),
+		OverrideConfig: `name: "new"`,
+	})
+	require.ErrorContains(t, err, "override config is provided and experiment")
+}
+
+func TestHPSearchContinueCompletedError(t *testing.T) {
+	api, curUser, ctx := setupAPITest(t, nil)
+	trial, _ := createTestTrial(t, api, curUser)
+
+	_, err := db.Bun().NewUpdate().Table("experiments").
+		Set("state = ?", model.CompletedState).
+		Set("config = jsonb_set(config, '{searcher}', "+
+			`'{"name": "random", "metric": "loss", "max_trials": 5, "max_length": 5}', false)`).
+		Where("id = ?", trial.ExperimentID).
+		Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.Bun().NewUpdate().Table("runs").
+		Set("state = ?", model.CompletedState).
+		Where("id = ?", trial.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = api.ContinueExperiment(ctx, &apiv1.ContinueExperimentRequest{
+		Id: int32(trial.ExperimentID),
+	})
+	require.ErrorIs(t, err, errHPSearchAllTriesCompleted)
+}
+
 func TestParseAndMergeContinueConfig(t *testing.T) {
 	// Blank config.
 	api, curUser, ctx := setupAPITest(t, nil)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -291,7 +291,7 @@ func TestHPSearchContinueCompletedError(t *testing.T) {
 	_, err = api.ContinueExperiment(ctx, &apiv1.ContinueExperimentRequest{
 		Id: int32(trial.ExperimentID),
 	})
-	require.ErrorIs(t, err, errHPSearchAllTriesCompleted)
+	require.ErrorIs(t, err, errContinueHPSearchCompleted)
 }
 
 func TestParseAndMergeContinueConfig(t *testing.T) {


### PR DESCRIPTION
## Description

Check for HP search being "done" was bugged due to converting across different proto enums. 

Improve this check.

Also move these tests from e2e_tests to integration. This is relevant to overall CI time.

## Test Plan

intg tests


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
