### PR TITLE
fix: logs shouldn't overlap when switching tabs [WEB-1915]

### DIFF
--- a/webui/react/src/pages/Cluster.tsx
+++ b/webui/react/src/pages/Cluster.tsx
@@ -93,7 +93,12 @@ const Cluster: React.FC = () => {
       id="cluster"
       title={`Cluster ${clusterStatus ? `- ${clusterStatus}` : ''}`}>
       <div className={css.pivoter}>
-        <Pivot defaultActiveKey={tabKey} items={tabItems} onChange={handleTabChange} />
+        <Pivot
+          defaultActiveKey={tabKey}
+          destroyInactiveTabPane
+          items={tabItems}
+          onChange={handleTabChange}
+        />
       </div>
     </Page>
   );

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -347,6 +347,7 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
       <div className={css.pivoter}>
         <Pivot
           activeKey={tabKey}
+          destroyInactiveTabPane
           items={tabItems}
           tabBarExtraContent={
             tabKey === TabType.Hyperparameters && showCreateExperiment && !experiment.unmanaged ? (


### PR DESCRIPTION
## Description
Previously, if you switched between a tab container a LogViewer and another tab, the logs would sometimes overlap on a single line until new logs streamed in. By destroying the tab contents on switching, this doesn't happen anymore, at the cost of an additional API call to refetch the logs.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
