### PR TITLE
fix: Sort order in users.active column [DET-10048]

### DIFF
--- a/webui/react/src/pages/Admin/UserManagement.tsx
+++ b/webui/react/src/pages/Admin/UserManagement.tsx
@@ -385,7 +385,7 @@ const UserManagement: React.FC = () => {
         key: V1GetUsersRequestSortBy.ACTIVE,
         onCell: onRightClickableCell,
         render: (isActive: boolean) => <>{isActive ? 'Active' : 'Inactive'}</>,
-        sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(a.isActive, b.isActive),
+        sorter: (a: DetailedUser, b: DetailedUser) => booleanSorter(b.isActive, a.isActive),
         title: 'Status',
       },
       {


### PR DESCRIPTION
## Description

Description of the bug: in latest-main there are two Inactive users
When viewing 10 users / page on latest-main , sorting by Active one direction (Active first) shows only Active users; sorting the other way (Inactive first) shows the two Inactive users but at the bottom of the table

The fix is changing the direction of `booleanSorter` for this column

## Test Plan

After the fix, when viewing 10 users / page with latest-main backend
- sorting by Active first shows only Active users [last page shows Inactive users at the bottom of the table]
- sorting by Inactive first shows two Inactive users at the top of the table

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.