### PR TITLE
fix: remove calls to Pytorch Dataset len

### DIFF
--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -940,7 +940,7 @@ class _PyTorchTrialController:
             for callback in self.callbacks.values():
                 callback.on_validation_epoch_start()
 
-            idx = -1
+            idx = -1  # Later, we'll use this default to see if we've iterated at all.
             for idx, batch in enumerate(iter(self.validation_loader)):
                 if self.context.experimental._auto_to_device:
                     batch = self.context.to_device(batch)
@@ -1531,11 +1531,11 @@ class PyTorchTrial(det.LegacyTrial):
         """
         Defines the data loader to use during training.
 
-        For full "determined" functionality, this must return an instance of
-        :py:class:`determined.pytorch.DataLoader`. It can also return an unwrapped
-        :py:class:`torch.utils.data.DataLoader` if you need more control over the underlying
-        DataLoader and are willing to sacrifice some determined features (ex: automatic data
-        sharding).
+        Most implementations of :class:`determined.pytorch.PyTorchTrial` will return a
+        :class:`determined.pytorch.DataLoader` here. Some use cases may not fit the assumptions of
+        :class:`determined.pytorch.DataLoader`. In that event, a bare
+        ``torch.utils.data.DataLoader`` may be returned if steps in the note atop
+        :ref:`pytorch-reproducible-dataset` are followed.
         """
         pass
 
@@ -1547,8 +1547,8 @@ class PyTorchTrial(det.LegacyTrial):
         Defines the data loader to use during validation.
 
         For full "determined" functionality, this must return an instance of
-        :py:class:`determined.pytorch.DataLoader`. It can also return an unwrapped
-        :py:class:`torch.utils.data.DataLoader` if you need more control over the underlying
+        class:`determined.pytorch.DataLoader`. It can also return an unwrapped
+        class:`torch.utils.data.DataLoader` if you need more control over the underlying
         DataLoader and are willing to sacrifice some Determined features (ex: automatic data
         sharding).
         """
@@ -1620,7 +1620,7 @@ class PyTorchTrial(det.LegacyTrial):
         """Count the number of records in a given batch.
 
         Override this method when you are using custom batch types, as produced
-        when iterating over the :py:class:`determined.pytorch.DataLoader`.
+        when iterating over the class:`determined.pytorch.DataLoader`.
         For example, when using ``pytorch_geometric``:
 
         .. code-block:: python

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1527,20 +1527,30 @@ class PyTorchTrial(det.LegacyTrial):
         pass
 
     @abstractmethod
-    def build_training_data_loader(self) -> pytorch.DataLoader:
+    def build_training_data_loader(self) -> Union[pytorch.DataLoader, torch.utils.data.DataLoader]:
         """
         Defines the data loader to use during training.
 
-        Must return an instance of :py:class:`determined.pytorch.DataLoader`.
+        For full "determined" functionality, this must return an instance of
+        :py:class:`determined.pytorch.DataLoader`. It can also return an unwrapped
+        :py:class:`torch.utils.data.DataLoader` if you need more control over the underlying
+        DataLoader and are willing to sacrifice some determined features (ex: automatic data
+        sharding).
         """
         pass
 
     @abstractmethod
-    def build_validation_data_loader(self) -> pytorch.DataLoader:
+    def build_validation_data_loader(
+        self,
+    ) -> Union[pytorch.DataLoader, torch.utils.data.DataLoader]:
         """
         Defines the data loader to use during validation.
 
-        Must return an instance of :py:class:`determined.pytorch.DataLoader`.
+        For full "determined" functionality, this must return an instance of
+        :py:class:`determined.pytorch.DataLoader`. It can also return an unwrapped
+        :py:class:`torch.utils.data.DataLoader` if you need more control over the underlying
+        DataLoader and are willing to sacrifice some Determined features (ex: automatic data
+        sharding).
         """
         pass
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1546,11 +1546,11 @@ class PyTorchTrial(det.LegacyTrial):
         """
         Defines the data loader to use during validation.
 
-        For full "determined" functionality, this must return an instance of
-        class:`determined.pytorch.DataLoader`. It can also return an unwrapped
-        class:`torch.utils.data.DataLoader` if you need more control over the underlying
-        DataLoader and are willing to sacrifice some Determined features (ex: automatic data
-        sharding).
+        Users with a MapDataset will normally return a :class:`determined.pytorch.DataLoader`, but
+        users with an IterableDataset or with other advanced needs may sacrifice some
+        Determined-managed functionality (ex: automatic data sharding) to return a bare
+        :class:`torch.utils.data.DataLoader` following the best-practices described in
+        :ref:`pytorch-reproducible-dataset`.
         """
         pass
 

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -986,6 +986,9 @@ class _PyTorchTrialController:
                 ),
             )
 
+            # Gather a list of per-worker (num_inputs, num_batches) tuples.
+            input_counts = self.context.distributed.gather((num_inputs, idx + 1))
+
         else:
             assert self._evaluate_full_dataset_defined(), "evaluate_full_dataset not defined."
             assert self.validation_loader is not None
@@ -1025,8 +1028,6 @@ class _PyTorchTrialController:
             # common than evaluate_batch() and we can't know how the user processed their
             # validation data.
             if self._evaluate_batch_defined():
-                # Gather a list of per-worker (num_inputs, num_batches) tuples.
-                input_counts = self.context.distributed.gather((num_inputs, idx + 1))
                 # Reshape and sum.
                 # TODO: remove the type directive once we upgrade to mypy >= 1.7.0
                 inputs_total, batches_total = [sum(n) for n in zip(*input_counts)]  # type: ignore

--- a/harness/determined/pytorch/_pytorch_trial.py
+++ b/harness/determined/pytorch/_pytorch_trial.py
@@ -1553,7 +1553,6 @@ class PyTorchTrial(det.LegacyTrial):
         """
         return {}
 
-    @abstractmethod
     def evaluate_batch(self, batch: pytorch.TorchData, batch_idx: int) -> Dict[str, Any]:
         """
         Calculate validation metrics for a batch and return them as a
@@ -1587,7 +1586,6 @@ class PyTorchTrial(det.LegacyTrial):
         """
         return pytorch.Reducer.AVG
 
-    @abstractmethod
     def evaluate_full_dataset(self, data_loader: torch.utils.data.DataLoader) -> Dict[str, Any]:
         """
         Calculate validation metrics on the entire validation dataset and


### PR DESCRIPTION
## Description

Pytorch Datasets (`torch.utils.data.Dataset`) aren't guaranteed to have a `__len__` implemented (Datasets can be either "map-style" or "iterable-style". When map-style, they must implement a `__len__`, and when iterable-style they _may_). The `__len__` on a Pytorch DataLoader may pass the call through to its Dataset.

A `det.pytorch.PyTorchTrial` is typically constructed from a `det.pytorch.DataLoader`. `det.pytorch.DataLoader` cannot, itself, front an iterable-style Pytorch Dataset. It is, however, possible to construct a `det.pytorch.PyTorchTrial` with an unwrapped `torch.utils.data.Dataset` if `context.experimental.disable_dataset_reproducibility_checks()` is called in the `PyTorchTrial`'s `__init__`.

Before this patch, during a `PyTorchTrialContext.run` we called `len` on the trial's validation dataloader. Per the above, it had been possible to construct a trial with a validation dataloader that did not have `__len__` implemented, and in this case `run` would raise a runtime `TypeError` exception.

Turns out, though, those existing calls to `__len__` that weren't actually necessary. This patch revises them with no functional change in behavior

* instead of `len(validation_loader)` to check for emptiness before iterating through it, instead check the number of times the validation_loader is iterated through, raising the same error if it was empty.
* removes a call to `len` where the result was entirely ignored.

This PR also makes a couple "continuous improvement" changes, including moving around a couple pieces of code and renames variables so that its logic is a little more obvious.




<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
I've tested this by hand by modifying `build_validation_training_loader` in the example https://github.com/determined-ai/determined/blob/main/examples/tutorials/mnist_pytorch/train.py to return a Dataset for a `torch.utils.data.Dataset` subclass that has no implemented `__len__` and then running https://github.com/determined-ai/determined/blob/main/harness/tests/experiment/pytorch/test_examples.py tests on it. Without the patch, validation fails because of the call to `__len__`. With the patch, validation succeeds.

We don't have any unit tests of the function I modified (`_PyTorchTrialController._run` or its caller `_PyTorchTrialController.run`), and this doesn't quite seem like enough of a patch to create unit tests for the class for it. It also doesn't seem quite appropriate to create another end-to-end test just to ensure `__len__` isn't called on a validation loader. Maybe more automated tests aren't needed?

For the release party, if you'd like to test this yourself, create a `PyTorchTrial` object of a class that's implemented `build_validation_data_loader` to return a plain, unwrapped `torch.utils.data.DataLoader` that itself has no `__len__`. Then run a training loop for this trial object.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
[MLG-1022]

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
