### PR TITLE
chore: move postgres_command.go to command module

### DIFF
--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -143,7 +143,7 @@ func processProxyAuthentication(c echo.Context) (done bool, err error) {
 
 	serviceNotFoundErr := api.NotFoundErrs("service", fmt.Sprint(taskID), false)
 
-	spec, err := db.IdentifyTask(ctx, taskID)
+	spec, err := command.IdentifyTask(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) || errors.Cause(err) == sql.ErrNoRows {
 		// Check if it's an experiment.
 		e, err := db.ExperimentByTaskID(ctx, taskID)

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -61,7 +61,7 @@ func expFromTaskID(
 }
 
 func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.TaskID) (bool, error) {
-	spec, err := db.IdentifyTask(ctx, taskID)
+	spec, err := command.IdentifyTask(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) {
 		// Non NTSC case like checkpointGC case or the task just does not exist.
 		// TODO(nick) eventually control access to checkpointGC.

--- a/master/internal/command/postgres_command_intg_test
+++ b/master/internal/command/postgres_command_intg_test
@@ -8,10 +8,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/etc"
-	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/master/pkg/etc"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 func TestGetCommandOwnerID(t *testing.T) {

--- a/master/internal/command/postgres_command_intg_test
+++ b/master/internal/command/postgres_command_intg_test
@@ -1,18 +1,17 @@
 //go:build integration
 // +build integration
 
-package db
+package command
 
 import (
 	"context"
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
-
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetCommandOwnerID(t *testing.T) {


### PR DESCRIPTION
## Description
Move postgres_command.go from the db module to command, following best code practices.

## Test Plan
Pass attached intg test.

## Checklist
- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10003

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
