### PR TITLE
fix: Revert "chore: Job/task displays Running instead of Scheduled"

### DIFF
--- a/webui/react/src/constants/states.ts
+++ b/webui/react/src/constants/states.ts
@@ -159,7 +159,7 @@ export const commandTypeToLabel: { [key in CommandType]: string } = {
 };
 
 export const jobStateToLabel: { [key in JobState]: string } = {
-  [JobState.SCHEDULED]: 'Running',
+  [JobState.SCHEDULED]: 'Scheduled',
   [JobState.SCHEDULEDBACKFILLED]: 'ScheduledBackfilled',
   [JobState.QUEUED]: 'Queued',
   [JobState.UNSPECIFIED]: 'Unspecified',


### PR DESCRIPTION
## Description

The term "Scheduled" is meaningful for the Jobs/Tasks page and will be restored

## Test Plan

Active/running tasks are labeled as "Scheduled" on `/det/tasks`

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.