### PR TITLE
fix: replace View Logs link with useNavigate [WEB-1893]

### DIFF
--- a/webui/react/src/components/TaskActionDropdown.tsx
+++ b/webui/react/src/components/TaskActionDropdown.tsx
@@ -3,6 +3,7 @@ import Dropdown, { MenuItem } from 'hew/Dropdown';
 import Icon from 'hew/Icon';
 import useConfirm from 'hew/useConfirm';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import css from 'components/ActionDropdown/ActionDropdown.module.scss';
 import usePermissions from 'hooks/usePermissions';
@@ -12,8 +13,6 @@ import { ExperimentAction as Action, AnyTask, CommandTask, DetailedUser } from '
 import handleError, { ErrorLevel, ErrorType } from 'utils/error';
 import { capitalize } from 'utils/string';
 import { isTaskKillable } from 'utils/task';
-
-import Link from './Link';
 
 interface Props {
   children?: React.ReactNode;
@@ -35,11 +34,13 @@ const TaskActionDropdown: React.FC<Props> = ({ task, onComplete, children }: Pro
   const menuItems: MenuItem[] = [
     {
       key: Action.ViewLogs,
-      label: <Link path={paths.taskLogs(task as CommandTask)}>View Logs</Link>,
+      label: 'View Logs',
     },
   ];
 
   if (isKillable) menuItems.unshift({ key: Action.Kill, label: 'Kill' });
+
+  const navigate = useNavigate();
 
   const handleDropdown = (key: string) => {
     try {
@@ -58,6 +59,8 @@ const TaskActionDropdown: React.FC<Props> = ({ task, onComplete, children }: Pro
           });
           break;
         case Action.ViewLogs:
+          onComplete?.(key);
+          navigate(paths.taskLogs(task as CommandTask));
           break;
       }
     } catch (e) {


### PR DESCRIPTION
## Description

This was an issue on the Tasks table, where using the dropdown to View Logs, then clicking the browser back button, disables most table actions.  In addition to the reported issue, I could not click the row checkbox or open the right-click context menu.

I can only replicate on latest-main + Firefox;  not with `devserver` or `make live` hosting. So I am unable to test this completely.

My theories are:
- we should call `onComplete?.()` when completing the menu action / before navigating
- it may help to replace the Link element with `useNavigate`

## Test Plan

On the tasks page, clicking the three-dots menu opens a dropdown.
Clicking "View Logs" opens the logs for that task 

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.