### PR TITLE
chore: reinstate original DuplicateError to postgres_users.go

### DIFF
--- a/master/internal/api/error.go
+++ b/master/internal/api/error.go
@@ -54,6 +54,10 @@ var (
 	// ErrAPIRemoved is an error to inform the client they are calling an old, removed API.
 	ErrAPIRemoved = errors.New(`the API being called was removed,
 please ensure the client consuming the API is up to date and report a bug if the problem persists`)
+
+	// ErrUserExists is an error to inform the client that a user cannot be added to the DB since
+	// there exists a duplicate. Pachyderm integration with Determined checks this error.
+	ErrUserExists = echo.NewHTTPError(http.StatusBadRequest, "user already exists")
 )
 
 // NotFoundErrMsg creates a formatted message about a resource not being found.

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -354,7 +354,7 @@ func (a *apiServer) PostUser(
 	userID, err := user.Add(ctx, userToAdd, agentUserGroup)
 	switch {
 	case err == db.ErrDuplicateRecord:
-		return nil, status.Error(codes.InvalidArgument, "")
+		return nil, api.ErrUserExists
 	case err != nil:
 		return nil, err
 	}

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -354,7 +354,7 @@ func (a *apiServer) PostUser(
 	userID, err := user.Add(ctx, userToAdd, agentUserGroup)
 	switch {
 	case err == db.ErrDuplicateRecord:
-		return nil, status.Error(codes.InvalidArgument, "user already exists")
+		return nil, status.Error(codes.InvalidArgument, "")
 	case err != nil:
 		return nil, err
 	}

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -353,7 +353,7 @@ func (a *apiServer) PostUser(
 
 	userID, err := user.Add(ctx, userToAdd, agentUserGroup)
 	switch {
-	case err == db.ErrDuplicateRecord:
+	case errors.Is(err, db.ErrDuplicateRecord):
 		return nil, api.ErrUserExists
 	case err != nil:
 		return nil, err

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -627,26 +627,21 @@ func TestAuthzPostUser(t *testing.T) {
 
 func TestAuthzPostUserDuplicate(t *testing.T) {
 	api, authzUsers, curUser, ctx := setupUserAuthzTest(t, nil)
-	username := uuid.New().String()
-	authzUsers.On("CanCreateUser", mock.Anything, curUser,
-		mock.Anything, mock.Anything).Return(nil)
-	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{
-		User: &userv1.User{
-			Username:       username,
-			Admin:          true,
-			AgentUserGroup: nil,
-		},
-	})
+	user := &userv1.User{
+		Username:       uuid.New().String(),
+		Admin:          true,
+		AgentUserGroup: nil,
+	}
+
+	authzUsers.On("CanCreateUser", mock.Anything, curUser, mock.Anything, mock.Anything).Return(nil)
+
+	// Successfully post user once.
+	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{User: user})
 	require.NoError(t, err)
 
+	// Post duplicate user & receive expected error.
 	expectedErr := apiPkg.ErrUserExists
-	_, err = api.PostUser(ctx, &apiv1.PostUserRequest{
-		User: &userv1.User{
-			Username:       username,
-			Admin:          true,
-			AgentUserGroup: nil,
-		},
-	})
+	_, err = api.PostUser(ctx, &apiv1.PostUserRequest{User: user})
 	require.Contains(t, expectedErr.Error(), err.Error())
 }
 

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -625,6 +625,31 @@ func TestAuthzPostUser(t *testing.T) {
 	require.Equal(t, expectedErr.Error(), err.Error())
 }
 
+func TestAuthzPostUserDuplicate(t *testing.T) {
+	api, authzUsers, curUser, ctx := setupUserAuthzTest(t, nil)
+	username := uuid.New().String()
+	authzUsers.On("CanCreateUser", mock.Anything, curUser,
+		mock.Anything, mock.Anything).Return(nil)
+	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{
+		User: &userv1.User{
+			Username:       username,
+			Admin:          true,
+			AgentUserGroup: nil,
+		},
+	})
+	require.NoError(t, err)
+
+	expectedErr := apiPkg.ErrUserExists
+	_, err = api.PostUser(ctx, &apiv1.PostUserRequest{
+		User: &userv1.User{
+			Username:       username,
+			Admin:          true,
+			AgentUserGroup: nil,
+		},
+	})
+	require.Contains(t, expectedErr.Error(), err.Error())
+}
+
 func TestAuthzSetUserPassword(t *testing.T) {
 	api, authzUsers, curUser, ctx := setupUserAuthzTest(t, nil)
 

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -626,14 +626,14 @@ func TestAuthzPostUser(t *testing.T) {
 }
 
 func TestAuthzPostUserDuplicate(t *testing.T) {
-	api, authzUsers, curUser, ctx := setupUserAuthzTest(t, nil)
+	api, authzUsers, _, ctx := setupUserAuthzTest(t, nil)
 	user := &userv1.User{
 		Username:       uuid.New().String(),
 		Admin:          true,
 		AgentUserGroup: nil,
 	}
 
-	authzUsers.On("CanCreateUser", mock.Anything, curUser, mock.Anything, mock.Anything).Return(nil)
+	authzUsers.On("CanCreateUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Successfully post user once.
 	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{User: user})

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -187,7 +187,7 @@ func AddUserTx(ctx context.Context, idb bun.IDB, user *model.User) (model.UserID
 		OwnerID: user.ID,
 	}
 	if _, err := idb.NewInsert().Model(&personalGroup).Exec(ctx); err != nil {
-		return 0, fmt.Errorf("error inserting personal grou: %s", err)
+		return 0, fmt.Errorf("error inserting personal group: %s", err)
 	}
 
 	groupMembership := model.GroupMembership{

--- a/master/internal/user/postgres_users_intg_test.go
+++ b/master/internal/user/postgres_users_intg_test.go
@@ -120,6 +120,7 @@ func TestUserAddDuplicate(t *testing.T) {
 	require.Error(t, err)
 	if pgerr, ok := errors.Cause(err).(*pgconn.PgError); ok {
 		require.Equal(t, pgerr.Code, db.CodeUniqueViolation)
+		require.Equal(t, err, db.ErrDuplicateRecord)
 	}
 }
 

--- a/master/internal/user/postgres_users_intg_test.go
+++ b/master/internal/user/postgres_users_intg_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgconn"
 	"github.com/o1egl/paseto"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,23 @@ func TestUserAdd(t *testing.T) {
 				require.Equal(t, tt.ug.UID, resAUG.UID)
 			}
 		})
+	}
+}
+
+func TestUserAddDuplicate(t *testing.T) {
+	username := uuid.NewString()
+	user1 := model.User{Username: username}
+	user2 := model.User{Username: username}
+
+	// Test Add.
+	_, err := Add(context.TODO(), &user1, &model.AgentUserGroup{})
+	require.NoError(t, err)
+
+	// Then try to add another user with the same username, expect an error.
+	_, err = Add(context.TODO(), &user2, &model.AgentUserGroup{})
+	require.Error(t, err)
+	if pgerr, ok := errors.Cause(err).(*pgconn.PgError); ok {
+		require.Equal(t, pgerr.Code, db.CodeUniqueViolation)
 	}
 }
 

--- a/master/internal/user/postgres_users_intg_test.go
+++ b/master/internal/user/postgres_users_intg_test.go
@@ -117,10 +117,10 @@ func TestUserAddDuplicate(t *testing.T) {
 
 	// Then try to add another user with the same username, expect an error.
 	_, err = Add(context.TODO(), &user2, &model.AgentUserGroup{})
-	require.Error(t, err)
+	require.Equal(t, err, db.ErrDuplicateRecord)
+
 	if pgerr, ok := errors.Cause(err).(*pgconn.PgError); ok {
 		require.Equal(t, pgerr.Code, db.CodeUniqueViolation)
-		require.Equal(t, err, db.ErrDuplicateRecord)
 	}
 }
 

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -546,8 +546,8 @@ func (s *Service) postUser(c echo.Context) (interface{}, error) {
 
 	_, err = Add(ctx, &userToAdd, ug)
 	switch {
-	case err == db.ErrDuplicateRecord:
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "user already exists")
+	case errors.Is(err, db.ErrDuplicateRecord):
+		return nil, api.ErrUserExists
 	case err != nil:
 		return nil, err
 	}

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -287,7 +287,7 @@ func TestAuthzPostUserDuplicate(t *testing.T) {
 	expectedErr := api.ErrUserExists
 
 	_, err = svc2.postUser(ctx2)
-	require.Equal(t, expectedErr.Error(), err.Error())
+	require.Contains(t, expectedErr.Error(), err.Error())
 }
 
 func TestAuthzGetUserImage(t *testing.T) {

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -258,7 +258,7 @@ func TestAuthzPostUserDuplicate(t *testing.T) {
 	ctx.SetParamNames("username")
 	ctx.SetParamValues("admin")
 	ctx.SetRequest(httptest.NewRequest("", "/", strings.NewReader(
-		`{"username":"e","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
+		`{"username":"abc","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
 
 	agentGroup := &model.AgentUserGroup{
 		UID:   1,
@@ -267,26 +267,22 @@ func TestAuthzPostUserDuplicate(t *testing.T) {
 		Group: "g",
 	}
 
-	authzUser.On("CanCreateUser", mock.Anything, model.User{}, model.User{Username: "e"}, agentGroup).
-		Return(nil).Once()
+	authzUser.On("CanCreateUser", mock.Anything, model.User{}, model.User{Username: "abc"}, agentGroup).Return(nil)
 
 	// post user once
 	_, err := svc.postUser(ctx)
 	require.NoError(t, err)
 
 	// post user a second time, expect an error.
-	svc2, authzUser2, ctx2 := setup(t)
+	_, _, ctx2 := setup(t)
 	ctx2.SetParamNames("username")
 	ctx2.SetParamValues("admin")
 	ctx2.SetRequest(httptest.NewRequest("", "/", strings.NewReader(
-		`{"username":"e","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
-
-	authzUser2.On("CanCreateUser", mock.Anything, model.User{}, model.User{Username: "e"}, agentGroup).
-		Return(nil).Once()
+		`{"username":"abc","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
 
 	expectedErr := api.ErrUserExists
 
-	_, err = svc2.postUser(ctx2)
+	_, err = svc.postUser(ctx2)
 	require.Contains(t, expectedErr.Error(), err.Error())
 }
 

--- a/master/internal/user/service_intg_test.go
+++ b/master/internal/user/service_intg_test.go
@@ -254,20 +254,11 @@ func TestAuthzPostUser(t *testing.T) {
 }
 
 func TestAuthzPostUserDuplicate(t *testing.T) {
+	userString := fmt.Sprintf("{\"username\":\"%s\"}", uuid.New().String())
 	svc, authzUser, ctx := setup(t)
-	ctx.SetParamNames("username")
-	ctx.SetParamValues("admin")
-	ctx.SetRequest(httptest.NewRequest("", "/", strings.NewReader(
-		`{"username":"abc","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
+	ctx.SetRequest(httptest.NewRequest("", "/", strings.NewReader(userString)))
 
-	agentGroup := &model.AgentUserGroup{
-		UID:   1,
-		GID:   2,
-		User:  "u",
-		Group: "g",
-	}
-
-	authzUser.On("CanCreateUser", mock.Anything, model.User{}, model.User{Username: "abc"}, agentGroup).Return(nil)
+	authzUser.On("CanCreateUser", mock.Anything, model.User{}, mock.Anything, mock.Anything).Return(nil)
 
 	// post user once
 	_, err := svc.postUser(ctx)
@@ -275,10 +266,7 @@ func TestAuthzPostUserDuplicate(t *testing.T) {
 
 	// post user a second time, expect an error.
 	_, _, ctx2 := setup(t)
-	ctx2.SetParamNames("username")
-	ctx2.SetParamValues("admin")
-	ctx2.SetRequest(httptest.NewRequest("", "/", strings.NewReader(
-		`{"username":"abc","agent_user_group":{"uid":1,"gid":2,"user":"u","group":"g"}}`)))
+	ctx2.SetRequest(httptest.NewRequest("", "/", strings.NewReader(userString)))
 
 	expectedErr := api.ErrUserExists
 


### PR DESCRIPTION
## Description
Fix an error message, to match previous Determined version.
Return db.ErrDuplicateRecord if attempting to add a user to the DB that returns db.CodeUniqueViolation.


## Test Plan
See attached intg test.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10051