### PR TITLE
fix: wait on algolia search upload

### DIFF
--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -232,8 +232,7 @@ def upload(app_id, api_key, records, version):
     # Pick some settings for this index.
     index.set_settings(SETTINGS)
 
-    num_tries = 1
-    while num_tries <= max_retries:
+    for _ in range(max_retries):
         # Upload to temp index.
         print(f"uploading {len(records)} records to temp index {temp_name}...", file=sys.stderr)
         index_response = index.save_objects(records, {"autoGenerateObjectIDIfNotExist": True})
@@ -247,7 +246,7 @@ def upload(app_id, api_key, records, version):
         print("rename done", file=sys.stderr)
 
         # Verify remote record length
-        print(f"checking that {final_name} contains {len(records)} records")
+        print(f"checking that {final_name} contains {len(records)} records", file=sys.stderr)
         final_index = client.init_index(final_name)
         search_iterator = final_index.browse_objects()
         search_iterator.next()
@@ -255,14 +254,13 @@ def upload(app_id, api_key, records, version):
         if remote_length == len(records):
             print(f"verified that {final_name} contains {len(records)} records", file=sys.stderr)
             break
-        else:
-            print(
-                f"{final_name} contains {remote_length} records but expected {len(records)}"
-                f" records.",
-                file=sys.stderr,
-            )
-            if num_tries == max_retries:
-                raise Exception("Maximum number of retries reached with no success")
+        print(
+            f"Expected {len(records)} in {final_name} but got {remote_length}  instead",
+            file=sys.stderr,
+        )
+
+    else:
+        raise ValueError("Maximum number of retries reached with no success")
 
 
 if __name__ == "__main__":

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -231,7 +231,7 @@ def upload(app_id, api_key, records, version):
 
     # Upload to temp index.
     print(f"uploading {len(records)} records to temp index {temp_name}...", file=sys.stderr)
-    index.save_objects(records, {"autoGenerateObjectIDIfNotExist": True})
+    index.save_objects(records, {"autoGenerateObjectIDIfNotExist": True}).wait()
     print("upload complete", file=sys.stderr)
 
     # Rename index into place.

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import re
 import sys
+import time
 import traceback
 from xml.etree import ElementTree
 
@@ -255,9 +256,10 @@ def upload(app_id, api_key, records, version):
             print(f"verified that {final_name} contains {len(records)} records", file=sys.stderr)
             break
         print(
-            f"Expected {len(records)} in {final_name} but got {remote_length}  instead",
+            f"Expected {len(records)} in {final_name} but got {remote_length} instead.",
             file=sys.stderr,
         )
+        time.sleep(60)
 
     else:
         raise ValueError("Maximum number of retries reached with no success")

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -248,15 +248,18 @@ def upload(app_id, api_key, records, version):
 
         # Verify remote record length
         print(f"checking that {final_name} contains {len(records)} records")
-        final_index=client.init_index(final_name)
+        final_index = client.init_index(final_name)
         search_iterator = final_index.browse_objects()
         search_iterator.next()
-        if search_iterator._raw_response['nbHits'] == len(records):
+        remote_length = search_iterator._raw_response["nbHits"]
+        if remote_length == len(records):
             print(f"verified that {final_name} contains {len(records)} records")
             break
         else:
-            print(f"{final_name} contains {search_iterator._raw_response['nbHits']} records "
-                  f"but expected {len(records)} records.")
+            print(
+                f"{final_name} contains {remote_length} records but expected {len(records)}"
+                f" records."
+            )
             if num_tries == max_retries:
                 raise Exception("Maximum number of retries reached with no success")
 

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -253,12 +253,13 @@ def upload(app_id, api_key, records, version):
         search_iterator.next()
         remote_length = search_iterator._raw_response["nbHits"]
         if remote_length == len(records):
-            print(f"verified that {final_name} contains {len(records)} records")
+            print(f"verified that {final_name} contains {len(records)} records", file=sys.stderr)
             break
         else:
             print(
                 f"{final_name} contains {remote_length} records but expected {len(records)}"
-                f" records."
+                f" records.",
+                file=sys.stderr,
             )
             if num_tries == max_retries:
                 raise Exception("Maximum number of retries reached with no success")


### PR DESCRIPTION
## Description

Algolia search index is uploaded, then renamed after uploading. We never explicitly wait for the upload to finish before renaming the object on the cloud, causing a potential race condition. This PR adds a wait step.



## Test Plan

Check algolia for number of index records. Should match what was uploaded.



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MLG-1513