### PR TITLE
fix wrong spelling in _index.rst

### DIFF
--- a/docs/model-hub-library/_index.rst
+++ b/docs/model-hub-library/_index.rst
@@ -21,5 +21,5 @@
    :maxdepth: 1
    :hidden:
 
-   Huggingface Trainsformers <transformers/_index>
+   Huggingface Transformers <transformers/_index>
    MMDetection <mmdetection/_index>


### PR DESCRIPTION
## Description

Just fix a simple spelling issue on index page