### PR TITLE
feat: Truncate and pad cell values in glide table [WEB-1778]

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -546,9 +546,11 @@ export const defaultNumberColumn = (
       }
       return {
         allowOverlay: false,
-        data: Number(data),
-        displayData: data !== undefined ? String(data) : '',
-        kind: GridCellKind.Number,
+        copyData: data !== undefined ? String(data) : '',
+        data: {
+          kind: 'text-cell',
+        },
+        kind: GridCellKind.Custom,
         themeOverride: theme,
       };
     },

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -134,9 +134,7 @@ export const getColumnDefs = ({
       copyData: record.experiment.checkpointSize
         ? humanReadableBytes(record.experiment.checkpointSize)
         : '',
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Checkpoint Size',
@@ -148,9 +146,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: String(record.experiment.description),
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Description',
@@ -163,9 +159,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: getDurationInEnglish(record.experiment),
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Duration',
@@ -177,9 +171,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: record.experiment.externalExperimentId ?? '',
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'External Experiment ID',
@@ -191,9 +183,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: record.experiment.externalTrialId ?? '',
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'External Trial ID',
@@ -307,9 +297,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: String(record.experiment.resourcePool),
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Resource Pool',
@@ -324,9 +312,7 @@ export const getColumnDefs = ({
       return {
         allowOverlay: false,
         copyData: sMetric,
-        data: {
-          kind: 'text-cell',
-        },
+        data: { kind: 'text-cell' },
         kind: GridCellKind.Custom,
       };
     },
@@ -339,9 +325,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: String(record.experiment.searcherType),
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Searcher',
@@ -372,9 +356,7 @@ export const getColumnDefs = ({
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: getTimeInEnglish(new Date(record.experiment.startTime)),
-      data: {
-        kind: 'text-cell',
-      },
+      data: { kind: 'text-cell' },
       kind: GridCellKind.Custom,
     }),
     title: 'Start Time',
@@ -472,9 +454,7 @@ export const searcherMetricsValColumn = (
             ? humanReadableNumber(sMetricValue)
             : sMetricValue
           : '',
-        data: {
-          kind: 'text-cell',
-        },
+        data: { kind: 'text-cell' },
         kind: GridCellKind.Custom,
         themeOverride: theme,
       };
@@ -497,9 +477,7 @@ export const defaultTextColumn = (
       return {
         allowOverlay: false,
         copyData: String(data ?? ''),
-        data: {
-          kind: 'text-cell',
-        },
+        data: { kind: 'text-cell' },
         kind: GridCellKind.Custom,
       };
     },
@@ -547,9 +525,7 @@ export const defaultNumberColumn = (
       return {
         allowOverlay: false,
         copyData: data !== undefined ? String(data) : '',
-        data: {
-          kind: 'text-cell',
-        },
+        data: { kind: 'text-cell' },
         kind: GridCellKind.Custom,
         themeOverride: theme,
       };
@@ -572,9 +548,7 @@ export const defaultDateColumn = (
       return {
         allowOverlay: false,
         copyData: formatDatetime(String(data), { outputUTC: false }),
-        data: {
-          kind: 'text-cell',
-        },
+        data: { kind: 'text-cell' },
         kind: GridCellKind.Custom,
       };
     },

--- a/webui/react/src/pages/F_ExpList/glide-table/columns.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/columns.ts
@@ -131,13 +131,13 @@ export const getColumnDefs = ({
     isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: record.experiment.checkpointSize
+      copyData: record.experiment.checkpointSize
         ? humanReadableBytes(record.experiment.checkpointSize)
         : '',
-      displayData: record.experiment.checkpointSize
-        ? humanReadableBytes(record.experiment.checkpointSize)
-        : '',
-      kind: GridCellKind.Text,
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Checkpoint Size',
     tooltip: () => undefined,
@@ -147,9 +147,11 @@ export const getColumnDefs = ({
     id: 'description',
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: String(record.experiment.description),
-      displayData: String(record.experiment.description),
-      kind: GridCellKind.Text,
+      copyData: String(record.experiment.description),
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Description',
     tooltip: () => undefined,
@@ -160,9 +162,11 @@ export const getColumnDefs = ({
     isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: getDurationInEnglish(record.experiment),
-      displayData: getDurationInEnglish(record.experiment),
-      kind: GridCellKind.Text,
+      copyData: getDurationInEnglish(record.experiment),
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Duration',
     tooltip: () => undefined,
@@ -172,9 +176,11 @@ export const getColumnDefs = ({
     id: 'externalExperimentId',
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: record.experiment.externalExperimentId ?? '',
-      displayData: record.experiment.externalExperimentId ?? '',
-      kind: GridCellKind.Text,
+      copyData: record.experiment.externalExperimentId ?? '',
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'External Experiment ID',
     tooltip: () => undefined,
@@ -184,9 +190,11 @@ export const getColumnDefs = ({
     id: 'externalTrialId',
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: record.experiment.externalTrialId ?? '',
-      displayData: record.experiment.externalTrialId ?? '',
-      kind: GridCellKind.Text,
+      copyData: record.experiment.externalTrialId ?? '',
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'External Trial ID',
     tooltip: () => undefined,
@@ -298,9 +306,11 @@ export const getColumnDefs = ({
     id: 'resourcePool',
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: String(record.experiment.resourcePool),
-      displayData: String(record.experiment.resourcePool),
-      kind: GridCellKind.Text,
+      copyData: String(record.experiment.resourcePool),
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Resource Pool',
     tooltip: () => undefined,
@@ -313,9 +323,11 @@ export const getColumnDefs = ({
       const sMetric = record.experiment.config.searcher.metric;
       return {
         allowOverlay: false,
-        data: sMetric,
-        displayData: sMetric,
-        kind: GridCellKind.Text,
+        copyData: sMetric,
+        data: {
+          kind: 'text-cell',
+        },
+        kind: GridCellKind.Custom,
       };
     },
     title: 'Searcher Metric',
@@ -326,9 +338,11 @@ export const getColumnDefs = ({
     id: 'searcherType',
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: String(record.experiment.searcherType),
-      displayData: String(record.experiment.searcherType),
-      kind: GridCellKind.Text,
+      copyData: String(record.experiment.searcherType),
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Searcher',
     tooltip: () => undefined,
@@ -357,9 +371,11 @@ export const getColumnDefs = ({
     isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
-      data: getTimeInEnglish(new Date(record.experiment.startTime)),
-      displayData: getTimeInEnglish(new Date(record.experiment.startTime)),
-      kind: GridCellKind.Text,
+      copyData: getTimeInEnglish(new Date(record.experiment.startTime)),
+      data: {
+        kind: 'text-cell',
+      },
+      kind: GridCellKind.Custom,
     }),
     title: 'Start Time',
     tooltip: () => undefined,
@@ -451,13 +467,15 @@ export const searcherMetricsValColumn = (
       }
       return {
         allowOverlay: false,
-        data: sMetricValue?.toString() || '',
-        displayData: sMetricValue
+        copyData: sMetricValue
           ? typeof sMetricValue === 'number'
             ? humanReadableNumber(sMetricValue)
             : sMetricValue
           : '',
-        kind: GridCellKind.Text,
+        data: {
+          kind: 'text-cell',
+        },
+        kind: GridCellKind.Custom,
         themeOverride: theme,
       };
     },
@@ -478,9 +496,11 @@ export const defaultTextColumn = (
       const data = isString(dataPath) ? getPath<string>(record, dataPath) : undefined;
       return {
         allowOverlay: false,
-        data: String(data),
-        displayData: String(data ?? ''),
-        kind: GridCellKind.Text,
+        copyData: String(data ?? ''),
+        data: {
+          kind: 'text-cell',
+        },
+        kind: GridCellKind.Custom,
       };
     },
     title: column.displayName || column.column,
@@ -549,9 +569,11 @@ export const defaultDateColumn = (
       const data = isString(dataPath) ? getPath<string>(record, dataPath) : undefined;
       return {
         allowOverlay: false,
-        data: String(data),
-        displayData: formatDatetime(String(data), { outputUTC: false }),
-        kind: GridCellKind.Text,
+        copyData: formatDatetime(String(data), { outputUTC: false }),
+        data: {
+          kind: 'text-cell',
+        },
+        kind: GridCellKind.Custom,
       };
     },
     title: column.displayName || column.column,

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/textCell.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/cells/textCell.tsx
@@ -1,0 +1,39 @@
+import {
+  CustomCell,
+  CustomRenderer,
+  getMiddleCenterBias,
+  GridCellKind,
+} from '@hpe.com/glide-data-grid';
+
+import { drawTextWithEllipsis } from 'pages/F_ExpList/glide-table/custom-renderers/utils';
+
+interface TextCellProps {
+  readonly kind: 'text-cell';
+}
+
+export type TextCell = CustomCell<TextCellProps>;
+
+const renderer: CustomRenderer<TextCell> = {
+  draw: (args, cell) => {
+    const { ctx, rect, theme } = args;
+    // hoverX = -100, highlighted
+
+    const xPad = theme.cellHorizontalPadding;
+    const font = `${theme.baseFontStyle} ${theme.fontFamily}`;
+    const middleCenterBias = getMiddleCenterBias(ctx, font);
+    const x = rect.x + xPad;
+    const y = rect.y + rect.height / 2 + middleCenterBias;
+    const maxWidth = rect.width - 2 * theme.cellHorizontalPadding;
+
+    ctx.fillStyle = theme.textHeader;
+    drawTextWithEllipsis(ctx, cell.copyData, x, y, maxWidth);
+
+    return true;
+  },
+  isMatch: (c): c is TextCell => (c.data as TextCellProps).kind === 'text-cell',
+  kind: GridCellKind.Custom,
+  needsHover: true,
+  provideEditor: () => undefined,
+};
+
+export default renderer;

--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/index.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/index.tsx
@@ -7,6 +7,7 @@ import LoadingCell from './cells/loadingCell';
 import ProgressCell from './cells/progressCell';
 import SparklineCell from './cells/sparklineCell';
 import TagsCell from './cells/tagsCell';
+import TextCell from './cells/textCell';
 import UserProfileCell from './cells/userAvatarCell';
 
 export const customRenderers: DataEditorProps['customRenderers'] = [
@@ -17,5 +18,6 @@ export const customRenderers: DataEditorProps['customRenderers'] = [
   ProgressCell,
   SparklineCell,
   TagsCell,
+  TextCell,
   UserProfileCell,
 ];


### PR DESCRIPTION
## Description

Copy `drawTextWithEllipsis` logic from the Glide Table column headers to other cells.

Includes text and number type columns (this doesn't affect number format or sorting)

Did not include min width text columns: Archived (single emoji), and Progress (values "0%" to "100%")

## Test Plan

On `/det/projects/1/experiments`, shrink the width of a text column such as "start time", name, or description:

<img width="465" alt="Screen Shot 2024-01-09 at 10 02 50 AM" src="https://github.com/determined-ai/determined/assets/643918/ff4db9f2-814b-4893-8911-b48fbdb35ccd">

- The value should be truncated with "..." and the right edge should line up with the header truncation
- Right-click the cell and select "Copy Value". You copy the untruncated value of the cell

Include a universally numeric metric such as `training.loss.min` in the table. Sort 0->9 and 9->0 to confirm it is being sorted numerically (2, 10, 300) and not alphabetic ("10", "2", "300")

<img width="345" alt="Screen Shot 2024-01-09 at 10 13 21 AM" src="https://github.com/determined-ai/determined/assets/643918/4731c9ea-c745-4873-bdff-b22d2809a109">

When width is shortened:
- The value should be truncated with "..." and the right edge should line up with the header truncation
- Right-click the cell and select "Copy Value". You copy the untruncated value of the cell
- We haven't used `toLocaleString` or scientific notation on these metric values

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.