### PR TITLE
fix: stop using distutils (for python 3.12) [MLG-1519]

### DIFF
--- a/harness/determined/cli/experiment.py
+++ b/harness/determined/cli/experiment.py
@@ -1,5 +1,4 @@
 import base64
-import distutils.util
 import json
 import numbers
 import pathlib
@@ -1269,7 +1268,7 @@ main_cmd = Cmd(
                 ),
                 Arg(
                     "--smaller-is-better",
-                    type=lambda s: bool(distutils.util.strtobool(s)),
+                    type=lambda s: util.strtobool(s),
                     default=None,
                     help="The sort order for metrics when using --sort-by. For "
                     "example, 'accuracy' would require passing '--smaller-is-better false'. If "

--- a/harness/determined/common/declarative_argparse.py
+++ b/harness/determined/common/declarative_argparse.py
@@ -1,4 +1,3 @@
-import distutils.util
 import functools
 import itertools
 from argparse import SUPPRESS, ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
@@ -247,4 +246,4 @@ def add_args(parser: ArgumentParser, description: ArgsDescription, depth: int = 
 
 def string_to_bool(s: str) -> bool:
     """Converts string values to boolean for flag arguments (e.g. --active=true)"""
-    return bool(distutils.util.strtobool(s))
+    return util.strtobool(s)

--- a/harness/determined/common/util.py
+++ b/harness/determined/common/util.py
@@ -348,3 +348,15 @@ def deprecated(message: Optional[str] = None) -> Callable[[U], U]:
         return cast(U, wrapper_deprecated)
 
     return decorator
+
+
+def strtobool(val: str) -> bool:
+    """
+    A port of the distutils.util.strtobool function, removed in python 3.12.
+
+    The only difference in this function is that any non-falsy value which is a non-empty string is
+    accepted as a true value.  That small difference gives us a small headstart on this todo:
+
+    TODO(MLG-1520): we should instead treat any nonempty string as "true".
+    """
+    return bool(val and val.lower() not in ("n", "no", "f", "false", "off", "0"))

--- a/harness/determined/pytorch/_pytorch_context.py
+++ b/harness/determined/pytorch/_pytorch_context.py
@@ -1023,7 +1023,12 @@ class PyTorchTrialContext(pytorch._PyTorchReducerContext):
             # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
             # without actually importing distutils.version.  We can workaround this by prepopulating
             # the distutils.version submodule in the distutils module.
-            import distutils.version  # noqa: F401
+            #
+            # Except, starting with python 3.12 distutils isn't available at all.
+            try:
+                import distutils.version  # noqa: F401
+            except ImportError:
+                pass
 
             from torch.utils.tensorboard import SummaryWriter
 

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -398,7 +398,12 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
             # 59.6.0.  The bug is that it attempts to import distutils then access distutils.version
             # without actually importing distutils.version.  We can workaround this by prepopulating
             # the distutils.version submodule in the distutils module.
-            import distutils.version  # noqa: F401
+            #
+            # Except, starting with python 3.12 distutils isn't available at all.
+            try:
+                import distutils.version  # noqa: F401
+            except ImportError:
+                pass
 
             from torch.utils.tensorboard import SummaryWriter
 

--- a/harness/determined/tensorboard/metric_writers/pytorch.py
+++ b/harness/determined/tensorboard/metric_writers/pytorch.py
@@ -12,7 +12,11 @@ from determined import tensorboard
 # importing distutils.version.  We can workaround this by prepopulating the distutils.version
 # submodule in the distutils module.
 if version.parse("1.9.0") <= version.parse(torch.__version__) < version.parse("1.11.0"):
-    import distutils.version  # isort:skip  # noqa: F401
+    # Except, starting with python 3.12 distutils isn't available at all.
+    try:
+        import distutils.version  # isort:skip  # noqa: F401
+    except ImportError:
+        pass
 
 from torch.utils.tensorboard import SummaryWriter  # isort:skip
 


### PR DESCRIPTION
distutils is removed in python 3.12.  We shouldn't really be using it anyway, but rather than do a breaking change to switch to the behavior I want us to have, here's a quick fix that unbreaks us, and I made a ticket to do the breaking change at some point in the future.

Note that to manifest the failure, you'll need to uninstall setuptools from your python environment (which provides its own distutils package starting in python 3.12).

## Test Plan

- [x] manually tested that a python 3.12 environment without this fix (and without setuptools) breaks during `det -h`.  With the fix, things work.