### PR TITLE
fix: break out stopping... states from stopped states in webui

### DIFF
--- a/webui/react/src/components/ExperimentIcons.tsx
+++ b/webui/react/src/components/ExperimentIcons.tsx
@@ -44,7 +44,12 @@ const ExperimentIcons: React.FC<Props> = ({
       case RunState.Unspecified:
       case JobState.UNSPECIFIED:
         return { name: 'active', title: stateToLabel(state) };
-      default:
+      case RunState.StoppingCanceled:
+      case RunState.StoppingCompleted:
+      case RunState.StoppingError:
+      case RunState.StoppingKilled:
+        return { color: 'cancel', name: 'spin-shadow', title: stateToLabel(state) };
+      case RunState.Canceled:
         return { color: 'cancel', name: 'cancelled', title: 'Stopped' };
     }
   }, [backgroundColor, opacity, state]);


### PR DESCRIPTION


## Description

This fixes an issue where experiments that were stopping for one reason or another showed as stopped.


## Test Plan

submit an experiment
on the experiment's detail page, cancel the experiment
the experiment state should show up as stopping before updating to stopped.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
WEB-1913


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
