### PR TITLE
chore: TrialsComparisonModal style fixes [WEB-1919] [WEB-1909]

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
@@ -36,7 +36,7 @@
       background-color: var(--theme-background);
       position: sticky;
       top: 0;
-      z-index: 10;
+      z-index: 15;
     }
     th:first-of-type {
       background-clip: padding-box;

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
@@ -45,6 +45,7 @@
       position: sticky;
       text-align: left;
       width: 200px;
+      z-index: 10;
     }
   }
   .trialTag {

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
@@ -50,11 +50,9 @@
   .trialTag {
     font-size: 14px;
 
-    & * {
-      margin: 0;
-    }
-    :hover {
-      color: var(--theme-status-active);
+    > * {
+      margin: 0 3px;
+      vertical-align: middle;
     }
   }
 }

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.module.scss
@@ -49,10 +49,5 @@
   }
   .trialTag {
     font-size: 14px;
-
-    > * {
-      margin: 0 3px;
-      vertical-align: middle;
-    }
   }
 }

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -242,11 +242,13 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                             : `Trial ${trial.id}`}
                         </Link>
                       </Label>
-                      <Button
-                        icon={<Icon name="close" size="tiny" title="close" />}
-                        size="small"
-                        onClick={() => handleTrialUnselect(trial.id)}
-                      />
+                      {onUnselect ? (
+                        <Button
+                          icon={<Icon name="close" size="tiny" title="close" />}
+                          size="small"
+                          onClick={() => handleTrialUnselect(trial.id)}
+                        />
+                      ) : null}
                     </Row>
                   </th>
                 ))}

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -1,4 +1,5 @@
-import { Tag } from 'antd';
+import Button from 'hew/Button';
+import Icon from 'hew/Icon';
 import Message from 'hew/Message';
 import { Modal } from 'hew/Modal';
 import Select, { Option, SelectValue } from 'hew/Select';
@@ -79,7 +80,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
   const [trialsDetails, setTrialsDetails] = useState(trials ?? []);
   const [selectedHyperparameters, setSelectedHyperparameters] = useState<string[]>([]);
   const [selectedMetrics, setSelectedMetrics] = useState<Metric[]>([]);
-  const colSpan = Array.isArray(experiment) ? experiment.length + 1 : 1;
+  const colSpan = Array.isArray(trialsDetails) ? trialsDetails.length + 1 : 2;
 
   useEffect(() => {
     if (trialIds === undefined) return;
@@ -231,22 +232,21 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
               <tr>
                 <th />
                 {trialsDetails.map((trial) => (
-                  <th key={trial.id}>
-                    <Tag
-                      className={css.trialTag}
-                      closable={!!onUnselect}
-                      style={{ width: '100%' }}
-                      onClose={() => handleTrialUnselect(trial.id)}>
-                      <Link path={paths.trialDetails(trial.id, trial.experimentId)}>
-                        {Array.isArray(experiment) ? (
-                          <Label truncate={{ tooltip: true }}>
-                            {experimentMap[trial.experimentId]?.name}
-                          </Label>
-                        ) : (
-                          `Trial ${trial.id}`
-                        )}
-                      </Link>
-                    </Tag>
+                  <th className={css.trialTag} key={trial.id}>
+                    <Link path={paths.trialDetails(trial.id, trial.experimentId)}>
+                      {Array.isArray(experiment) ? (
+                        <Label truncate={{ tooltip: true }}>
+                          {experimentMap[trial.experimentId]?.name}
+                        </Label>
+                      ) : (
+                        `Trial ${trial.id}`
+                      )}
+                    </Link>
+                    <Button
+                      icon={<Icon name="close" size="tiny" title="close" />}
+                      size="small"
+                      onClick={() => handleTrialUnselect(trial.id)}
+                    />
                   </th>
                 ))}
               </tr>

--- a/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
+++ b/webui/react/src/pages/ExperimentDetails/TrialsComparisonModal.tsx
@@ -2,6 +2,7 @@ import Button from 'hew/Button';
 import Icon from 'hew/Icon';
 import Message from 'hew/Message';
 import { Modal } from 'hew/Modal';
+import Row from 'hew/Row';
 import Select, { Option, SelectValue } from 'hew/Select';
 import Spinner from 'hew/Spinner';
 import { Label } from 'hew/Typography';
@@ -80,7 +81,7 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
   const [trialsDetails, setTrialsDetails] = useState(trials ?? []);
   const [selectedHyperparameters, setSelectedHyperparameters] = useState<string[]>([]);
   const [selectedMetrics, setSelectedMetrics] = useState<Metric[]>([]);
-  const colSpan = Array.isArray(trialsDetails) ? trialsDetails.length + 1 : 2;
+  const colSpan = (Array.isArray(experiment) ? experiment.length : trialIds?.length ?? 0) + 1;
 
   useEffect(() => {
     if (trialIds === undefined) return;
@@ -233,20 +234,20 @@ export const TrialsComparisonTable: React.FC<TableProps> = ({
                 <th />
                 {trialsDetails.map((trial) => (
                   <th className={css.trialTag} key={trial.id}>
-                    <Link path={paths.trialDetails(trial.id, trial.experimentId)}>
-                      {Array.isArray(experiment) ? (
-                        <Label truncate={{ tooltip: true }}>
-                          {experimentMap[trial.experimentId]?.name}
-                        </Label>
-                      ) : (
-                        `Trial ${trial.id}`
-                      )}
-                    </Link>
-                    <Button
-                      icon={<Icon name="close" size="tiny" title="close" />}
-                      size="small"
-                      onClick={() => handleTrialUnselect(trial.id)}
-                    />
+                    <Row justifyContent="space-between" width="fill">
+                      <Label truncate={{ tooltip: true }}>
+                        <Link path={paths.trialDetails(trial.id, trial.experimentId)}>
+                          {Array.isArray(experiment)
+                            ? experimentMap[trial.experimentId]?.name
+                            : `Trial ${trial.id}`}
+                        </Link>
+                      </Label>
+                      <Button
+                        icon={<Icon name="close" size="tiny" title="close" />}
+                        size="small"
+                        onClick={() => handleTrialUnselect(trial.id)}
+                      />
+                    </Row>
                   </th>
                 ))}
               </tr>

--- a/webui/react/src/pages/F_ExpList/ComparisonView.tsx
+++ b/webui/react/src/pages/F_ExpList/ComparisonView.tsx
@@ -92,19 +92,16 @@ const ComparisonView: React.FC<Props> = ({
       children
     );
 
-  const rightPane = useMemo(
-    () =>
-      selectedExperiments.length === 0 ? (
-        <Message
-          description="Select experiments you would like to compare."
-          icon="warning"
-          title="No experiments selected."
-        />
-      ) : (
-        <Pivot items={tabs} />
-      ),
-    [selectedExperiments.length, tabs],
-  );
+  const rightPane =
+    selectedExperiments.length === 0 ? (
+      <Message
+        description="Select experiments you would like to compare."
+        icon="warning"
+        title="No experiments selected."
+      />
+    ) : (
+      <Pivot items={tabs} />
+    );
 
   return (
     <SplitPane

--- a/webui/react/src/pages/F_ExpList/ComparisonView.tsx
+++ b/webui/react/src/pages/F_ExpList/ComparisonView.tsx
@@ -92,16 +92,19 @@ const ComparisonView: React.FC<Props> = ({
       children
     );
 
-  const rightPane =
-    selectedExperiments.length === 0 ? (
-      <Message
-        description="Select experiments you would like to compare."
-        icon="warning"
-        title="No experiments selected."
-      />
-    ) : (
-      <Pivot items={tabs} />
-    );
+  const rightPane = useMemo(
+    () =>
+      selectedExperiments.length === 0 ? (
+        <Message
+          description="Select experiments you would like to compare."
+          icon="warning"
+          title="No experiments selected."
+        />
+      ) : (
+        <Pivot items={tabs} />
+      ),
+    [selectedExperiments.length, tabs],
+  );
 
   return (
     <SplitPane


### PR DESCRIPTION
## Description

Addresses an Antd / UI Kit  ticket, plus a bug ticket, around the `TrialsComparisonModal`

- Replaces `antd.Tag` with `Row` containing `Label` and close icon button
- Updates `colSpan` to cover multiple experiments or multiple trialIds (+1 to include original column)

As used in multi-trial experiment trials table:

<img width="755" alt="Screen Shot 2024-01-10 at 5 03 44 PM" src="https://github.com/determined-ai/determined/assets/643918/53b5f04b-8f18-4a0b-be6e-eea0fe518d0a">

-

As used in the experiments Glide Table:

<img width="1064" alt="Screen Shot 2024-01-10 at 5 03 32 PM" src="https://github.com/determined-ai/determined/assets/643918/989e4423-59b8-4ad5-bf2d-c6d63139f6de">


## Test Plan

Open a multi-trial experiment such as `/det/experiments/1290/trials`. Check to select multiple trial rows. In the action menu, select Compare trials to open the modal

Open a project such as `/det/projects/1/experiments`. Check multiple successful / completed experiments which can be compared.
Open the Compare section using the button at top right of the table.
In the Compare section, click the Details tab to see the table as used here

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.
