### PR TITLE
feat: set jupyter notebook file browser root to `/`.

### DIFF
--- a/docs/release-notes/jupyter-root.rst
+++ b/docs/release-notes/jupyter-root.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Improvements**
+
+-  Notebooks: Jupyter notebook file browser (``ContentManager``) will no longer be locked down to
+   ``work_dir``, and it'll have entire ``/`` filesystem visible. ``work_dir`` will stay the default
+   starting directory.

--- a/master/static/srv/notebook-entrypoint.sh
+++ b/master/static/srv/notebook-entrypoint.sh
@@ -58,4 +58,6 @@ jupyter lab --ServerApp.port=${NOTEBOOK_PORT} \
     --LabServerApp.log_format="$JUPYTER_LAB_LOG_FORMAT" \
     --LabApp.log_format="$JUPYTER_LAB_LOG_FORMAT" \
     --ServerApp.log_format="$JUPYTER_LAB_LOG_FORMAT" \
+    --ServerApp.root_dir="/" \
+    --ContentsManager.preferred_dir="$PWD" \
     2> >(tee -p >("$DET_PYTHON_EXECUTABLE" /run/determined/check_ready_logs.py --ready-regex "${READINESS_REGEX}") >&2)


### PR DESCRIPTION
## Description

Set the root of the jupyter notebook file browser to `/`, and the default starting location to the `work_dir`.
Pros:
* full file tree becomes visible
* default starting directory in the file browser, launched notebooks or terminals stays the same (`work_dir`), unless you navigate away in the browser
* you can always return back using the home icon, so it’s really hard to get lost
* if you navigate somewhere you don’t have write permissions, creating new notebook will return a “permission denied” error. there’s no new permissions obtained by the user (as they could always reach whatever location outside the `work_dir` using the terminal).

Background: https://hpe-aiatscale.slack.com/archives/C02T7L0593K/p1704929788275849

## Test Plan

- Launch a notebook with or without `work_dir` config setting. Check if the default directories are still `/run/determined/workdir`, but you can access any directory you want (and have fs permissions to) from the file browser.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
