### PR TITLE
chore: update oss/ee oidc & saml helm config

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -94,6 +94,15 @@ stringData:
       {{- if .Values.oidc.scimAuthenticationAttribute }}
       scim_authentication_attribute: {{ .Values.oidc.scimAuthenticationAttribute }}
       {{- end }}
+      {{- if .Values.oidc.autoProvisionUsers }}
+      auto_provision_users: {{ .Values.oidc.autoProvisionUsers }}
+      {{- end }}
+      {{- if .Values.oidc.groupsClaimName }}
+      groups_claim_name: {{ .Values.oidc.groupsClaimName }}
+      {{- end }}
+      {{- if .Values.oidc.displayNameClaimName }}
+      groups_claim_name: {{ .Values.oidc.displayNameClaimName }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.scim }}
@@ -105,6 +114,25 @@ stringData:
         username: {{ required "A valid username is required!" .Values.scim.auth.username }}
         password: {{ required "A valid password type is required!" .Values.scim.auth.password }}
         {{- end }}
+    {{- end }}
+
+    {{- if .Values.saml }}
+    saml:
+      enabled: {{ .Values.saml.enabled | default false }}
+      provider: {{ required "A valid provider entry is required!" .Values.saml.provider}}
+      idp_recipient_url: {{ required "A valid recipient url is required!" .Values.saml.idpRecipientUrl }}
+      idp_sso_url: {{ required "A valid sso url is required!" .Values.saml.idpSsoUrl }}
+      idp_sso_descriptor_url: {{ required "A valid sso descriptor url is required!" .Values.saml.idpSsoDescriptorUrl }}
+      idp_cert_path: {{ required "A valid idp cert path is required!" .Values.saml.idpCertPath }}
+      {{- if .Values.saml.autoProvisionUsers }}
+      auto_provision_users: {{ .Values.saml.autoProvisionUsers }}
+      {{- end }}
+      {{- if .Values.saml.groupsAttributeName }}
+      groups_claim_name: {{ .Values.saml.groupsAttributeName }}
+      {{- end }}
+      {{- if .Values.saml.displayNameAttributeName }}
+      display_name_attribute_name: {{ .Values.saml.displayNameAttributeName }}
+      {{- end }}
     {{- end }}
     {{- end }}
 

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -101,7 +101,7 @@ stringData:
       groups_claim_name: {{ .Values.oidc.groupsClaimName }}
       {{- end }}
       {{- if .Values.oidc.displayNameClaimName }}
-      groups_claim_name: {{ .Values.oidc.displayNameClaimName }}
+      display_name_claim_name: {{ .Values.oidc.displayNameClaimName }}
       {{- end }}
     {{- end }}
 
@@ -128,7 +128,7 @@ stringData:
       auto_provision_users: {{ .Values.saml.autoProvisionUsers }}
       {{- end }}
       {{- if .Values.saml.groupsAttributeName }}
-      groups_claim_name: {{ .Values.saml.groupsAttributeName }}
+      groups_attribute_name: {{ .Values.saml.groupsAttributeName }}
       {{- end }}
       {{- if .Values.saml.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.saml.displayNameAttributeName }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -114,6 +114,9 @@ useNodePortForMaster: false
 #   clientSecretName:
 #   authenticationClaim:
 #   scimAuthenticationAttribute:
+#   autoProvisionUsers:
+#   groupsClaimName:
+#   displayNameClaimName:
 
 # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
 # only available if enterpriseEdition is true. It allows administrators to easily and securely
@@ -124,6 +127,20 @@ useNodePortForMaster: false
 #     type: basic
 #     username: determined
 #     password: password
+
+# saml (EE-only) enables Security Assertion Markup Language Integration, which is only available if
+# enterpriseEdition is true. It allows users to use single sign-on with their organization’s identity
+# provider.
+# saml:
+#   enabled:
+#   provider:
+#   idpRecipientUrl:
+#   idpSsoUrl:
+#   idpSsoDescriptorUrl:
+#   idpCertPath:
+#   autoProvisionUsers:
+#   groupsAttributeName:
+#   displayNameAttributeName:
 
 # db sets the configurations for the database.
 db:


### PR DESCRIPTION
## Description
In the user auth project, we only added the helm edits to EE -- this PR ports them back to OSS to standardize the oidc/saml helm config.

tldr; haran noticed that the helm changes were in EE only, but should be in OSS, plus all the user auth provisioning features hadn't been properly included there.

## Test Plan

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->