### PR TITLE
fix: add zmq heartbeat in DistributedContext [MLG-1133]

### DIFF
--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -70,6 +70,10 @@ class ZMQBroadcastServer:
         self._pub_socket = context.socket(zmq.PUB)
         self._pull_socket = context.socket(zmq.PULL)
 
+        # Enable a 60-second keepalive.
+        self._pub_socket.setsockopt(zmq.HEARTBEAT_IVL, 60 * 1000)
+        self._pull_socket.setsockopt(zmq.HEARTBEAT_IVL, 60 * 1000)
+
         self._pub_port = None  # type: Optional[int]
         self._pull_port = None  # type: Optional[int]
 
@@ -181,6 +185,10 @@ class ZMQBroadcastClient:
 
         self._push_socket = context.socket(zmq.PUSH)
         self._push_socket.connect(srv_pull_url)
+
+        # Enable a 60-second keepalive.
+        self._sub_socket.setsockopt(zmq.HEARTBEAT_IVL, 60 * 1000)
+        self._push_socket.setsockopt(zmq.HEARTBEAT_IVL, 60 * 1000)
 
         self._send_serial = 0
         self._recv_serial = 0


### PR DESCRIPTION
## Description

When the time between zmq allgathers was greater than the tcp timeout
configured for the machine, zmq allgathers would hang.

Solves #8222, using @igor0's suggestion.

## Test Plan

- [x] tried and failed to reproduce the bug.  Even configured a 3-hour delay between algathers
- [x] I manually set the HEARTBEAT_IVL to less than a second and put a bunch of random waits in the code and see if you can get some weird ordering between normal traffic and heartbeat traffic to cause a problem (I could not cause a problem, I tried pretty hard)
- [x] I read the zmq docs to confirm that the HEARTBEAT option is supposed to be transparent and this change shouldn't break anything.

(If you are in the release party, I recommend you mark this as "won't fix" since the fix has basically already been verified by the oss user who suggested, and it's unclear what conditions are required to reproduce it).