### PR TITLE
fix: HP ScatterPlots show unnecessary scrollbar

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentVisualization/HpScatterPlots.module.scss
@@ -2,7 +2,7 @@
   height: 100%;
 
   .container {
-    min-height: 200px;
+    min-height: 400px;
     position: relative;
   }
   .container > [class*='Message_base'] {


### PR DESCRIPTION
## Description

Currently the `HPScatterPlots` shows a vertical scrollbar when only one row of plots exist which is unnecessary. The height for the scatter plots is set to `350px` however the min height for the containers is set `200px` causing the vertical scroll bar to show. This is a simple fix to update the container height.

 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

1. Visit the HP Scatter plot tab for a completed multi-trial experiment with several Hyperparameters.
2. Select HPs so that only one row of plots show, change your screen size and ensure that a vertical scrollbar is only shown within the scatter plot grid container when there is more than one row of scatter plots. 

https://github.com/determined-ai/determined/assets/103522725/9461b9e7-63f8-41b7-b411-92701fa797ed

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
