### PR TITLE
fix: Trial APIs `--local` should respect `.detignore`. [MLG-1352]

### DIFF
--- a/harness/determined/common/detignore.py
+++ b/harness/determined/common/detignore.py
@@ -1,0 +1,99 @@
+import os
+import pathlib
+from typing import TYPE_CHECKING, Callable, Iterable, List, Set
+
+if TYPE_CHECKING:
+    import pathspec
+
+from determined.common import constants, v1file_utils
+from determined.common.api import bindings
+
+
+def _build_detignore_pathspec(root_path: pathlib.Path) -> "pathspec.PathSpec":
+    ignore = list(constants.DEFAULT_DETIGNORE)
+    ignore_path = root_path / ".detignore"
+    if ignore_path.is_file():
+        with ignore_path.open("r") as detignore_file:
+            ignore.extend(detignore_file)
+
+    # Lazy import to speed up load time.
+    # See https://github.com/determined-ai/determined/pull/6590 for details.
+    import pathspec
+
+    return pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, ignore)
+
+
+def make_shutil_ignore(root_path: pathlib.Path) -> Callable:
+    ignore_spec = _build_detignore_pathspec(root_path)
+
+    def _ignore(path: str, names: List[str]) -> Set[str]:
+        ignored_names = set()  # type: Set[str]
+        for name in names:
+            if name == ".detignore":
+                ignored_names.add(name)
+                continue
+
+            file_path = pathlib.Path(path) / name
+            file_rel_path = file_path.relative_to(root_path)
+
+            if (
+                file_path.is_dir() and ignore_spec.match_file(str(file_rel_path) + "/")
+            ) or ignore_spec.match_file(str(file_rel_path)):
+                ignored_names.add(name)
+
+        return ignored_names
+
+    return _ignore
+
+
+def os_walk_to_v1Files(
+    root_path: pathlib.Path, entry_prefix: pathlib.Path
+) -> Iterable[bindings.v1File]:
+    ignore_spec = _build_detignore_pathspec(root_path)
+
+    # We could use pathlib.Path.rglob for scanning the directory;
+    # however, the Python documentation claims a warning that rglob may be
+    # inefficient on large directory trees, so we use the older os.walk().
+    for parent, dirs, files in os.walk(str(root_path)):
+        keep_dirs = []
+        for directory in dirs:
+            dir_path = pathlib.Path(parent).joinpath(directory)
+            dir_rel_path = dir_path.relative_to(root_path)
+
+            # If the directory matches any path specified in .detignore, then ignore it.
+            if ignore_spec.match_file(str(dir_rel_path)):
+                continue
+            if ignore_spec.match_file(str(dir_rel_path) + "/"):
+                continue
+            keep_dirs.append(directory)
+            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+            # is executed in a non-POSIX environment.
+            entry_path = (entry_prefix / dir_rel_path).as_posix()
+
+            yield v1file_utils.v1File_from_local_dir(entry_path, dir_path)
+        # We can modify dirs in-place so that we do not recurse into ignored directories
+        #  See https://docs.python.org/3/library/os.html#os.walk
+        dirs[:] = keep_dirs
+
+        for file in files:
+            file_path = pathlib.Path(parent).joinpath(file)
+            file_rel_path = file_path.relative_to(root_path)
+
+            # If the file is the .detignore file or matches one of the
+            # paths specified in .detignore, then ignore it.
+            if file_rel_path.name == ".detignore":
+                continue
+            if ignore_spec.match_file(str(file_rel_path)):
+                continue
+
+            # Determined only supports POSIX-style file paths.  Use as_posix() in case this code
+            # is executed in a non-POSIX environment.
+            entry_path = (entry_prefix / file_rel_path).as_posix()
+
+            try:
+                entry = v1file_utils.v1File_from_local_file(entry_path, file_path)
+            except OSError:
+                print(f"Error reading '{entry_path}', skipping this file.")
+                continue
+
+            yield entry

--- a/harness/determined/common/detignore.py
+++ b/harness/determined/common/detignore.py
@@ -51,9 +51,6 @@ def os_walk_to_v1Files(
 ) -> Iterable[bindings.v1File]:
     ignore_spec = _build_detignore_pathspec(root_path)
 
-    # We could use pathlib.Path.rglob for scanning the directory;
-    # however, the Python documentation claims a warning that rglob may be
-    # inefficient on large directory trees, so we use the older os.walk().
     for parent, dirs, files in os.walk(str(root_path)):
         keep_dirs = []
         for directory in dirs:

--- a/harness/determined/common/v1file_utils.py
+++ b/harness/determined/common/v1file_utils.py
@@ -1,0 +1,58 @@
+import base64
+import pathlib
+import tarfile
+from typing import Any, Dict
+
+from determined.common.api import bindings
+
+
+def v1File_size(f: bindings.v1File) -> int:
+    if f.content:
+        # The content is already base64-encoded, and we want the real length.
+        return len(f.content) // 4 * 3
+    return 0
+
+
+def v1File_to_dict(f: bindings.v1File) -> Dict[str, Any]:
+    d = {
+        "path": f.path,
+        "type": f.type,
+        "uid": f.uid,
+        "gid": f.gid,
+        # Echo API expects int-type int64 value
+        "mtime": int(f.mtime),
+        "mode": f.mode,
+    }
+    if f.type in (ord(tarfile.REGTYPE), ord(tarfile.DIRTYPE)):
+        d["content"] = f.content
+    return d
+
+
+def v1File_from_local_file(archive_path: str, path: pathlib.Path) -> bindings.v1File:
+    with path.open("rb") as f:
+        content = base64.b64encode(f.read()).decode("utf8")
+    st = path.stat()
+    return bindings.v1File(
+        path=archive_path,
+        type=ord(tarfile.REGTYPE),
+        content=content,
+        # Protobuf expects string-encoded int64
+        mtime=str(int(st.st_mtime)),
+        mode=st.st_mode,
+        uid=0,
+        gid=0,
+    )
+
+
+def v1File_from_local_dir(archive_path: str, path: pathlib.Path) -> bindings.v1File:
+    st = path.stat()
+    return bindings.v1File(
+        path=archive_path,
+        type=ord(tarfile.DIRTYPE),
+        content="",
+        # Protobuf expects string-encoded int64
+        mtime=str(int(st.st_mtime)),
+        mode=st.st_mode,
+        uid=0,
+        gid=0,
+    )

--- a/harness/determined/util.py
+++ b/harness/determined/util.py
@@ -263,7 +263,7 @@ def write_user_code(path: pathlib.Path, on_cluster: bool) -> None:
     # When running locally, we filter out the files using detignore.
     if on_cluster:
         model_dir = constants.MANAGED_TRAINING_MODEL_COPY
-        ignore_func = shutil.ignore_patterns("__pycache__")
+        ignore_func = None
     else:
         model_dir = "."
         ignore_func = detignore.make_shutil_ignore(pathlib.Path(model_dir))

--- a/harness/tests/filetree.py
+++ b/harness/tests/filetree.py
@@ -1,8 +1,10 @@
+import contextlib
+import os
 import shutil
 import tempfile
 from pathlib import Path
 from types import TracebackType
-from typing import ContextManager, Dict, Optional, Type, Union
+from typing import ContextManager, Dict, Iterator, Optional, Type, Union
 
 
 class FileTree(ContextManager[Path]):
@@ -39,3 +41,13 @@ class FileTree(ContextManager[Path]):
         traceback: Optional[TracebackType],
     ) -> None:
         shutil.rmtree(str(self.dir), ignore_errors=True)
+
+
+@contextlib.contextmanager
+def chdir(path: Path) -> Iterator:
+    old = os.getcwd()
+    os.chdir(str(path))
+    try:
+        yield
+    finally:
+        os.chdir(old)

--- a/harness/tests/test_imports.py
+++ b/harness/tests/test_imports.py
@@ -10,6 +10,7 @@ from typing import Iterator
 import pytest
 
 import determined as det
+from tests import filetree
 
 
 def test_import_side_effects() -> None:
@@ -75,15 +76,6 @@ def test_import_from_path() -> None:
         finally:
             sys.path = old
 
-    @contextlib.contextmanager
-    def chdir(path: pathlib.Path) -> Iterator:
-        old = os.getcwd()
-        os.chdir(str(path))
-        try:
-            yield
-        finally:
-            os.chdir(old)
-
     fixture = pathlib.Path(__file__).parent / "fixtures" / "import_from_path"
     # Modify sys.path so that lib1.py and lib2.py are treated as if it were an installed library.
     # Installed libraries should not be affected by the caching behavior
@@ -92,7 +84,7 @@ def test_import_from_path() -> None:
         import lib1
 
         # Execute from the a/ directory like we were in a normal interactive interpreter.
-        with chdir(fixture / "a"), prepend_sys_path(""):
+        with filetree.chdir(fixture / "a"), prepend_sys_path(""):
             import model_def as a  # noqa: I2001
 
             with det.import_from_path(fixture / "b"):


### PR DESCRIPTION
## Description

When trial APIs in `--local` mode are making checkpoints, they should respect `.detignore` similar to the usual context directory creation.

## Test Plan

- Added a unit test.
- Per original OSS complaint, make a directory with some root-only files which are ignored by detignore, and then try a `--local` run.

For example, 
- `det e create ... --local -test`— initial state, works ok
- `touch root.txt`
- `sudo chown root root.txt`
- `sudo chmod 400 root.txt`
- `det e create ... --local -test` — will fail because of a permission error
- `echo root.txt >> .detignore`
- `det e create ... --local -test` — now works ok

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
