### PR TITLE
chore: standardize oidc/saml group & display attribute names in helm config

### DIFF
--- a/docs/manage/users-remote.rst
+++ b/docs/manage/users-remote.rst
@@ -50,7 +50,7 @@ enable user auto-provisioning and the remote management of any information attac
              client_id: "xx0xx0"
              client_secret: "xx0xx0"
              auto_provision_users: true
-             display_name_claim_name: "XYZ"
+             display_name_attribute_name: "XYZ"
 
    .. tab::
 
@@ -93,7 +93,7 @@ To enable group membership synchronization:
 
       OIDC
 
-      -  Set the ``groups_claim_name`` option to match the claim name for group memberships from
+      -  Set the ``groups_attribute_name`` option to match the claim name for group memberships from
          your authenticator (i.e., either a custom user attribute such as ``groups_memberships`` or
          ``usergroup_memberships``, or the authenticator's groups claim, passed in as ``groups``,
          etc.).

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1613,8 +1613,8 @@ used for :ref:`remote user <remote-users>` management.
           authentication_claim: "string"
           scim_authentication_attribute: "string"
           auto_provision_users: true
-          groups_claim_name: "XYZ"
-          display_name_claim_name: "XYZ"
+          groups_attribute_name: "XYZ"
+          display_name_attribute_name: "XYZ"
 
 ``enabled``
 ===========
@@ -1673,15 +1673,15 @@ Determines if users should be automatically created in Determined upon successfu
    -  ``true``: Automatic user provisioning is enabled.
    -  ``false``: Automatic user provisioning is disabled.
 
-``groups_claim_name``
+``groups_attribute_name``
 =====================
 
-The claim name that specifies group memberships in OIDC.
+The name of the attribute passed in through the claim that specifies group memberships in OIDC.
 
-``display_name_claim_name``
+``display_name_attribute_name``
 ===========================
 
-The claim name from the OIDC provider used to set the user's display name in Determined.
+The name of the attribute passed in through the claim from the OIDC provider used to set the user's display name in Determined.
 
 **********
  ``saml``

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1674,14 +1674,15 @@ Determines if users should be automatically created in Determined upon successfu
    -  ``false``: Automatic user provisioning is disabled.
 
 ``groups_attribute_name``
-=====================
+=========================
 
 The name of the attribute passed in through the claim that specifies group memberships in OIDC.
 
 ``display_name_attribute_name``
-===========================
+===============================
 
-The name of the attribute passed in through the claim from the OIDC provider used to set the user's display name in Determined.
+The name of the attribute passed in through the claim from the OIDC provider used to set the user's
+display name in Determined.
 
 **********
  ``saml``

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -97,10 +97,10 @@ stringData:
       {{- if .Values.oidc.autoProvisionUsers }}
       auto_provision_users: {{ .Values.oidc.autoProvisionUsers }}
       {{- end }}
-      {{- if .Values.oidc.groupsClaimName }}
+      {{- if .Values.oidc.groupsAttributeName }}
       groups_attribute_name: {{ .Values.oidc.groupsAttributeName }}
       {{- end }}
-      {{- if .Values.oidc.displayNameClaimName }}
+      {{- if .Values.oidc.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.oidc.displayNameAttributeName }}
       {{- end }}
     {{- end }}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -98,10 +98,10 @@ stringData:
       auto_provision_users: {{ .Values.oidc.autoProvisionUsers }}
       {{- end }}
       {{- if .Values.oidc.groupsClaimName }}
-      groups_claim_name: {{ .Values.oidc.groupsClaimName }}
+      groups_attribute_name: {{ .Values.oidc.groupsAttributeName }}
       {{- end }}
       {{- if .Values.oidc.displayNameClaimName }}
-      display_name_claim_name: {{ .Values.oidc.displayNameClaimName }}
+      display_name_attribute_name: {{ .Values.oidc.displayNameAttributeName }}
       {{- end }}
     {{- end }}
 

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -115,8 +115,8 @@ useNodePortForMaster: false
 #   authenticationClaim:
 #   scimAuthenticationAttribute:
 #   autoProvisionUsers:
-#   groupsClaimName:
-#   displayNameClaimName:
+#   groupsAttributeName:
+#   displayNameAttributeName:
 
 # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
 # only available if enterpriseEdition is true. It allows administrators to easily and securely


### PR DESCRIPTION
## Description
change groupsClaimName -> groupsAttributeName, and displayNameCLaimName -> displayNameAttributeName in OIDC. This standardizes the fields with OIDC


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
This will break EE -- so there needs to be an extra PR to be landed shortly after this is merged (& ee is rebased) that changes the relevant variable names in the OIDC ID Token Claims struct.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
