### PR TITLE
test: make compute_stats have a min tolerance of 3 seconds

### DIFF
--- a/e2e_tests/tests/nightly/compute_stats.py
+++ b/e2e_tests/tests/nightly/compute_stats.py
@@ -129,6 +129,8 @@ def compare_stats() -> None:
     print(f"Agent time: logs={gpu_from_log}, api={gpu_from_api}")
     # make sure agent stats get from script is less than 5% difference with those get from api
     max_diff = max(gpu_from_api, gpu_from_log) * 0.05
+    # For shorter tests, a tolerance that is percentage based can make unreasonably tight timing.
+    max_diff = max(max_diff, 3)
     # slurm and pbs needs looser tolerances
     if api_utils.is_hpc():
         max_diff = max(max_diff, 10)


### PR DESCRIPTION
## Description

Make compute_stats have a min tolerance of 3 seconds so shorter tests won't flake using it.


## Test Plan

See if ee tests flake less.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
