### PR TITLE
fix: docs version switcher [MLG-1524]

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,7 +15,8 @@ sphinx-book-theme==1.0.0
 # forked version of pydata-sphinx-theme
 # - pinned to 0.13.1
 # - Includes some aria labelling changes to satisfy compliance
-pydata-sphinx-theme @ git+https://github.com/determined-ai/pydata-sphinx-theme@chore/WEB-1292/hpe-accessibility-patches
+# - Includes a backported version-switcher fix from 0.14.0
+pydata-sphinx-theme @ git+https://github.com/determined-ai/pydata-sphinx-theme@9993e98e8a3a54ae4ad81903e9f93c68261b5226
 
 # live.py
 watchdog


### PR DESCRIPTION
A bug in the pydata-sphinx-theme caused the version switcher to not properly avoid 404 errors when switching between versions, if the current doc url did not exist in the target version.

pydata-sphinx-theme has a fix in 0.14.0, but we cannot upgrade due to sphinx-book-theme.  So I backported the relevant fix.  This commit pulls the backported fix into the determined docs build system.

## Test Plan

I copied the modified javascript to https://docs.determined.ai/latest so you can make sure this works (there's not really another way to test it).

- [x] navigate to https://docs.determined.ai/latest/manage/upgrade.html
- [x] go to version 0.26.7, verify that you are on the 0.26.7 "upgrade" page.
- [x] click back, then navigate to 0.25.0.  You should be at the docs homepage for 0.25.0, which didn't have the `/manage` subtree (instead of seeing the pre-fix 404).