### PR TITLE
docs: fix a few hyperlinks in the Python SDK reference.

### DIFF
--- a/docs/reference/python-sdk.rst
+++ b/docs/reference/python-sdk.rst
@@ -78,7 +78,8 @@ with an object-oriented interface.
 ==========
 
 .. automodule:: determined.experimental.client
-   :members: login, create_experiment, get_experiment, get_trial, get_checkpoint, create_model, get_model, get_models, iter_trials_metrics
+   :members:
+   :exclude-members: stream_trials_metrics, stream_trials_training_metrics, stream_trials_validation_metrics
    :member-order: bysource
 
 ``OrderBy``
@@ -147,6 +148,13 @@ with an object-oriented interface.
    :members:
    :member-order: bysource
 
+``ResourcePool``
+================
+
+.. autoclass:: determined.experimental.client.ResourcePool
+   :members:
+   :member-order: bysource
+
 ``Trial``
 =========
 
@@ -159,6 +167,13 @@ with an object-oriented interface.
 ================
 
 .. autoclass:: determined.experimental.client.TrialMetrics
+
+``User``
+========
+
+.. autoclass:: determined.experimental.client.User
+   :members:
+   :member-order: bysource
 
 ``Workspace``
 =============

--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -120,10 +120,10 @@ class Checkpoint:
     A class representing a Checkpoint instance of a trained model.
 
     A Checkpoint object is usually obtained from
-    ``determined.experimental.client.get_checkpoint()``. This class provides helper functionality
+    :func:`determined.experimental.client.get_checkpoint`. This class provides helper functionality
     for downloading checkpoints to local storage and loading checkpoints into memory.
 
-    The :class:`~determined.experimental.Trial` class contains methods
+    The :class:`~determined.experimental.client.Trial` class contains methods
     that return instances of this class.
 
     Attributes:
@@ -143,7 +143,7 @@ class Checkpoint:
             All attributes are cached by default.
 
             Some attributes are mutable and may be changed by methods that update these values,
-            either automatically (eg. `add_metadata()`) or explicitly with `reload()`.
+            either automatically (eg. :meth:`add_metadata()`) or explicitly with :meth:`reload()`.
     """
 
     def __init__(
@@ -196,7 +196,6 @@ class Checkpoint:
 
           - :func:`determined.pytorch.load_trial_from_checkpoint_path`
           - :func:`determined.keras.load_model_from_checkpoint_path`
-          - :func:`determined.estimator.load_estimator_from_checkpoint_path`
 
         Arguments:
             path (string, optional): Top level directory to place the

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -86,9 +86,9 @@ class Experiment:
     """A class representing an Experiment object.
 
     An Experiment object is usually obtained from
-    ``determined.experimental.client.create_experiment()``
-    or ``determined.experimental.client.get_experiment()`` and contains helper methods that support
-    querying the set of checkpoints associated with an experiment.
+    :func:`determined.experimental.client.create_experiment`
+    or :func:`determined.experimental.client.get_experiment` and contains helper methods
+    that support querying the set of checkpoints associated with an experiment.
 
     Attributes:
         id: ID of experiment object in database.
@@ -109,7 +109,7 @@ class Experiment:
         All attributes are cached by default.
 
         Some attributes are mutable and may be changed by methods that update these values,
-        either automatically (eg. `wait()`) or explicitly with `reload()`.
+        either automatically (eg. :meth:`wait()`) or explicitly with :meth:`reload()`.
     """
 
     def __init__(

--- a/harness/determined/common/experimental/model.py
+++ b/harness/determined/common/experimental/model.py
@@ -16,9 +16,10 @@ from determined.common.experimental._util import OrderBy  # noqa: I2041
 class ModelVersion:
     """A class representing a combination of Model and Checkpoint.
 
-    This class can be fetched using the ``model.get_version()`` method. Once a model has been
-    added to the registry, checkpoints can be added to it. These registered checkpoints are
-    ModelVersions.
+    This class can be fetched using the
+    :meth:`model.get_version() <determined.experimental.client.Model.get_version>` method.
+    Once a model has been added to the registry, checkpoints can be added to it.
+    These registered checkpoints are ModelVersions.
 
     Attributes:
         session: HTTP request session.
@@ -35,7 +36,7 @@ class ModelVersion:
         All attributes are cached by default.
 
         Mutable properties may be changed by methods that update these values either automatically
-        (eg. `set_name`, `set_notes`) or explicitly with `reload()`.
+        (eg. :meth:`set_name`, :meth:`set_notes`) or explicitly with :meth:`reload`.
     """
 
     def __init__(
@@ -203,8 +204,8 @@ class Model:
     """
     Class representing a model in the model registry.
 
-    A Model object is usually obtained from ``determined.experimental.client.create_model()``
-    or ``determined.experimental.client.get_model()``. It contains methods for model
+    A Model object is usually obtained from :func:`determined.experimental.client.create_model`
+    or :func:`determined.experimental.client.get_model`. It contains methods for model
     versions and metadata.
     """
 

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -45,7 +45,7 @@ class Trial:
     """
     A class representing a Trial object.
 
-    A Trial object is usually obtained from ``determined.experimental.client.get_trial()``.
+    A Trial object is usually obtained from :func:`determined.experimental.client.get_trial`.
     Trial reference class used for querying relevant :class:`~determined.experimental.Checkpoint`
     instances.
 
@@ -59,6 +59,7 @@ class Trial:
         summary_metrics: (Mutable, Optional[Dict]) Summary metrics for the trial. Includes
             aggregated metrics for training and validation steps for each reported metric name.
             Example:
+
             .. code::
 
                 {
@@ -76,8 +77,8 @@ class Trial:
     Note:
         All attributes are cached by default.
 
-        The `hparams` and `summary` attributes are mutable and may be changed by methods that
-        update these values, either automatically or explicitly with `reload()`.
+        The :attr:`hparams` and :attr:`summary_metrics` attributes are mutable and may be changed
+        by methods that update these values, either automatically or explicitly with :meth:`reload`.
 
     """
 

--- a/harness/determined/common/experimental/user.py
+++ b/harness/determined/common/experimental/user.py
@@ -8,7 +8,8 @@ class User:
     """
     A User object represents an individual account on a Determined installation.
 
-    It can be obtained from ``client.list_users`` or ``client.get_user_by_name()``.
+    It can be obtained from :func:`determined.experimental.client.list_users`
+    or :func:`determined.experimental.client.get_user_by_name`.
 
     Attributes:
         session: HTTP request session.
@@ -27,7 +28,7 @@ class User:
         All attributes are cached by default.
 
         Mutable properties may be changed by methods that update these values either automatically
-        (eg. `rename`, `change_display_name`) or explicitly with `reload()`.
+        (eg. `rename`, `change_display_name`) or explicitly with :meth:`reload()`.
     """
 
     def __init__(self, user_id: int, session: api.Session):

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -303,7 +303,7 @@ def list_users(active: Optional[bool] = None) -> List[User]:
             When false, filter for inactive users. Return all users otherwise.
 
     Returns:
-        :class:`~determined.common.experimental.user.User`.
+        A list of :class:`~determined.experimental.client.User` objects.
     """
     assert _determined is not None
     return _determined.list_users(active=active)

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -70,6 +70,7 @@ from determined.common.experimental.metrics import TrainingMetrics, TrialMetrics
 from determined.common.experimental.model import Model, ModelOrderBy, ModelSortBy  # noqa: F401
 from determined.common.experimental.oauth2_scim_client import Oauth2ScimClient
 from determined.common.experimental.project import Project  # noqa: F401
+from determined.common.experimental.resource_pool import ResourcePool  # noqa: F401
 from determined.common.experimental.trial import (  # noqa: F401
     Trial,
     TrialOrderBy,
@@ -295,7 +296,15 @@ def logout() -> None:
 
 @_require_singleton
 def list_users(active: Optional[bool] = None) -> List[User]:
-    """Get a list of all Users."""
+    """Get a list of all Users.
+
+    Arg:
+        active: if this parameter is set to True, filter for active users only.
+            When false, filter for inactive users. Return all users otherwise.
+
+    Returns:
+        :class:`~determined.common.experimental.user.User`.
+    """
     assert _determined is not None
     return _determined.list_users(active=active)
 


### PR DESCRIPTION
## Description

I’ve been asked why did the docstring for the `Experiment` class https://docs.determined.ai/latest/reference/python-sdk.html#determined.experimental.client.Experiment
has `determined.experimental.client.get_experiment()` in it, but it’s not a hyperlink.

I went in and added `:func:`, `:attr:`, and `:meth:` annotations for it and a few classes nearby.
Also added docs autogen for a bunch of missing methods in `determined.experimental.client`, and missing `User` and `ResourcePool` class references.

## Test Plan

Are things which look like methods and functions in the docs actually getting rendered as hyperlinks?

## Commentary (optional)

If you find more broken or nonexisting links which are not in this PR, please make your own PR to fix them.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
