### PR TITLE
chore: Replace custom archived note with Hew badge [WEB-1886]

### DIFF
--- a/webui/react/src/components/ProjectCard.module.scss
+++ b/webui/react/src/components/ProjectCard.module.scss
@@ -18,13 +18,6 @@
       gap: 4px;
     }
   }
-  .archivedBadge {
-    background-color: var(--theme-status-inactive);
-    border-radius: var(--theme-border-radius);
-    color: var(--theme-status-warning-on);
-    opacity: 1;
-    padding: 2px 4px;
-  }
 }
 .archived .name,
 .archived .experiments {

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -1,4 +1,5 @@
 import Avatar, { Size } from 'hew/Avatar';
+import Badge from 'hew/Badge';
 import Card from 'hew/Card';
 import Column from 'hew/Column';
 import Icon from 'hew/Icon';
@@ -79,7 +80,7 @@ const ProjectCard: React.FC<Props> = ({
                 </Tooltip>
               </div>
               {project.archived ? (
-                <div className={css.archivedBadge}>Archived</div>
+                <Badge backgroundColor={{ h: 0, l: 40, s: 0 }} text="Archived" />
               ) : (
                 project.lastExperimentStartedAt && (
                   <TimeAgo

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.module.scss
@@ -1,12 +1,6 @@
 .archived {
   opacity: 0.55;
 }
-.archivedBadge {
-  background-color: var(--theme-status-inactive);
-  border-radius: var(--theme-border-radius);
-  color: var(--theme-status-warning-on);
-  padding: 2px 4px;
-}
 .info {
   flex-direction: column;
   justify-content: space-between;

--- a/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
+++ b/webui/react/src/pages/WorkspaceList/WorkspaceCard.tsx
@@ -1,4 +1,5 @@
 import Avatar, { Size } from 'hew/Avatar';
+import Badge from 'hew/Badge';
 import Card from 'hew/Card';
 import Column from 'hew/Column';
 import Icon from 'hew/Icon';
@@ -60,7 +61,9 @@ const WorkspaceCard: React.FC<Props> = ({ workspace, fetchWorkspaces }: Props) =
                 <Spinner conditionalRender spinning={Loadable.isNotLoaded(loadableUser)}>
                   {Loadable.isLoaded(loadableUser) && <UserAvatar user={user} />}
                 </Spinner>
-                {workspace.archived && <div className={css.archivedBadge}>Archived</div>}
+                {workspace.archived && (
+                  <Badge backgroundColor={{ h: 0, l: 40, s: 0 }} text="Archived" />
+                )}
               </Row>
             </Column>
           </div>


### PR DESCRIPTION
## Description

Uses a standard Hew.Badge to mark archived workspaces and projects. The CSS variable `--theme-status-inactive` must be replaced with an HSL color; both light and dark themes use the same color.

<img width="184" alt="Screen Shot 2024-01-16 at 1 30 52 PM" src="https://github.com/determined-ai/determined/assets/643918/76d08bf8-40e6-4780-b72a-399f5af97d4e">

<img width="388" alt="Screen Shot 2024-01-16 at 1 29 31 PM" src="https://github.com/determined-ai/determined/assets/643918/dd88ba00-dc7c-4621-a66d-3f892d423f1c">


## Test Plan

- On `/det/workspaces`, turn on Show Archived, and find or test appearance of an archived workspace
- On a workspace with multiple projects, turn on Show Archived, and find or test appearance of an archived workspace

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.