### PR TITLE
chore: codecov reports to match go coverage reports

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1675,7 +1675,7 @@ jobs:
       - run: make -C master test-intg
       - codecov/upload:
           flags: "backend"
-          xtra_args: "-v"
+          xtra_args: "-v -X fixes"
       - store_test_results:
           path: master/test-intg.junit.xml
       - persist_to_workspace:
@@ -1701,7 +1701,7 @@ jobs:
       - run: make -C agent test-intg
       - codecov/upload:
           flags: "backend"
-          xtra_args: "-v"
+          xtra_args: "-v -X fixes"
       - store_test_results:
           path: agent/test-intg.junit.xml
       - persist_to_workspace:

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,7 @@ coverage:
         flags: 
           - backend
         informational: false
+        only_pulls: true
 
 flags:
   backend:
@@ -35,3 +36,7 @@ github_checks:
 comment: 
   layout: "diff, flags, files"
   behavior: default
+
+parsers:
+  go:
+    partials_as_hits: true


### PR DESCRIPTION
## Description

Currently, Codecov coverage reports do not precisely match the coverage reports generated by Go Codecov coverage tends to be lower than Go coverage output due to Codecov's defaults to ignore LOC that are not directly within the body of a function as well as marking certain LOC as partially covered or uncovered for branches that evaluate to `false`.

This PR overwrites those defaults to bring Codecov reports inline with Go coverage reports by 
- Counting all LOC in a file (as the Go cover tool does) when calculating coverage metrics and generating reports.
- Changing lines marked by Codecov as `partial` to `hit` (so that Codecov coverage percentages are calculated to mark the code in such lines as "covered")

This PR also lowers the per-PR coverage target by 5% for Go code in the event that backend coverage status checks are required to pass before merging into main (to avoid too many blockers for PRs opened before this one). 

## Test Plan

**NOTE**: The test plan can be used on this commit.

- Go to CircleCI runs and select the `test-go` status check.
- Select `go-coverage` (CI run needs to be a success for all jobs in this workflow)
- In the CircleCI dashboard for the `go-coverage` job, select "Artifacts" -> "go-coverage/master-coverage.html"
- Select a random file from the drop-down (preferable a file with > 50 LOC and coverage > 40%. `master/internal/api_experiments.go`, for example, is a good file to choose). 
  - Then, note the parenthesized coverage percentage next to the file path.
- Now, return back to the Github UI where the CI builds are running and click on "Details" to the right of the `codecov/patch/backend` status check to go to the Codecov UI.
  - In the UI, under the given commit for which you checked the `go-coverage` artifacts, navigate to the "File explorer" tab and then navigate into the same file that you observed metrics for above.
  - Verify that Codecov coverage percentage (at the top right of the file) shows a percentage that is either 
  -  +/- 1% of the value you saw earlier (from the Go coverage artifact)
  - 1% higher than the Go coverage percentage.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
