### PR TITLE
fix: restore original user store poll on leaving workspace details

### DIFF
--- a/webui/react/src/pages/WorkspaceDetails.tsx
+++ b/webui/react/src/pages/WorkspaceDetails.tsx
@@ -75,7 +75,12 @@ const WorkspaceDetails: React.FC = () => {
   const loadableWorkspace = useObservable(workspaceStore.getWorkspace(id));
   const workspace = Loadable.getOrElse(undefined, loadableWorkspace);
 
-  useEffect(() => userStore.startPolling(), []);
+  useEffect(() => {
+    userStore.startPolling();
+    return () => {
+      userStore.startPolling({ delay: 60_000 });
+    };
+  }, []);
 
   const fetchGroups = useCallback(async (): Promise<void> => {
     try {


### PR DESCRIPTION


## Description

this fixes an issue where the user store would cease polling when leaving the workspace details page. we start polling the user store at 10s (up from 60s) when getting to the workspace details page. by default, the `startPolling` function returns a cleanup function that stops polling altogether on unmount, so the user store would stop polling when the user leaves the workspace details page. this fixes that by instead polling at the original amount on unmount.



## Test Plan

- as an admin, open two windows.
- in one window, visit a workspace with projects available, in the other, visit the users page
- in the users window, edit one of the project owners of the workspace and wait about 10 seconds
- you should see the changes reflected in the workspace window
- in the workspace window, navigate to the experiment list and filter the results by a user. ensure that there are experiments in the view
- in the users window, edit the display name of the user you filtered in the workspace window and wait about one minute
- you should see the name change reflected in the workspace window



## Commentary (optional)
opted against an "increase/descrease polling" function because this is the only place in the codebase where we do this. we can revisit if this becomes more of a thing later.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

[WEB-1807]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1807]: https://hpe-aiatscale.atlassian.net/browse/WEB-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ