### PR TITLE
fix: exclude queued from active experiments on cluster page

### DIFF
--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -17,7 +17,10 @@ import { getSlotContainerStates } from 'utils/cluster';
 import { useObservable } from 'utils/observable';
 
 const ACTIVE_EXPERIMENTS_PARAMS: Readonly<GetExperimentsParams> = {
-  limit: -2, // according to API swagger doc, [limit] -2 - returns pagination info but no experiments.
+  /**
+   * We don't use `limit: -2` since `total` counts `QUEUED` states as active.
+   * Instead we get the full active list and filter out queued experiments.
+   */
   states: activeRunStates,
 };
 

--- a/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
+++ b/webui/react/src/pages/Cluster/ClusterOverallStats.tsx
@@ -12,7 +12,7 @@ import clusterStore, { maxClusterSlotCapacity } from 'stores/cluster';
 import determinedStore from 'stores/determinedInfo';
 import experimentStore from 'stores/experiments';
 import taskStore from 'stores/tasks';
-import { ResourceType } from 'types';
+import { ResourceType, RunState } from 'types';
 import { getSlotContainerStates } from 'utils/cluster';
 import { useObservable } from 'utils/observable';
 
@@ -87,12 +87,14 @@ export const ClusterOverallStats: React.FC = () => {
           <>
             {Loadable.match(activeExperiments, {
               _: () => null,
-              Loaded: (activeExperiments) =>
-                (activeExperiments.pagination?.total ?? 0) > 0 && (
-                  <OverviewStats title="Active Experiments">
-                    {activeExperiments.pagination?.total}
-                  </OverviewStats>
-                ),
+              Loaded: (activeExperiments) => {
+                const count = activeExperiments.experiments.filter(
+                  (e) => e.state !== RunState.Queued,
+                ).length;
+                return (
+                  count > 0 && <OverviewStats title="Active Experiments">{count}</OverviewStats>
+                );
+              },
             })}
             {Loadable.match(activeTasks, {
               _: () => null,


### PR DESCRIPTION
## Description

ISSUE:

The active experiments counts `QUEUED` experiments as active when considering the `total` property, which does not make sense on the cluster page.

<img width="1314" alt="Screenshot 2024-01-17 at 1 19 48 PM" src="https://github.com/determined-ai/determined/assets/220971/8280181c-03b2-4fce-ae2d-f0743664ac20">

SOLUTION:

Get the full active experiment list and filtering out `QUEUED` experiments when tallying up for `Active Experiments`.

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- create an experiment (preferably on a gke cluster that's not warmed yet to cause the experiment to be QUEUED for a while)
- navigate to cluster page
- verify that the active experiments does not show the QUEUED experiment as part of the count

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
