### PR TITLE
fix: Update hew for chart fix, avoid error from Typography.Label

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#scinote",
+        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.26",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -6587,8 +6587,8 @@
       }
     },
     "node_modules/hew": {
-      "version": "0.6.25",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#108865842003f713bf2c1b4bd522121735a641b4",
+      "version": "0.6.26",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#8a0ae7d601b310b0e41510c3e9abccd9b0694b20",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.23",
+        "hew": "git+https://git@github.com/determined-ai/hew.git#scinote",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -6587,8 +6587,8 @@
       }
     },
     "node_modules/hew": {
-      "version": "0.6.23",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#f2041d20ae248cf532365ca40b3ff3b39fb12f21",
+      "version": "0.6.25",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#108865842003f713bf2c1b4bd522121735a641b4",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#scinote",
+    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.26",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.23",
+    "hew": "git+https://git@github.com/determined-ai/hew.git#scinote",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",

--- a/webui/react/src/components/HyperparameterSearchModal.tsx
+++ b/webui/react/src/components/HyperparameterSearchModal.tsx
@@ -668,7 +668,7 @@ const HyperparameterRow: React.FC<RowProps> = ({ hyperparameter, name, searcher 
   return (
     <>
       <div className={css.hyperparameterName}>
-        <Label size={TypographySize.L} truncate={{ rows: 1, tooltip: true }}>
+        <Label size={TypographySize.L} truncate={{ tooltip: true }}>
           {name}
         </Label>
       </div>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -21,7 +21,7 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
         </Label>
       </Row>
       <Row width="fill">
-        <Label strong truncate={{ rows: 1, tooltip: true }}>
+        <Label strong truncate={{ tooltip: true }}>
           {props.children}
         </Label>
       </Row>

--- a/webui/react/src/components/OverviewStats.tsx
+++ b/webui/react/src/components/OverviewStats.tsx
@@ -16,7 +16,7 @@ const OverviewStats: React.FC<Props> = (props: Props) => {
   const column = (
     <Column>
       <Row>
-        <Label size={TypographySize.XS} truncate={{ rows: 1, tooltip: true }}>
+        <Label size={TypographySize.XS} truncate={{ tooltip: true }}>
           {props.title}
         </Label>
       </Row>


### PR DESCRIPTION
## Description

Uses an updated hew to fix a reported issue with the chart: https://github.com/determined-ai/hew/pull/99

Also fixes an issue where a Label with `rows: 1` is putting an error in the JS Console

## Test Plan

Builds successfully, Typography change is valid

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.