### PR TITLE
fix: use Hew dropdown on FilterGroup [WEB-1938]

### DIFF
--- a/webui/react/src/components/FilterForm/TableFilter.tsx
+++ b/webui/react/src/components/FilterForm/TableFilter.tsx
@@ -60,7 +60,8 @@ const TableFilter = ({
               if (e.key === 'Escape') {
                 onHidePopOver();
               }
-            }}>
+            }}
+            onMouseMove={(e) => e.stopPropagation()}>
             <FilterForm columns={columns} formStore={formStore} onHidePopOver={onHidePopOver} />
           </div>
         }

--- a/webui/react/src/components/FilterForm/components/FilterGroup.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterGroup.tsx
@@ -1,7 +1,7 @@
 import Button from 'hew/Button';
 import Dropdown, { MenuItem } from 'hew/Dropdown';
 import Icon from 'hew/Icon';
-import { useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
 import ConjunctionContainer from 'components/FilterForm/components/ConjunctionContainer';
@@ -90,8 +90,8 @@ const FilterGroup = ({
     },
   });
 
-  const onItemClick = useMemo(
-    () => (key: string) => {
+  const onItemClick = useCallback(
+    (key: string) => {
       if (key === FormKind.Field || key === FormKind.Group) {
         formStore.addChild(group.id, key);
         setTimeout(() => {

--- a/webui/react/src/components/FilterForm/components/FilterGroup.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterGroup.tsx
@@ -1,5 +1,5 @@
-import { Dropdown, DropDownProps, type MenuProps } from 'antd';
 import Button from 'hew/Button';
+import Dropdown, { MenuItem } from 'hew/Dropdown';
 import Icon from 'hew/Icon';
 import { useMemo, useRef } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
@@ -90,26 +90,29 @@ const FilterGroup = ({
     },
   });
 
-  const menuItems: DropDownProps['menu'] = useMemo(() => {
-    const onItemClick: MenuProps['onClick'] = (e) => {
-      if (e.key === FormKind.Field || e.key === FormKind.Group) {
-        formStore.addChild(group.id, e.key);
+  const onItemClick = useMemo(
+    () => (key: string) => {
+      if (key === FormKind.Field || key === FormKind.Group) {
+        formStore.addChild(group.id, key);
         setTimeout(() => {
           scrollBottomRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
         }, 100);
       }
-    };
+    },
+    [formStore, group.id],
+  );
 
-    const items: MenuProps['items'] = [
+  const menuItems: MenuItem[] = useMemo(
+    () => [
       { key: FormKind.Field, label: <div>Add condition</div> },
       {
         disabled: level > 1,
         key: FormKind.Group,
         label: <div>Add condition group</div>,
       },
-    ];
-    return { items: items, onClick: onItemClick };
-  }, [formStore, group.id, level]);
+    ],
+    [level],
+  );
 
   if (level === 0 && group.children.length === 0) {
     // return empty div if there's nothing to show
@@ -141,7 +144,7 @@ const FilterGroup = ({
               <Dropdown
                 disabled={group.children.length > ITEM_LIMIT}
                 menu={menuItems}
-                trigger={['click']}>
+                onClick={onItemClick}>
                 <Button icon={<Icon name="add" size="tiny" title="Add field" />} type="text" />
               </Dropdown>
               <Button


### PR DESCRIPTION
## Description

This fixes the dropdown in WEB-1938.

<img width="761" alt="Screen Shot 2024-01-18 at 11 51 31 AM" src="https://github.com/determined-ai/determined/assets/643918/9c49d3e4-a1d8-49b1-ab5e-83bfb6cd8cde">


I saw an unrelated bug in FilterForm, where tooltips from the table below appear over the form elements. We can (mostly) avoid this with `e.stopPropagation` in `onMouseMove`.


<img width="378" alt="Screen Shot 2024-01-18 at 11 31 06 AM" src="https://github.com/determined-ai/determined/assets/643918/fbacf866-b16c-4e89-bb3f-548d3919685d">


## Test Plan

In the experiment filters, click "Add condition group", then in that row, click the "+" to see these two options. Confirm you can add conditions to filter experiments.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.