### PR TITLE
fix: Update get_task sql query to match TaskState proto + add test

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -13147,11 +13147,13 @@ class v1Task(Printable):
         taskType: "v1TaskType",
         config: "typing.Union[str, None, Unset]" = _unset,
         endTime: "typing.Union[str, None, Unset]" = _unset,
+        taskState: "v1GenericTaskState",
     ):
         self.allocations = allocations
         self.startTime = startTime
         self.taskId = taskId
         self.taskType = taskType
+        self.taskState = taskState
         if not isinstance(config, Unset):
             self.config = config
         if not isinstance(endTime, Unset):
@@ -13164,6 +13166,7 @@ class v1Task(Printable):
             "startTime": obj["startTime"],
             "taskId": obj["taskId"],
             "taskType": v1TaskType(obj["taskType"]),
+            "taskState": v1GenericTaskState(obj["taskState"])
         }
         if "config" in obj:
             kwargs["config"] = obj["config"]
@@ -13177,6 +13180,7 @@ class v1Task(Printable):
             "startTime": self.startTime,
             "taskId": self.taskId,
             "taskType": self.taskType.value,
+            "taskState": self.taskState.value,
         }
         if not omit_unset or "config" in vars(self):
             out["config"] = self.config
@@ -13459,6 +13463,20 @@ class v1TaskType(DetEnum):
     TENSORBOARD = "TASK_TYPE_TENSORBOARD"
     CHECKPOINT_GC = "TASK_TYPE_CHECKPOINT_GC"
     GENERIC = "TASK_TYPE_GENERIC"
+
+class v1GenericTaskState(DetEnum):
+    """
+    """
+    UNSPECIFIED = "GENERIC_TASK_STATE_UNSPECIFIED"
+    ACTIVE = "GENERIC_TASK_STATE_ACTIVE"
+    CANCELED = "GENERIC_TASK_STATE_CANCELED"
+    COMPLETED = "GENERIC_TASK_STATE_COMPLETED"
+    ERROR = "GENERIC_TASK_STATE_ERROR"
+    PAUSED = "GENERIC_TASK_STATE_PAUSED"
+    STOPPING_PAUSED = "GENERIC_TASK_STATE_STOPPING_PAUSED"
+    STOPPING_CANCELED = "GENERIC_TASK_STATE_STOPPING_CANCELED"
+    STOPPING_COMPLETED = "GENERIC_TASK_STATE_STOPPING_COMPLETED"
+    STOPPING_ERROR = "GENERIC_TASK_STATE_STOPPING_ERROR"
 
 class v1Template(Printable):
     """Templates move settings that are shared by many experiments into a single

--- a/master/internal/api_task_intg_test.go
+++ b/master/internal/api_task_intg_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
 
 func TestGetGenericTaskConfig(t *testing.T) {
@@ -27,4 +28,21 @@ func TestGetGenericTaskConfig(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, expectedConfig, resp.Config)
+}
+
+func TestGetTask(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+
+	taskID := model.NewTaskID()
+	state := model.TaskStateCompleted
+
+	task := &model.Task{TaskType: model.TaskTypeGeneric, TaskID: taskID, State: &state}
+	require.NoError(t, api.m.db.AddTask(task))
+
+	resp, err := api.GetTask(ctx, &apiv1.GetTaskRequest{TaskId: taskID.String()})
+
+	require.NoError(t, err)
+	require.Equal(t, taskv1.GenericTaskState_GENERIC_TASK_STATE_COMPLETED, *resp.Task.TaskState)
+	require.Equal(t, taskID.String(), resp.Task.TaskId)
+	require.Equal(t, taskv1.TaskType_TASK_TYPE_GENERIC, resp.Task.TaskType)
 }

--- a/master/static/srv/get_task.sql
+++ b/master/static/srv/get_task.sql
@@ -3,7 +3,7 @@ SELECT
     CONCAT('TASK_TYPE_', t.task_type) AS task_type,
     t.start_time,
     t.end_time,
-    t.task_state,
+    CONCAT('GENERIC_TASK_STATE_', t.task_state) as task_state,
     (
         SELECT
             COALESCE(


### PR DESCRIPTION
## Description


## Test Plan


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket



