### PR TITLE
docs: [FE-270] add PBS known issue - Cluster tab does not display GPU information

### DIFF
--- a/docs/setup-cluster/slurm/slurm-known-issues.rst
+++ b/docs/setup-cluster/slurm/slurm-known-issues.rst
@@ -381,9 +381,9 @@ Some constraints are due to differences in behavior between Docker and Singulari
  PBS Known Issues
 ******************
 
--  If the ``Cluster`` tab on the DeterminedAI WebUI does not display the GPU information, there
-   could be an issue in the PBS configuration. Please refer to :ref:`PBS Requirements
-   <pbs-config-requirements>` to ensure PBS is configured properly.
+-  If the ``Cluster`` tab in the WebUI does not display the GPU information, there may be an issue
+   with the PBS configuration. Visit :ref:`PBS Requirements <pbs-config-requirements>` to ensure PBS
+   is properly configured.
 
 -  Jobs are treated as successful even in the presence of a failure when PBS job history is not
    enabled. Without job history enabled, the launcher is unable to obtain the exit status of jobs

--- a/docs/setup-cluster/slurm/slurm-known-issues.rst
+++ b/docs/setup-cluster/slurm/slurm-known-issues.rst
@@ -381,6 +381,10 @@ Some constraints are due to differences in behavior between Docker and Singulari
  PBS Known Issues
 ******************
 
+-  If the ``Cluster`` tab on the DeterminedAI WebUI does not display the GPU information, there
+   could be an issue in the PBS configuration. Please refer to :ref:`PBS Requirements
+   <pbs-config-requirements>` to ensure PBS is configured properly.
+
 -  Jobs are treated as successful even in the presence of a failure when PBS job history is not
    enabled. Without job history enabled, the launcher is unable to obtain the exit status of jobs
    and therefore they are all reported as successful. This will prevent failed jobs from

--- a/docs/setup-cluster/slurm/slurm-known-issues.rst
+++ b/docs/setup-cluster/slurm/slurm-known-issues.rst
@@ -382,8 +382,8 @@ Some constraints are due to differences in behavior between Docker and Singulari
 ******************
 
 -  If the ``Cluster`` tab in the WebUI does not display the GPU information, there may be an issue
-   with the PBS configuration. Visit :ref:`PBS Requirements <pbs-config-requirements>` to ensure PBS
-   is properly configured.
+   with the PBS configuration. Visit :ref:`Ensure the ngpus resource is defined with the correct
+   values <pbs-ngpus-config>` section to ensure PBS is properly configured.
 
 -  Jobs are treated as successful even in the presence of a failure when PBS job history is not
    enabled. Without job history enabled, the launcher is unable to obtain the exit status of jobs

--- a/docs/setup-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/slurm/slurm-requirements.rst
@@ -227,6 +227,8 @@ interacts with PBS, we recommend the following steps:
    configure ``CUDA_VISIBLE_DEVICES`` or set the ``pbs.slots_per_node`` setting in your experiment
    configuration file to indicate the desired number of GPU slots for Determined.
 
+.. _pbs-ngpus-config:
+
 -  Ensure the ``ngpus`` resource is defined with the correct values.
 
    To ensure the successful operation of Determined, define the ``ngpus`` resource value for each


### PR DESCRIPTION
## Description
Add a new PBS known issue "Cluster tab does not display GPU information" including a link to the PBS requirements section.
This is a follow up for the PR #8714 


## Test Plan
Tested manually
<img width="850" alt="image" src="https://github.com/determined-ai/determined/assets/7717367/3751fbdc-9a4f-4748-b8cb-b4eeec3d02fb">

## Commentary (optional)


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
FE-270