### PR TITLE
fix: compress data from API for the page load performance improvement

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -966,10 +966,15 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	// Other static files should only be cached for a short period of time
 	cacheFileShortTerm := regexp.MustCompile(`.(antd.\S+(.css)|ico|png|jpe*g|gif|svg)$`)
 
+	// API endpoints
+	apiRegex := regexp.MustCompile(`^/api/.+$`)
+
 	gzipConfig := middleware.GzipConfig{
 		Skipper: func(c echo.Context) bool {
 			reqPath := c.Request().URL.Path
-			return !cacheFileLongTerm.MatchString(reqPath) && !cacheFileShortTerm.MatchString(reqPath)
+			return !cacheFileLongTerm.MatchString(reqPath) &&
+				!cacheFileShortTerm.MatchString(reqPath) &&
+				!apiRegex.MatchString(reqPath)
 		},
 	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -966,17 +966,7 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	// Other static files should only be cached for a short period of time
 	cacheFileShortTerm := regexp.MustCompile(`.(antd.\S+(.css)|ico|png|jpe*g|gif|svg)$`)
 
-	// API endpoints
-	apiRegex := regexp.MustCompile(`^/api/.+$`)
-
-	gzipConfig := middleware.GzipConfig{
-		Skipper: func(c echo.Context) bool {
-			reqPath := c.Request().URL.Path
-			return !cacheFileLongTerm.MatchString(reqPath) &&
-				!cacheFileShortTerm.MatchString(reqPath) &&
-				!apiRegex.MatchString(reqPath)
-		},
-	}
+	gzipConfig := middleware.GzipConfig{}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))
 
 	m.echo.Use(middleware.AddTrailingSlashWithConfig(middleware.TrailingSlashConfig{

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -966,7 +966,17 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	// Other static files should only be cached for a short period of time
 	cacheFileShortTerm := regexp.MustCompile(`.(antd.\S+(.css)|ico|png|jpe*g|gif|svg)$`)
 
-	gzipConfig := middleware.GzipConfig{}
+	// API endpoints
+	apiRegex := regexp.MustCompile(`^/api/.+$`)
+
+	gzipConfig := middleware.GzipConfig{
+		Skipper: func(c echo.Context) bool {
+			reqPath := c.Request().URL.Path
+			return !cacheFileLongTerm.MatchString(reqPath) &&
+				!cacheFileShortTerm.MatchString(reqPath) &&
+				!apiRegex.MatchString(reqPath)
+		},
+	}
 	m.echo.Use(middleware.GzipWithConfig(gzipConfig))
 
 	m.echo.Use(middleware.AddTrailingSlashWithConfig(middleware.TrailingSlashConfig{


### PR DESCRIPTION
## Description
[WEB-1870]

The response data from (almost?) all determined AI API endpoints were not compressed at all, so that caused long response time with `Fast 3G network` (look at `Content download` time). 

Especially,  `experiments-search` API usually returns big data, so this PR improve the page loading time around **10x**.

### Before

<img width="1019" alt="Screenshot 2024-01-19 at 12 27 22 PM" src="https://github.com/determined-ai/determined/assets/109113616/43b5f97c-a701-4d6e-a06a-28e1cd800af3">

---

<img width="1018" alt="Screenshot 2024-01-19 at 1 08 27 PM" src="https://github.com/determined-ai/determined/assets/109113616/61d373bd-a96d-4e4a-9277-f3c2f62d2c4d">



### After

<img width="1015" alt="Screenshot 2024-01-19 at 12 25 09 PM" src="https://github.com/determined-ai/determined/assets/109113616/7d6152f0-2710-4d82-814b-6ceb5d305613">

---

<img width="1018" alt="Screenshot 2024-01-19 at 1 07 29 PM" src="https://github.com/determined-ai/determined/assets/109113616/1213d3b3-0be6-4c86-9a16-083bb04865ea">



<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Check if API data are compressed
- Check if there's `Content-Encoding: gzip` in response header
- Check if `js/css/html` files are still compressed
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[WEB-1870]: https://hpe-aiatscale.atlassian.net/browse/WEB-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ