### PR TITLE
feat: Add a modal to enable/disable Agents [WEB-1718]

### DIFF
--- a/webui/react/src/components/ManageNodesModal.module.scss
+++ b/webui/react/src/components/ManageNodesModal.module.scss
@@ -1,0 +1,8 @@
+.content {
+  :global(div.ant-typography) {
+    margin-bottom: 1em;
+  }
+  :global(span.ant-typography) {
+    margin-bottom: 0;
+  }
+}

--- a/webui/react/src/components/ManageNodesModal.tsx
+++ b/webui/react/src/components/ManageNodesModal.tsx
@@ -6,7 +6,7 @@ import Row from 'hew/Row';
 import Toggle from 'hew/Toggle';
 import { Body, Label } from 'hew/Typography';
 import { isEqual } from 'lodash';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { disableAgent, enableAgent } from 'services/api';
 import { Agent } from 'types';
@@ -18,17 +18,21 @@ interface Props {
   nodes: Agent[];
 }
 
-// const defaultNodes: Agent[] = [
+// const testNodes: Agent[] = [
 //   { id: 'ABC', enabled: true, registeredTime: 1000, resourcePools: [], resources: []},
 //   { id: 'DEF', enabled: false, registeredTime: 2000, resourcePools: [], resources: [] },
 // ];
 
 const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
-  // nodes = defaultNodes;
-  const originalNodes = nodes.reduce((obj: Record<string, boolean>, node: Agent) => {
-    obj[node.id] = !!node.enabled;
-    return obj;
-  }, {});
+  // nodes = testNodes;
+  const originalNodes = useMemo(
+    () =>
+      nodes.reduce((obj: Record<string, boolean>, node: Agent) => {
+        obj[node.id] = !!node.enabled;
+        return obj;
+      }, {}),
+    [nodes],
+  );
 
   const [searchText, setSearchText] = useState<string>('');
   const [toggleStates, setToggleStates] = useState<Record<string, boolean>>(originalNodes);

--- a/webui/react/src/components/ManageNodesModal.tsx
+++ b/webui/react/src/components/ManageNodesModal.tsx
@@ -18,13 +18,13 @@ interface Props {
   nodes: Agent[];
 }
 
-const defaultNodes: Agent[] = [
-  { enabled: true, id: 'ABC', registeredTime: 1000, resourcePools: [], resources: [] },
-  { enabled: false, id: 'DEF', registeredTime: 2000, resourcePools: [], resources: [] },
-];
+// const defaultNodes: Agent[] = [
+//   { id: 'ABC', enabled: true, registeredTime: 1000, resourcePools: [], resources: []},
+//   { id: 'DEF', enabled: false, registeredTime: 2000, resourcePools: [], resources: [] },
+// ];
 
 const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
-  nodes = defaultNodes;
+  // nodes = defaultNodes;
   const originalNodes = nodes.reduce((obj: Record<string, boolean>, node: Agent) => {
     obj[node.id] = !!node.enabled;
     return obj;
@@ -83,7 +83,6 @@ const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
             <Row height={35} key={node.id}>
               <Toggle checked={toggleStates[node.id]} onChange={() => onToggleNode(node.id)} />
               <Label>{node.id}</Label>
-              {!toggleStates[node.id] && originalNodes[node.id] && <Label>Turned Off</Label>}
             </Row>
           ))}
       </div>

--- a/webui/react/src/components/ManageNodesModal.tsx
+++ b/webui/react/src/components/ManageNodesModal.tsx
@@ -1,6 +1,3 @@
-import { isEqual } from 'lodash';
-import React, { useCallback, useState } from 'react';
-
 import Icon from 'hew/Icon';
 import Input from 'hew/Input';
 import Message from 'hew/Message';
@@ -8,6 +5,9 @@ import { Modal } from 'hew/Modal';
 import Row from 'hew/Row';
 import Toggle from 'hew/Toggle';
 import { Body, Label } from 'hew/Typography';
+import { isEqual } from 'lodash';
+import React, { useCallback, useState } from 'react';
+
 import { disableAgent, enableAgent } from 'services/api';
 import { Agent } from 'types';
 import handleError from 'utils/error';
@@ -19,8 +19,8 @@ interface Props {
 }
 
 const defaultNodes: Agent[] = [
-  { id: 'ABC', enabled: true, registeredTime: 1000, resourcePools: [], resources: []},
-  { id: 'DEF', enabled: false, registeredTime: 2000, resourcePools: [], resources: [] },
+  { enabled: true, id: 'ABC', registeredTime: 1000, resourcePools: [], resources: [] },
+  { enabled: false, id: 'DEF', registeredTime: 2000, resourcePools: [], resources: [] },
 ];
 
 const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
@@ -56,13 +56,13 @@ const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
   return (
     <Modal
       cancel
+      size="small"
       submit={{
         disabled: isEqual(originalNodes, toggleStates),
-        text: "Apply Changes",
-        handler: onFormSubmit,
         handleError,
+        handler: onFormSubmit,
+        text: 'Apply Changes',
       }}
-      size="small"
       title="Manage Nodes">
       <div className={css.content}>
         <Body>Disable nodes to make them temporarily unavailable for job assignment.</Body>
@@ -76,18 +76,16 @@ const ManageNodesModalComponent = ({ nodes }: Props): JSX.Element => {
             onChange={onFilterChange}
           />
         )}
-        {nodes.length === 0 && (
-          <Message title="No active agents."/>
-        )}
-        {nodes.filter(node => !searchText.trim() || node.id.includes(searchText)).map((node) => (
-          <Row height={35} key={node.id}>
-            <Toggle checked={toggleStates[node.id]} onChange={() => onToggleNode(node.id)} />
-            <Label>{node.id}</Label>
-            {!toggleStates[node.id] && originalNodes[node.id] && (
-              <Label>Turned Off</Label>
-            )}
-          </Row>
-        ))}
+        {nodes.length === 0 && <Message title="No active agents." />}
+        {nodes
+          .filter((node) => !searchText.trim() || node.id.includes(searchText))
+          .map((node) => (
+            <Row height={35} key={node.id}>
+              <Toggle checked={toggleStates[node.id]} onChange={() => onToggleNode(node.id)} />
+              <Label>{node.id}</Label>
+              {!toggleStates[node.id] && originalNodes[node.id] && <Label>Turned Off</Label>}
+            </Row>
+          ))}
       </div>
     </Modal>
   );

--- a/webui/react/src/components/ManageNodesModal.tsx
+++ b/webui/react/src/components/ManageNodesModal.tsx
@@ -1,0 +1,17 @@
+import { Modal } from 'hew/Modal';
+
+interface Props {
+}
+
+const ManageNodesModalComponent = ({}: Props): JSX.Element => {
+  return (
+    <Modal
+      cancel
+      size="medium"
+      title="Manage Resource Pool Nodes">
+      <div>Hello World</div>
+    </Modal>
+  );
+};
+
+export default ManageNodesModalComponent;

--- a/webui/react/src/components/ManageNodesModal.tsx
+++ b/webui/react/src/components/ManageNodesModal.tsx
@@ -1,15 +1,78 @@
+import React, { useCallback, useState } from 'react';
+
+import Icon from 'hew/Icon';
+import Input from 'hew/Input';
+import Row from 'hew/Row';
 import { Modal } from 'hew/Modal';
+import Toggle from 'hew/Toggle';
+import { Body, Label } from 'hew/Typography';
+import { Agent, Resource, ResourceType } from 'types';
+import handleError from 'utils/error';
+
+import css from './ManageNodesModal.module.scss';
 
 interface Props {
+  nodes: Agent[];
 }
 
-const ManageNodesModalComponent = ({}: Props): JSX.Element => {
+const defaultNodes: Agent[] = [
+  { id: 'ABC', registeredTime: 1000, resourcePools: [], resources: [
+    { id: 'A', type: ResourceType.UNSPECIFIED, name: 'A', enabled: true },
+  ]},
+  { id: 'DEF', registeredTime: 2000, resourcePools: [], resources: [] },
+];
+
+const ManageNodesModalComponent = ({ nodes = defaultNodes }: Props): JSX.Element => {
+  const [searchText, setSearchText] = useState<string>('');
+  const [toggleStates, setToggleStates] = useState<Record<string, boolean>>(
+    nodes.reduce((obj: Record<string, boolean>, node: Agent) => {
+      node.resources.forEach((r: Resource) => {
+        obj[r.id] = r.enabled;
+      });
+      return obj;
+    }, {})
+  );
+
+  const onFilterChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchText(e.target.value);
+  }, []);
+
+  const onToggleNode = useCallback((nodeId: string) => {
+    setToggleStates((prev) => ({ ...prev, [nodeId]: !prev[nodeId] }));
+  }, []);
+
+  const onFormSubmit = useCallback(() => {
+
+  }, []);
+
   return (
     <Modal
       cancel
-      size="medium"
-      title="Manage Resource Pool Nodes">
-      <div>Hello World</div>
+      submit={{
+        disabled: false,
+        text: "Apply Changes",
+        handler: onFormSubmit,
+        handleError,
+      }}
+      size="small"
+      title="Manage Nodes">
+      <div className={css.content}>
+        <Body>Disable nodes to make them temporarily unavailable for job assignment.</Body>
+        <Label>Node Availability</Label>
+        <Input
+          autoFocus
+          placeholder="Filter nodes"
+          prefix={<Icon name="search" title="Search" />}
+          value={searchText}
+          onChange={onFilterChange}
+        />
+        {nodes.map((node) => (
+          <Row key={node.id}>
+            <Toggle checked={toggleStates[node.id]} onChange={() => onToggleNode(node.id)} />
+            {node.id}
+          </Row>
+        ))}
+      </div>
     </Modal>
   );
 };

--- a/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
@@ -211,14 +211,19 @@ const ResourcepoolDetailInner: React.FC = () => {
 
   const ManageNodesModal = useModal(ManageNodesModalComponent);
 
-  const menu: MenuItem[] | undefined = useMemo(() =>
-    canManageResourcePoolBindings ? [
-      {
-        disabled: false,
-        key: MenuKey.ManageNodes,
-        label: 'Manage Nodes',
-      },
-    ] : undefined, [canManageResourcePoolBindings]);
+  const menu: MenuItem[] | undefined = useMemo(
+    () =>
+      canManageResourcePoolBindings
+        ? [
+            {
+              disabled: false,
+              key: MenuKey.ManageNodes,
+              label: 'Manage Nodes',
+            },
+          ]
+        : undefined,
+    [canManageResourcePoolBindings],
+  );
 
   const handleDropdown = useCallback(
     (key: string) => {

--- a/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
@@ -1,5 +1,6 @@
-import { Divider } from 'antd';
+import { MenuItem } from 'hew/Dropdown';
 import Message from 'hew/Message';
+import { useModal } from 'hew/Modal';
 import Pivot, { PivotProps } from 'hew/Pivot';
 import Spinner from 'hew/Spinner';
 import { ShirtSize } from 'hew/Theme';
@@ -8,6 +9,7 @@ import React, { Fragment, Suspense, useCallback, useEffect, useMemo, useState } 
 import { useNavigate, useParams } from 'react-router-dom';
 
 import JsonGlossary from 'components/JsonGlossary';
+import ManageNodesModalComponent from 'components/ManageNodesModal';
 import Page from 'components/Page';
 import ResourcePoolBindings from 'components/ResourcePoolBindings';
 import { RenderAllocationBarResourcePool } from 'components/ResourcePoolCard';
@@ -47,6 +49,10 @@ const TabType = {
 type TabType = ValueOf<typeof TabType>;
 
 export const DEFAULT_POOL_TAB_KEY = TabType.Active;
+
+const MenuKey = {
+  ManageNodes: 'manage-nodes',
+} as const;
 
 const ResourcepoolDetailInner: React.FC = () => {
   const { poolname, tab } = useParams<Params>();
@@ -203,6 +209,28 @@ const ResourcepoolDetailInner: React.FC = () => {
     return tabItems;
   }, [canManageResourcePoolBindings, pool, poolStats, renderPoolConfig, rpStats, rpBindingFlagOn]);
 
+  const ManageNodesModal = useModal(ManageNodesModalComponent);
+
+  const menu: MenuItem[] = useMemo(() =>
+    canManageResourcePoolBindings ? [
+      {
+        disabled: false,
+        key: MenuKey.ManageNodes,
+        label: 'Manage Nodes',
+      },
+    ] : [], [canManageResourcePoolBindings]);
+
+  const handleDropdown = useCallback(
+    (key: string) => {
+      switch (key) {
+        case MenuKey.ManageNodes:
+          ManageNodesModal.open();
+          break;
+      }
+    },
+    [ManageNodesModal],
+  );
+
   if (!pool || Loadable.isNotLoaded(resourcePools)) {
     return <Spinner center spinning />;
   } else if (Loadable.isFailed(resourcePools)) {
@@ -220,11 +248,13 @@ const ResourcepoolDetailInner: React.FC = () => {
           path: '',
         },
       ]}
+      menuItems={menu}
       title={
         tabKey === TabType.Active || tabKey === TabType.Queued
           ? 'Job Queue by Resource Pool'
           : undefined
-      }>
+      }
+      onClickMenu={handleDropdown}>
       <div className={css.poolDetailPage}>
         <Section>
           <RenderAllocationBarResourcePool
@@ -248,6 +278,7 @@ const ResourcepoolDetailInner: React.FC = () => {
             />
           )}
         </Section>
+        <ManageNodesModal.Component />
       </div>
     </Page>
   );

--- a/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
+++ b/webui/react/src/pages/ResourcePool/ResourcepoolDetail.tsx
@@ -153,7 +153,7 @@ const ResourcepoolDetailInner: React.FC = () => {
         <JsonGlossary alignValues="right" json={mainSection} translateLabel={camelCaseToSentence} />
         {Object.keys(details).map((key) => (
           <Fragment key={key}>
-            <Divider />
+            <hr />
             <div className={css.subTitle}>{camelCaseToSentence(key)}</div>
             <JsonGlossary
               json={details[key as keyof V1ResourcePoolDetail] as unknown as JsonObject}
@@ -211,14 +211,14 @@ const ResourcepoolDetailInner: React.FC = () => {
 
   const ManageNodesModal = useModal(ManageNodesModalComponent);
 
-  const menu: MenuItem[] = useMemo(() =>
+  const menu: MenuItem[] | undefined = useMemo(() =>
     canManageResourcePoolBindings ? [
       {
         disabled: false,
         key: MenuKey.ManageNodes,
         label: 'Manage Nodes',
       },
-    ] : [], [canManageResourcePoolBindings]);
+    ] : undefined, [canManageResourcePoolBindings]);
 
   const handleDropdown = useCallback(
     (key: string) => {
@@ -278,7 +278,7 @@ const ResourcepoolDetailInner: React.FC = () => {
             />
           )}
         </Section>
-        <ManageNodesModal.Component />
+        <ManageNodesModal.Component nodes={topologyAgentPool} />
       </div>
     </Page>
   );

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -209,6 +209,14 @@ export const getAgents = generateDetApi<EmptyParams, Api.V1GetAgentsResponse, Ty
   Config.getAgents,
 );
 
+export const enableAgent = generateDetApi<string, Api.V1EnableAgentResponse, Type.Agent | null>(
+  Config.enableAgent,
+);
+
+export const disableAgent = generateDetApi<string, Api.V1DisableAgentResponse, Type.Agent | null>(
+  Config.disableAgent,
+);
+
 export const getResourcePools = generateDetApi<
   Service.GetResourcePoolsParams,
   Api.V1GetResourcePoolsResponse,

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -484,6 +484,18 @@ export const getAgents: DetApi<EmptyParams, Api.V1GetAgentsResponse, Type.Agent[
   request: () => detApi.Cluster.getAgents(),
 };
 
+export const enableAgent: DetApi<string, Api.V1EnableAgentResponse, Type.Agent | null> = {
+  name: 'enableAgent',
+  postProcess: (response) =>response.agent ? decoder.jsonToAgents([response.agent])[0] : null,
+  request: (agentId) => detApi.Cluster.enableAgent(agentId, {}),
+};
+
+export const disableAgent: DetApi<string, Api.V1DisableAgentResponse, Type.Agent | null> = {
+  name: 'disableAgent',
+  postProcess: (response) => response.agent ? decoder.jsonToAgents([response.agent])[0] : null,
+  request: (agentId) => detApi.Cluster.disableAgent(agentId, {}),
+};
+
 export const getResourcePools: DetApi<
   Service.GetResourcePoolsParams,
   Api.V1GetResourcePoolsResponse,

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -486,13 +486,13 @@ export const getAgents: DetApi<EmptyParams, Api.V1GetAgentsResponse, Type.Agent[
 
 export const enableAgent: DetApi<string, Api.V1EnableAgentResponse, Type.Agent | null> = {
   name: 'enableAgent',
-  postProcess: (response) =>response.agent ? decoder.jsonToAgents([response.agent])[0] : null,
+  postProcess: (response) => (response.agent ? decoder.jsonToAgents([response.agent])[0] : null),
   request: (agentId) => detApi.Cluster.enableAgent(agentId, {}),
 };
 
 export const disableAgent: DetApi<string, Api.V1DisableAgentResponse, Type.Agent | null> = {
   name: 'disableAgent',
-  postProcess: (response) => response.agent ? decoder.jsonToAgents([response.agent])[0] : null,
+  postProcess: (response) => (response.agent ? decoder.jsonToAgents([response.agent])[0] : null),
   request: (agentId) => detApi.Cluster.disableAgent(agentId, {}),
 };
 

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -156,6 +156,7 @@ export const jsonToAgents = (agents: Array<Sdk.V1Agent>): types.Agent[] => {
     });
 
     return {
+      enabled: agent.enabled,
       id: agent.id,
       registeredTime: dayjs(agent.registeredTime).unix(),
       resourcePools: agent.resourcePools,

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -236,6 +236,7 @@ export interface Resource {
 export type SlotsRecord = { [k: string]: V1Slot };
 
 export interface Agent {
+  enabled?: boolean;
   id: string;
   registeredTime: number;
   resourcePools: string[];


### PR DESCRIPTION
## Description

When admin views a cluster resource pool, they'll see a dropdown in the breadcrumbs section:

<img width="419" alt="Screen Shot 2024-01-19 at 3 05 07 PM" src="https://github.com/determined-ai/determined/assets/643918/5577d0b4-7646-4371-b185-367ffcd87fda">

If there are no active agents, there is a Message

<img width="377" alt="Screen Shot 2024-01-19 at 3 05 03 PM" src="https://github.com/determined-ai/determined/assets/643918/617db191-14c1-4bfb-b2a6-76471000addd">

If there are available agents, they appear as a set of toggle switches reflecting enabled/disabled state.
The "Apply Changes" button becomes enabled once changes are made.

<img width="379" alt="Screen Shot 2024-01-19 at 3 06 50 PM" src="https://github.com/determined-ai/determined/assets/643918/12458f5e-d194-4732-9b01-7c214f8850ef">

When there are 10+ toggles, there is a text filter:

<img width="395" alt="Screen Shot 2024-01-19 at 3 09 00 PM" src="https://github.com/determined-ai/determined/assets/643918/e253b174-13ac-4673-bf3c-ec283555a075">

**The original ticket suggests a dropdown to allow jobs to finish or 'gracefully terminate', but no such option is available in the current EnableAgent Go code**

## Test Plan

I've included `const defaultNodes` and `nodes = defaultNodes` as comments; uncommenting these makes two agents visible. When you click Apply Changes, you will see an API call and error (because these are not real agent IDs).

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.