### PR TITLE
feat: Preserve 'redirect' query during logout [GAS-489]

### DIFF
--- a/webui/react/src/ee/SamlAuth.test.ts
+++ b/webui/react/src/ee/SamlAuth.test.ts
@@ -16,6 +16,24 @@ describe('SamlAuth', () => {
         default: 'sortDesc=false&r=0.123&sortKey=SORT_BY_NAME&tags=mnist',
         encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
       },
+      {
+        default:
+          'sortDesc=false&r=0.123&redirect=http://www.website.com&sortKey=SORT_BY_NAME&tags=mnist',
+        encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
+      },
+      {
+        default:
+          'sortDesc=false&r=0.123&redirect=https://anotherwebsite.org&sortKey=SORT_BY_NAME&tags=mnist',
+        encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
+      },
+      {
+        default: 'sortDesc=false&r=0.123&redirect=&sortKey=SORT_BY_NAME&tags=mnist',
+        encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
+      },
+      {
+        default: 'sortDesc=false&r=0.123&redirect=nothing&sortKey=SORT_BY_NAME&tags=mnist',
+        encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
+      },
     ];
 
     it('should return base path only if no queries are provided', () => {

--- a/webui/react/src/ee/SamlAuth.test.ts
+++ b/webui/react/src/ee/SamlAuth.test.ts
@@ -27,11 +27,12 @@ describe('SamlAuth', () => {
         encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
       },
       {
-        default: 'sortDesc=false&r=0.123&redirect=&sortKey=SORT_BY_NAME&tags=mnist',
+        default: 'sortDesc=false&r=0.123&sortKey=SORT_BY_NAME&tags=mnist&redirect=',
         encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
       },
       {
-        default: 'sortDesc=false&r=0.123&redirect=nothing&sortKey=SORT_BY_NAME&tags=mnist',
+        default:
+          'sortDesc=false&r=0.123&sortKey=SORT_BY_NAME&tags=mnist&redirect=www.nothing.com/directory',
         encoded: 'sortDesc%3Dfalse%26sortKey%3DSORT_BY_NAME%26tags%3Dmnist',
       },
     ];

--- a/webui/react/src/ee/SamlAuth.ts
+++ b/webui/react/src/ee/SamlAuth.ts
@@ -6,7 +6,11 @@ export const samlUrl = (basePath: string, queries?: string): string => {
     if (queries.includes('&redirect=')) {
       const redirectStartIndex = queries.indexOf('&redirect=');
       const redirectEndIndex = queries.indexOf('&', redirectStartIndex + 1);
-      queries = queries.slice(0, redirectStartIndex) + queries.slice(redirectEndIndex);
+      if (redirectEndIndex === -1) {
+        queries = queries.slice(0, redirectStartIndex);
+      } else {
+        queries = queries.slice(0, redirectStartIndex) + queries.slice(redirectEndIndex);
+      }
     }
   }
   if (!queries) return basePath;

--- a/webui/react/src/ee/SamlAuth.ts
+++ b/webui/react/src/ee/SamlAuth.ts
@@ -3,6 +3,11 @@ import router from 'router';
 export const samlUrl = (basePath: string, queries?: string): string => {
   if (queries) {
     queries = queries.replace(/r=0\.\d+[&]?/, '');
+    if (queries.includes('&redirect=')) {
+      const redirectStartIndex = queries.indexOf('&redirect=');
+      const redirectEndIndex = queries.indexOf('&', redirectStartIndex + 1);
+      queries = queries.slice(0, redirectStartIndex) + queries.slice(redirectEndIndex);
+    }
   }
   if (!queries) return basePath;
   return `${basePath}?relayState=${encodeURIComponent(queries)}`;

--- a/webui/react/src/pages/SignOut.tsx
+++ b/webui/react/src/pages/SignOut.tsx
@@ -1,5 +1,5 @@
 import { useObservable } from 'micro-observables';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import useAuthCheck from 'hooks/useAuthCheck';
@@ -21,6 +21,7 @@ const SignOut: React.FC = () => {
   const location = useLocation();
   const info = useObservable(determinedStore.info);
   const [isSigningOut, setIsSigningOut] = useState(false);
+  const queries = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const checkAuth = useAuthCheck();
 
   useEffect(() => {
@@ -50,12 +51,15 @@ const SignOut: React.FC = () => {
         const isAuthenticated = await checkAuth();
         if (isAuthenticated) routeAll(info.externalLogoutUri);
       } else {
-        navigate(paths.login() + '?r=' + Math.random(), { state: location.state });
+        const searchParameters = [`?r=${Math.random()}`];
+        if (queries.has('redirect'))
+          searchParameters.push(`&redirect=${queries.get('redirect') || ''}`);
+        navigate(paths.login() + searchParameters.join(''), { state: location.state });
       }
     };
 
     if (!isSigningOut) signOut();
-  }, [checkAuth, navigate, info.externalLogoutUri, location.state, isSigningOut]);
+  }, [checkAuth, navigate, info.externalLogoutUri, location.state, isSigningOut, queries]);
 
   return null;
 };


### PR DESCRIPTION
## Description

Currently in MLDE we accept a `redirect` parameter when visiting the sign in page, after signing in the user will be auto-redirected to that page. However, today it is not possible to preserve a `redirect` from the `logout` page. This actually makes it impossible to sign a user out from an `outside url` and then redirect them back to the `outside url`.


<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
1. Visit the logout url with a `?redirect=<some url>`
2. Ensure you are redirected to the sign in page with the `?redirect=<some url>` preserved.
3. After signing in, ensure that you are redirected to `<some url>`
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
The ultimate issue is that isAuthenticated (https://github.com/determined-ai/determined/blob/main/webui/react/src/pages/SignIn.tsx#L39) can never be set to false after logging in if a user is not on MLDE. You can test this on a cluster by signing in as a user and then using the API to sign out then going to the "sign in" page. You would expect to stay on the sign in page since you are logged out, however you'll see that you briefly see the sign in page, then get redirected to the home page, then instantly kicked out to the sign in page.

To get around this issue we will allow the user to hit the `logout` page so that they can be properly logged out, and then log back in.

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
