### PR TITLE
fix: Filter value resets when switching column types [WEB-1949]

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -1,6 +1,4 @@
 import dayjs from 'dayjs';
-import { Observable } from 'micro-observables';
-
 import Button from 'hew/Button';
 import DatePicker, { DatePickerProps } from 'hew/DatePicker';
 import Icon from 'hew/Icon';
@@ -8,7 +6,7 @@ import Input from 'hew/Input';
 import InputNumber from 'hew/InputNumber';
 import Select, { SelectProps, SelectValue } from 'hew/Select';
 import { Loadable } from 'hew/utils/loadable';
-import { useObservable } from 'micro-observables';
+import { Observable, useObservable } from 'micro-observables';
 import { useCallback, useState } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { debounce } from 'throttle-debounce';

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -402,15 +402,17 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     };
   }, [canceler, stopPolling]);
 
-  useEffect(() => {
-    return formStore.asJsonString.subscribe(() => {
-      resetPagination();
-      const loadableFormset = formStore.formset.get();
-      Loadable.forEach(loadableFormset, (formSet) =>
-        updateSettings({ filterset: JSON.stringify(formSet) }),
-      );
-    });
-  }, [resetPagination, updateSettings]);
+  useEffect(
+    () =>
+      formStore.asJsonString.subscribe(() => {
+        resetPagination();
+        const loadableFormset = formStore.formset.get();
+        Loadable.forEach(loadableFormset, (formSet) =>
+          updateSettings({ filterset: JSON.stringify(formSet) }),
+        );
+      }),
+    [resetPagination, updateSettings],
+  );
 
   const handleActionComplete = useCallback(async () => {
     /**


### PR DESCRIPTION
## Description

In the experiment filter UI, switching from a text filter (Name contains "profile") to a numeric filter (metric = _), calls `updateFieldValue(field.id, null);`.

~Update: the issue is `isValid` filters fields for the API calls and for saving in `updateSettings`, so temporary invalid states such as `value == null` won't be stored, and can get overwritten by previous values. The best option is to separate `asJsonString` and `asSettingsString` in the new approach.~

2nd Update: now treating this as a race condition, where anything which updates the form field operators and values, is wrapped in an `Observable.batch`

## Test Plan

Set a text query (Name contains "val"); experiments are filtered
Change column name to another text column (Searcher Metric); text value is still used for filter
Change column name to a numeric metric (Searcher Metric Value); value becomes blank
Add new filters; there is no error
Searcher Metric Value filter's value can be set to a number

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.