### PR TITLE
feat: helm option to mount shared_fs checkpoints to master

### DIFF
--- a/docs/release-notes/master-mount.rst
+++ b/docs/release-notes/master-mount.rst
@@ -3,7 +3,7 @@
 **Improvements**
 
 -  Helm: Add support for Downloading Checkpoints when using ``shared_fs``. Adds a ``mountToServer``
-   value under ``checkpointStorage``. By default, this parameter is set to ``false`` preserving the current
-   behavior. However when it's set to ``true`` and the storage type is ``shared_fs`` it enables the hostpath mount
-   on the server. This allows for the use of ``checkpoint.download()`` to work with ``shared_fs`` on
-   Determined starting from version ``0.27.0`` and later.
+   value under ``checkpointStorage``. By default, this parameter is set to ``false`` preserving the
+   current behavior. However when it's set to ``true`` and the storage type is ``shared_fs`` it
+   enables the hostpath mount on the server. This allows for the use of ``checkpoint.download()`` to
+   work with ``shared_fs`` on Determined starting from version ``0.27.0`` and later.

--- a/docs/release-notes/master-mount.rst
+++ b/docs/release-notes/master-mount.rst
@@ -2,9 +2,8 @@
 
 **Improvements**
 
-*  Master: Add support for Downloading Checkpoints when using ``shared_fs``
-
-   *  Adds a ``mountToMaster`` value under ``checkpointStorage``. Set to ``false`` by default means 
-   no change to current behavior. If it's set to ``true`` and the type is ``shared_fs`` it will add
-    that hostpath mount to the master as well. This allows for ``checkpoint.download()`` to work with
-     ``shared_fs`` on Kubernetes on version ``0.27.0`` and up.
+-  Helm: Add support for Downloading Checkpoints when using ``shared_fs``. Adds a ``mountToMaster``
+   value under ``checkpointStorage``. Set to ``false`` by default means no change to current
+   behavior. If it's set to ``true`` and the type is ``shared_fs`` it will add that hostpath mount
+   to the master as well. This allows for ``checkpoint.download()`` to work with ``shared_fs`` on
+   Kubernetes on version ``0.27.0`` and up.

--- a/docs/release-notes/master-mount.rst
+++ b/docs/release-notes/master-mount.rst
@@ -2,8 +2,8 @@
 
 **Improvements**
 
--  Helm: Add support for Downloading Checkpoints when using ``shared_fs``. Adds a ``mountToMaster``
-   value under ``checkpointStorage``. Set to ``false`` by default means no change to current
-   behavior. If it's set to ``true`` and the type is ``shared_fs`` it will add that hostpath mount
-   to the master as well. This allows for ``checkpoint.download()`` to work with ``shared_fs`` on
-   Kubernetes on version ``0.27.0`` and up.
+-  Helm: Add support for Downloading Checkpoints when using ``shared_fs``. Adds a ``mountToServer``
+   value under ``checkpointStorage``. By default, this parameter is set to ``false`` preserving the current
+   behavior. However when it's set to ``true`` and the storage type is ``shared_fs`` it enables the hostpath mount
+   on the server. This allows for the use of ``checkpoint.download()`` to work with ``shared_fs`` on
+   Determined starting from version ``0.27.0`` and later.

--- a/docs/release-notes/master-mount.rst
+++ b/docs/release-notes/master-mount.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+**Improvements**
+
+*  Master: Add support for Downloading Checkpoints when using ``shared_fs``
+
+   *  Adds a ``mountToMaster`` value under ``checkpointStorage``. Set to ``false`` by default means 
+   no change to current behavior. If it's set to ``true`` and the type is ``shared_fs`` it will add
+    that hostpath mount to the master as well. This allows for ``checkpoint.download()`` to work with
+     ``shared_fs`` on Kubernetes on version ``0.27.0`` and up.

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -51,6 +51,10 @@ spec:
           - name: master-config
             mountPath: /etc/determined/
             readOnly: true
+          {{- if and (.Values.checkpointStorage.mountToMaster) (eq .Values.checkpointStorage.type "shared_fs") }}
+          - name: checkpoint-storage
+            mountPath: {{ .Values.checkpointStorage.hostPath }}
+          {{ end }}
           {{- if .Values.tlsSecret }}
           - name: tls-secret
             mountPath: {{ include "determined.secretPath" . }}
@@ -113,6 +117,12 @@ spec:
         - name: master-config
           secret:
             secretName: determined-master-config-{{ .Release.Name }}
+        {{- if and (.Values.checkpointStorage.mountToMaster) ( eq .Values.checkpointStorage.type "shared_fs") }}
+        - name: checkpoint-storage
+          hostPath:
+            path: {{ .Values.checkpointStorage.hostPath }}
+            type: Directory
+        {{ end }}
         {{- if .Values.tlsSecret }}
         - name: tls-secret
           secret:

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -51,7 +51,7 @@ spec:
           - name: master-config
             mountPath: /etc/determined/
             readOnly: true
-          {{- if and (.Values.checkpointStorage.mountToMaster) (eq .Values.checkpointStorage.type "shared_fs") }}
+          {{- if and (.Values.checkpointStorage.mountToServer) (eq .Values.checkpointStorage.type "shared_fs") }}
           - name: checkpoint-storage
             mountPath: {{ .Values.checkpointStorage.hostPath }}
           {{ end }}
@@ -117,7 +117,7 @@ spec:
         - name: master-config
           secret:
             secretName: determined-master-config-{{ .Release.Name }}
-        {{- if and (.Values.checkpointStorage.mountToMaster) ( eq .Values.checkpointStorage.type "shared_fs") }}
+        {{- if and (.Values.checkpointStorage.mountToServer) ( eq .Values.checkpointStorage.type "shared_fs") }}
         - name: checkpoint-storage
           hostPath:
             path: {{ .Values.checkpointStorage.hostPath }}

--- a/helm/charts/determined/templates/master-deployment.yaml
+++ b/helm/charts/determined/templates/master-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             readOnly: true
           {{- if and (.Values.checkpointStorage.mountToServer) (eq .Values.checkpointStorage.type "shared_fs") }}
           - name: checkpoint-storage
-            mountPath: {{ .Values.checkpointStorage.hostPath }}
+            mountPath: /determined_shared_fs
           {{ end }}
           {{- if .Values.tlsSecret }}
           - name: tls-secret

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -196,7 +196,8 @@ checkpointStorage:
   # system.
   type: shared_fs
   hostPath: /checkpoints
-
+  # By default don't mount the shared_fs to the master pod. change this to true to enabled checkpoint downloads from master
+  mountToMaster: true
   # For storing in GCS.
   # type: gcs
   # bucket: <bucket_name>

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -197,7 +197,7 @@ checkpointStorage:
   type: shared_fs
   hostPath: /checkpoints
   # By default don't mount the shared_fs to the master pod. change this to true to enabled checkpoint downloads from master
-  mountToMaster: true
+  mountToMaster: false
   # For storing in GCS.
   # type: gcs
   # bucket: <bucket_name>

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -196,8 +196,8 @@ checkpointStorage:
   # system.
   type: shared_fs
   hostPath: /checkpoints
-  # By default don't mount the shared_fs to the master pod. change this to true to enabled checkpoint downloads from master
-  mountToMaster: false
+  # By default, shared_fs is not mounted to the server pod. Change this to true to enable checkpoint downloads from the server.
+  mountToServer: false
   # For storing in GCS.
   # type: gcs
   # bucket: <bucket_name>


### PR DESCRIPTION
## Description

Adds a `mountToMaster` value under `checkpointStorage`. Set to `false` by default means no change to current behavior.
If it's set to `true` and the type is `shared_fs` it will add that hostpath mount to the master as well. This allows for `checkpoint.download()` to work with `shared_fs` on Kubernetes on version `0.27.0` and up.

## Test Plan

tested with both true/false set on both shared_fs and other checkpoint storage. Works as expected- only creates volume mount when true and shared_fs.

## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ N/A] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

No Ticket


