### PR TITLE
perf: avoid loading model def in experiment model

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1392,10 +1392,10 @@ func (a *apiServer) GetExperimentCheckpoints(
 }
 
 func (a *apiServer) createUnmanagedExperimentTx(
-	ctx context.Context, idb bun.IDB, dbExp *model.Experiment, activeConfig expconf.ExperimentConfigV0,
-	taskSpec *tasks.TaskSpec, user *model.User,
+	ctx context.Context, idb bun.IDB, dbExp *model.Experiment, modelDef []byte,
+	activeConfig expconf.ExperimentConfigV0, taskSpec *tasks.TaskSpec, user *model.User,
 ) (*apiv1.CreateExperimentResponse, error) {
-	e, _, err := newUnmanagedExperiment(ctx, idb, a.m, dbExp, activeConfig, taskSpec)
+	e, _, err := newUnmanagedExperiment(ctx, idb, a.m, dbExp, modelDef, activeConfig, taskSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make new unmanaged experiment: %w", err)
 	}
@@ -1494,20 +1494,18 @@ func (a *apiServer) ContinueExperiment(
 		return nil, err
 	}
 
-	dbExp, activeConfig, _, taskSpec, err := a.m.parseCreateExperiment(
+	dbExp, modelDef, activeConfig, _, taskSpec, err := a.m.parseCreateExperiment(
 		&apiv1.CreateExperimentRequest{
-			Config:   string(configBytes),
-			ParentId: req.Id, // Use parent logic.
+			Config: string(configBytes),
 		}, user,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("parsing continue experiment request: %w", err)
 	}
-	dbExp.ParentID = nil // Not actually a parent though.
 	dbExp.ID = int(req.Id)
 	dbExp.JobID = origExperiment.JobID // Revive job.
 
-	e, launchWarnings, err := newExperiment(a.m, dbExp, activeConfig, taskSpec)
+	e, launchWarnings, err := newExperiment(a.m, dbExp, modelDef, activeConfig, taskSpec)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}
@@ -1653,7 +1651,7 @@ func (a *apiServer) CreateExperiment(
 		}
 	}
 
-	dbExp, activeConfig, p, taskSpec, err := a.m.parseCreateExperiment(
+	dbExp, modelDef, activeConfig, p, taskSpec, err := a.m.parseCreateExperiment(
 		req, user,
 	)
 	if err != nil {
@@ -1681,7 +1679,7 @@ func (a *apiServer) CreateExperiment(
 	}
 
 	if req.Unmanaged != nil && *req.Unmanaged {
-		return a.createUnmanagedExperimentTx(ctx, db.Bun(), dbExp, activeConfig, taskSpec, user)
+		return a.createUnmanagedExperimentTx(ctx, db.Bun(), dbExp, modelDef, activeConfig, taskSpec, user)
 	}
 	// Check user has permission for what they are trying to do
 	// before actually saving the experiment.
@@ -1691,10 +1689,11 @@ func (a *apiServer) CreateExperiment(
 		}
 	}
 
-	e, launchWarnings, err := newExperiment(a.m, dbExp, activeConfig, taskSpec)
+	e, launchWarnings, err := newExperiment(a.m, dbExp, modelDef, activeConfig, taskSpec)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create experiment: %s", err)
 	}
+	modelDef = nil //nolint:ineffassign
 
 	if err = e.Start(); err != nil {
 		return nil, errors.Wrapf(err, "failed to start experiment %d", e.ID)
@@ -1734,7 +1733,7 @@ func (a *apiServer) PutExperiment(
 		return nil, status.Errorf(codes.Internal, "failed to get the user: %s", err)
 	}
 
-	dbExp, activeConfig, p, taskSpec, err := a.m.parseCreateExperiment(
+	dbExp, modelDef, activeConfig, p, taskSpec, err := a.m.parseCreateExperiment(
 		req.CreateExperimentRequest, user,
 	)
 	if err != nil {
@@ -1748,8 +1747,9 @@ func (a *apiServer) PutExperiment(
 
 	dbExp.ExternalExperimentID = &req.ExternalExperimentId
 
-	innerResp, err = a.createUnmanagedExperimentTx(ctx, db.Bun(), dbExp, activeConfig, taskSpec, user)
-
+	innerResp, err = a.createUnmanagedExperimentTx(
+		ctx, db.Bun(), dbExp, modelDef, activeConfig, taskSpec, user,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create unmanaged experiment: %w", err)
 	}

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -574,18 +574,17 @@ func TestGetExperiments(t *testing.T) {
 	})
 	activeConfig0 = schemas.WithDefaults(activeConfig0)
 	exp0 := &model.Experiment{
-		StartTime:            startTime,
-		EndTime:              &endTime,
-		ModelDefinitionBytes: []byte{1, 2, 3},
-		JobID:                model.JobID(job0ID),
-		Archived:             false,
-		State:                model.PausedState,
-		Notes:                "notes",
-		Config:               activeConfig0.AsLegacy(),
-		OwnerID:              ptrs.Ptr(model.UserID(1)),
-		ProjectID:            int(pid),
+		StartTime: startTime,
+		EndTime:   &endTime,
+		JobID:     model.JobID(job0ID),
+		Archived:  false,
+		State:     model.PausedState,
+		Notes:     "notes",
+		Config:    activeConfig0.AsLegacy(),
+		OwnerID:   ptrs.Ptr(model.UserID(1)),
+		ProjectID: int(pid),
 	}
-	require.NoError(t, api.m.db.AddExperiment(exp0, activeConfig0))
+	require.NoError(t, api.m.db.AddExperiment(exp0, []byte{1, 2, 3}, activeConfig0))
 	for i := 0; i < 3; i++ {
 		task := &model.Task{TaskType: model.TaskTypeTrial, TaskID: model.NewTaskID()}
 		require.NoError(t, db.AddTask(ctx, task))
@@ -631,17 +630,16 @@ func TestGetExperiments(t *testing.T) {
 	})
 	activeConfig1 = schemas.WithDefaults(activeConfig1)
 	exp1 := &model.Experiment{
-		StartTime:            secondStartTime,
-		ModelDefinitionBytes: []byte{1, 2, 3},
-		JobID:                model.JobID(job1ID),
-		Archived:             true,
-		State:                model.ErrorState,
-		ParentID:             ptrs.Ptr(exp0.ID),
-		Config:               activeConfig1.AsLegacy(),
-		OwnerID:              ptrs.Ptr(model.UserID(userResp.User.Id)),
-		ProjectID:            int(pid),
+		StartTime: secondStartTime,
+		JobID:     model.JobID(job1ID),
+		Archived:  true,
+		State:     model.ErrorState,
+		ParentID:  ptrs.Ptr(exp0.ID),
+		Config:    activeConfig1.AsLegacy(),
+		OwnerID:   ptrs.Ptr(model.UserID(userResp.User.Id)),
+		ProjectID: int(pid),
 	}
-	require.NoError(t, api.m.db.AddExperiment(exp1, activeConfig1))
+	require.NoError(t, api.m.db.AddExperiment(exp1, []byte{1, 2, 3}, activeConfig1))
 	exp1Expected := &experimentv1.Experiment{
 		StartTime:      timestamppb.New(secondStartTime),
 		Duration:       ptrs.Ptr(int32(0)),
@@ -1028,18 +1026,17 @@ func benchmarkGetExperiments(b *testing.B, n int) {
 	})
 	activeConfig = schemas.WithDefaults(activeConfig)
 	exp := &model.Experiment{
-		ModelDefinitionBytes: []byte{1, 2, 3},
-		State:                model.PausedState,
-		Config:               activeConfig.AsLegacy(),
-		OwnerID:              ptrs.Ptr(model.UserID(userResp.User.Id)),
-		ProjectID:            1,
+		State:     model.PausedState,
+		Config:    activeConfig.AsLegacy(),
+		OwnerID:   ptrs.Ptr(model.UserID(userResp.User.Id)),
+		ProjectID: 1,
 	}
 	for i := 0; i < n; i++ {
 		jobID := uuid.New().String()
 		exp.ID = 0
 		exp.JobID = model.JobID(jobID)
 
-		if err := api.m.db.AddExperiment(exp, activeConfig); err != nil {
+		if err := api.m.db.AddExperiment(exp, []byte{1, 2, 3}, activeConfig); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -1081,15 +1078,14 @@ func createTestExpWithProjectID(
 	})
 	activeConfig = schemas.WithDefaults(activeConfig)
 	exp := &model.Experiment{
-		JobID:                model.JobID(uuid.New().String()),
-		State:                model.PausedState,
-		OwnerID:              &curUser.ID,
-		ProjectID:            projectID,
-		StartTime:            time.Now(),
-		ModelDefinitionBytes: []byte{10, 11, 12},
-		Config:               activeConfig.AsLegacy(),
+		JobID:     model.JobID(uuid.New().String()),
+		State:     model.PausedState,
+		OwnerID:   &curUser.ID,
+		ProjectID: projectID,
+		StartTime: time.Now(),
+		Config:    activeConfig.AsLegacy(),
 	}
-	require.NoError(t, api.m.db.AddExperiment(exp, activeConfig))
+	require.NoError(t, api.m.db.AddExperiment(exp, []byte{10, 11, 12}, activeConfig))
 
 	// Get experiment as our API mostly will to make it easier to mock.
 	exp, err := db.ExperimentByID(context.TODO(), exp.ID)

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -463,16 +463,15 @@ func mockExperimentS3(
 	})
 
 	exp := model.Experiment{
-		JobID:                model.NewJobID(),
-		State:                model.ActiveState,
-		Config:               cfg.AsLegacy(),
-		ModelDefinitionBytes: db.ReadTestModelDefiniton(t, folderPath),
-		StartTime:            time.Now().Add(-time.Hour),
-		OwnerID:              &user.ID,
-		Username:             user.Username,
-		ProjectID:            1,
+		JobID:     model.NewJobID(),
+		State:     model.ActiveState,
+		Config:    cfg.AsLegacy(),
+		StartTime: time.Now().Add(-time.Hour),
+		OwnerID:   &user.ID,
+		Username:  user.Username,
+		ProjectID: 1,
 	}
-	err := pgDB.AddExperiment(&exp, cfg)
+	err := pgDB.AddExperiment(&exp, db.ReadTestModelDefiniton(t, folderPath), cfg)
 	require.NoError(t, err, "failed to add experiment")
 	return &exp
 }

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -300,7 +300,7 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 	}
 	isSingleNode := resources.IsSingleNode() != nil && *resources.IsSingleNode()
 	if err = m.rm.ValidateResources(poolName, resources.SlotsPerTrial(), isSingleNode); err != nil {
-		return nil, config, nil, nil, errors.Wrapf(err, "error validating resources")
+		return nil, nil, config, nil, nil, errors.Wrapf(err, "error validating resources")
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
 		poolName,

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -262,13 +262,13 @@ func getCreateExperimentsProject(
 }
 
 func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner *model.User) (
-	*model.Experiment, expconf.ExperimentConfig, *projectv1.Project, *tasks.TaskSpec, error,
+	*model.Experiment, []byte, expconf.ExperimentConfig, *projectv1.Project, *tasks.TaskSpec, error,
 ) {
 	ctx := context.TODO()
 	// Read the config as the user provided it.
 	config, err := expconf.ParseAnyExperimentConfigYAML([]byte(req.Config))
 	if err != nil {
-		return nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	// Apply the template that the user specified.
@@ -276,7 +276,7 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		var tc expconf.ExperimentConfig
 		err := templates.UnmarshalTemplateConfig(ctx, *req.Template, owner, &tc, true)
 		if err != nil {
-			return nil, config, nil, nil, err
+			return nil, nil, config, nil, nil, err
 		}
 		config = schemas.Merge(config, tc)
 	}
@@ -286,17 +286,17 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 
 	p, err := getCreateExperimentsProject(m, req, owner, defaulted)
 	if err != nil {
-		return nil, config, nil, nil, err
+		return nil, nil, config, nil, nil, err
 	}
 	workspaceModel, err := workspace.WorkspaceByProjectID(ctx, int(p.Id))
 	if err != nil && errors.Cause(err) != sql.ErrNoRows {
-		return nil, config, nil, nil, err
+		return nil, nil, config, nil, nil, err
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
 	poolName, err := m.rm.ResolveResourcePool(
 		resources.ResourcePool(), workspaceID, resources.SlotsPerTrial())
 	if err != nil {
-		return nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
+		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
 	isSingleNode := resources.IsSingleNode() != nil && *resources.IsSingleNode()
 	if err = m.rm.ValidateResources(poolName, resources.SlotsPerTrial(), isSingleNode); err != nil {
@@ -307,13 +307,13 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {
-		return nil, config, nil, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
+		return nil, nil, config, nil, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
 	}
 	taskSpec := *m.taskSpec
 	taskSpec.TaskContainerDefaults = taskContainerDefaults
 	taskSpec.TaskContainerDefaults.MergeIntoExpConfig(&config)
 	if defaulted.RawEntrypoint == nil && (req.Unmanaged == nil || !*req.Unmanaged) {
-		return nil, config, nil, nil, errors.New("managed experiments require entrypoint")
+		return nil, nil, config, nil, nil, errors.New("managed experiments require entrypoint")
 	}
 
 	// Merge in workspace's checkpoint storage into the conifg.
@@ -322,7 +322,7 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		Where("id = ?", p.WorkspaceId).
 		Column("checkpoint_storage_config").
 		Scan(ctx); err != nil {
-		return nil, config, nil, nil, err
+		return nil, nil, config, nil, nil, err
 	}
 	config.RawCheckpointStorage = schemas.Merge(
 		config.RawCheckpointStorage, w.CheckpointStorageConfig)
@@ -337,12 +337,12 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 
 	// Make sure the experiment config has all eventuallyRequired fields.
 	if err = schemas.IsComplete(config); err != nil {
-		return nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	// Disallow EOL searchers.
 	if err = config.Searcher().AssertCurrent(); err != nil {
-		return nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
+		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
 
 	modelBytes := []byte{}
@@ -352,7 +352,7 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		var dbErr error
 		modelBytes, dbErr = m.db.ExperimentModelDefinitionRaw(int(req.ParentId))
 		if dbErr != nil {
-			return nil, config, nil, nil, errors.Wrapf(
+			return nil, nil, config, nil, nil, errors.Wrapf(
 				dbErr, "unable to find parent experiment %v", req.ParentId)
 		}
 	} else {
@@ -360,7 +360,7 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		if req.ModelDefinition != nil {
 			modelBytes, compressErr = archive.ToTarGz(filesToArchive(req.ModelDefinition))
 			if compressErr != nil {
-				return nil, config, nil, nil, errors.Wrapf(
+				return nil, nil, config, nil, nil, errors.Wrapf(
 					compressErr, "unable to find compress model definition")
 			}
 		}
@@ -368,18 +368,18 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 
 	token, createSessionErr := user.StartSession(ctx, owner)
 	if createSessionErr != nil {
-		return nil, config, nil, nil, errors.Wrapf(
+		return nil, nil, config, nil, nil, errors.Wrapf(
 			createSessionErr, "unable to create user session inside task")
 	}
 	taskSpec.UserSessionToken = token
 	taskSpec.Owner = owner
 
 	dbExp, err := model.NewExperiment(
-		config, req.Config, modelBytes, parentID, false,
+		config, req.Config, parentID, false,
 		int(p.Id), req.Unmanaged != nil && *req.Unmanaged,
 	)
 	if err != nil {
-		return nil, config, nil, nil, err
+		return nil, nil, config, nil, nil, err
 	}
 
 	if owner != nil {
@@ -393,5 +393,5 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 		taskSpec.Labels = append(taskSpec.Labels, label)
 	}
 
-	return dbExp, config, p, &taskSpec, err
+	return dbExp, modelBytes, config, p, &taskSpec, err
 }

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -23,7 +23,7 @@ type DB interface {
 	CheckExperimentExists(id int) (bool, error)
 	CheckTrialExists(id int) (bool, error)
 	TrialExperimentAndRequestID(id int) (int, model.RequestID, error)
-	AddExperiment(experiment *model.Experiment, activeConfig expconf.ExperimentConfig) error
+	AddExperiment(experiment *model.Experiment, modelDef []byte, activeConfig expconf.ExperimentConfig) error
 	ExperimentIDByTrialID(trialID int) (int, error)
 	NonTerminalExperiments() ([]*model.Experiment, error)
 	TerminateExperimentInRestart(id int, state model.State) error

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -329,7 +329,6 @@ func RequireMockExperimentParams(
 		JobID:                model.NewJobID(),
 		State:                model.ActiveState,
 		Config:               cfg.AsLegacy(),
-		ModelDefinitionBytes: ReadTestModelDefiniton(t, DefaultTestSrcPath),
 		StartTime:            time.Now().Add(-time.Hour).Truncate(time.Millisecond),
 		OwnerID:              &user.ID,
 		Username:             user.Username,
@@ -343,7 +342,7 @@ func RequireMockExperimentParams(
 		exp.State = *p.State
 	}
 
-	err := db.AddExperiment(&exp, cfg)
+	err := db.AddExperiment(&exp, ReadTestModelDefiniton(t, DefaultTestSrcPath), cfg)
 	require.NoError(t, err, "failed to add experiment")
 	return &exp
 }

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -839,7 +839,7 @@ func TestProtoGetTrial(t *testing.T) {
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
-	err := db.AddExperiment(exp, activeConfig)
+	err := db.AddExperiment(exp, []byte{}, activeConfig)
 	require.NoError(t, err, "failed to add experiment")
 
 	task := RequireMockTask(t, db, exp.OwnerID)
@@ -889,7 +889,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
-	require.NoError(t, db.AddExperiment(exp, activeConfig))
+	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
 	task := RequireMockTask(t, db, exp.OwnerID)
 	tr := model.Trial{
 		ExperimentID: exp.ID,
@@ -990,7 +990,7 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
-	require.NoError(t, db.AddExperiment(exp, activeConfig))
+	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
 	task := RequireMockTask(t, db, exp.OwnerID)
 	tr := model.Trial{
 		ExperimentID: exp.ID,
@@ -1137,7 +1137,7 @@ func TestGenericMetricsIO(t *testing.T) {
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	exp, activeConfig := model.ExperimentModel()
-	require.NoError(t, db.AddExperiment(exp, activeConfig))
+	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
 	task := RequireMockTask(t, db, exp.OwnerID)
 	tr := model.Trial{
 		ExperimentID: exp.ID,
@@ -1263,10 +1263,10 @@ func TestConcurrentMetricUpdate(t *testing.T) {
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	exp, activeConfig := model.ExperimentModel()
-	require.NoError(t, db.AddExperiment(exp, activeConfig))
+	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
 	createTrial := func() *model.Trial {
 		exp, activeConfig := model.ExperimentModel()
-		require.NoError(t, db.AddExperiment(exp, activeConfig))
+		require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
 		task := RequireMockTask(t, db, exp.OwnerID)
 		tr := model.Trial{
 			ExperimentID: exp.ID,

--- a/master/internal/populate_metrics.go
+++ b/master/internal/populate_metrics.go
@@ -230,15 +230,14 @@ func PopulateExpTrialsMetrics(pgdb *db.PgDB, masterConfig *config.Config, trivia
 	var defaultDeterminedUID model.UserID = 2
 	jID := model.NewJobID()
 	exp := &model.Experiment{
-		JobID:                jID,
-		State:                model.CompletedState,
-		Config:               activeConfig.AsLegacy(),
-		StartTime:            time.Now(),
-		OwnerID:              &defaultDeterminedUID,
-		ModelDefinitionBytes: []byte{},
-		ProjectID:            1,
+		JobID:     jID,
+		State:     model.CompletedState,
+		Config:    activeConfig.AsLegacy(),
+		StartTime: time.Now(),
+		OwnerID:   &defaultDeterminedUID,
+		ProjectID: 1,
 	}
-	err = pgdb.AddExperiment(exp, activeConfig)
+	err = pgdb.AddExperiment(exp, []byte{}, activeConfig)
 	if err != nil {
 		return err
 	}

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -124,7 +124,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to restore experiment %d", expModel.ID)
 	}
-	e, _, err := newExperiment(m, expModel, activeConfig, &taskSpec)
+	e, _, err := newExperiment(m, expModel, nil, activeConfig, &taskSpec)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create experiment %d from model", expModel.ID)
 	}

--- a/master/pkg/model/experiment.go
+++ b/master/pkg/model/experiment.go
@@ -342,8 +342,6 @@ type Experiment struct {
 	Config         expconf.LegacyConfig `db:"config"`
 	OriginalConfig string               `db:"original_config"`
 
-	// The model definition is stored as a .tar.gz file (raw bytes).
-	ModelDefinitionBytes []byte     `db:"model_definition" bun:"model_definition"`
 	StartTime            time.Time  `db:"start_time"`
 	EndTime              *time.Time `db:"end_time"`
 	ParentID             *int       `db:"parent_id"`
@@ -409,22 +407,20 @@ func ExperimentFromProto(e *experimentv1.Experiment) (*Experiment, error) {
 func NewExperiment(
 	config expconf.ExperimentConfig,
 	originalConfig string,
-	modelDefinitionBytes []byte,
 	parentID *int,
 	archived bool,
 	projectID int,
 	unmanaged bool,
 ) (*Experiment, error) {
 	return &Experiment{
-		State:                PausedState,
-		JobID:                NewJobID(),
-		Config:               config.AsLegacy(),
-		OriginalConfig:       originalConfig,
-		ModelDefinitionBytes: modelDefinitionBytes,
-		StartTime:            time.Now().UTC(),
-		ParentID:             parentID,
-		Archived:             archived,
-		ProjectID:            projectID,
+		State:          PausedState,
+		JobID:          NewJobID(),
+		Config:         config.AsLegacy(),
+		OriginalConfig: originalConfig,
+		StartTime:      time.Now().UTC(),
+		ParentID:       parentID,
+		Archived:       archived,
+		ProjectID:      projectID,
 	}, nil
 }
 

--- a/master/pkg/model/test_utils.go
+++ b/master/pkg/model/test_utils.go
@@ -48,13 +48,12 @@ func ExperimentModel(opts ...ExperimentModelOption) (*Experiment, expconf.Experi
 	DefaultTaskContainerDefaults().MergeIntoExpConfig(&activeConfig)
 
 	e := &Experiment{
-		JobID:                NewJobID(),
-		State:                ActiveState,
-		Config:               activeConfig.AsLegacy(),
-		StartTime:            time.Now(),
-		OwnerID:              &defaultDeterminedUID,
-		ModelDefinitionBytes: []byte{},
-		ProjectID:            1,
+		JobID:     NewJobID(),
+		State:     ActiveState,
+		Config:    activeConfig.AsLegacy(),
+		StartTime: time.Now(),
+		OwnerID:   &defaultDeterminedUID,
+		ProjectID: 1,
 	}
 
 	for _, o := range opts {

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -363,7 +363,7 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 	*model.Experiment, *model.Trial, *model.Allocation,
 ) {
 	experiment, activeConfig := model.ExperimentModel()
-	err := pgDB.AddExperiment(experiment, activeConfig)
+	err := pgDB.AddExperiment(experiment, []byte{}, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -386,7 +386,7 @@ func setupTrial(t *testing.T, pgDB *db.PgDB) (
 	*model.Experiment, expconf.ExperimentConfig, *model.Trial,
 ) {
 	experiment, activeConfig := model.ExperimentModel()
-	err := pgDB.AddExperiment(experiment, activeConfig)
+	err := pgDB.AddExperiment(experiment, []byte{}, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)


### PR DESCRIPTION
## Description

We often load model def for experiments when we really shouldn't. This change makes it a lot harder to load the model def if you don't mean to.

## Test Plan

Existing tests pass


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
