### PR TITLE
test: add intg tests for tasks module

### DIFF
--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -27,19 +27,6 @@ DELETE FROM allocation_sessions WHERE allocation_id in (
 	return err
 }
 
-// CheckTaskExists checks if the task exists.
-func (db *PgDB) CheckTaskExists(id model.TaskID) (bool, error) {
-	var exists bool
-	err := db.sql.QueryRow(`
-SELECT
-EXISTS(
-  SELECT task_id
-  FROM tasks
-  WHERE task_id = $1
-)`, id).Scan(&exists)
-	return exists, err
-}
-
 // AddTask UPSERT's the existence of a task.
 //
 // TODO(ilia): deprecate and use module function instead.

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -35,9 +35,6 @@ import (
 
 var db *PgDB
 
-// TestMain sets up the DB for tests that *don't* use the Bun ORM.
-// All other references to `db := MustResolveTestPostgres(t)` will be removed
-// when the tasks module is completely bunified.
 func TestMain(m *testing.M) {
 	pgDB, err := ResolveTestPostgres()
 	db = pgDB
@@ -407,20 +404,6 @@ func TestAddTask(t *testing.T) {
 	task, err := TaskByID(context.Background(), tIn.TaskID)
 	require.NoError(t, err)
 	require.Equal(t, tIn, task)
-}
-
-func TestAddNonExperimentTasksContextDirectory(t *testing.T) {
-	ctx := context.Background()
-	tIn := RequireMockTask(t, db, nil)
-	b := []byte(`testing123`)
-
-	err := AddNonExperimentTasksContextDirectory(ctx, tIn.TaskID, b)
-	require.NoError(t, err)
-
-	var taskCtxDir model.TaskContextDirectory
-	err = Bun().NewSelect().Model(&taskCtxDir).Where("task_id = ?", tIn.TaskID).Scan(ctx, &taskCtxDir)
-	require.NoError(t, err)
-	require.Equal(t, b, taskCtxDir.ContextDirectory)
 }
 
 func TestTaskCompleted(t *testing.T) {

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -628,9 +628,23 @@ func TestTaskLogsFlow(t *testing.T) {
 	err := db.AddTaskLogs([]*model.TaskLog{taskLog1})
 	require.NoError(t, err)
 
-	count, err := db.TaskLogsCount(t1In.TaskID, []api.Filter{})
+	// Try filtering by agentID & taskID -- only 1 exists.
+	count, err := db.TaskLogsCount(t1In.TaskID, []api.Filter{{
+		Field:     "agent_id",
+		Operation: api.FilterOperationIn,
+		Values:    []string{"testing-agent-1"},
+	}})
 	require.NoError(t, err)
 	require.Equal(t, count, 1)
+
+	// Try filtering by agentID & taskID -- none exist with this combination.
+	count, err = db.TaskLogsCount(t2In.TaskID, []api.Filter{{
+		Field:     "agent_id",
+		Operation: api.FilterOperationIn,
+		Values:    []string{"testing-agent-1"},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, count, 0)
 
 	// Try adding the rest of the Task logs, and count 2 for t1In.TaskID, and 1 for t2In.TaskID
 	err = db.AddTaskLogs([]*model.TaskLog{taskLog2, taskLog3})

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -33,11 +33,8 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
 
-var db *PgDB
-
 func TestMain(m *testing.M) {
-	pgDB, err := ResolveTestPostgres()
-	db = pgDB
+	db, err := ResolveTestPostgres()
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -59,6 +56,7 @@ func TestMain(m *testing.M) {
 // database are total. We should look into an ORM in the near to medium term future.
 func TestJobTaskAndAllocationAPI(t *testing.T) {
 	ctx := context.Background()
+	db := SingleDB()
 
 	// Add a mock user.
 	user := RequireMockUser(t, db)
@@ -150,6 +148,8 @@ func TestJobTaskAndAllocationAPI(t *testing.T) {
 }
 
 func TestRecordAndEndTaskStats(t *testing.T) {
+	db := SingleDB()
+
 	tID := model.NewTaskID()
 	require.NoError(t, db.AddTask(&model.Task{
 		TaskID:    tID,
@@ -196,6 +196,7 @@ func TestRecordAndEndTaskStats(t *testing.T) {
 
 func TestNonExperimentTasksContextDirectory(t *testing.T) {
 	ctx := context.Background()
+	db := SingleDB()
 
 	// Task doesn't exist.
 	_, err := NonExperimentTasksContextDirectory(ctx, model.TaskID(uuid.New().String()))
@@ -232,6 +233,8 @@ func TestNonExperimentTasksContextDirectory(t *testing.T) {
 }
 
 func TestAllocationState(t *testing.T) {
+	db := SingleDB()
+
 	// Add an allocation of every possible state.
 	states := []model.AllocationState{
 		model.AllocationStatePending,
@@ -303,6 +306,8 @@ func TestExhaustiveEnums(t *testing.T) {
 		postgresMembers map[string]bool
 		ignore          map[string]bool
 	}
+	db := SingleDB()
+
 	checks := map[string]*check{}
 	addCheck := func(goType, postgresType string, ignore map[string]bool) {
 		checks[goType] = &check{
@@ -385,6 +390,8 @@ func TestExhaustiveEnums(t *testing.T) {
 }
 
 func TestAddTask(t *testing.T) {
+	db := SingleDB()
+
 	u := RequireMockUser(t, db)
 	jID := RequireMockJob(t, db, &u.ID)
 
@@ -408,6 +415,8 @@ func TestAddTask(t *testing.T) {
 
 func TestTaskCompleted(t *testing.T) {
 	ctx := context.Background()
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 
 	completed, err := TaskCompleted(ctx, tIn.TaskID)
@@ -423,6 +432,8 @@ func TestTaskCompleted(t *testing.T) {
 }
 
 func TestAddAllocation(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	a := model.Allocation{
 		AllocationID: model.AllocationID(fmt.Sprintf("%s-1", tIn.TaskID)),
@@ -443,6 +454,8 @@ func TestAddAllocation(t *testing.T) {
 }
 
 func TestAddAllocationExitStatus(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
@@ -465,6 +478,8 @@ func TestAddAllocationExitStatus(t *testing.T) {
 }
 
 func TestCompleteAllocation(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
@@ -479,6 +494,8 @@ func TestCompleteAllocation(t *testing.T) {
 }
 
 func TestCompleteAllocationTelemetry(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
@@ -490,6 +507,8 @@ func TestCompleteAllocationTelemetry(t *testing.T) {
 }
 
 func TestAllocationByID(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
@@ -499,6 +518,8 @@ func TestAllocationByID(t *testing.T) {
 }
 
 func TestAllocationSessionFlow(t *testing.T) {
+	db := SingleDB()
+
 	uIn := RequireMockUser(t, db)
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
@@ -529,6 +550,8 @@ func TestAllocationSessionFlow(t *testing.T) {
 }
 
 func TestUpdateAllocation(t *testing.T) {
+	db := SingleDB()
+
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
@@ -565,6 +588,8 @@ func TestUpdateAllocation(t *testing.T) {
 }
 
 func TestCloseOpenAllocations(t *testing.T) {
+	db := SingleDB()
+
 	// Create test allocations, with a NULL end time.
 	t1In := RequireMockTask(t, db, nil)
 	a1In := RequireMockAllocation(t, db, t1In.TaskID)
@@ -599,6 +624,8 @@ func TestCloseOpenAllocations(t *testing.T) {
 }
 
 func TestTaskLogsFlow(t *testing.T) {
+	db := SingleDB()
+
 	t1In := RequireMockTask(t, db, nil)
 	t2In := RequireMockTask(t, db, nil)
 

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -11,6 +11,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"log"
+	"os"
 	"reflect"
 	"slices"
 	"strings"
@@ -22,20 +24,44 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
+
+var db *PgDB
+
+// TestMain sets up the DB for tests that *don't* use the Bun ORM.
+// All other references to `db := MustResolveTestPostgres(t)` will be removed
+// when the tasks module is completely bunified.
+func TestMain(m *testing.M) {
+	pgDB, err := ResolveTestPostgres()
+	db = pgDB
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	err = MigrateTestPostgres(db, "file://../../static/migrations", "up")
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	err = etc.SetRootPath("../../static/srv")
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	os.Exit(m.Run())
+}
 
 // TestJobTaskAndAllocationAPI, in lieu of an ORM, ensures that the mappings into and out of the
 // database are total. We should look into an ORM in the near to medium term future.
 func TestJobTaskAndAllocationAPI(t *testing.T) {
 	ctx := context.Background()
-	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db := MustResolveTestPostgres(t)
-	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	// Add a mock user.
 	user := RequireMockUser(t, db)
@@ -127,10 +153,6 @@ func TestJobTaskAndAllocationAPI(t *testing.T) {
 }
 
 func TestRecordAndEndTaskStats(t *testing.T) {
-	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db := MustResolveTestPostgres(t)
-	MustMigrateTestPostgres(t, db, MigrationsFromDB)
-
 	tID := model.NewTaskID()
 	require.NoError(t, db.AddTask(&model.Task{
 		TaskID:    tID,
@@ -170,13 +192,13 @@ func TestRecordAndEndTaskStats(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ElementsMatch(t, expected, actual)
+
+	err = db.EndAllTaskStats()
+	require.NoError(t, err)
 }
 
 func TestNonExperimentTasksContextDirectory(t *testing.T) {
 	ctx := context.Background()
-	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db := MustResolveTestPostgres(t)
-	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	// Task doesn't exist.
 	_, err := NonExperimentTasksContextDirectory(ctx, model.TaskID(uuid.New().String()))
@@ -213,10 +235,6 @@ func TestNonExperimentTasksContextDirectory(t *testing.T) {
 }
 
 func TestAllocationState(t *testing.T) {
-	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db := MustResolveTestPostgres(t)
-	MustMigrateTestPostgres(t, db, MigrationsFromDB)
-
 	// Add an allocation of every possible state.
 	states := []model.AllocationState{
 		model.AllocationStatePending,
@@ -281,10 +299,6 @@ func TestAllocationState(t *testing.T) {
 }
 
 func TestExhaustiveEnums(t *testing.T) {
-	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db := MustResolveTestPostgres(t)
-	MustMigrateTestPostgres(t, db, MigrationsFromDB)
-
 	type check struct {
 		goType          string
 		goMembers       map[string]bool
@@ -371,4 +385,313 @@ func TestExhaustiveEnums(t *testing.T) {
 		// Gives pretty diff.
 		require.JSONEq(t, string(pb), string(gb))
 	}
+}
+
+func TestAddTask(t *testing.T) {
+	u := RequireMockUser(t, db)
+	jID := RequireMockJob(t, db, &u.ID)
+
+	// Add a task.
+	tID := model.NewTaskID()
+	tIn := &model.Task{
+		TaskID:     tID,
+		JobID:      &jID,
+		TaskType:   model.TaskTypeTrial,
+		StartTime:  time.Now().UTC().Truncate(time.Millisecond),
+		LogVersion: model.TaskLogVersion0,
+	}
+	err := AddTask(context.Background(), tIn)
+	require.NoError(t, err, "failed to add task")
+
+	// Check that task is added to the db & test TaskByID.
+	task, err := TaskByID(context.Background(), tIn.TaskID)
+	require.NoError(t, err)
+	require.Equal(t, tIn, task)
+}
+
+func TestAddNonExperimentTasksContextDirectory(t *testing.T) {
+	ctx := context.Background()
+	tIn := RequireMockTask(t, db, nil)
+	b := []byte(`testing123`)
+
+	err := AddNonExperimentTasksContextDirectory(ctx, tIn.TaskID, b)
+	require.NoError(t, err)
+
+	var taskCtxDir model.TaskContextDirectory
+	err = Bun().NewSelect().Model(&taskCtxDir).Where("task_id = ?", tIn.TaskID).Scan(ctx, &taskCtxDir)
+	require.NoError(t, err)
+	require.Equal(t, b, taskCtxDir.ContextDirectory)
+}
+
+func TestTaskCompleted(t *testing.T) {
+	ctx := context.Background()
+	tIn := RequireMockTask(t, db, nil)
+
+	completed, err := TaskCompleted(ctx, tIn.TaskID)
+	require.False(t, completed)
+	require.NoError(t, err)
+
+	err = db.CompleteTask(tIn.TaskID, time.Now().UTC().Truncate(time.Millisecond))
+	require.NoError(t, err)
+
+	completed, err = TaskCompleted(ctx, tIn.TaskID)
+	require.True(t, completed)
+	require.NoError(t, err)
+}
+
+func TestAddAllocation(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	a := model.Allocation{
+		AllocationID: model.AllocationID(fmt.Sprintf("%s-1", tIn.TaskID)),
+		TaskID:       tIn.TaskID,
+		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
+		State:        ptrs.Ptr(model.AllocationStateTerminated),
+	}
+
+	err := db.AddAllocation(&a)
+	require.NoError(t, err, "failed to add allocation")
+
+	res, err := db.AllocationByID(a.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, a.AllocationID, res.AllocationID)
+	require.Equal(t, a.TaskID, res.TaskID)
+	require.Equal(t, a.StartTime, res.StartTime)
+	require.Equal(t, a.State, res.State)
+}
+
+func TestAddAllocationExitStatus(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	statusCode := int32(1)
+	exitReason := "testing-exit-reason"
+	exitErr := "testing-exit-err"
+
+	aIn.ExitReason = &exitReason
+	aIn.ExitErr = &exitErr
+	aIn.StatusCode = &statusCode
+
+	err := AddAllocationExitStatus(context.Background(), aIn)
+	require.NoError(t, err)
+
+	res, err := db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.ExitErr, res.ExitErr)
+	require.Equal(t, aIn.ExitReason, res.ExitReason)
+	require.Equal(t, aIn.StatusCode, res.StatusCode)
+}
+
+func TestCompleteAllocation(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	aIn.EndTime = ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond))
+
+	err := db.CompleteAllocation(aIn)
+	require.NoError(t, err)
+
+	res, err := db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.EndTime, res.EndTime)
+}
+
+func TestCompleteAllocationTelemetry(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	bytes, err := db.CompleteAllocationTelemetry(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Contains(t, string(bytes), string(aIn.AllocationID))
+	require.Contains(t, string(bytes), string(*tIn.JobID))
+	require.Contains(t, string(bytes), string(tIn.TaskType))
+}
+
+func TestAllocationByID(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	a, err := db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn, a)
+}
+
+func TestAllocationSessionFlow(t *testing.T) {
+	uIn := RequireMockUser(t, db)
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	tok, err := db.StartAllocationSession(aIn.AllocationID, &uIn)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+
+	as, err := allocationSessionByID(t, aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, uIn.ID, *as.OwnerID)
+
+	running := model.AllocationStatePulling
+	aIn.State = &running
+	err = db.UpdateAllocationState(*aIn)
+	require.NoError(t, err)
+
+	a, err := db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.State, a.State)
+
+	err = db.DeleteAllocationSession(aIn.AllocationID)
+	require.NoError(t, err)
+
+	as, err = allocationSessionByID(t, aIn.AllocationID)
+	require.ErrorContains(t, err, "no rows in result set")
+	require.Nil(t, as)
+}
+
+func TestUpdateAllocation(t *testing.T) {
+	tIn := RequireMockTask(t, db, nil)
+	aIn := RequireMockAllocation(t, db, tIn.TaskID)
+
+	// Testing UpdateAllocation Ports
+	aIn.Ports = map[string]int{"abc": 123, "def": 456}
+	err := UpdateAllocationPorts(*aIn)
+	require.NoError(t, err)
+
+	a, err := db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.Ports, a.Ports)
+
+	// Testing UpdateAllocationStartTime
+	newStartTime := ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond))
+	aIn.StartTime = newStartTime
+
+	err = db.UpdateAllocationStartTime(*aIn)
+	require.NoError(t, err)
+
+	a, err = db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.StartTime, a.StartTime)
+
+	// Testing UpdateAllocationProxyAddress
+	proxyAddr := "here"
+	aIn.ProxyAddress = &proxyAddr
+
+	err = db.UpdateAllocationProxyAddress(*aIn)
+	require.NoError(t, err)
+
+	a, err = db.AllocationByID(aIn.AllocationID)
+	require.NoError(t, err)
+	require.Equal(t, aIn.ProxyAddress, a.ProxyAddress)
+}
+
+func TestCloseOpenAllocations(t *testing.T) {
+	// Create test allocations, with a NULL end time.
+	t1In := RequireMockTask(t, db, nil)
+	a1In := RequireMockAllocation(t, db, t1In.TaskID)
+
+	t2In := RequireMockTask(t, db, nil)
+	a2In := RequireMockAllocation(t, db, t2In.TaskID)
+
+	// Set status for both open allocation as 'terminated'.
+	terminated := model.AllocationStateTerminated
+	a1In.State = &terminated
+	a2In.State = &terminated
+
+	// Close only a2In open allocations (filter out the rest).
+	err := db.CloseOpenAllocations([]model.AllocationID{a1In.AllocationID})
+	require.NoError(t, err)
+
+	a1, err := db.AllocationByID(a1In.AllocationID)
+	require.NoError(t, err)
+	require.Nil(t, a1.EndTime)
+
+	a2, err := db.AllocationByID(a2In.AllocationID)
+	require.NoError(t, err)
+	require.NotNil(t, a2.EndTime)
+
+	// Close the rest of the open allocations.
+	err = db.CloseOpenAllocations([]model.AllocationID{})
+	require.NoError(t, err)
+
+	a1, err = db.AllocationByID(a1In.AllocationID)
+	require.NoError(t, err)
+	require.NotNil(t, a1.EndTime)
+}
+
+func TestTaskLogsFlow(t *testing.T) {
+	t1In := RequireMockTask(t, db, nil)
+	t2In := RequireMockTask(t, db, nil)
+
+	// Test AddTaskLogs & TaskLogCounts
+	taskLog1 := RequireMockTaskLog(t, db, t1In.TaskID, "1")
+	taskLog2 := RequireMockTaskLog(t, db, t1In.TaskID, "2")
+	taskLog3 := RequireMockTaskLog(t, db, t2In.TaskID, "3")
+
+	// Try adding only taskLog1, and count only 1 log.
+	err := db.AddTaskLogs([]*model.TaskLog{taskLog1})
+	require.NoError(t, err)
+
+	count, err := db.TaskLogsCount(t1In.TaskID, []api.Filter{})
+	require.NoError(t, err)
+	require.Equal(t, count, 1)
+
+	// Try adding the rest of the Task logs, and count 2 for t1In.TaskID, and 1 for t2In.TaskID
+	err = db.AddTaskLogs([]*model.TaskLog{taskLog2, taskLog3})
+	require.NoError(t, err)
+
+	count, err = db.TaskLogsCount(t1In.TaskID, []api.Filter{})
+	require.NoError(t, err)
+	require.Equal(t, count, 2)
+
+	count, err = db.TaskLogsCount(t2In.TaskID, []api.Filter{})
+	require.NoError(t, err)
+	require.Equal(t, count, 1)
+
+	// Test TaskLogsFields.
+	resp, err := db.TaskLogsFields(t1In.TaskID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, resp.AgentIds, []string{"testing-agent-1", "testing-agent-2"})
+	require.ElementsMatch(t, resp.ContainerIds, []string{"1", "2"})
+
+	// Test TaskLogs.
+	// Get 1 task log matching t1In task ID.
+	logs, _, err := db.TaskLogs(t1In.TaskID, 1, []api.Filter{}, apiv1.OrderBy_ORDER_BY_UNSPECIFIED, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(logs))
+	require.Equal(t, logs[0].TaskID, string(t1In.TaskID))
+	require.Contains(t, []string{"1", "2"}, *logs[0].ContainerID)
+
+	// Get up to 5 tasks matching t2In task ID -- receive only 2.
+	logs, _, err = db.TaskLogs(t1In.TaskID, 5, []api.Filter{}, apiv1.OrderBy_ORDER_BY_UNSPECIFIED, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(logs))
+
+	// Test DeleteTaskLogs.
+	err = db.DeleteTaskLogs([]model.TaskID{t2In.TaskID})
+	require.NoError(t, err)
+
+	count, err = db.TaskLogsCount(t2In.TaskID, []api.Filter{})
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}
+
+func RequireMockTaskLog(t *testing.T, db *PgDB, tID model.TaskID, suffix string) *model.TaskLog {
+	mockA := RequireMockAllocation(t, db, tID)
+	agentID := fmt.Sprintf("testing-agent-%s", suffix)
+	containerID := suffix
+	log := &model.TaskLog{
+		TaskID:       string(tID),
+		AllocationID: (*string)(&mockA.AllocationID),
+		Log:          fmt.Sprintf("this is a log for task %s-%s", tID, suffix),
+		AgentID:      &agentID,
+		ContainerID:  &containerID,
+	}
+	return log
+}
+
+func allocationSessionByID(t *testing.T, aID model.AllocationID) (*model.AllocationSession, error) {
+	var res model.AllocationSession
+	if err := Bun().NewSelect().Table("allocation_sessions").
+		Where("allocation_id = ?", aID).Scan(context.Background(), &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
 }

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -467,7 +467,7 @@ func RequireMockAllocation(t *testing.T, db *PgDB, tID model.TaskID) *model.Allo
 	a := model.Allocation{
 		AllocationID: model.AllocationID(fmt.Sprintf("%s-1", tID)),
 		TaskID:       tID,
-		StartTime:    ptrs.Ptr(time.Now().UTC()),
+		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 		State:        ptrs.Ptr(model.AllocationStateTerminated),
 	}
 	err := db.AddAllocation(&a)

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -356,7 +356,7 @@ func TaskLogLevelFromLogrus(l logrus.Level) string {
 // TaskLog represents a structured log emitted by an allocation.
 type TaskLog struct {
 	// A task log should have one of these IDs after being persisted. All should be unique.
-	ID *int `db:"id" json:"id,omitempty"`
+	ID *int `db:"id" bun:"id,pk,autoincrement" json:"id,omitempty"`
 	// The body of an Elasticsearch log response will look something like
 	// { _id: ..., _source: { ... }} where _source is the rest of this struct.
 	// StringID doesn't have serialization tags because it is not part of

--- a/master/pkg/model/task_session.go
+++ b/master/pkg/model/task_session.go
@@ -5,7 +5,7 @@ import "github.com/uptrace/bun"
 // AllocationSession corresponds to a row in the "allocation_sessions" DB table.
 type AllocationSession struct {
 	bun.BaseModel `bun:"table:allocation_sessions"`
-	ID            SessionID    `db:"id" json:"id"`
-	AllocationID  AllocationID `db:"allocation_id" json:"allocation_id"`
-	OwnerID       *UserID      `db:"owner_id" json:"owner_id"`
+	ID            SessionID    `db:"id" bun:"id,pk,autoincrement" json:"id"`
+	AllocationID  AllocationID `db:"allocation_id" bun:"allocation_id" json:"allocation_id"`
+	OwnerID       *UserID      `db:"owner_id" bun:"owner_id" json:"owner_id"`
 }


### PR DESCRIPTION
## Description
Add integration tests for all exported functions in `db/postgres_tasks.go`, and initialize the db in TestMain.

Add bun descriptions to the AllocationSession & TaskLog models, so that the ID key is auto-incremented with each addition.

## Test Plan

See attached test.



## Commentary (optional)
Truncated the start time in `RequireMockAllocation` to match what the db stores.
Remove `CheckTaskExists ` from `postgres_tasks.go`, as it's used nowhere.

Writing the tests first, then bun-ifying db/postgres_tasks.go in https://github.com/determined-ai/determined/pull/8764

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10124