### PR TITLE
perf: improve get_workspaces query

### DIFF
--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -5,6 +5,7 @@ package internal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/workspace"
+	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -115,6 +117,107 @@ func TestPostWorkspace(t *testing.T) {
 	require.NoError(t, err)
 	proto.Equal(expected, getWorkResp.Workspace)
 	require.Equal(t, expected, getWorkResp.Workspace)
+}
+
+func TestGetWorkspaces(t *testing.T) {
+	require.NoError(t, etc.SetRootPath("../static/srv"))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, "file://../static/migrations")
+
+	api, curUser, ctx := setupAPITest(t, pgDB)
+
+	w0Resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: "w0name"})
+	require.NoError(t, err)
+	w0 := int(w0Resp.Workspace.Id)
+
+	w1, p0 := createProjectAndWorkspace(ctx, t, api)
+
+	w2, p1 := createProjectAndWorkspace(ctx, t, api)
+	_, err = api.PostProject(ctx, &apiv1.PostProjectRequest{
+		Name:        uuid.New().String(),
+		WorkspaceId: int32(w2),
+	})
+	require.NoError(t, err)
+
+	createTestExpWithProjectID(t, api, curUser, p0)
+	createTestExpWithProjectID(t, api, curUser, p0)
+	createTestExpWithProjectID(t, api, curUser, p1)
+	createTestExpWithProjectID(t, api, curUser, p1)
+
+	cases := []struct {
+		name     string
+		req      *apiv1.GetWorkspacesRequest
+		expected []int
+	}{
+		{"empty request", &apiv1.GetWorkspacesRequest{}, []int{1, w0, w1, w2}},
+		{"id desc request", &apiv1.GetWorkspacesRequest{
+			OrderBy: apiv1.OrderBy_ORDER_BY_DESC,
+		}, []int{w2, w1, w0, 1}},
+		{"w0 name", &apiv1.GetWorkspacesRequest{
+			Name: "w0name",
+		}, []int{w0}},
+		{"w0 name subset doesn't match", &apiv1.GetWorkspacesRequest{
+			Name: "0nam",
+		}, []int{}},
+		{"w0 name case insensitive", &apiv1.GetWorkspacesRequest{
+			Name: "w0nAMe",
+		}, []int{w0}},
+		{"archive false", &apiv1.GetWorkspacesRequest{
+			Archived: wrapperspb.Bool(false),
+		}, []int{1, w0, w1, w2}},
+		{"archive true", &apiv1.GetWorkspacesRequest{
+			Archived: wrapperspb.Bool(true),
+		}, []int{}},
+		{"users determined", &apiv1.GetWorkspacesRequest{
+			Users: []string{"determined"},
+		}, []int{}},
+		{"users admin", &apiv1.GetWorkspacesRequest{
+			Users: []string{"admin"},
+		}, []int{1}},
+		{"users determined", &apiv1.GetWorkspacesRequest{
+			Users: []string{curUser.Username},
+		}, []int{w0, w1, w2}},
+		{"userID determined", &apiv1.GetWorkspacesRequest{
+			UserIds: []int32{2},
+		}, []int{}},
+		{"userID admin", &apiv1.GetWorkspacesRequest{
+			UserIds: []int32{1},
+		}, []int{1}},
+		{"userID determined", &apiv1.GetWorkspacesRequest{
+			UserIds: []int32{int32(curUser.ID)},
+		}, []int{w0, w1, w2}},
+		{"w0 name case sensitive", &apiv1.GetWorkspacesRequest{
+			NameCaseSensitive: "w0name",
+		}, []int{w0}},
+		{"w0 name case sensitive subset doesn't match", &apiv1.GetWorkspacesRequest{
+			NameCaseSensitive: "0nam",
+		}, []int{}},
+		{"w0 name case sensative doesn't match", &apiv1.GetWorkspacesRequest{
+			NameCaseSensitive: "w0nAMe",
+		}, []int{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Make expected workspaces from GetWorkspace endpoint.
+			expectedWorkspaces := []*workspacev1.Workspace{} // Do empty and not null.
+			for _, w := range c.expected {
+				getResp, err := api.GetWorkspace(ctx, &apiv1.GetWorkspaceRequest{Id: int32(w)})
+				require.NoError(t, err)
+				getResp.Workspace.CheckpointStorageConfig = nil // Not returned in list endpoint.
+				expectedWorkspaces = append(expectedWorkspaces, getResp.Workspace)
+			}
+			expectedJSON, err := json.MarshalIndent(expectedWorkspaces, "", "  ")
+			require.NoError(t, err)
+
+			actual, err := api.GetWorkspaces(ctx, c.req)
+			require.NoError(t, err)
+			actualJSON, err := json.MarshalIndent(actual.Workspaces, "", "  ")
+			require.NoError(t, err)
+
+			require.Equal(t, string(expectedJSON), string(actualJSON))
+		})
+	}
 }
 
 // This should eventually be in internal/workspaces.

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -69,6 +69,7 @@ func TestPostWorkspace(t *testing.T) {
 
 	// Valid workspace.
 	workspaceName := uuid.New().String()
+	// TODO PostWorkspace should returned pinnedAt.
 	resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{
 		Name: workspaceName,
 		CheckpointStorageConfig: newProtoStruct(t, map[string]any{
@@ -115,6 +116,8 @@ func TestPostWorkspace(t *testing.T) {
 	// Workspace persisted correctly?
 	getWorkResp, err := api.GetWorkspace(ctx, &apiv1.GetWorkspaceRequest{Id: resp.Workspace.Id})
 	require.NoError(t, err)
+	require.NotNil(t, getWorkResp.Workspace.PinnedAt)
+	getWorkResp.Workspace.PinnedAt = nil // Can't check timestamp exactly.
 	proto.Equal(expected, getWorkResp.Workspace)
 	require.Equal(t, expected, getWorkResp.Workspace)
 }
@@ -409,6 +412,8 @@ func TestAuthzPostWorkspace(t *testing.T) {
 		Return(nil).Once()
 	getResp, err := api.GetWorkspace(ctx, &apiv1.GetWorkspaceRequest{Id: resp.Workspace.Id})
 	require.NoError(t, err)
+	require.NotNil(t, getResp.Workspace.PinnedAt)
+	getResp.Workspace.PinnedAt = nil // Can't check timestamp exactly.
 	proto.Equal(resp.Workspace, getResp.Workspace)
 	require.Equal(t, resp.Workspace, getResp.Workspace)
 

--- a/master/static/srv/get_workspace.sql
+++ b/master/static/srv/get_workspace.sql
@@ -33,7 +33,11 @@ SELECT
     (
         SELECT COUNT(*) > 0 FROM workspace_pins
         WHERE workspace_id = $1 AND user_id = $2
-    ) AS pinned
+    ) AS pinned,
+    (
+        SELECT created_at FROM workspace_pins
+        WHERE workspace_id = $1 AND user_id = $2
+    ) AS pinned_at
 FROM workspaces AS w
 LEFT JOIN users AS u ON u.id = w.user_id
 WHERE w.id = $1;

--- a/master/static/srv/get_workspaces.sql
+++ b/master/static/srv/get_workspaces.sql
@@ -4,13 +4,12 @@ SELECT w.id, w.name, w.archived, w.immutable, u.username, w.user_id,
 (CASE WHEN uid IS NOT NULL OR gid IS NOT NULL OR user_ IS NOT NULL OR group_ IS NOT NULL THEN
   jsonb_build_object('agent_uid', uid, 'agent_user', user_, 'agent_gid', gid, 'agent_group', group_)
   ELSE NULL END) AS agent_user_group,
-COUNT(DISTINCT p.id) AS num_projects,
-COUNT(DISTINCT e.id) AS num_experiments
+(SELECT COUNT(*) FROM projects WHERE workspace_id = w.id) AS num_projects,
+(SELECT COUNT(*) FROM experiments WHERE project_id IN
+  (SELECT id FROM projects WHERE workspace_id = w.id)) AS num_experiments
 FROM workspaces AS w
 LEFT JOIN users AS u ON u.id = w.user_id
 LEFT JOIN workspace_pins AS pins ON pins.workspace_id = w.id AND pins.user_id = $6
-LEFT JOIN projects AS p ON p.workspace_id = w.id
-LEFT JOIN experiments AS e ON e.project_id = p.id
 
 WHERE ($1 = '' OR (u.username IN (SELECT unnest(string_to_array($1, ',')))))
 AND ($2 = '' OR w.user_id IN (SELECT unnest(string_to_array($2, ',')::int [])))
@@ -19,5 +18,4 @@ AND ($7 = '' OR w.name LIKE $7)
 AND ($4 = '' OR w.archived = $4::BOOL)
 AND ($5 = '' OR (pins.id IS NOT NULL) = $5::BOOL)
 
-GROUP BY w.id, u.username, pins.id
 ORDER BY %s, pins.created_at DESC;


### PR DESCRIPTION
## Description

Improve performance of ```get_workspaces.sql```. 

The anon db revealed the query is taking way longer than it should.

This PR essentially undoes the optimization added in https://github.com/determined-ai/determined/pull/5929

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
