### PR TITLE
fix: Experiment table, right-click context menu [WEB-1942]

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -5,7 +5,7 @@ import Message from 'hew/Message';
 import Pagination from 'hew/Pagination';
 import Row from 'hew/Row';
 import { useTheme } from 'hew/Theme';
-import { notification } from 'hew/Toast';
+import { useToast } from 'hew/Toast';
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
 import { observable, useObservable } from 'micro-observables';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -130,6 +130,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     Loaded: (formset: FilterFormSet) => formset.filterGroup.children,
   });
   const isMobile = useMobile();
+  const { openToast } = useToast();
 
   const [selection, setSelection] = React.useState<GridSelection>({
     columns: CompactSelection.empty(),
@@ -551,7 +552,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
           break;
         case ExperimentAction.Edit:
           if (data) updateExperiment(data);
-          notification.success({ message: 'Experiment updated successfully' });
+          openToast({ severity: 'Confirm', title: 'Experiment updated successfully' });
           break;
         case ExperimentAction.Move:
         case ExperimentAction.Delete:
@@ -570,7 +571,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
       }
       handleSelectionChange('remove-all', [0, selectedExperimentIds.size]);
     },
-    [handleSelectionChange, selectedExperimentIds],
+    [handleSelectionChange, selectedExperimentIds, openToast],
   );
 
   const handleContextMenuComplete = useCallback(

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -1,10 +1,34 @@
 import { GridCell } from '@glideapps/glide-data-grid';
 import { MenuProps } from 'antd';
 import { DropdownEvent } from 'hew/Dropdown';
-import React, { useCallback, useRef } from 'react';
+import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
 
 import ExperimentActionDropdown from 'components/ExperimentActionDropdown';
 import { ExperimentAction, ExperimentItem, ProjectExperiment } from 'types';
+
+// eslint-disable-next-line
+function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Event) => void) {
+  useEffect(() => {
+    /**
+     * Alert if clicked on outside of element
+     */
+    function handleClickOutside(event: Event) {
+      if (
+        ref.current &&
+        !ref.current.contains(event.target) &&
+        !(event.srcElement as Element).className?.includes('ant-dropdown')
+      ) {
+        handler(event);
+      }
+    }
+    // Bind the event listener
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref, handler]);
+}
 
 export interface TableContextMenuProps extends MenuProps {
   cell?: GridCell;
@@ -28,6 +52,7 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
   y,
 }) => {
   const containerRef = useRef(null);
+  useOutsideClickHandler(containerRef, onClose);
 
   const handleComplete = useCallback(
     (action: ExperimentAction, id: number, data?: Partial<ExperimentItem>) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -16,7 +16,7 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Eve
       if (
         ref.current &&
         !ref.current.contains(event.target) &&
-        !(event.srcElement as Element).className?.includes('ant-dropdown')
+        !(event.target as Element).className?.includes('ant-dropdown')
       ) {
         handler(event);
       }

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -1,36 +1,10 @@
 import { GridCell } from '@glideapps/glide-data-grid';
 import { MenuProps } from 'antd';
 import { DropdownEvent } from 'hew/Dropdown';
-import React, { MutableRefObject, useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 import ExperimentActionDropdown from 'components/ExperimentActionDropdown';
 import { ExperimentAction, ExperimentItem, ProjectExperiment } from 'types';
-
-// eslint-disable-next-line
-function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Event) => void) {
-  useEffect(() => {
-    /**
-     * Alert if clicked on outside of element
-     */
-    function handleClickOutside(event: Event) {
-      if (
-        ref.current &&
-        !ref.current.contains(event.target) &&
-        !(event.target ? (event.target as Element) : null)?.classList?.contains(
-          'ant-dropdown-menu-title-content',
-        )
-      ) {
-        handler(event);
-      }
-    }
-    // Bind the event listener
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      // Unbind the event listener on clean up
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [ref, handler]);
-}
 
 export interface TableContextMenuProps extends MenuProps {
   cell?: GridCell;
@@ -54,7 +28,6 @@ export const TableContextMenu: React.FC<TableContextMenuProps> = ({
   y,
 }) => {
   const containerRef = useRef(null);
-  useOutsideClickHandler(containerRef, onClose);
 
   const handleComplete = useCallback(
     (action: ExperimentAction, id: number, data?: Partial<ExperimentItem>) => {

--- a/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
+++ b/webui/react/src/pages/F_ExpList/glide-table/contextMenu.tsx
@@ -16,7 +16,7 @@ function useOutsideClickHandler(ref: MutableRefObject<any>, handler: (event: Eve
       if (
         ref.current &&
         !ref.current.contains(event.target) &&
-        !(event.target as Element).className?.includes('ant-dropdown')
+        (!(event.target instanceof Element) || !event.target.className.includes('ant-dropdown'))
       ) {
         handler(event);
       }


### PR DESCRIPTION
## Description

The bug: Options in the right-click context menu sometimes close the menu but do not execute the action (archive/unarchive, open edit modal, etc.)

A few days after the bug report, we upgraded to glide-table v6. The bug is still present.
The easiest way to repeat the bug is to right-click the top row, and then click an option which is overlayed over the table header, or outside the glide table.

<img width="586" alt="Screen Shot 2024-01-25 at 1 03 55 PM" src="https://github.com/determined-ai/determined/assets/643918/03b84fa7-1af4-4615-8a02-d360935f3ce8">

The issue was `useOutsideClickHandler` - from https://github.com/determined-ai/determined/pull/6532 - we use it to close the ContextMenu by clicking somewhere outside. We keep this handler but make it trigger in fewer cases.

I fixed an unrelated bug with the "Experiment updated successfully" message. `notification.success` (pictured) is replaced by more standard `openToast`.

<img width="335" alt="Screen Shot 2024-01-25 at 10 03 40 AM" src="https://github.com/determined-ai/determined/assets/643918/9878533c-417d-4ff8-b074-70081c93a408">


## Test Plan

It is easier to test context menu overlap on `/det/projects/107/experiments`

- Right-click an experiment row to open the context menu. Right-click another row to open a new menu. Click somewhere away from the menu to close. 

- Right-click a row, select Edit, and change the title or description of the experiment. A confirmation message appears.

- Right-click the top row, and then click an option (Archive/Edit) which is above the table header, or outside the glide table
- Right-click a row where we have checkbox, a link, text, blank space, etc. and select Edit - a modal should appear each time

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.