### PR TITLE
Update helm chart config ref

### DIFF
--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -128,6 +128,12 @@
       -  ``hostPath``: The file system path on each node to use. This directory will be mounted to
          ``/determined_shared_fs`` inside the trial pod.
 
+      -  ``mountToServer``: Allows users to download checkpoints.
+
+         -  ``false``: Default.
+         -  ``true``: Mounts the shared directory on the server to allow ``checkpoint.download()``
+            to work.
+
    -  ``type: directory``: Checkpoints are written to a local directory in the task container. Users
       are responsible for mounting a persistent storage at this path, e.g., a shared PVC using
       ``pod_spec`` configuration.


### PR DESCRIPTION
Update helm chart configuration reference to support #8741 as described in the 0.27.1 release notes.

Specifically, update the documentation, adding the `mountToServer` value under checkpointStorage. Describe `false` (default) and `true` (when storage type is `shared_fs`, the shared directory will be mounted on the server, allowing `checkpoint.download()` to work with `shared_fs`.