### PR TITLE
chore: bunify db/postgres_tasks.go 

### DIFF
--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -45,7 +45,7 @@ func createVersionTwoCheckpoint(
 		ResourcePool: "somethingelse",
 		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 	}
-	require.NoError(t, api.m.db.AddAllocation(aIn))
+	require.NoError(t, db.AddAllocation(ctx, aIn))
 
 	checkpoint := &model.CheckpointV2{
 		ID:           0,

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2735,7 +2735,7 @@ func (a *apiServer) createTrialTx(
 		nil,
 		0)
 
-	if err := a.m.db.AddTask(&model.Task{
+	if err := db.AddTask(ctx, &model.Task{
 		TaskID:     taskID,
 		TaskType:   model.TaskTypeTrial,
 		StartTime:  time.Now(),

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -237,7 +237,7 @@ func TestGetTaskContextDirectoryExperiment(t *testing.T) {
 func TestGetTaskContextDirectoryTask(t *testing.T) {
 	api, _, ctx := setupAPITest(t, nil)
 	task := &model.Task{TaskType: model.TaskTypeNotebook, TaskID: model.NewTaskID()}
-	require.NoError(t, api.m.db.AddTask(task))
+	require.NoError(t, db.AddTask(ctx, task))
 
 	expectedContextDirectory := []byte("expectedContextDirectory")
 	_, err := db.Bun().NewInsert().Model(&model.TaskContextDirectory{
@@ -567,7 +567,7 @@ func TestGetExperiments(t *testing.T) {
 	require.NoError(t, api.m.db.AddExperiment(exp0, activeConfig0))
 	for i := 0; i < 3; i++ {
 		task := &model.Task{TaskType: model.TaskTypeTrial, TaskID: model.NewTaskID()}
-		require.NoError(t, api.m.db.AddTask(task))
+		require.NoError(t, db.AddTask(ctx, task))
 		require.NoError(t, db.AddTrial(ctx, &model.Trial{
 			State:        model.PausedState,
 			ExperimentID: exp0.ID,
@@ -819,7 +819,7 @@ func TestSearchExperiments(t *testing.T) {
 	// Trial without validations doesn't cause issues.
 	noValidationsExp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
 	task := &model.Task{TaskType: model.TaskTypeTrial, TaskID: model.NewTaskID()}
-	require.NoError(t, api.m.db.AddTask(task))
+	require.NoError(t, db.AddTask(ctx, task))
 	require.NoError(t, db.AddTrial(ctx, &model.Trial{
 		State:        model.PausedState,
 		ExperimentID: noValidationsExp.ID,

--- a/master/internal/api_tasks_intg_test.go
+++ b/master/internal/api_tasks_intg_test.go
@@ -113,10 +113,10 @@ func mockNotebookWithWorkspaceID(
 		TaskID:   model.NewTaskID(),
 		TaskType: model.TaskTypeNotebook,
 	}
-	require.NoError(t, api.m.db.AddTask(nb))
+	require.NoError(t, db.AddTask(ctx, nb))
 
 	allocationID := model.AllocationID(string(nb.TaskID) + ".1")
-	require.NoError(t, api.m.db.AddAllocation(&model.Allocation{
+	require.NoError(t, db.AddAllocation(ctx, &model.Allocation{
 		TaskID:       nb.TaskID,
 		AllocationID: allocationID,
 	}))
@@ -324,7 +324,7 @@ func TestAddAllocationAcceleratorData(t *testing.T) {
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	require.NoError(t, api.m.db.AddTask(task), "failed to add task")
+	require.NoError(t, db.AddTask(ctx, task), "failed to add task")
 
 	aID := tID + "-1"
 	a := &model.Allocation{
@@ -333,7 +333,7 @@ func TestAddAllocationAcceleratorData(t *testing.T) {
 		Slots:        1,
 		ResourcePool: "default",
 	}
-	require.NoError(t, api.m.db.AddAllocation(a), "failed to add allocation")
+	require.NoError(t, db.AddAllocation(ctx, a), "failed to add allocation")
 	accData := &model.AcceleratorData{
 		ContainerID:      uuid.NewString(),
 		AllocationID:     model.AllocationID(aID),
@@ -362,7 +362,7 @@ func TestGetAllocationAcceleratorDataWithNoData(t *testing.T) {
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	require.NoError(t, api.m.db.AddTask(task), "failed to add task")
+	require.NoError(t, db.AddTask(ctx, task), "failed to add task")
 
 	aID := tID + "-1"
 	a := &model.Allocation{
@@ -371,7 +371,7 @@ func TestGetAllocationAcceleratorDataWithNoData(t *testing.T) {
 		Slots:        1,
 		ResourcePool: "default",
 	}
-	require.NoError(t, api.m.db.AddAllocation(a), "failed to add allocation")
+	require.NoError(t, db.AddAllocation(ctx, a), "failed to add allocation")
 
 	resp, err := api.GetTaskAcceleratorData(ctx,
 		&apiv1.GetTaskAcceleratorDataRequest{TaskId: tID.String()})
@@ -390,7 +390,7 @@ func TestGetAllocationAcceleratorData(t *testing.T) {
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	require.NoError(t, api.m.db.AddTask(task), "failed to add task")
+	require.NoError(t, db.AddTask(ctx, task), "failed to add task")
 
 	aID1 := tID + "-1"
 	a1 := &model.Allocation{
@@ -399,7 +399,7 @@ func TestGetAllocationAcceleratorData(t *testing.T) {
 		Slots:        1,
 		ResourcePool: "default",
 	}
-	require.NoError(t, api.m.db.AddAllocation(a1), "failed to add allocation")
+	require.NoError(t, db.AddAllocation(ctx, a1), "failed to add allocation")
 	accData := &model.AcceleratorData{
 		ContainerID:      uuid.NewString(),
 		AllocationID:     model.AllocationID(aID1),
@@ -418,7 +418,7 @@ func TestGetAllocationAcceleratorData(t *testing.T) {
 		Slots:        1,
 		ResourcePool: "default",
 	}
-	require.NoError(t, api.m.db.AddAllocation(a2), "failed to add allocation")
+	require.NoError(t, db.AddAllocation(ctx, a2), "failed to add allocation")
 
 	resp, err := api.GetTaskAcceleratorData(ctx,
 		&apiv1.GetTaskAcceleratorDataRequest{TaskId: tID.String()})

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -41,7 +41,6 @@ var inferenceMetricGroup = "inference"
 func createTestTrial(
 	t *testing.T, api *apiServer, curUser model.User,
 ) (*model.Trial, *model.Task) {
-	ctx := context.TODO()
 	exp := createTestExpWithProjectID(t, api, curUser, 1)
 
 	task := &model.Task{
@@ -50,17 +49,17 @@ func createTestTrial(
 		StartTime:  time.Now(),
 		TaskID:     trialTaskID(exp.ID, model.NewRequestID(rand.Reader)),
 	}
-	require.NoError(t, db.AddTask(ctx, task))
+	require.NoError(t, db.AddTask(context.TODO(), task))
 
 	trial := &model.Trial{
 		StartTime:    time.Now(),
 		State:        model.PausedState,
 		ExperimentID: exp.ID,
 	}
-	require.NoError(t, db.AddTrial(ctx, trial, task.TaskID))
+	require.NoError(t, db.AddTrial(context.TODO(), trial, task.TaskID))
 
 	// Return trial exactly the way the API will generally get it.
-	outTrial, err := db.TrialByID(ctx, trial.ID)
+	outTrial, err := db.TrialByID(context.TODO(), trial.ID)
 	require.NoError(t, err)
 	return outTrial, task
 }
@@ -918,7 +917,7 @@ func TestExperimentIDFromTrialTaskID(t *testing.T) {
 		StartTime:  time.Now(),
 		TaskID:     model.TaskID(uuid.New().String()),
 	}
-	require.NoError(t, db.AddTask(context.Background(), task))
+	require.NoError(t, db.AddTask(context.TODO(), task))
 	_, err = experimentIDFromTrialTaskID(notTrialTask.TaskID)
 	require.ErrorIs(t, err, errIsNotTrialTaskID)
 

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -41,7 +41,7 @@ var inferenceMetricGroup = "inference"
 func createTestTrial(
 	t *testing.T, api *apiServer, curUser model.User,
 ) (*model.Trial, *model.Task) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	exp := createTestExpWithProjectID(t, api, curUser, 1)
 
 	task := &model.Task{

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -140,8 +140,7 @@ func runCheckpointGCTask(
 	})
 	syslog := logrus.WithField("component", "checkpointgc").WithFields(logCtx.Fields())
 
-	ctx := context.TODO()
-	if err := db.AddTask(ctx, &model.Task{
+	if err := db.AddTask(context.TODO(), &model.Task{
 		TaskID:     taskID,
 		TaskType:   model.TaskTypeCheckpointGC,
 		StartTime:  time.Now().UTC(),
@@ -156,7 +155,7 @@ func runCheckpointGCTask(
 
 	resultChan := make(chan error, 1)
 	onExit := func(ae *task.AllocationExited) {
-		if err := db.CompleteTask(ctx, taskID, time.Now().UTC()); err != nil {
+		if err := db.CompleteTask(context.TODO(), taskID, time.Now().UTC()); err != nil {
 			syslog.WithError(err).Error("marking GC task complete")
 		}
 		if err := tasklist.GroupPriorityChangeRegistry.Delete(gcJobID); err != nil {

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -140,7 +140,7 @@ func runCheckpointGCTask(
 	})
 	syslog := logrus.WithField("component", "checkpointgc").WithFields(logCtx.Fields())
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	if err := db.AddTask(ctx, &model.Task{
 		TaskID:     taskID,
 		TaskType:   model.TaskTypeCheckpointGC,

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -230,10 +230,11 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	c.exitStatus = ae
 
-	if err := c.db.CompleteTask(c.taskID, time.Now().UTC()); err != nil {
+	ctx := context.Background()
+	if err := db.CompleteTask(ctx, c.taskID, time.Now().UTC()); err != nil {
 		c.syslog.WithError(err).Error("marking task complete")
 	}
-	if err := user.DeleteSessionByToken(context.TODO(), c.GenericCommandSpec.Base.UserSessionToken); err != nil {
+	if err := user.DeleteSessionByToken(ctx, c.GenericCommandSpec.Base.UserSessionToken); err != nil {
 		c.syslog.WithError(err).Errorf(
 			"failure to delete user session for task: %v", c.taskID)
 	}
@@ -251,7 +252,7 @@ func (c *Command) garbageCollect() {
 	}
 
 	if c.exitStatus == nil {
-		if err := c.db.CompleteTask(c.taskID, time.Now().UTC()); err != nil {
+		if err := db.CompleteTask(context.Background(), c.taskID, time.Now().UTC()); err != nil {
 			c.syslog.WithError(err).Error("marking task complete")
 		}
 	}

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -230,7 +230,7 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	c.exitStatus = ae
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	if err := db.CompleteTask(ctx, c.taskID, time.Now().UTC()); err != nil {
 		c.syslog.WithError(err).Error("marking task complete")
 	}

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -230,11 +230,10 @@ func (c *Command) OnExit(ae *task.AllocationExited) {
 
 	c.exitStatus = ae
 
-	ctx := context.TODO()
-	if err := db.CompleteTask(ctx, c.taskID, time.Now().UTC()); err != nil {
+	if err := db.CompleteTask(context.TODO(), c.taskID, time.Now().UTC()); err != nil {
 		c.syslog.WithError(err).Error("marking task complete")
 	}
-	if err := user.DeleteSessionByToken(ctx, c.GenericCommandSpec.Base.UserSessionToken); err != nil {
+	if err := user.DeleteSessionByToken(context.TODO(), c.GenericCommandSpec.Base.UserSessionToken); err != nil {
 		c.syslog.WithError(err).Errorf(
 			"failure to delete user session for task: %v", c.taskID)
 	}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -791,9 +791,9 @@ func (m *Master) restoreNonTerminalExperiments() error {
 	return nil
 }
 
-func (m *Master) closeOpenAllocations() error {
+func (m *Master) closeOpenAllocations(ctx context.Context) error {
 	allocationIds := task.DefaultService.GetAllAllocationIDs()
-	if err := m.db.CloseOpenAllocations(allocationIds); err != nil {
+	if err := db.CloseOpenAllocations(ctx, allocationIds); err != nil {
 		return err
 	}
 	return nil
@@ -1081,11 +1081,11 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 		return err
 	}
 
-	if err = m.closeOpenAllocations(); err != nil {
+	if err = m.closeOpenAllocations(ctx); err != nil {
 		return err
 	}
 
-	if err = m.db.EndAllTaskStats(); err != nil {
+	if err = db.EndAllTaskStats(ctx); err != nil {
 		return err
 	}
 

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -43,13 +43,8 @@ type DB interface {
 		id int,
 		experimentBest, trialBest, trialLatest int,
 	) ([]uuid.UUID, error)
-	AddTask(t *model.Task) error
-	UpdateTrial(id int, newState model.State) error
 	UpdateTrialRunnerState(id int, state string) error
 	UpdateTrialRunnerMetadata(id int, md *trialv1.TrialRunnerMetadata) error
-	AddAllocation(a *model.Allocation) error
-	CompleteAllocation(a *model.Allocation) error
-	CompleteAllocationTelemetry(aID model.AllocationID) ([]byte, error)
 	TrialRunIDAndRestarts(trialID int) (int, int, error)
 	UpdateTrialRunID(id, runID int) error
 	UpdateTrialRestarts(id, restarts int) error
@@ -89,11 +84,6 @@ type DB interface {
 		trials []*apiv1.TrialsSnapshotResponse_Trial, endTime time.Time, err error)
 	TopTrialsByTrainingLength(experimentID int, maxTrials int, metric string,
 		smallerIsBetter bool) (trials []int32, err error)
-	StartAllocationSession(allocationID model.AllocationID, owner *model.User) (string, error)
-	DeleteAllocationSession(allocationID model.AllocationID) error
-	UpdateAllocationState(allocation model.Allocation) error
-	UpdateAllocationStartTime(allocation model.Allocation) error
-	UpdateAllocationProxyAddress(allocation model.Allocation) error
 	ExperimentSnapshot(experimentID int) ([]byte, int, error)
 	SaveSnapshot(
 		experimentID int, version int, experimentSnapshot []byte,
@@ -114,9 +104,6 @@ type DB interface {
 	RecordInstanceStats(a *model.InstanceStats) error
 	EndInstanceStats(a *model.InstanceStats) error
 	EndAllInstanceStats() error
-	EndAllTaskStats() error
-	RecordTaskEndStats(stats *model.TaskStats) error
-	RecordTaskStats(stats *model.TaskStats) error
 	UpdateJobPosition(jobID model.JobID, position decimal.Decimal) error
 }
 

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -211,47 +211,9 @@ func (db *PgDB) Close() error {
 	return db.sql.Close()
 }
 
-// namedGet is a convenience method for a named query for a single value.
-func (db *PgDB) namedGet(dest interface{}, query string, arg interface{}) error {
-	nstmt, err := db.sql.PrepareNamed(query)
-	if err != nil {
-		return errors.Wrapf(err, "error preparing query %s", query)
-	}
-
-	defer nstmt.Close()
-
-	if sErr := nstmt.QueryRowx(arg).Scan(dest); sErr != nil {
-		err = errors.Wrapf(sErr, "error scanning query %s", query)
-	}
-	if cErr := nstmt.Close(); cErr != nil && err != nil {
-		err = errors.Wrap(cErr, "error closing named DB statement")
-	}
-
-	return err
-}
-
 // namedExecOne is a convenience method for a NamedExec that should affect only one row.
 func (db *PgDB) namedExecOne(query string, arg interface{}) error {
 	res, err := db.sql.NamedExec(query, arg)
-	if err != nil {
-		return errors.Wrapf(err, "error in query %v \narg %v", query, arg)
-	}
-	num, err := res.RowsAffected()
-	if err != nil {
-		return errors.Wrapf(
-			err,
-			"error checking rows affected for query %v\n arg %v",
-			query, arg)
-	}
-	if num != 1 {
-		return errors.Errorf("error: %v rows affected on query %v \narg %v", num, query, arg)
-	}
-	return nil
-}
-
-// namedExecOne is a convenience method for a NamedExec that should affect only one row.
-func namedExecOne(tx *sqlx.Tx, query string, arg interface{}) error {
-	res, err := tx.NamedExec(query, arg)
 	if err != nil {
 		return errors.Wrapf(err, "error in query %v \narg %v", query, arg)
 	}

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -46,7 +47,8 @@ func TestClusterAPI(t *testing.T) {
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
 
-	err = db.AddTask(tIn)
+	ctx := context.Background()
+	err = AddTask(ctx, tIn)
 	require.NoError(t, err, "failed to add task")
 
 	// Add an allocation
@@ -59,7 +61,7 @@ func TestClusterAPI(t *testing.T) {
 		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 	}
 
-	err = db.AddAllocation(aIn)
+	err = AddAllocation(ctx, aIn)
 	require.NoError(t, err, "failed to add allocation")
 
 	// Add a cluster heartbeat after allocation, so it is as if the master died with it open.
@@ -74,10 +76,10 @@ func TestClusterAPI(t *testing.T) {
 		"Retrieved cluster heartbeat doesn't match the correct time")
 
 	// Don't complete the above allocation and call CloseOpenAllocations
-	require.NoError(t, db.CloseOpenAllocations(nil))
+	require.NoError(t, CloseOpenAllocations(ctx, nil))
 
 	// Retrieve the open allocation and check if end time is set to cluster_heartbeat
-	aOut, err := db.AllocationByID(aIn.AllocationID)
+	aOut, err := AllocationByID(ctx, aIn.AllocationID)
 	require.NoError(t, err)
 	require.NotNil(t, aOut, "aOut is Nil")
 	require.NotNil(t, aOut.EndTime, "aOut.EndTime is Nil")

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -47,7 +47,7 @@ func TestClusterAPI(t *testing.T) {
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	err = AddTask(ctx, tIn)
 	require.NoError(t, err, "failed to add task")
 

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -47,8 +47,7 @@ func TestClusterAPI(t *testing.T) {
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
 
-	ctx := context.TODO()
-	err = AddTask(ctx, tIn)
+	err = AddTask(context.TODO(), tIn)
 	require.NoError(t, err, "failed to add task")
 
 	// Add an allocation
@@ -61,7 +60,7 @@ func TestClusterAPI(t *testing.T) {
 		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 	}
 
-	err = AddAllocation(ctx, aIn)
+	err = AddAllocation(context.TODO(), aIn)
 	require.NoError(t, err, "failed to add allocation")
 
 	// Add a cluster heartbeat after allocation, so it is as if the master died with it open.
@@ -76,10 +75,10 @@ func TestClusterAPI(t *testing.T) {
 		"Retrieved cluster heartbeat doesn't match the correct time")
 
 	// Don't complete the above allocation and call CloseOpenAllocations
-	require.NoError(t, CloseOpenAllocations(ctx, nil))
+	require.NoError(t, CloseOpenAllocations(context.TODO(), nil))
 
 	// Retrieve the open allocation and check if end time is set to cluster_heartbeat
-	aOut, err := AllocationByID(ctx, aIn.AllocationID)
+	aOut, err := AllocationByID(context.TODO(), aIn.AllocationID)
 	require.NoError(t, err)
 	require.NotNil(t, aOut, "aOut is Nil")
 	require.NotNil(t, aOut.EndTime, "aOut.EndTime is Nil")

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jmoiron/sqlx"
 	"github.com/o1egl/paseto"
 	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
@@ -18,25 +17,15 @@ import (
 )
 
 // initAllocationSessions purges sessions of all closed allocations.
-func (db *PgDB) initAllocationSessions() error {
-	_, err := db.sql.Exec(`
-DELETE FROM allocation_sessions WHERE allocation_id in (
-	SELECT allocation_id FROM allocations
-	WHERE start_time IS NOT NULL AND end_time IS NOT NULL
-)`)
+func initAllocationSessions(ctx context.Context) error {
+	subq := Bun().NewSelect().Table("allocations").
+		Column("allocation_id").Where("start_time IS NOT NULL AND end_time IS NOT NULL")
+	_, err := Bun().NewDelete().Table("allocation_sessions").Where("allocation_id in (?)", subq).Exec(ctx)
 	return err
 }
 
 // AddTask UPSERT's the existence of a task.
-//
-// TODO(ilia): deprecate and use module function instead.
-func (db *PgDB) AddTask(t *model.Task) error {
-	return AddTask(context.TODO(), t)
-}
-
-// AddTask UPSERT's the existence of a task.
 func AddTask(ctx context.Context, t *model.Task) error {
-	// Since AddTaskTx is a single query, RunInTx is an overkill.
 	return AddTaskTx(ctx, Bun(), t)
 }
 
@@ -99,29 +88,9 @@ func TaskCompleted(ctx context.Context, tID model.TaskID) (bool, error) {
 }
 
 // CompleteTask persists the completion of a task.
-func (db *PgDB) CompleteTask(tID model.TaskID, endTime time.Time) error {
-	return completeTask(db.sql, tID, endTime)
-}
-
-func completeTask(ex sqlx.Execer, tID model.TaskID, endTime time.Time) error {
-	if _, err := ex.Exec(`
-UPDATE tasks
-SET end_time = $2
-WHERE task_id = $1
-	`, tID, endTime); err != nil {
-		return errors.Wrap(err, "completing task")
-	}
-	return nil
-}
-
-func completeTrialsTasks(ex sqlx.Execer, trialID int, endTime time.Time) error {
-	if _, err := ex.Exec(`
-UPDATE tasks
-SET end_time = $2
-FROM run_id_task_id
-WHERE run_id_task_id.task_id = tasks.task_id
-  AND run_id_task_id.run_id = $1
-  AND end_time IS NULL`, trialID, endTime); err != nil {
+func CompleteTask(ctx context.Context, tID model.TaskID, endTime time.Time) error {
+	if _, err := Bun().NewUpdate().Table("tasks").Set("end_time = ?", endTime).
+		Where("task_id = ?", tID).Exec(ctx); err != nil {
 		return fmt.Errorf("completing task: %w", err)
 	}
 	return nil
@@ -130,75 +99,67 @@ WHERE run_id_task_id.task_id = tasks.task_id
 // AddAllocation upserts the existence of an allocation. Allocation IDs may conflict in the event
 // the master restarts and the trial run ID increment is not persisted, but it is the same
 // allocation so this is OK.
-func (db *PgDB) AddAllocation(a *model.Allocation) error {
-	return db.namedExecOne(`
-INSERT INTO allocations
-	(task_id, allocation_id, slots, resource_pool, start_time, state, ports)
-VALUES
-	(:task_id, :allocation_id, :slots, :resource_pool, :start_time, :state, :ports)
-ON CONFLICT
-	(allocation_id)
-DO UPDATE SET
-	task_id=EXCLUDED.task_id, slots=EXCLUDED.slots, resource_pool=EXCLUDED.resource_pool,
-	start_time=EXCLUDED.start_time, state=EXCLUDED.state, ports=EXCLUDED.ports
-`, a)
+func AddAllocation(ctx context.Context, a *model.Allocation) error {
+	_, err := Bun().NewInsert().Model(a).On("CONFLICT (allocation_id) DO UPDATE").
+		Set("task_id=EXCLUDED.task_id, slots=EXCLUDED.slots").
+		Set("resource_pool=EXCLUDED.resource_pool,start_time=EXCLUDED.start_time").
+		Set("state=EXCLUDED.state, ports=EXCLUDED.ports").Exec(ctx)
+	return err
 }
 
 // AddAllocationExitStatus adds the allocation exit status to the allocations table.
 func AddAllocationExitStatus(ctx context.Context, a *model.Allocation) error {
-	_, err := Bun().NewUpdate().
-		Model(a).
+	if _, err := Bun().NewUpdate().Model(a).
 		Column("exit_reason", "exit_error", "status_code").
-		Where("allocation_id = ?", a.AllocationID).
-		Exec(ctx)
-	if err != nil {
+		Where("allocation_id = ?", a.AllocationID).Exec(ctx); err != nil {
 		return fmt.Errorf("adding allocation exit status to db: %w", err)
 	}
 	return nil
 }
 
 // CompleteAllocation persists the end of an allocation lifetime.
-func (db *PgDB) CompleteAllocation(a *model.Allocation) error {
+func CompleteAllocation(ctx context.Context, a *model.Allocation) error {
 	if a.StartTime == nil {
 		a.StartTime = a.EndTime
 	}
 
-	_, err := db.sql.Exec(`
-UPDATE allocations
-SET start_time = $2, end_time = $3
-WHERE allocation_id = $1`, a.AllocationID, a.StartTime, a.EndTime)
+	_, err := Bun().NewUpdate().Model(a).Set("start_time = ?, end_time = ?", a.StartTime, a.EndTime).
+		Where("allocation_id = ?", a.AllocationID).Exec(ctx)
 
 	return err
 }
 
 // CompleteAllocationTelemetry returns the analytics of an allocation for the telemetry.
-func (db *PgDB) CompleteAllocationTelemetry(aID model.AllocationID) ([]byte, error) {
-	return db.rawQuery(`
-SELECT json_build_object(
-	'allocation_id', a.allocation_id,
-	'job_id', t.job_id,
-	'task_type', t.task_type,
-    'duration_sec', COALESCE(EXTRACT(EPOCH FROM (a.end_time - a.start_time)), 0)
-)
-FROM allocations as a JOIN tasks as t
-ON a.task_id = t.task_id
-WHERE a.allocation_id = $1;
-`, aID)
+func CompleteAllocationTelemetry(ctx context.Context, aID model.AllocationID) ([]byte, error) {
+	var res []byte
+	err := Bun().NewRaw(`
+	SELECT json_build_object(
+		'allocation_id', a.allocation_id,
+		'job_id', t.job_id,
+		'task_type', t.task_type,
+		'duration_sec', COALESCE(EXTRACT(EPOCH FROM (a.end_time - a.start_time)), 0)
+	)
+	FROM allocations as a JOIN tasks as t
+	ON a.task_id = t.task_id
+	WHERE a.allocation_id = ?`, aID).Scan(ctx, &res)
+	return res, err
 }
 
 // AllocationByID retrieves an allocation by its ID.
-func (db *PgDB) AllocationByID(aID model.AllocationID) (*model.Allocation, error) {
+func AllocationByID(ctx context.Context, aID model.AllocationID) (*model.Allocation, error) {
 	var a model.Allocation
-	if err := Bun().NewSelect().Model(&a).Where("allocation_id = ?", aID).
-		Scan(context.TODO()); err != nil {
+	if err := Bun().NewSelect().Table("allocations").
+		Where("allocation_id = ?", aID).Scan(ctx, &a); err != nil {
 		return nil, err
 	}
 	return &a, nil
 }
 
 // StartAllocationSession creates a row in the allocation_sessions table.
-func (db *PgDB) StartAllocationSession(
-	allocationID model.AllocationID, owner *model.User,
+func StartAllocationSession(
+	ctx context.Context,
+	allocationID model.AllocationID,
+	owner *model.User,
 ) (string, error) {
 	if owner == nil {
 		return "", errors.New("owner cannot be nil for allocation session")
@@ -209,74 +170,63 @@ func (db *PgDB) StartAllocationSession(
 		OwnerID:      &owner.ID,
 	}
 
-	query := `
-INSERT INTO allocation_sessions (allocation_id, owner_id) VALUES
-	(:allocation_id, :owner_id) RETURNING id`
-	if err := db.namedGet(&taskSession.ID, query, *taskSession); err != nil {
+	if _, err := Bun().NewInsert().Model(taskSession).
+		Returning("id").Exec(ctx, &taskSession.ID); err != nil {
 		return "", err
 	}
 
 	v2 := paseto.NewV2()
 	token, err := v2.Sign(GetTokenKeys().PrivateKey, taskSession, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate task authentication token")
+		return "", fmt.Errorf("failed to generate task authentication token: %w", err)
 	}
 	return token, nil
 }
 
 // DeleteAllocationSession deletes the task session with the given AllocationID.
-func (db *PgDB) DeleteAllocationSession(allocationID model.AllocationID) error {
-	_, err := db.sql.Exec(
-		"DELETE FROM allocation_sessions WHERE allocation_id=$1", allocationID)
+func DeleteAllocationSession(ctx context.Context, allocationID model.AllocationID) error {
+	_, err := Bun().NewDelete().Table("allocation_sessions").Where("allocation_id = ?", allocationID).Exec(ctx)
 	return err
 }
 
 // UpdateAllocationState stores the latest task state and readiness.
-func (db *PgDB) UpdateAllocationState(a model.Allocation) error {
-	_, err := db.sql.Exec(`
-		UPDATE allocations
-		SET state=$2, is_ready=$3
-		WHERE allocation_id=$1
-	`, a.AllocationID, a.State, a.IsReady)
+func UpdateAllocationState(ctx context.Context, a model.Allocation) error {
+	_, err := Bun().NewUpdate().Table("allocations").
+		Set("state = ?, is_ready = ?", a.State, a.IsReady).
+		Where("allocation_id = ?", a.AllocationID).Exec(ctx)
+
 	return err
 }
 
 // UpdateAllocationPorts stores the latest task state and readiness.
-func UpdateAllocationPorts(a model.Allocation) error {
+func UpdateAllocationPorts(ctx context.Context, a model.Allocation) error {
 	_, err := Bun().NewUpdate().Table("allocations").
 		Set("ports = ?", a.Ports).
 		Where("allocation_id = ?", a.AllocationID).
-		Exec(context.TODO())
+		Exec(ctx)
 	return err
 }
 
 // UpdateAllocationStartTime stores the latest start time.
-func (db *PgDB) UpdateAllocationStartTime(a model.Allocation) error {
-	_, err := db.sql.Exec(`
-		UPDATE allocations
-		SET start_time = $2
-		WHERE allocation_id = $1
-	`, a.AllocationID, a.StartTime)
+func UpdateAllocationStartTime(ctx context.Context, a model.Allocation) error {
+	_, err := Bun().NewUpdate().Table("allocations").
+		Set("start_time = ?", a.StartTime).Where("allocation_id = ?", a.AllocationID).Exec(ctx)
 	return err
 }
 
 // UpdateAllocationProxyAddress stores the proxy address.
-func (db *PgDB) UpdateAllocationProxyAddress(a model.Allocation) error {
-	_, err := db.sql.Exec(`
-		UPDATE allocations
-		SET proxy_address = $2
-		WHERE allocation_id = $1
-	`, a.AllocationID, a.ProxyAddress)
+func UpdateAllocationProxyAddress(ctx context.Context, a model.Allocation) error {
+	_, err := Bun().NewUpdate().Table("allocations").Set("proxy_address = ?", a.ProxyAddress).
+		Where("allocation_id = ?", a.AllocationID).Exec(ctx)
 	return err
 }
 
 // CloseOpenAllocations finds all allocations that were open when the master crashed
 // and adds an end time.
-func (db *PgDB) CloseOpenAllocations(exclude []model.AllocationID) error {
-	if _, err := db.sql.Exec(`
-	UPDATE allocations
-	SET start_time = cluster_heartbeat FROM cluster_id
-	WHERE start_time is NULL`); err != nil {
+func CloseOpenAllocations(ctx context.Context, exclude []model.AllocationID) error {
+	if _, err := Bun().NewUpdate().Table("allocations", "cluster_id").
+		Set("start_time = cluster_id.cluster_heartbeat").
+		Where("start_time is NULL").Exec(ctx); err != nil {
 		return errors.Wrap(err,
 			"setting start time to cluster heartbeat when it's assigned to zero value")
 	}
@@ -287,19 +237,68 @@ func (db *PgDB) CloseOpenAllocations(exclude []model.AllocationID) error {
 		for _, v := range exclude {
 			excludeStr = append(excludeStr, v.String())
 		}
-
 		excludedFilter = strings.Join(excludeStr, ",")
 	}
 
-	if _, err := db.sql.Exec(`
-	UPDATE allocations
-	SET end_time = greatest(cluster_heartbeat, start_time), state = 'TERMINATED'
-	FROM cluster_id
-	WHERE end_time IS NULL AND
-	($1 = '' OR allocation_id NOT IN (
-		SELECT unnest(string_to_array($1, ','))))`, excludedFilter); err != nil {
+	if _, err := Bun().NewUpdate().Table("allocations", "cluster_id").
+		Set("end_time = greatest(cluster_id.cluster_heartbeat, allocations.start_time)").
+		Set("state = 'TERMINATED'").
+		Where("end_time IS NULL AND (? = '' OR allocation_id NOT IN (SELECT unnest(string_to_array(?, ','))))",
+			excludedFilter, excludedFilter).Exec(ctx); err != nil {
 		return errors.Wrap(err, "closing old allocations")
 	}
+	return nil
+}
+
+// RecordTaskStats record stats for tasks.
+func RecordTaskStats(ctx context.Context, stats *model.TaskStats) error {
+	return RecordTaskStatsBun(ctx, stats)
+}
+
+// RecordTaskStatsBun record stats for tasks with bun.
+func RecordTaskStatsBun(ctx context.Context, stats *model.TaskStats) error {
+	_, err := Bun().NewInsert().Model(stats).Exec(context.TODO())
+	return err
+}
+
+// RecordTaskEndStats record end stats for tasks.
+func RecordTaskEndStats(ctx context.Context, stats *model.TaskStats) error {
+	return RecordTaskEndStatsBun(ctx, stats)
+}
+
+// RecordTaskEndStatsBun record end stats for tasks with bun.
+func RecordTaskEndStatsBun(ctx context.Context, stats *model.TaskStats) error {
+	query := Bun().NewUpdate().Model(stats).Column("end_time").
+		Where("allocation_id = ?", stats.AllocationID).
+		Where("event_type = ?", stats.EventType).
+		Where("end_time IS NULL")
+	if stats.ContainerID == nil {
+		// Just doing Where("container_id = ?", stats.ContainerID) in the null case
+		// generates WHERE container_id = NULL which doesn't seem to match on null rows.
+		// We don't use this case anywhere currently but this feels like an easy bug to write
+		// without this.
+		query = query.Where("container_id IS NULL")
+	} else {
+		query = query.Where("container_id = ?", stats.ContainerID)
+	}
+
+	if _, err := query.Exec(ctx); err != nil {
+		return fmt.Errorf("recording task end stats %+v: %w", stats, err)
+	}
+
+	return nil
+}
+
+// EndAllTaskStats called at master starts, in case master previously crashed.
+func EndAllTaskStats(ctx context.Context) error {
+	_, err := Bun().NewUpdate().Table("task_stats", "cluster_id", "allocations").
+		Set("end_time = greatest(cluster_id.cluster_heartbeat, task_stats.start_time)").
+		Where("allocations.allocation_id = task_stats.allocation_id").
+		Where("task_stats.end_time IS NULL").Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("ending all task stats: %w", err)
+	}
+
 	return nil
 }
 
@@ -362,7 +361,7 @@ ORDER BY l.id %s LIMIT $2
 	return b, followState, nil
 }
 
-// AddTaskLogs adds a list of *model.TaskLog objects to the database with automatic IDs.
+// AddTaskLogs bulk-inserts a list of *model.TaskLog objects to the database with automatic IDs.
 func (db *PgDB) AddTaskLogs(logs []*model.TaskLog) error {
 	if len(logs) == 0 {
 		return nil
@@ -424,60 +423,6 @@ WHERE task_id = $1
 	return count, nil
 }
 
-// RecordTaskStats record stats for tasks.
-func (db *PgDB) RecordTaskStats(stats *model.TaskStats) error {
-	return RecordTaskStatsBun(stats)
-}
-
-// RecordTaskStatsBun record stats for tasks with bun.
-func RecordTaskStatsBun(stats *model.TaskStats) error {
-	_, err := Bun().NewInsert().Model(stats).Exec(context.TODO())
-	return err
-}
-
-// RecordTaskEndStats record end stats for tasks.
-func (db *PgDB) RecordTaskEndStats(stats *model.TaskStats) error {
-	return RecordTaskEndStatsBun(stats)
-}
-
-// RecordTaskEndStatsBun record end stats for tasks with bun.
-func RecordTaskEndStatsBun(stats *model.TaskStats) error {
-	query := Bun().NewUpdate().Model(stats).Column("end_time").
-		Where("allocation_id = ?", stats.AllocationID).
-		Where("event_type = ?", stats.EventType).
-		Where("end_time IS NULL")
-	if stats.ContainerID == nil {
-		// Just doing Where("container_id = ?", stats.ContainerID) in the null case
-		// generates WHERE container_id = NULL which doesn't seem to match on null rows.
-		// We don't use this case anywhere currently but this feels like an easy bug to write
-		// without this.
-		query = query.Where("container_id IS NULL")
-	} else {
-		query = query.Where("container_id = ?", stats.ContainerID)
-	}
-
-	if _, err := query.Exec(context.TODO()); err != nil {
-		return fmt.Errorf("recording task end stats %+v: %w", stats, err)
-	}
-
-	return nil
-}
-
-// EndAllTaskStats called at master starts, in case master previously crashed.
-func (db *PgDB) EndAllTaskStats() error {
-	_, err := db.sql.Exec(`
-UPDATE task_stats SET end_time = greatest(cluster_heartbeat, task_stats.start_time)
-FROM cluster_id, allocations
-WHERE allocations.allocation_id = task_stats.allocation_id
-AND allocations.end_time IS NOT NULL
-AND task_stats.end_time IS NULL`)
-	if err != nil {
-		return fmt.Errorf("ending all task stats: %w", err)
-	}
-
-	return nil
-}
-
 // TaskLogsFields returns the unique fields that can be filtered on for the given task.
 func (db *PgDB) TaskLogsFields(taskID model.TaskID) (*apiv1.TaskLogsFieldsResponse, error) {
 	var fields apiv1.TaskLogsFieldsResponse
@@ -487,7 +432,7 @@ func (db *PgDB) TaskLogsFields(taskID model.TaskID) (*apiv1.TaskLogsFieldsRespon
 
 // MaxTerminationDelay is the max delay before a consumer can be sure all logs have been recevied.
 // For Postgres, we don't need to wait very long at all; this was a hypothetical cap on fluent
-// to DB latency prior to fluent's deprecation.
+// to DB latency prior to fluent's deprecation.	// to DB latency prior to fluent's deprecation.
 func (db *PgDB) MaxTerminationDelay() time.Duration {
 	// TODO: K8s logs can take a bit to get to us, so much so we should investigate.
 	return 5 * time.Second

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -432,7 +432,7 @@ func (db *PgDB) TaskLogsFields(taskID model.TaskID) (*apiv1.TaskLogsFieldsRespon
 
 // MaxTerminationDelay is the max delay before a consumer can be sure all logs have been recevied.
 // For Postgres, we don't need to wait very long at all; this was a hypothetical cap on fluent
-// to DB latency prior to fluent's deprecation.	// to DB latency prior to fluent's deprecation.
+// to DB latency prior to fluent's deprecation.
 func (db *PgDB) MaxTerminationDelay() time.Duration {
 	// TODO: K8s logs can take a bit to get to us, so much so we should investigate.
 	return 5 * time.Second

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 // TestJobTaskAndAllocationAPI, in lieu of an ORM, ensures that the mappings into and out of the
 // database are total. We should look into an ORM in the near to medium term future.
 func TestJobTaskAndAllocationAPI(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	// Add a mock user.
@@ -148,7 +148,7 @@ func TestJobTaskAndAllocationAPI(t *testing.T) {
 }
 
 func TestRecordAndEndTaskStats(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	tID := model.NewTaskID()
 	require.NoError(t, AddTask(ctx, &model.Task{
@@ -195,7 +195,7 @@ func TestRecordAndEndTaskStats(t *testing.T) {
 }
 
 func TestNonExperimentTasksContextDirectory(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	// Task doesn't exist.
 	_, err := NonExperimentTasksContextDirectory(ctx, model.TaskID(uuid.New().String()))
@@ -232,7 +232,7 @@ func TestNonExperimentTasksContextDirectory(t *testing.T) {
 }
 
 func TestAllocationState(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	// Add an allocation of every possible state.
@@ -390,6 +390,7 @@ func TestExhaustiveEnums(t *testing.T) {
 }
 
 func TestAddTask(t *testing.T) {
+	ctx := context.TODO()
 	db := SingleDB()
 
 	u := RequireMockUser(t, db)
@@ -404,17 +405,17 @@ func TestAddTask(t *testing.T) {
 		StartTime:  time.Now().UTC().Truncate(time.Millisecond),
 		LogVersion: model.TaskLogVersion0,
 	}
-	err := AddTask(context.Background(), tIn)
+	err := AddTask(ctx, tIn)
 	require.NoError(t, err, "failed to add task")
 
 	// Check that task is added to the db & test TaskByID.
-	task, err := TaskByID(context.Background(), tIn.TaskID)
+	task, err := TaskByID(ctx, tIn.TaskID)
 	require.NoError(t, err)
 	require.Equal(t, tIn, task)
 }
 
 func TestTaskCompleted(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	tIn := RequireMockTask(t, db, nil)
@@ -432,7 +433,7 @@ func TestTaskCompleted(t *testing.T) {
 }
 
 func TestAddAllocation(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	tIn := RequireMockTask(t, db, nil)
@@ -455,7 +456,7 @@ func TestAddAllocation(t *testing.T) {
 }
 
 func TestAddAllocationExitStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	tIn := RequireMockTask(t, db, nil)
@@ -480,7 +481,7 @@ func TestAddAllocationExitStatus(t *testing.T) {
 }
 
 func TestCompleteAllocation(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	tIn := RequireMockTask(t, db, nil)
@@ -502,7 +503,7 @@ func TestCompleteAllocationTelemetry(t *testing.T) {
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
-	bytes, err := CompleteAllocationTelemetry(context.Background(), aIn.AllocationID)
+	bytes, err := CompleteAllocationTelemetry(context.TODO(), aIn.AllocationID)
 	require.NoError(t, err)
 	require.Contains(t, string(bytes), string(aIn.AllocationID))
 	require.Contains(t, string(bytes), string(*tIn.JobID))
@@ -515,13 +516,13 @@ func TestAllocationByID(t *testing.T) {
 	tIn := RequireMockTask(t, db, nil)
 	aIn := RequireMockAllocation(t, db, tIn.TaskID)
 
-	a, err := AllocationByID(context.Background(), aIn.AllocationID)
+	a, err := AllocationByID(context.TODO(), aIn.AllocationID)
 	require.NoError(t, err)
 	require.Equal(t, aIn, a)
 }
 
 func TestAllocationSessionFlow(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	uIn := RequireMockUser(t, db)
@@ -554,7 +555,7 @@ func TestAllocationSessionFlow(t *testing.T) {
 }
 
 func TestUpdateAllocation(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	tIn := RequireMockTask(t, db, nil)
@@ -593,7 +594,7 @@ func TestUpdateAllocation(t *testing.T) {
 }
 
 func TestCloseOpenAllocations(t *testing.T) {
-	ctx := context.Background()
+	ctx := context.TODO()
 	db := SingleDB()
 
 	// Create test allocations, with a NULL end time.
@@ -719,7 +720,7 @@ func RequireMockTaskLog(t *testing.T, db *PgDB, tID model.TaskID, suffix string)
 func allocationSessionByID(t *testing.T, aID model.AllocationID) (*model.AllocationSession, error) {
 	var res model.AllocationSession
 	if err := Bun().NewSelect().Table("allocation_sessions").
-		Where("allocation_id = ?", aID).Scan(context.Background(), &res); err != nil {
+		Where("allocation_id = ?", aID).Scan(context.TODO(), &res); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -180,77 +180,9 @@ func RequireMockJob(t *testing.T, db *PgDB, userID *model.UserID) model.JobID {
 		OwnerID: userID,
 		QPos:    decimal.New(0, 0),
 	}
-	err := db.AddJob(jIn)
+	err := AddJobTx(context.TODO(), Bun(), jIn)
 	require.NoError(t, err, "failed to add job")
 	return jID
-}
-
-// RequireMockCommandID creates a mock command and returns a command ID.
-func RequireMockCommandID(t *testing.T, db *PgDB, userID model.UserID) model.TaskID {
-	task := RequireMockTask(t, db, &userID)
-	alloc := RequireMockAllocation(t, db, task.TaskID)
-
-	mockCommand := struct {
-		bun.BaseModel `bun:"table:command_state"`
-
-		TaskID             model.TaskID
-		AllocationID       model.AllocationID
-		GenericCommandSpec map[string]any
-	}{
-		TaskID:       task.TaskID,
-		AllocationID: alloc.AllocationID,
-		GenericCommandSpec: map[string]any{
-			"TaskType": model.TaskTypeCommand,
-			"Metadata": map[string]any{
-				"workspace_id": 1,
-			},
-			"Base": map[string]any{
-				"Owner": map[string]any{
-					"id": userID,
-				},
-			},
-		},
-	}
-	_, err := Bun().NewInsert().Model(&mockCommand).Exec(context.TODO())
-	require.NoError(t, err)
-
-	return task.TaskID
-}
-
-// RequireMockTensorboardID creates a mock tensorboard and returns a tensorboard ID.
-func RequireMockTensorboardID(
-	t *testing.T, db *PgDB, userID model.UserID, expIDs, trialIDs []int,
-) model.TaskID {
-	task := RequireMockTask(t, db, &userID)
-	alloc := RequireMockAllocation(t, db, task.TaskID)
-
-	mockTensorboard := struct {
-		bun.BaseModel `bun:"table:command_state"`
-
-		TaskID             model.TaskID
-		AllocationID       model.AllocationID
-		GenericCommandSpec map[string]any
-	}{
-		TaskID:       task.TaskID,
-		AllocationID: alloc.AllocationID,
-		GenericCommandSpec: map[string]any{
-			"TaskType": model.TaskTypeTensorboard,
-			"Metadata": map[string]any{
-				"workspace_id":   1,
-				"experiment_ids": expIDs,
-				"trial_ids":      trialIDs,
-			},
-			"Base": map[string]any{
-				"Owner": map[string]any{
-					"id": userID,
-				},
-			},
-		},
-	}
-	_, err := Bun().NewInsert().Model(&mockTensorboard).Exec(context.TODO())
-	require.NoError(t, err)
-
-	return task.TaskID
 }
 
 // RequireMockWorkspaceID returns a mock workspace ID.
@@ -315,7 +247,7 @@ func RequireMockTask(t *testing.T, db *PgDB, userID *model.UserID) *model.Task {
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	err := db.AddTask(tIn)
+	err := AddTask(context.Background(), tIn)
 	require.NoError(t, err, "failed to add task")
 	return tIn
 }
@@ -470,7 +402,7 @@ func RequireMockAllocation(t *testing.T, db *PgDB, tID model.TaskID) *model.Allo
 		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 		State:        ptrs.Ptr(model.AllocationStateTerminated),
 	}
-	err := db.AddAllocation(&a)
+	err := AddAllocation(context.Background(), &a)
 	require.NoError(t, err, "failed to add allocation")
 	return &a
 }

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -247,7 +247,7 @@ func RequireMockTask(t *testing.T, db *PgDB, userID *model.UserID) *model.Task {
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	err := AddTask(context.Background(), tIn)
+	err := AddTask(context.TODO(), tIn)
 	require.NoError(t, err, "failed to add task")
 	return tIn
 }
@@ -402,7 +402,7 @@ func RequireMockAllocation(t *testing.T, db *PgDB, tID model.TaskID) *model.Allo
 		StartTime:    ptrs.Ptr(time.Now().UTC().Truncate(time.Millisecond)),
 		State:        ptrs.Ptr(model.AllocationStateTerminated),
 	}
-	err := AddAllocation(context.Background(), &a)
+	err := AddAllocation(context.TODO(), &a)
 	require.NoError(t, err, "failed to add allocation")
 	return &a
 }

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -148,8 +148,8 @@ func UpdateTrial(ctx context.Context, id int, newState model.State) error {
 	}
 
 	if !model.TrialTransitions[trial.State][newState] {
-		return fmt.Errorf("illegal transition %v -> %v for trial %v: %w",
-			trial.State, newState, trial.ID, err)
+		return fmt.Errorf("illegal transition %v -> %v for trial %v",
+			trial.State, newState, trial.ID)
 	}
 	toUpdate := []string{"state"}
 	trial.State = newState
@@ -160,8 +160,8 @@ func UpdateTrial(ctx context.Context, id int, newState model.State) error {
 	}
 
 	return Bun().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		run := trial.ToRun()
-		if _, err := tx.NewUpdate().Model(run).Column(toUpdate...).Where("id = ?", trial.ID).
+		run, _ := trial.ToRunAndTrialV2()
+		if _, err := tx.NewUpdate().Model(run).Column(toUpdate...).Where("id = ?", trial).
 			Exec(ctx); err != nil {
 			return fmt.Errorf("error updating (%v) in trial %v: %w", strings.Join(toUpdate, ", "), id, err)
 		}

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -859,9 +859,9 @@ func TestProtoGetTrial(t *testing.T) {
 			StartTime:    ptrs.Ptr(startTime.Add(time.Duration(i) * time.Second)),
 			EndTime:      ptrs.Ptr(startTime.Add(time.Duration(i+1) * time.Second)),
 		}
-		err = db.AddAllocation(a)
+		err = AddAllocation(ctx, a)
 		require.NoError(t, err, "failed to add allocation")
-		err = db.CompleteAllocation(a)
+		err = CompleteAllocation(ctx, a)
 		require.NoError(t, err, "failed to complete allocation")
 	}
 
@@ -909,7 +909,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		TaskID:       task.TaskID,
 		StartTime:    ptrs.Ptr(time.Now()),
 	}
-	require.NoError(t, db.AddAllocation(a))
+	require.NoError(t, AddAllocation(ctx, a))
 
 	// Report training metrics.
 	require.NoError(t, db.AddTrainingMetrics(ctx, &trialv1.TrialMetrics{
@@ -934,7 +934,7 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		TaskID:       task.TaskID,
 		StartTime:    ptrs.Ptr(time.Now()),
 	}
-	require.NoError(t, db.AddAllocation(a))
+	require.NoError(t, AddAllocation(ctx, a))
 	require.NoError(t, db.UpdateTrialRunID(tr.ID, 1))
 
 	// Now trial runs validation.
@@ -1008,7 +1008,7 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 		TaskID:       task.TaskID,
 		StartTime:    ptrs.Ptr(time.Now()),
 	}
-	err = db.AddAllocation(a)
+	err = AddAllocation(ctx, a)
 	require.NoError(t, err, "failed to add allocation")
 
 	metrics, err := structpb.NewStruct(map[string]any{"loss": 10})
@@ -1156,7 +1156,7 @@ func TestGenericMetricsIO(t *testing.T) {
 		TaskID:       task.TaskID,
 		StartTime:    ptrs.Ptr(time.Now()),
 	}
-	err = db.AddAllocation(a)
+	err = AddAllocation(ctx, a)
 	require.NoError(t, err, "failed to add allocation")
 
 	metrics, err := structpb.NewStruct(map[string]any{
@@ -1279,7 +1279,7 @@ func TestConcurrentMetricUpdate(t *testing.T) {
 			TaskID:       task.TaskID,
 			StartTime:    ptrs.Ptr(time.Now()),
 		}
-		err := db.AddAllocation(a)
+		err := AddAllocation(ctx, a)
 		require.NoError(t, err, "failed to add allocation")
 
 		dbTr, err := TrialByID(ctx, tr.ID)

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -98,7 +98,7 @@ func Setup(opts *config.DBConfig) (*PgDB, error) {
 		return nil, err
 	}
 
-	if err = db.initAllocationSessions(); err != nil {
+	if err = initAllocationSessions(context.Background()); err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -98,7 +98,7 @@ func Setup(opts *config.DBConfig) (*PgDB, error) {
 		return nil, err
 	}
 
-	if err = initAllocationSessions(context.Background()); err != nil {
+	if err = initAllocationSessions(context.TODO()); err != nil {
 		return nil, err
 	}
 	return db, nil

--- a/master/internal/populate_metrics.go
+++ b/master/internal/populate_metrics.go
@@ -250,7 +250,7 @@ func PopulateExpTrialsMetrics(pgdb *db.PgDB, masterConfig *config.Config, trivia
 		TaskType:  model.TaskTypeTrial,
 		StartTime: time.Now().UTC().Truncate(time.Millisecond),
 	}
-	if err = pgdb.AddTask(tIn); err != nil {
+	if err = db.AddTask(ctx, tIn); err != nil {
 		return err
 	}
 

--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -1,6 +1,7 @@
 package agentrm
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -593,6 +594,8 @@ func (a *agent) HandleIncomingWebsocketMessage(msg *aproto.MasterMessage) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
+	ctx := context.Background()
+
 	switch {
 	case msg.AgentStarted != nil:
 		a.syslog.Infof("agent connected ip: %v resource pool: %s slots: %d",
@@ -647,9 +650,9 @@ func (a *agent) HandleIncomingWebsocketMessage(msg *aproto.MasterMessage) {
 		if a.taskNeedsRecording(msg.ContainerStatsRecord) {
 			var err error
 			if msg.ContainerStatsRecord.EndStats {
-				err = db.RecordTaskEndStatsBun(msg.ContainerStatsRecord.Stats)
+				err = db.RecordTaskEndStatsBun(ctx, msg.ContainerStatsRecord.Stats)
 			} else {
-				err = db.RecordTaskStatsBun(msg.ContainerStatsRecord.Stats)
+				err = db.RecordTaskStatsBun(ctx, msg.ContainerStatsRecord.Stats)
 			}
 			if err != nil {
 				a.syslog.Errorf("error recording task stats %s", err)

--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -594,7 +594,7 @@ func (a *agent) HandleIncomingWebsocketMessage(msg *aproto.MasterMessage) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	switch {
 	case msg.AgentStarted != nil:

--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -594,8 +594,6 @@ func (a *agent) HandleIncomingWebsocketMessage(msg *aproto.MasterMessage) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	ctx := context.TODO()
-
 	switch {
 	case msg.AgentStarted != nil:
 		a.syslog.Infof("agent connected ip: %v resource pool: %s slots: %d",
@@ -650,9 +648,9 @@ func (a *agent) HandleIncomingWebsocketMessage(msg *aproto.MasterMessage) {
 		if a.taskNeedsRecording(msg.ContainerStatsRecord) {
 			var err error
 			if msg.ContainerStatsRecord.EndStats {
-				err = db.RecordTaskEndStatsBun(ctx, msg.ContainerStatsRecord.Stats)
+				err = db.RecordTaskEndStatsBun(context.TODO(), msg.ContainerStatsRecord.Stats)
 			} else {
-				err = db.RecordTaskStatsBun(ctx, msg.ContainerStatsRecord.Stats)
+				err = db.RecordTaskStatsBun(context.TODO(), msg.ContainerStatsRecord.Stats)
 			}
 			if err != nil {
 				a.syslog.Errorf("error recording task stats %s", err)

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -75,7 +75,7 @@ func TestAgentStatePersistence(t *testing.T) {
 
 	// Run through some container states.
 	tID := model.TaskID(uuid.NewString())
-	err = db.SingleDB().AddTask(&model.Task{
+	err = db.AddTask(context.Background(), &model.Task{
 		TaskID:     tID,
 		JobID:      nil,
 		TaskType:   model.TaskTypeCommand,
@@ -85,7 +85,7 @@ func TestAgentStatePersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	aID := model.AllocationID(uuid.NewString())
-	err = db.SingleDB().AddAllocation(&model.Allocation{
+	err = db.AddAllocation(context.Background(), &model.Allocation{
 		AllocationID: aID,
 		TaskID:       tID,
 		Slots:        2,

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -43,10 +43,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestAgentStatePersistence(t *testing.T) {
-	ctx := context.TODO()
-
 	// Clear all agent states.
-	_, err := db.Bun().NewDelete().Model((*agentSnapshot)(nil)).Where("1 = 1").Exec(ctx)
+	_, err := db.Bun().NewDelete().Model((*agentSnapshot)(nil)).Where("1 = 1").Exec(context.TODO())
 	require.NoError(t, err)
 
 	// Fake an agent, test adding it to the db.
@@ -77,7 +75,7 @@ func TestAgentStatePersistence(t *testing.T) {
 
 	// Run through some container states.
 	tID := model.TaskID(uuid.NewString())
-	err = db.AddTask(ctx, &model.Task{
+	err = db.AddTask(context.TODO(), &model.Task{
 		TaskID:     tID,
 		JobID:      nil,
 		TaskType:   model.TaskTypeCommand,
@@ -87,7 +85,7 @@ func TestAgentStatePersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	aID := model.AllocationID(uuid.NewString())
-	err = db.AddAllocation(ctx, &model.Allocation{
+	err = db.AddAllocation(context.TODO(), &model.Allocation{
 		AllocationID: aID,
 		TaskID:       tID,
 		Slots:        2,

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -43,8 +43,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestAgentStatePersistence(t *testing.T) {
+	ctx := context.TODO()
+
 	// Clear all agent states.
-	_, err := db.Bun().NewDelete().Model((*agentSnapshot)(nil)).Where("1 = 1").Exec(context.TODO())
+	_, err := db.Bun().NewDelete().Model((*agentSnapshot)(nil)).Where("1 = 1").Exec(ctx)
 	require.NoError(t, err)
 
 	// Fake an agent, test adding it to the db.
@@ -75,7 +77,7 @@ func TestAgentStatePersistence(t *testing.T) {
 
 	// Run through some container states.
 	tID := model.TaskID(uuid.NewString())
-	err = db.AddTask(context.Background(), &model.Task{
+	err = db.AddTask(ctx, &model.Task{
 		TaskID:     tID,
 		JobID:      nil,
 		TaskType:   model.TaskTypeCommand,
@@ -85,7 +87,7 @@ func TestAgentStatePersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	aID := model.AllocationID(uuid.NewString())
-	err = db.AddAllocation(context.Background(), &model.Allocation{
+	err = db.AddAllocation(ctx, &model.Allocation{
 		AllocationID: aID,
 		TaskID:       tID,
 		Slots:        2,

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -323,7 +323,7 @@ func (a *allocation) Signal(sig AllocationSignal, reason string) {
 
 // SetProxyAddress sets the proxy address of the allocation and sets up proxies for any services
 // it provides.
-func (a *allocation) SetProxyAddress(_ context.Context, address string) error {
+func (a *allocation) SetProxyAddress(ctx context.Context, address string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -332,7 +332,7 @@ func (a *allocation) SetProxyAddress(_ context.Context, address string) error {
 		return nil
 	}
 	a.model.ProxyAddress = &address
-	if err := a.db.UpdateAllocationProxyAddress(a.model); err != nil {
+	if err := db.UpdateAllocationProxyAddress(ctx, a.model); err != nil {
 		a.crash(err)
 		return err
 	}
@@ -347,12 +347,12 @@ func (a *allocation) SendContainerLog(log *sproto.ContainerLog) {
 }
 
 // SetWaiting moves the allocation to the waiting state if it has not progressed past it yet.
-func (a *allocation) SetWaiting(_ context.Context) error {
+func (a *allocation) SetWaiting(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	a.setMostProgressedModelState(model.AllocationStateWaiting)
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	if err := db.UpdateAllocationState(ctx, a.model); err != nil {
 		a.crash(err)
 		return err
 	}
@@ -361,7 +361,7 @@ func (a *allocation) SetWaiting(_ context.Context) error {
 
 // SetReady sets the ready bit and moves the allocation to the running state if it has not
 // progressed past it already.
-func (a *allocation) SetReady(_ context.Context) error {
+func (a *allocation) SetReady(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -371,7 +371,7 @@ func (a *allocation) SetReady(_ context.Context) error {
 	a.sendTaskLog(&model.TaskLog{Log: fmt.Sprintf("Service of %s is available", a.req.Name)})
 	a.setMostProgressedModelState(model.AllocationStateRunning)
 	a.model.IsReady = ptrs.Ptr(true)
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	if err := db.UpdateAllocationState(ctx, a.model); err != nil {
 		a.crash(err)
 		return err
 	}
@@ -388,7 +388,7 @@ func (a *allocation) persistRendezvousComplete() error {
 	if a.model.IsReady == nil || (a.model.IsReady != nil && !*a.model.IsReady) {
 		a.syslog.Info("all containers are connected successfully (task container state changed)")
 		a.model.IsReady = ptrs.Ptr(true)
-		if err := a.db.UpdateAllocationState(a.model); err != nil {
+		if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
 			return err
 		}
 	}
@@ -520,7 +520,7 @@ func (a *allocation) requestResources() (*sproto.ResourcesSubscription, error) {
 	a.syslog.Debug("requestResources add allocation")
 
 	a.setModelState(model.AllocationStatePending)
-	if err := a.db.AddAllocation(&a.model); err != nil {
+	if err := db.AddAllocation(context.Background(), &a.model); err != nil {
 		return nil, errors.Wrap(err, "saving trial allocation")
 	}
 
@@ -573,7 +573,7 @@ func (a *allocation) finalize(
 	}
 
 	a.setMostProgressedModelState(model.AllocationStateTerminated)
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
 		a.syslog.WithError(err).Error("failed to set allocation state to terminated")
 	}
 	a.purgeRestorableResources()
@@ -617,12 +617,12 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 		}
 	})
 
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
 		return errors.Wrap(err, "updating allocation state")
 	}
 
 	now := time.Now().UTC()
-	err = a.db.RecordTaskStats(&model.TaskStats{
+	err = db.RecordTaskStats(context.Background(), &model.TaskStats{
 		AllocationID: msg.ID,
 		EventType:    "QUEUED",
 		StartTime:    &msg.JobSubmissionTime,
@@ -672,7 +672,7 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 	} else {
 		spec := a.specifier.ToTaskSpec()
 
-		token, err := a.db.StartAllocationSession(a.model.AllocationID, spec.Owner)
+		token, err := db.StartAllocationSession(context.Background(), a.model.AllocationID, spec.Owner)
 		if err != nil {
 			return errors.Wrap(err, "starting a new allocation session")
 		}
@@ -687,7 +687,7 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 			}
 		})
 
-		err = db.UpdateAllocationPorts(a.model)
+		err = db.UpdateAllocationPorts(context.Background(), a.model)
 		if err != nil {
 			return fmt.Errorf("updating allocation db")
 		}
@@ -841,7 +841,7 @@ func (a *allocation) resourcesStateChanged(msg *sproto.ResourcesStateChanged) {
 		}
 	}
 
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
 		a.syslog.Error(err)
 	}
 }
@@ -851,7 +851,9 @@ func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesRestoreError) {
 	a.syslog.Debugf("allocation resource failure")
 	a.setMostProgressedModelState(model.AllocationStateTerminating)
 
-	if err := a.db.UpdateAllocationState(a.model); err != nil {
+	ctx := context.Background()
+
+	if err := db.UpdateAllocationState(ctx, a.model); err != nil {
 		a.syslog.Error(err)
 	}
 
@@ -869,7 +871,7 @@ func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesRestoreError) {
 		a.model.EndTime = ptrs.Ptr(time.Now().UTC())
 	}
 
-	if err := a.db.CompleteAllocation(&a.model); err != nil {
+	if err := db.CompleteAllocation(ctx, &a.model); err != nil {
 		a.syslog.WithError(err).Error("failed to mark allocation completed")
 	}
 
@@ -1191,7 +1193,7 @@ func (a *allocation) markResourcesStarted() {
 	} else {
 		a.sendTaskLog(&model.TaskLog{Log: fmt.Sprintf("%s was assigned to an agent", a.req.Name)})
 	}
-	if err := a.db.UpdateAllocationStartTime(a.model); err != nil {
+	if err := db.UpdateAllocationStartTime(context.Background(), a.model); err != nil {
 		a.syslog.
 			WithError(err).
 			Errorf("allocation will not be properly accounted for")
@@ -1200,18 +1202,19 @@ func (a *allocation) markResourcesStarted() {
 
 // markResourcesReleased persists completion information.
 func (a *allocation) markResourcesReleased() {
-	if err := a.db.DeleteAllocationSession(a.model.AllocationID); err != nil {
+	ctx := context.Background()
+	if err := db.DeleteAllocationSession(ctx, a.model.AllocationID); err != nil {
 		a.syslog.WithError(err).Error("error deleting allocation session")
 	}
 	if a.model.StartTime == nil {
 		return
 	}
 	a.model.EndTime = ptrs.Ptr(time.Now().UTC())
-	if err := a.db.CompleteAllocation(&a.model); err != nil {
+	if err := db.CompleteAllocation(ctx, &a.model); err != nil {
 		a.syslog.WithError(err).Error("failed to mark allocation completed")
 	}
 
-	telemetry.ReportAllocationTerminal(a.db, a.model, a.resources.firstDevice())
+	telemetry.ReportAllocationTerminal(a.model, a.resources.firstDevice())
 }
 
 func (a *allocation) purgeRestorableResources() {

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -388,7 +388,7 @@ func (a *allocation) persistRendezvousComplete() error {
 	if a.model.IsReady == nil || (a.model.IsReady != nil && !*a.model.IsReady) {
 		a.syslog.Info("all containers are connected successfully (task container state changed)")
 		a.model.IsReady = ptrs.Ptr(true)
-		if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
+		if err := db.UpdateAllocationState(context.TODO(), a.model); err != nil {
 			return err
 		}
 	}
@@ -520,7 +520,7 @@ func (a *allocation) requestResources() (*sproto.ResourcesSubscription, error) {
 	a.syslog.Debug("requestResources add allocation")
 
 	a.setModelState(model.AllocationStatePending)
-	if err := db.AddAllocation(context.Background(), &a.model); err != nil {
+	if err := db.AddAllocation(context.TODO(), &a.model); err != nil {
 		return nil, errors.Wrap(err, "saving trial allocation")
 	}
 
@@ -573,7 +573,7 @@ func (a *allocation) finalize(
 	}
 
 	a.setMostProgressedModelState(model.AllocationStateTerminated)
-	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
+	if err := db.UpdateAllocationState(context.TODO(), a.model); err != nil {
 		a.syslog.WithError(err).Error("failed to set allocation state to terminated")
 	}
 	a.purgeRestorableResources()
@@ -617,12 +617,12 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 		}
 	})
 
-	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
+	if err := db.UpdateAllocationState(context.TODO(), a.model); err != nil {
 		return errors.Wrap(err, "updating allocation state")
 	}
 
 	now := time.Now().UTC()
-	err = db.RecordTaskStats(context.Background(), &model.TaskStats{
+	err = db.RecordTaskStats(context.TODO(), &model.TaskStats{
 		AllocationID: msg.ID,
 		EventType:    "QUEUED",
 		StartTime:    &msg.JobSubmissionTime,
@@ -672,7 +672,7 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 	} else {
 		spec := a.specifier.ToTaskSpec()
 
-		token, err := db.StartAllocationSession(context.Background(), a.model.AllocationID, spec.Owner)
+		token, err := db.StartAllocationSession(context.TODO(), a.model.AllocationID, spec.Owner)
 		if err != nil {
 			return errors.Wrap(err, "starting a new allocation session")
 		}
@@ -687,7 +687,7 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 			}
 		})
 
-		err = db.UpdateAllocationPorts(context.Background(), a.model)
+		err = db.UpdateAllocationPorts(context.TODO(), a.model)
 		if err != nil {
 			return fmt.Errorf("updating allocation db")
 		}
@@ -841,7 +841,7 @@ func (a *allocation) resourcesStateChanged(msg *sproto.ResourcesStateChanged) {
 		}
 	}
 
-	if err := db.UpdateAllocationState(context.Background(), a.model); err != nil {
+	if err := db.UpdateAllocationState(context.TODO(), a.model); err != nil {
 		a.syslog.Error(err)
 	}
 }
@@ -851,7 +851,7 @@ func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesRestoreError) {
 	a.syslog.Debugf("allocation resource failure")
 	a.setMostProgressedModelState(model.AllocationStateTerminating)
 
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	if err := db.UpdateAllocationState(ctx, a.model); err != nil {
 		a.syslog.Error(err)
@@ -1193,7 +1193,7 @@ func (a *allocation) markResourcesStarted() {
 	} else {
 		a.sendTaskLog(&model.TaskLog{Log: fmt.Sprintf("%s was assigned to an agent", a.req.Name)})
 	}
-	if err := db.UpdateAllocationStartTime(context.Background(), a.model); err != nil {
+	if err := db.UpdateAllocationStartTime(context.TODO(), a.model); err != nil {
 		a.syslog.
 			WithError(err).
 			Errorf("allocation will not be properly accounted for")
@@ -1202,7 +1202,7 @@ func (a *allocation) markResourcesStarted() {
 
 // markResourcesReleased persists completion information.
 func (a *allocation) markResourcesReleased() {
-	ctx := context.Background()
+	ctx := context.TODO()
 	if err := db.DeleteAllocationSession(ctx, a.model.AllocationID); err != nil {
 		a.syslog.WithError(err).Error("error deleting allocation session")
 	}

--- a/master/internal/task/allocation_service_test.go
+++ b/master/internal/task/allocation_service_test.go
@@ -44,7 +44,7 @@ func TestRestoreFailed(t *testing.T) {
 		FailureType: sproto.RestoreError,
 		ErrMsg:      "things weren't there",
 	})
-	requireTerminated(t, db, id, exitFuture)
+	requireTerminated(t, id, exitFuture)
 }
 
 func TestInvalidResourcesRequest(t *testing.T) {
@@ -55,7 +55,7 @@ func TestInvalidResourcesRequest(t *testing.T) {
 	q.Put(&sproto.InvalidResourcesRequestError{
 		Cause: fmt.Errorf("eternal gke quota error"),
 	})
-	requireTerminated(t, db, id, exitFuture)
+	requireTerminated(t, id, exitFuture)
 }
 
 type checkWriter struct {
@@ -100,7 +100,7 @@ func TestSetReady(t *testing.T) {
 	err := DefaultService.SetReady(context.TODO(), id)
 	require.NoError(t, err)
 
-	state, dbState := requireState(t, db, id, model.AllocationStateRunning)
+	state, dbState := requireState(t, id, model.AllocationStateRunning)
 	require.True(t, state.Ready)
 	require.NotNil(t, dbState.IsReady)
 	require.True(t, *dbState.IsReady)
@@ -113,7 +113,7 @@ func TestSetWaiting(t *testing.T) {
 	err := DefaultService.SetWaiting(context.TODO(), id)
 	require.NoError(t, err)
 
-	requireState(t, db, id, model.AllocationStateWaiting)
+	requireState(t, id, model.AllocationStateWaiting)
 }
 
 func TestSetProxyAddress(t *testing.T) {
@@ -130,7 +130,7 @@ func TestSetProxyAddress(t *testing.T) {
 	err := DefaultService.SetProxyAddress(context.TODO(), id, addr)
 	require.NoError(t, err)
 
-	_, dbState := requireState(t, db, id, model.AllocationStatePending)
+	_, dbState := requireState(t, id, model.AllocationStatePending)
 	require.NotNil(t, dbState.ProxyAddress)
 	require.Equal(t, addr, *dbState.ProxyAddress)
 
@@ -164,7 +164,7 @@ func TestServiceRendezvous(t *testing.T) {
 			},
 		},
 	})
-	requireState(t, db, id, model.AllocationStateRunning)
+	requireState(t, id, model.AllocationStateRunning)
 
 	info, err := DefaultService.WatchRendezvous(context.TODO(), id, rID)
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestGracefullyTerminateAfterRestart(t *testing.T) {
 			},
 		},
 	})
-	requireState(t, pgDB, ar.AllocationID, model.AllocationStateRunning)
+	requireState(t, ar.AllocationID, model.AllocationStateRunning)
 
 	t.Log("do rendezvous (sets ready bit)")
 	info, err := DefaultService.WatchRendezvous(context.TODO(), ar.AllocationID, rID)
@@ -302,7 +302,7 @@ func TestAllGather(t *testing.T) {
 			},
 		},
 	})
-	requireState(t, db, id, model.AllocationStateRunning)
+	requireState(t, id, model.AllocationStateRunning)
 
 	wID := uuid.New()
 	msg := "hello world"
@@ -354,14 +354,14 @@ func TestPreemption(t *testing.T) {
 				ResourcesID:    rID,
 				ResourcesState: sproto.Starting,
 			})
-			requireState(t, db, id, model.AllocationStateStarting)
+			requireState(t, id, model.AllocationStateStarting)
 
 			q.Put(&sproto.ResourcesStateChanged{
 				ResourcesID:      rID,
 				ResourcesState:   sproto.Running,
 				ResourcesStarted: &sproto.ResourcesStarted{},
 			})
-			requireState(t, db, id, model.AllocationStateRunning)
+			requireState(t, id, model.AllocationStateRunning)
 			err := DefaultService.SetReady(context.Background(), id)
 			require.NoError(t, err)
 
@@ -380,7 +380,7 @@ func TestPreemption(t *testing.T) {
 				ResourcesState:   sproto.Terminated,
 				ResourcesStopped: &sproto.ResourcesStopped{},
 			})
-			requireTerminated(t, db, id, exitFuture)
+			requireTerminated(t, id, exitFuture)
 		})
 	}
 }
@@ -410,7 +410,7 @@ func TestSignalBeforeLaunch(t *testing.T) {
 			err := DefaultService.Signal(id, tt.args.sig, "some severe reason")
 			require.NoError(t, err)
 
-			exit := requireTerminated(t, db, id, exitFuture)
+			exit := requireTerminated(t, id, exitFuture)
 			require.NoError(t, exit.Err)
 			require.True(t, rm.AssertExpectations(t), "rm didn't receive release in time")
 		})
@@ -444,7 +444,7 @@ func TestSignalBeforeReady(t *testing.T) {
 			err := DefaultService.Signal(id, tt.args.sig, "some severe reason")
 			require.NoError(t, err)
 
-			exit := requireTerminated(t, db, id, exitFuture)
+			exit := requireTerminated(t, id, exitFuture)
 			require.NoError(t, exit.Err)
 			require.True(t, rm.AssertExpectations(t), "rm didn't receive release in time")
 		})
@@ -463,7 +463,7 @@ func TestSetResourcesDaemon(t *testing.T) {
 	for _, rID := range ranked[1:] {
 		err := DefaultService.SetResourcesAsDaemon(context.TODO(), id, rID)
 		require.NoError(t, err)
-		requireState(t, db, id, model.AllocationStateAssigned) // should still be running
+		requireState(t, id, model.AllocationStateAssigned) // should still be running
 	}
 
 	t.Log("daemon exit should wait on chief")
@@ -472,7 +472,7 @@ func TestSetResourcesDaemon(t *testing.T) {
 		ResourcesState:   sproto.Terminated,
 		ResourcesStopped: &sproto.ResourcesStopped{},
 	})
-	requireState(t, db, id, model.AllocationStateTerminating)
+	requireState(t, id, model.AllocationStateTerminating)
 	require.False(t, waitForCondition(time.Second, func() bool {
 		return exitFuture.Load() != nil
 	}), "allocation exited prematurely")
@@ -484,7 +484,7 @@ func TestSetResourcesDaemon(t *testing.T) {
 		ResourcesStopped: &sproto.ResourcesStopped{},
 	})
 
-	exit := requireTerminated(t, db, id, exitFuture)
+	exit := requireTerminated(t, id, exitFuture)
 	require.NoError(t, exit.Err)
 	require.True(t, resources[ranked[2]].AssertExpectations(t), "daemon wasn't killed")
 	require.True(t, rm.AssertExpectations(t), "rm didn't receive release in time")
@@ -517,7 +517,7 @@ func TestRestore(t *testing.T) {
 	restoredAr := stubAllocateRequest(restoredTask)
 	restoredAr.Restore = true
 
-	err := pgDB.AddAllocation(&model.Allocation{
+	err := db.AddAllocation(context.Background(), &model.Allocation{
 		AllocationID: restoredAr.AllocationID,
 		TaskID:       restoredAr.TaskID,
 		Slots:        restoredAr.SlotsNeeded,
@@ -661,7 +661,7 @@ func requireAssignedMany(
 		ResourcePool: stubResourcePoolName,
 		Resources:    assigned,
 	})
-	requireState(t, db, id, model.AllocationStateAssigned)
+	requireState(t, id, model.AllocationStateAssigned)
 	return resources
 }
 
@@ -677,12 +677,11 @@ func requireKilled(
 	}
 
 	_ = DefaultService.Signal(id, KillAllocation, "cleanup for tests")
-	return requireTerminated(t, db, id, exitFuture)
+	return requireTerminated(t, id, exitFuture)
 }
 
 func requireTerminated(
 	t *testing.T,
-	db *db.PgDB,
 	id model.AllocationID,
 	exitFuture *atomic.Pointer[AllocationExited],
 ) *AllocationExited {
@@ -691,17 +690,16 @@ func requireTerminated(
 	}), "allocation did not exit in time")
 	exit := exitFuture.Load()
 	require.True(t, exit.FinalState.State == model.AllocationStateTerminated)
-	requireDBState(t, db, id, model.AllocationStateTerminated)
+	requireDBState(t, id, model.AllocationStateTerminated)
 	return exit
 }
 
 func requireState(
 	t *testing.T,
-	db *db.PgDB,
 	id model.AllocationID,
 	state model.AllocationState,
 ) (AllocationState, *model.Allocation) {
-	return requireAllocationState(t, id, state), requireDBState(t, db, id, state)
+	return requireAllocationState(t, id, state), requireDBState(t, id, state)
 }
 
 func requireAllocationState(
@@ -735,11 +733,10 @@ func requireAllocationState(
 
 func requireDBState(
 	t *testing.T,
-	db *db.PgDB,
 	id model.AllocationID,
 	expected model.AllocationState,
 ) *model.Allocation {
-	dbState, err := db.AllocationByID(id)
+	dbState, err := db.AllocationByID(context.Background(), id)
 	require.NoError(t, err)
 	require.NotNil(t, dbState.State)
 	require.Equal(t, expected, *dbState.State)

--- a/master/internal/task/allocation_service_test.go
+++ b/master/internal/task/allocation_service_test.go
@@ -517,7 +517,7 @@ func TestRestore(t *testing.T) {
 	restoredAr := stubAllocateRequest(restoredTask)
 	restoredAr.Restore = true
 
-	err := db.AddAllocation(context.Background(), &model.Allocation{
+	err := db.AddAllocation(context.TODO(), &model.Allocation{
 		AllocationID: restoredAr.AllocationID,
 		TaskID:       restoredAr.TaskID,
 		Slots:        restoredAr.SlotsNeeded,
@@ -736,7 +736,7 @@ func requireDBState(
 	id model.AllocationID,
 	expected model.AllocationState,
 ) *model.Allocation {
-	dbState, err := db.AllocationByID(context.Background(), id)
+	dbState, err := db.AllocationByID(context.TODO(), id)
 	require.NoError(t, err)
 	require.NotNil(t, dbState.State)
 	require.Equal(t, expected, *dbState.State)

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"math/big"
@@ -131,9 +132,9 @@ func ReportExperimentCreated(id int, config expconf.ExperimentConfig) {
 }
 
 // ReportAllocationTerminal reports that an allocation ends.
-func ReportAllocationTerminal(db db.DB, a model.Allocation, d *device.Device,
+func ReportAllocationTerminal(a model.Allocation, d *device.Device,
 ) {
-	res, err := db.CompleteAllocationTelemetry(a.AllocationID)
+	res, err := db.CompleteAllocationTelemetry(context.Background(), a.AllocationID)
 	if err != nil {
 		syslog.WithError(err).Warn("failed to fetch allocation telemetry")
 		return

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -134,7 +134,7 @@ func ReportExperimentCreated(id int, config expconf.ExperimentConfig) {
 // ReportAllocationTerminal reports that an allocation ends.
 func ReportAllocationTerminal(a model.Allocation, d *device.Device,
 ) {
-	res, err := db.CompleteAllocationTelemetry(context.Background(), a.AllocationID)
+	res, err := db.CompleteAllocationTelemetry(context.TODO(), a.AllocationID)
 	if err != nil {
 		syslog.WithError(err).Warn("failed to fetch allocation telemetry")
 		return

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -301,14 +301,13 @@ func (t *trial) create() error {
 		t.warmStartCheckpoint,
 		int64(t.searcher.Create.TrialSeed),
 	)
-	ctx := context.TODO()
 
-	err := t.addTask(ctx)
+	err := t.addTask(context.TODO())
 	if err != nil {
 		return err
 	}
 
-	err = db.AddTrial(ctx, m, t.taskID)
+	err = db.AddTrial(context.TODO(), m, t.taskID)
 	if err != nil {
 		return errors.Wrap(err, "failed to save trial to database")
 	}

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -301,7 +301,7 @@ func (t *trial) create() error {
 		t.warmStartCheckpoint,
 		int64(t.searcher.Create.TrialSeed),
 	)
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	err := t.addTask(ctx)
 	if err != nil {
@@ -350,12 +350,12 @@ func (t *trial) continueSetup(continueFromTrialID *int) error {
 
 	t.taskID = model.TaskID(fmt.Sprintf("%s-%d", t.taskID, len(trialIDTaskIDs)))
 
-	ctx := context.Background()
-	err = t.addTask(ctx)
+	err = t.addTask(context.TODO())
 	if err != nil {
 		return err
 	}
-	if _, err := db.Bun().NewInsert().Model(&model.RunTaskID{RunID: t.id, TaskID: t.taskID}).Exec(ctx); err != nil {
+	if _, err := db.Bun().NewInsert().Model(&model.RunTaskID{RunID: t.id, TaskID: t.taskID}).
+		Exec(context.TODO()); err != nil {
 		return fmt.Errorf("adding trial ID task ID relationship: %w", err)
 	}
 	return nil
@@ -697,7 +697,7 @@ func (t *trial) transition(s model.StateWithReason) error {
 	if t.state != s.State {
 		t.syslog.Infof("trial changed from state %s to %s", t.state, s.State)
 		if t.idSet {
-			if err := db.UpdateTrial(context.Background(), t.id, s.State); err != nil {
+			if err := db.UpdateTrial(context.TODO(), t.id, s.State); err != nil {
 				return fmt.Errorf("updating trial with end state (%s, %s): %w", s.State, s.InformationalReason, err)
 			}
 		}

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -301,13 +301,14 @@ func (t *trial) create() error {
 		t.warmStartCheckpoint,
 		int64(t.searcher.Create.TrialSeed),
 	)
+	ctx := context.Background()
 
-	err := t.addTask()
+	err := t.addTask(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = db.AddTrial(context.TODO(), m, t.taskID)
+	err = db.AddTrial(ctx, m, t.taskID)
 	if err != nil {
 		return errors.Wrap(err, "failed to save trial to database")
 	}
@@ -349,14 +350,12 @@ func (t *trial) continueSetup(continueFromTrialID *int) error {
 
 	t.taskID = model.TaskID(fmt.Sprintf("%s-%d", t.taskID, len(trialIDTaskIDs)))
 
-	err = t.addTask()
+	ctx := context.Background()
+	err = t.addTask(ctx)
 	if err != nil {
 		return err
 	}
-	if _, err := db.Bun().
-		NewInsert().
-		Model(&model.RunTaskID{RunID: t.id, TaskID: t.taskID}).
-		Exec(context.TODO()); err != nil {
+	if _, err := db.Bun().NewInsert().Model(&model.RunTaskID{RunID: t.id, TaskID: t.taskID}).Exec(ctx); err != nil {
 		return fmt.Errorf("adding trial ID task ID relationship: %w", err)
 	}
 	return nil
@@ -475,8 +474,8 @@ func (t *trial) maybeAllocateTask() error {
 	return nil
 }
 
-func (t *trial) addTask() error {
-	return t.db.AddTask(&model.Task{
+func (t *trial) addTask(ctx context.Context) error {
+	return db.AddTask(ctx, &model.Task{
 		TaskID:     t.taskID,
 		TaskType:   model.TaskTypeTrial,
 		StartTime:  t.jobSubmissionTime, // TODO: Why is this the job submission time..?
@@ -698,7 +697,7 @@ func (t *trial) transition(s model.StateWithReason) error {
 	if t.state != s.State {
 		t.syslog.Infof("trial changed from state %s to %s", t.state, s.State)
 		if t.idSet {
-			if err := t.db.UpdateTrial(t.id, s.State); err != nil {
+			if err := db.UpdateTrial(context.Background(), t.id, s.State); err != nil {
 				return fmt.Errorf("updating trial with end state (%s, %s): %w", s.State, s.InformationalReason, err)
 			}
 		}

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -366,6 +366,7 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 	err := pgDB.AddExperiment(experiment, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
+	ctx := context.Background()
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)
 	trial := &model.Trial{
 		ExperimentID: experiment.ID,
@@ -373,7 +374,7 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 		StartTime:    time.Now(),
 	}
 
-	err = db.AddTrial(context.TODO(), trial, task.TaskID)
+	err = db.AddTrial(ctx, trial, task.TaskID)
 	assert.NilError(t, err, "failed to insert trial")
 	t.Logf("Created trial=%v", trial)
 
@@ -384,9 +385,9 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 		StartTime:    ptrs.Ptr(startTime),
 		EndTime:      ptrs.Ptr(startTime.Add(time.Duration(1) * time.Second)),
 	}
-	err = pgDB.AddAllocation(a)
+	err = db.AddAllocation(ctx, a)
 	assert.NilError(t, err, "failed to add allocation")
-	err = pgDB.CompleteAllocation(a)
+	err = db.CompleteAllocation(ctx, a)
 	assert.NilError(t, err, "failed to complete allocation")
 
 	return experiment, trial, a

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -366,7 +366,6 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 	err := pgDB.AddExperiment(experiment, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
-	ctx := context.TODO()
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)
 	trial := &model.Trial{
 		ExperimentID: experiment.ID,
@@ -374,7 +373,7 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 		StartTime:    time.Now(),
 	}
 
-	err = db.AddTrial(ctx, trial, task.TaskID)
+	err = db.AddTrial(context.TODO(), trial, task.TaskID)
 	assert.NilError(t, err, "failed to insert trial")
 	t.Logf("Created trial=%v", trial)
 
@@ -385,9 +384,9 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 		StartTime:    ptrs.Ptr(startTime),
 		EndTime:      ptrs.Ptr(startTime.Add(time.Duration(1) * time.Second)),
 	}
-	err = db.AddAllocation(ctx, a)
+	err = db.AddAllocation(context.TODO(), a)
 	assert.NilError(t, err, "failed to add allocation")
-	err = db.CompleteAllocation(ctx, a)
+	err = db.CompleteAllocation(context.TODO(), a)
 	assert.NilError(t, err, "failed to complete allocation")
 
 	return experiment, trial, a

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -366,7 +366,7 @@ func createPrereqs(t *testing.T, pgDB *db.PgDB) (
 	err := pgDB.AddExperiment(experiment, activeConfig)
 	assert.NilError(t, err, "failed to insert experiment")
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	task := db.RequireMockTask(t, pgDB, experiment.OwnerID)
 	trial := &model.Trial{
 		ExperimentID: experiment.ID,

--- a/master/test/integration/api/api_trials_test.go
+++ b/master/test/integration/api/api_trials_test.go
@@ -262,9 +262,9 @@ func trialProfilerMetricsTests(
 		assert.Assert(t, origEqRecv, "received:\nt\t%s\noriginal:\n\t%s", bRecv, bOrig)
 	}
 
-	err = pgDB.UpdateTrial(trial.ID, model.StoppingCompletedState)
+	err = db.UpdateTrial(ctx, trial.ID, model.StoppingCompletedState)
 	assert.NilError(t, err, "failed to update trial state")
-	err = pgDB.UpdateTrial(trial.ID, model.CompletedState)
+	err = db.UpdateTrial(ctx, trial.ID, model.CompletedState)
 	assert.NilError(t, err, "failed to update trial state")
 
 	_, err = tlCl.Recv()


### PR DESCRIPTION
## Description
Bunify methods in `db/postgres_tasks.go`, and add a context.Context parameter to those functions. 

For functions that call methods from `postgres_tasks.go`, define `ctx := context.Background()` if it's not already passed in as a parameter. For functions that passed in the db as a parameter, but no longer need it because the relevant method is bun-ified, remove the db parameter. (_in other words, streamline the substitutions_).

Remove unused functions in `postgres_test_utils.go, postgres.go`.

For the method `completeTrialsTask`, originally in `postgres_tasks.go`, remove the function wrapper, and insert it directly into the `postgres_trials.go`  method where it's only used once.

`errors.Errorf(...) --> fmt.Errorf(...)` for all methods bun-ified, or majorly refactored.

Unmocked the db in `telemetry_test.go` since there was a newly bunified db tasks call there -- followed the same template as postgres_tasks_intg_test.go & started the db in TestMain.

## Test Plan
See `postgres_tasks_intg_test.go`, originally from https://github.com/determined-ai/determined/pull/8750, but edited here to include context.Context parameters etc

## Commentary (optional)
To limit the scope of this ticket:
1. I didn't bunify any of the `model.TaskLogs` functions. They're tricky (use sql filters, or use queryProto for super long queries, or have better perf with bulk-insert than Bun), and part of the `TaskLogBackend` interface. Honestly, I think this deserves its own ticket if we prioritize bun-ifying it. Untangling the db struct from the `TaskLogBackend` interface also isn't super obvious.
2. I didn't move `db/postgres_tasks.go` to the `task` module. The task db functions are called in several places within the db module still, so if we attempt to move it out _before_ all these other calls are in separate modules, then we'll get a very messy import cycle. I propose bunifying all files in db first (or at least the job/cluster/checkpoint/experiment/trial) and then moving to their respective module.  I'm happy to create another ticket or JIRA epic on the order of bunifying the db module & moving them if the team cares -- but (1) is this a high enough priority and (2) will this be a cluster/resource management/?? responsibility?

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-7957


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
