### PR TITLE
docs: Fix minor issues

### DIFF
--- a/docs/get-started/example-solutions/_index.rst
+++ b/docs/get-started/example-solutions/_index.rst
@@ -70,12 +70,12 @@ For an introduction to using the training APIs, please visit :ref:`Training APIs
       -  ImageNet (Generated)
       -  :download:`torchvision.tgz </examples/torchvision.tgz>`
 
-   -  -  HuggingFace (DeepSpeed/PyTorch)
-      -  Beans (HuggingFace)
+   -  -  Hugging Face (DeepSpeed/PyTorch)
+      -  Beans (Hugging Face)
       -  :download:`hf_image_classification.tgz </examples/hf_image_classification.tgz>`
 
-   -  -  HuggingFace (DeepSpeed/PyTorch)
-      -  WikiText (HuggingFace)
+   -  -  Hugging Face (DeepSpeed/PyTorch)
+      -  WikiText (Hugging Face)
       -  :download:`hf_language_modeling.tgz </examples/hf_language_modeling.tgz>`
 
 ***********

--- a/docs/model-dev-guide/api-guides/apis-howto/deepspeed/autotuning.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/deepspeed/autotuning.rst
@@ -12,7 +12,7 @@ properties of your hardware and model. Determined AI's DeepSpeed Autotune (``dsa
 optimize these settings through an easy-to-use API with very few changes required in user-code, as
 we describe in the remainder of this user guide. ``dsat`` can be used with
 :class:`~determined.pytorch.deepspeed.DeepSpeedTrial`, :ref:`Core API <core-getting-started>`, and
-`HuggingFace Trainer <https://huggingface.co/docs/transformers/main_classes/trainer>`__.
+`Hugging Face Trainer <https://huggingface.co/docs/transformers/main_classes/trainer>`__.
 
 **************
  How it Works
@@ -74,9 +74,9 @@ results of each subsequent trial, all of whose results are fed back to the searc
  User Code Changes
 *******************
 
-To use ``dsat`` with :class:`~determined.pytorch.deepspeed.DeepSpeedTrial`, Core API, and
-HuggingFace Trainer, specific changes must be made to your user code. In the following sections, we
-will describe specific use cases and the changes needed for each.
+To use ``dsat`` with :class:`~determined.pytorch.deepspeed.DeepSpeedTrial`, Core API, and Hugging
+Face Trainer, specific changes must be made to your user code. In the following sections, we will
+describe specific use cases and the changes needed for each.
 
 .. _using_deepspeed_trial:
 
@@ -167,10 +167,10 @@ Repo
 <https://github.com/determined-ai/determined/tree/master/examples/deepspeed_autotune/torchvision/core_api>`__
 and navigate to ``examples/deepspeed_autotune/torchvision/core_api`` .
 
-HuggingFace Trainer
-===================
+Hugging Face Trainer
+====================
 
-You can also use Determined's DeepSpeed Autotune with the HuggingFace (HF) Trainer and Determined's
+You can also use Determined's DeepSpeed Autotune with the Hugging Face (HF) Trainer and Determined's
 :class:`~determined.transformers.DetCallback` callback object to optimize your DeepSpeed parameters.
 
 Similar to the previous case (Core API), you need to add a ``deepspeed_config`` field to the
@@ -180,12 +180,12 @@ the DS ``json`` config file.
 Reporting results back to the Determined master requires both the ``dsat.dsat_reporting_context``
 context manager and ``DetCallback``.
 
-Furthermore, since ``dsat`` performs a search over different batch sizes and HuggingFace expects
+Furthermore, since ``dsat`` performs a search over different batch sizes and Hugging Face expects
 parameters to be specified as command-line arguments, an additional helper function,
-:func:`~determined.pytorch.dsat.get_hf_args_with_overwrites`, is needed to create consistent
-HuggingFace arguments.
+:func:`~determined.pytorch.dsat.get_hf_args_with_overwrites`, is needed to create consistent Hugging
+Face arguments.
 
-Here is an example code snippet from a HuggingFace Trainer script that contains key pieces of
+Here is an example code snippet from a Hugging Face Trainer script that contains key pieces of
 relevant code:
 
 .. code:: python
@@ -211,10 +211,10 @@ relevant code:
       :class:`~determined.core.SearcherOperation` as the ``DetCallback`` instance through its
       ``op=det_callback.current_op`` argument.
 
-   -  The entire ``train`` method of the HuggingFace trainer is wrapped in the
+   -  The entire ``train`` method of the Hugging Face trainer is wrapped in the
       ``dsat_reporting_context`` context manager.
 
-To find examples that use DeepSpeed Autotune with HuggingFace Trainer, visit the `Determined GitHub
+To find examples that use DeepSpeed Autotune with Hugging Face Trainer, visit the `Determined GitHub
 Repo <https://github.com/determined-ai/determined/tree/master/examples/hf_trainer_api>`__ and
 navigate to ``examples/hf_trainer_api``.
 

--- a/docs/model-hub-library/_index.rst
+++ b/docs/model-hub-library/_index.rst
@@ -5,21 +5,21 @@
 .. meta::
    :description: The Model Hub Library page contains info about Transformers and MMDetection where you can access the benefits of using Determined.
 
-+-------------------------------+----------------------------------------------------------------+
-| Title                         | Description                                                    |
-+===============================+================================================================+
-| :ref:`model-hub-transformers` | The Determined library serves as an alternative to the         |
-|                               | HuggingFace Trainer Class and provides access to the benefits  |
-|                               | of using Determined.                                           |
-+-------------------------------+----------------------------------------------------------------+
-| :ref:`model-hub-mmdetection`  | The MMDetection library serves as an alternative to the        |
-|                               | trainer used by MMDetection and provides access to all of the  |
-|                               | Determined benefits.                                           |
-+-------------------------------+----------------------------------------------------------------+
++-------------------------------+-----------------------------------------------------------------+
+| Title                         | Description                                                     |
++===============================+=================================================================+
+| :ref:`model-hub-transformers` | The Determined library serves as an alternative to the Hugging  |
+|                               | Face Trainer Class and provides access to the benefits of using |
+|                               | Determined.                                                     |
++-------------------------------+-----------------------------------------------------------------+
+| :ref:`model-hub-mmdetection`  | The MMDetection library serves as an alternative to the trainer |
+|                               | used by MMDetection and provides access to all of the           |
+|                               | Determined benefits.                                            |
++-------------------------------+-----------------------------------------------------------------+
 
 .. toctree::
    :maxdepth: 1
    :hidden:
 
-   Huggingface Trainsformers <transformers/_index>
+   Hugging Face Transformers <transformers/_index>
    MMDetection <mmdetection/_index>

--- a/docs/model-hub-library/transformers/_index.rst
+++ b/docs/model-hub-library/transformers/_index.rst
@@ -1,17 +1,17 @@
 .. _model-hub-transformers:
 
-##############
- Transformers
-##############
+###########################
+ Hugging Face Transformers
+###########################
 
-`The Huggingface transformers library <https://github.com/huggingface/transformers>`_ is the de
+`The Hugging Face Transformers Library <https://github.com/huggingface/transformers>`_ is the de
 facto library for natural language processing (NLP) models. It provides pretrained weights for
 leading NLP models and lets you easily use these pretrained models for the most common NLP tasks,
 such as language modeling, text classification, and question answering.
 
 **model-hub** makes it easy to train transformer models in Determined while keeping the developer
 experience as close as possible to working directly with **transformers**. The Determined library
-serves as an alternative to the HuggingFace `Trainer Class
+serves as an alternative to the Hugging Face `Trainer Class
 <https://huggingface.co/transformers/main_classes/trainer.html>`_ and provides access to the
 benefits of using Determined, including:
 
@@ -39,7 +39,7 @@ Given the above benefits, this library can be particularly useful if any of the 
  Limitations
 *************
 
-The following HuggingFace **transformers** features are currently not supported:
+The following Hugging Face **transformers** features are currently not supported:
 
 -  TensorFlow version of transformers
 -  Support for fairscale

--- a/docs/reference/model-hub/_index.rst
+++ b/docs/reference/model-hub/_index.rst
@@ -4,19 +4,19 @@
 
 This section includes reference documentation for the model hub APIs:
 
-+-----------------------------------+-------------------------------------------------------------+
-| Title                             | Description                                                 |
-+===================================+=============================================================+
-| :ref:`model-hub-mmdetection-api`  | The MMDetection API reference, which makes it easy to use   |
-|                                   | the popular `MMDetection library                            |
-|                                   | <https://mmdetection.readthedocs.io/en/latest>`_ with       |
-|                                   | Determined.                                                 |
-+-----------------------------------+-------------------------------------------------------------+
-| :ref:`model-hub-transformers-api` | The Transformers API reference for using the `Huggingface   |
-|                                   | transformers library                                        |
-|                                   | <https://github.com/huggingface/transformers>`_ with        |
-|                                   | Determined.                                                 |
-+-----------------------------------+-------------------------------------------------------------+
++-----------------------------------+--------------------------------------------------------------+
+| Title                             | Description                                                  |
++===================================+==============================================================+
+| :ref:`model-hub-mmdetection-api`  | The MMDetection API reference, which makes it easy to use    |
+|                                   | the popular `MMDetection library                             |
+|                                   | <https://mmdetection.readthedocs.io/en/latest>`_ with        |
+|                                   | Determined.                                                  |
++-----------------------------------+--------------------------------------------------------------+
+| :ref:`model-hub-transformers-api` | The Transformers API reference for using the `Hugging Face   |
+|                                   | Transformers Library                                         |
+|                                   | <https://github.com/huggingface/transformers>`_ with         |
+|                                   | Determined.                                                  |
++-----------------------------------+--------------------------------------------------------------+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -2588,7 +2588,7 @@ Version 0.15.4
 
 -  Model Hub: Publish Determined's Model Hub library to make it easy to train models from supported
    third-party libraries with a Determined cluster. The first library supported in Model Hub is the
-   `HuggingFace transformers library for NLP <https://huggingface.co/transformers>`__.
+   `Hugging Face Transformers Library for NLP <https://huggingface.co/transformers>`__.
 
 **Minor Changes**
 


### PR DESCRIPTION
At huggingface.co the name of the organization is Hugging Face (two words, both capitalized). When referencing the name of the organization use Hugging Face rather than Huggingface or huggingface. This rule does not apply to names of libraries or functions.

Fixes instances where Hugging Face Transformer was misspelled as Trainsformer.