### PR TITLE
test: do not import model_hub test requirements

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1793,6 +1793,7 @@ jobs:
           determined: true
           model-hub: true
           extra-requirements-file: "requirements.txt"
+          extra-requirements-file: "model_hub/tests/requirements.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: make -C harness check
       - run: make -C model_hub check

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -365,7 +365,9 @@ commands:
             fi
             echo <<parameters.extras-requires>> >> /tmp/cachefile
             if [ -n <<parameters.extra-requirements-file>> ]; then
-              cat <<parameters.extra-requirements-file>> >> /tmp/cachefile
+              for i in <<parameters.extra-requirements-file>>; do
+                cat <<parameters.extra-requirements-file>> >> /tmp/cachefile
+              done
             fi
             echo '<<parameters.python-version>>' >> /tmp/cachefile
             echo '<<parameters.install-python>>' >> /tmp/cachefile
@@ -466,7 +468,9 @@ commands:
           name: Install <<parameters.extra-requirements-file>>
           command: |
             if [ -n "<<parameters.extra-requirements-file>>" ]; then
-              tools/scripts/retry.sh pip install -r <<parameters.extra-requirements-file>>
+              for i in <<parameters.extra-requirements-file>>; do
+                tools/scripts/retry.sh pip install -r <<parameters.extra-requirements-file>>
+              done
             fi
       - save_cache:
           key: det-python-deps-<<pipeline.parameters.cache-buster>>-{{ checksum "/tmp/cachefile" }}
@@ -1792,8 +1796,7 @@ jobs:
           install-python: false
           determined: true
           model-hub: true
-          extra-requirements-file: "requirements.txt"
-          extra-requirements-file: "model_hub/tests/requirements.txt"
+          extra-requirements-file: "requirements.txt model_hub/tests/requirements.txt"
           executor: <<pipeline.parameters.docker-image>>
       - run: make -C harness check
       - run: make -C model_hub check

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -366,7 +366,7 @@ commands:
             echo <<parameters.extras-requires>> >> /tmp/cachefile
             if [ -n <<parameters.extra-requirements-file>> ]; then
               for i in <<parameters.extra-requirements-file>>; do
-                cat <<parameters.extra-requirements-file>> >> /tmp/cachefile
+                cat $i >> /tmp/cachefile
               done
             fi
             echo '<<parameters.python-version>>' >> /tmp/cachefile
@@ -469,7 +469,7 @@ commands:
           command: |
             if [ -n "<<parameters.extra-requirements-file>>" ]; then
               for i in <<parameters.extra-requirements-file>>; do
-                tools/scripts/retry.sh pip install -r <<parameters.extra-requirements-file>>
+                tools/scripts/retry.sh pip install -r $i
               done
             fi
       - save_cache:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 -e model_hub
 -r docs/requirements.txt
 -r harness/tests/requirements/requirements-harness.txt
--r model_hub/tests/requirements.txt
 -r e2e_tests/tests/requirements.txt
 -r bindings/requirements.txt
 


### PR DESCRIPTION
## Description

Model_hub tests require building tokenizers, that are pinned to an older version and require a now old version of the rust compiler. Remove the requirement for local development; the CI imports the requirement independently. 



## Test Plan

Confirm all CI tests complete successfully.



## Commentary (optional)

Context: https://hpe-aiatscale.slack.com/archives/CSG3W08JY/p1706227736615449?thread_ts=1691690041.149519&cid=CSG3W08JY




## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
