### PR TITLE
fix: allocation average time queued broken [DET-9709]

### DIFF
--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -275,8 +275,8 @@ def _test_exp_restart_allocations_start_time(managed_cluster_restarts: Cluster) 
     exp.wait_for_experiment_state(exp_id, EXP_STATE.CANCELED, max_wait_secs=30)
 
     resp = bindings.get_GetJobQueueStats(sess).to_json()
-    for rp in resp.get("results"):
-        for period in rp.get("aggregates"):
+    for rp in resp.get("results", []):
+        for period in rp.get("aggregates", []):
             assert period["seconds"] <= EXPECTED_MAX_AVG_ALLOCATION_QUEUED_SECONDS
 
 

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -220,6 +220,7 @@ func (rp *resourcePool) restoreResources(
 		ResourcePool: rp.config.PoolName,
 		Resources:    resources,
 		Recovered:    true,
+		RequestTime:  req.RequestTime,
 	}
 
 	rp.taskList.AddTask(req)
@@ -476,6 +477,7 @@ func (rp *resourcePool) allocateResources(req *sproto.AllocateRequest) bool {
 		ResourcePool:      rp.config.PoolName,
 		Resources:         sprotoResources,
 		JobSubmissionTime: req.JobSubmissionTime,
+		RequestTime:       req.RequestTime,
 	}
 	rp.taskList.AddAllocation(req.AllocationID, &allocated)
 	rmevents.Publish(req.AllocationID, allocated.Clone())

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -534,8 +534,11 @@ func (k *kubernetesResourcePool) assignResources(
 		k.allocationIDToContainerID[req.AllocationID] = rs.containerID
 		k.containerIDtoAllocationID[rs.containerID.String()] = req.AllocationID
 	}
-
-	assigned := sproto.ResourcesAllocated{ID: req.AllocationID, Resources: allocations}
+	assigned := sproto.ResourcesAllocated{
+		ID:          req.AllocationID,
+		Resources:   allocations,
+		RequestTime: req.RequestTime,
+	}
 	k.reqList.AddAllocationRaw(req.AllocationID, &assigned)
 	rmevents.Publish(req.AllocationID, assigned.Clone())
 

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -255,6 +255,7 @@ type (
 		ResourcePool      string
 		Resources         ResourceList
 		JobSubmissionTime time.Time
+		RequestTime       time.Time
 		Recovered         bool
 	}
 	// PendingPreemption notifies the task actor that it should release
@@ -312,6 +313,7 @@ func (ra ResourcesAllocated) Clone() *ResourcesAllocated {
 		ResourcePool:      ra.ResourcePool,
 		Resources:         maps.Clone(ra.Resources),
 		JobSubmissionTime: ra.JobSubmissionTime,
+		RequestTime:       ra.RequestTime,
 		Recovered:         ra.Recovered,
 	}
 }

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -625,7 +625,7 @@ func (a *allocation) resourcesAllocated(msg *sproto.ResourcesAllocated) error {
 	err = a.db.RecordTaskStats(&model.TaskStats{
 		AllocationID: msg.ID,
 		EventType:    "QUEUED",
-		StartTime:    &msg.JobSubmissionTime,
+		StartTime:    &msg.RequestTime,
 		EndTime:      &now,
 	})
 	if err != nil {

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -140,15 +140,17 @@ type AllocationState string
 
 // TaskStats is the model for task stats in the database.
 type TaskStats struct {
-	AllocationID AllocationID
-	EventType    string
+	bun.BaseModel `bun:"table:task_stats"`
+
+	AllocationID AllocationID `db:"allocation_id" bun:"allocation_id,notnull"`
+	EventType    string       `db:"event_type" bun:"event_type,notnull"`
 	// ContainerID is sent by the agent. This won't always be present in the database
 	// This is a weird table since sometimes it is one row per allocation
 	// (like in record queued stats) and sometimes it is many per allocation like in
 	// pulled time.
-	ContainerID *cproto.ID
-	StartTime   *time.Time
-	EndTime     *time.Time
+	ContainerID *cproto.ID `db:"container_id" bun:"container_id"`
+	StartTime   *time.Time `db:"start_time" bun:"start_time,notnull"`
+	EndTime     *time.Time `db:"end_time" bun:"end_time"`
 }
 
 // ResourceAggregates is the model for resource_aggregates in the database.


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

The Avg Queue Time chart in http://{DET_MASTER}/det/resourcepool/default/stats has a queue time of thousands of years. Two reasons: k8s doesn't send allocation start time, and in agent we don't send allocation start time when we restore allocations. The start time is stored as 0001-01-01 00:00:00+00 in the DB.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
e2e tests


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
DET-9709

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
