### PR TITLE
fix: Text filter on ProjectMoveModal [WEB-1495]

### DIFF
--- a/webui/react/src/components/ProjectMoveModal.tsx
+++ b/webui/react/src/components/ProjectMoveModal.tsx
@@ -88,7 +88,11 @@ const ProjectMoveModalComponent: React.FC<Props> = ({ onMove, project }: Props) 
         {workspaces.map((workspace) => {
           const disabled = workspace.archived || workspace.id === project.workspaceId;
           return (
-            <Option disabled={disabled} key={workspace.id} value={workspace.id}>
+            <Option
+              disabled={disabled}
+              key={workspace.id}
+              label={workspace.name}
+              value={workspace.id}>
               <div className={disabled ? css.workspaceOptionDisabled : ''}>
                 <Label truncate={{ tooltip: true }}>{workspace.name}</Label>
                 {workspace.archived && <Icon name="archive" title="Archived" />}


### PR DESCRIPTION
## Description

A ticket about workspaces in the ProjectMoveModal dropdown
- appearing in alphabetic order (currently ✔️ )
- search / autocomplete (currently ❌ )

Sets searchable text of workspaces using `label={workspace.name}`

The filter might have broken when we updated Typography. `ExperimentMoveModal` is already working

## Test Plan

Open a workspace other than default (such as `/det/workspaces/1486/projects`)
Click the three dots menu to select "Move..."

<img width="209" alt="Screen Shot 2024-01-30 at 10 45 11 AM" src="https://github.com/determined-ai/determined/assets/643918/774d428e-f528-4656-ae38-3be4441b5be5">

In the modal, test text autocomplete is case-insensitive

<img width="392" alt="Screen Shot 2024-01-30 at 10 46 17 AM" src="https://github.com/determined-ai/determined/assets/643918/7efd40c5-90e0-4fc2-8af6-8e324ce66a2d">


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.