### PR TITLE
docs: Update oidc and saml docs

### DIFF
--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1747,7 +1747,7 @@ Determines if users should be automatically created in Determined upon successfu
 ``groups_attribute_name``
 =========================
 
-The name of the attribute passed in through the claim that specifies group memberships in SAML.
+The name of the attribute passed in through the SAML assertion.
 
 ``display_name_attribute_name``
 ===============================

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1747,7 +1747,7 @@ Determines if users should be automatically created in Determined upon successfu
 ``groups_attribute_name``
 =========================
 
-The claim name that specifies group memberships in SAML.
+The name of the attribute passed in through the claim that specifies group memberships in SAML.
 
 ``display_name_attribute_name``
 ===============================

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -105,8 +105,8 @@ Version 0.26.5
    environment variable called ``DEX_TOKEN`` in task containers.
 
 -  Authentication: In the enterprise edition, add synchronization of OIDC user group memberships
-   with existing groups. Configure by setting ``oidc.groups_claim_name`` in the master config to the
-   string value of the authenticator's claim name for groups.
+   with existing groups. Configure by setting ``oidc.groups_attribute_name`` in the master config to
+   the string value of the authenticator's claim name for groups.
 
 Version 0.26.4
 ==============


### PR DESCRIPTION
## Description

Update reference docs to be more consistent. Update the name of the option, `oidc.groups_claim_name` to `oidc.groups_attribute_name` in the 0.26.5 release notes so that users know which option to look for in master config file.

Purpose: There were changes to the enterprise only edition features (security and authentication) as described in the enterprise only edition of the release notes for 0.27.1.
