### PR TITLE
chore: update gke version to comply with latest release for e2e tests

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -51,7 +51,7 @@ parameters:
     default: v1dev25
   gke-version:
     type: string
-    default: "1.25.10"
+    default: "1.29.0"
   master-build-resource-class:
     type: string
     default: xlarge


### PR DESCRIPTION
## Description

Update GKE version to comply with latest release for e2e tests.

## Test Plan

CI passes on main.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

