### PR TITLE
fix: update hew to a version without broken documentcard prompts

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.29",
+        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.30-0",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -7333,8 +7333,8 @@
       }
     },
     "node_modules/hew": {
-      "version": "0.6.29",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#3730d99f035354f173c2b8016953dfc682297f1f",
+      "version": "0.6.30-0",
+      "resolved": "git+https://git@github.com/determined-ai/hew.git#c61feba03a1d644ad2da8623af2ccc362600e227",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.29",
+    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.30-0",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",


### PR DESCRIPTION


## Description

this fixes an issue where, when switching between document cards, the prompt asking th euser if they're sure and warning against data loss appears with no buttons and the wrong text



## Test Plan

* visit the notes section of a project
* add a new note
* edit the content of the note
* add another new note
* switch to the new note you just created
* a modal should appear with proper fonts and options



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

WEB-1961


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
