### PR TITLE
fix: remove extra quotes around IdentifyTask

### DIFF
--- a/docs/release-notes/identify-task.rst
+++ b/docs/release-notes/identify-task.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  API: For tensorboard task types, fix a bug that would allow users to view tensorboards,
+-  TensorBoard: For TensorBoard task types, fix a bug that would allow users to view TensorBoards,
       even if they did not have permission to view the all workspaces it included.

--- a/docs/release-notes/identify-task.rst
+++ b/docs/release-notes/identify-task.rst
@@ -2,6 +2,5 @@
 
 **Bug Fixes**
 
--  API: Fix a bug where a database query would add extra quotes around the task type.
-      For tensorboard task types, this bug would allow users to view tensorboards, even if they did
-      not have permission to view the all workspaces it included.
+-  API: For tensorboard task types, fix a bug that would allow users to view tensorboards,
+      even if they did not have permission to view the all workspaces it included.

--- a/docs/release-notes/identify-task.rst
+++ b/docs/release-notes/identify-task.rst
@@ -3,5 +3,5 @@
 **Bug Fixes**
 
 -  API: Fix a bug where a database query would add extra quotes around the task type.
-      For tensorboard task types, this bug would always error and not allow authorized users to view
-      the tensorboard or the experiments associated with it.
+      For tensorboard task types, this bug would allow users to view tensorboards, even if they did
+      not have permission to view the all workspaces it included.

--- a/docs/release-notes/identify-task.rst
+++ b/docs/release-notes/identify-task.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes** 
+
+- API: Fix a bug where a database query would add extra quotes around the task type.
+For tensorboard task types, this bug would always error and not allow authorized users to view the
+tensorboard or the experiments associated with it.

--- a/docs/release-notes/identify-task.rst
+++ b/docs/release-notes/identify-task.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-**Bug Fixes** 
+**Bug Fixes**
 
-- API: Fix a bug where a database query would add extra quotes around the task type.
-For tensorboard task types, this bug would always error and not allow authorized users to view the
-tensorboard or the experiments associated with it.
+-  API: Fix a bug where a database query would add extra quotes around the task type.
+      For tensorboard task types, this bug would always error and not allow authorized users to view
+      the tensorboard or the experiments associated with it.

--- a/master/internal/command/postgres_command.go
+++ b/master/internal/command/postgres_command.go
@@ -47,9 +47,7 @@ func IdentifyTask(ctx context.Context, taskID model.TaskID) (TaskMetadata, error
 	metadata := TaskMetadata{}
 	if err := db.Bun().NewSelect().Model(&metadata).
 		ColumnExpr("generic_command_spec->'Metadata'->'workspace_id' AS workspace_id").
-		// TODO(DET-10004) TaskType needs
-		// to have ->> instead of -> so task_type doesn't get surrounded by double quotes.
-		ColumnExpr("generic_command_spec->'TaskType' as task_type").
+		ColumnExpr("generic_command_spec->>'TaskType' as task_type").
 		ColumnExpr("generic_command_spec->'Metadata'->'experiment_ids' as experiment_ids").
 		ColumnExpr("generic_command_spec->'Metadata'->'trial_ids' as trial_ids").
 		Where("task_id = ?", taskID).

--- a/master/internal/command/postgres_command_intg_test.go
+++ b/master/internal/command/postgres_command_intg_test.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -67,8 +66,7 @@ func TestIdentifyTask(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, TaskMetadata{
 		WorkspaceID: 1,
-		// TODO(DET-10004) remove these double quotes.
-		TaskType: model.TaskType(fmt.Sprintf(`"%s"`, model.TaskTypeCommand)),
+		TaskType:    model.TaskTypeCommand,
 	}, meta)
 
 	// Tensorboard.
@@ -84,9 +82,8 @@ func TestIdentifyTask(t *testing.T) {
 	meta, err = IdentifyTask(ctx, tensorboardID)
 	require.NoError(t, err)
 	require.Equal(t, TaskMetadata{
-		WorkspaceID: 1,
-		// TODO(DET-10004) remove these double quotes.
-		TaskType:      model.TaskType(fmt.Sprintf(`"%s"`, model.TaskTypeTensorboard)),
+		WorkspaceID:   1,
+		TaskType:      model.TaskTypeTensorboard,
 		ExperimentIDs: []int32{int32(expIDs[0]), int32(expIDs[1])},
 		TrialIDs:      []int32{int32(trialIDs[0]), int32(trialIDs[1])},
 	}, meta)


### PR DESCRIPTION
## Description
Remove extra quotes around TaskType from IdentifyTask -- fix the corresponding intg test to match this.

These changes will affect api_auth.go in the following code block:
```
if spec.TaskType == model.TaskTypeTensorboard {
		err = command.AuthZProvider.Get().CanGetTensorboard(...)
	} else {
		err = command.AuthZProvider.Get().CanGetNSC(...)
	}
```
The 'if' block would never be true before, but now it can be.


## Test Plan
Run intg tests.

## Commentary (optional)
We could test this feature's effect in api_auth.go by duplicating the processProxyAuthentication, but I believe TestIdentifyTask suffices when we replace the equality check with `model.TaskTypeABC` exactly. What's important is that the equality check is triggered with the right TaskType (tensorboard), and the postgres intg test also ensures that.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10004