### PR TITLE
chore: update backend coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,14 +3,14 @@ codecov:
   notify:
     wait_for_ci: no
 
-# Backend code coverage must be >= 37% +/- 3%. Backend PR coverage must be >= 80% +/- 5%.
+# Backend code coverage must be >= 42% +/- 3%. Backend PR coverage must be >= 80% +/- 5%.
 coverage:
   status:
     project:
       default:
         informational: true
       backend:
-        target: 37%
+        target: 42%
         threshold: 3%
         flags: 
           - backend


### PR DESCRIPTION
## Description

Backend code coverage has increased to about 43%, so increasing the target to 42% (with the same 3% threshold).


## Test Plan

CI passes.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
