### PR TITLE
feat: Generic task restore

### DIFF
--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -103,7 +103,9 @@ def test_master_restart_generic_task(managed_cluster_restarts: ManagedCluster) -
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Wait for task to start
-    time.sleep(1)
+    started = task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
+    if not started:
+        pytest.fail("task failed to started")
     managed_cluster_restarts.kill_master()
     managed_cluster_restarts.restart_master()
     is_valid_state = task.wait_for_task_state(

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -7,13 +7,14 @@ import pytest
 import requests
 
 from determined.common import constants
-from determined.common.api import authentication, task_is_ready, task_logs
+from determined.common.api import authentication, bindings, task_is_ready, task_logs
 from determined.common.api.bindings import experimentv1State as EXP_STATE
 from tests import api_utils
 from tests import command as cmd
 from tests import config as conf
 from tests import experiment as exp
 from tests.cluster.test_users import det_spawn
+from tests.task import task
 
 from .abstract_cluster import Cluster
 from .managed_cluster import ManagedCluster, get_agent_data
@@ -80,6 +81,37 @@ def test_master_restart_reattach_recover_experiment_k8s(
     downtime: int,
 ) -> None:
     _test_master_restart_reattach_recover_experiment(k8s_managed_cluster, downtime)
+
+
+@pytest.mark.managed_devcluster
+def test_master_restart_generic_task(managed_cluster_restarts: ManagedCluster) -> None:
+    test_session = api_utils.determined_test_session()
+
+    with open(conf.fixtures_path("generic_task/test_config.yaml"), "r") as config_file:
+        # Create task
+        config_text = config_file.read()
+
+    req = bindings.v1CreateGenericTaskRequest(
+        config=config_text,
+        contextDirectory=[],
+        projectId=None,
+        forkedFrom=None,
+        parentId=None,
+        inheritContext=False,
+        noPause=False,
+    )
+    task_resp = bindings.post_CreateGenericTask(test_session, body=req)
+
+    # Wait for task to start
+    time.sleep(1)
+    managed_cluster_restarts.kill_master()
+    managed_cluster_restarts.restart_master()
+    is_valid_state = task.wait_for_task_state(
+        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.managed_devcluster

--- a/e2e_tests/tests/task/__init__.py
+++ b/e2e_tests/tests/task/__init__.py
@@ -1,0 +1,1 @@
+from .task import wait_for_task_state

--- a/e2e_tests/tests/task/__init__.py
+++ b/e2e_tests/tests/task/__init__.py
@@ -1,1 +1,1 @@
-from .task import wait_for_task_state
+from .task import wait_for_task_state, wait_for_task_start

--- a/e2e_tests/tests/task/task.py
+++ b/e2e_tests/tests/task/task.py
@@ -14,6 +14,20 @@ def wait_for_task_state(
         resp = api.bindings.get_GetTask(test_session, taskId=task_id)
         if expected_state == resp.task.taskState:
             return True
-        print(resp.task.taskState)
+        time.sleep(0.1)
+    return False
+
+
+def wait_for_task_start(
+    test_session: api.Session,
+    task_id: str,
+    timeout: int,
+) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = api.bindings.get_GetTask(test_session, taskId=task_id)
+        print(resp.task.allocations[0].state)
+        if resp.task.allocations[0].state == api.bindings.taskv1State.RUNNING:
+            return True
         time.sleep(0.1)
     return False

--- a/e2e_tests/tests/task/task.py
+++ b/e2e_tests/tests/task/task.py
@@ -26,7 +26,6 @@ def wait_for_task_start(
     deadline = time.time() + timeout
     while time.time() < deadline:
         resp = api.bindings.get_GetTask(test_session, taskId=task_id)
-        print(resp.task.allocations[0].state)
         if resp.task.allocations[0].state == api.bindings.taskv1State.RUNNING:
             return True
         time.sleep(0.1)

--- a/e2e_tests/tests/task/task.py
+++ b/e2e_tests/tests/task/task.py
@@ -1,0 +1,19 @@
+import time
+
+from determined.common import api
+
+
+def wait_for_task_state(
+    test_session: api.Session,
+    task_id: str,
+    expected_state: api.bindings.v1GenericTaskState,
+    timeout: int,
+) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = api.bindings.get_GetTask(test_session, taskId=task_id)
+        if expected_state == resp.task.taskState:
+            return True
+        print(resp.task.taskState)
+        time.sleep(0.1)
+    return False

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -1,28 +1,13 @@
 import subprocess
-import time
 
 import pytest
 
 from determined.cli import ntsc
-from determined.common import api, util
+from determined.common import util
 from determined.common.api import bindings
 from tests import api_utils
 from tests import config as conf
-
-
-def wait_for_task_state(
-    test_session: api.Session,
-    task_id: str,
-    expected_state: bindings.v1GenericTaskState,
-    timeout: int,
-) -> bool:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        resp = bindings.get_GetTask(test_session, taskId=task_id)
-        if expected_state == resp.task.taskState:
-            return True
-        time.sleep(0.1)
-    return False
+from tests.task import task
 
 
 @pytest.mark.e2e_cpu
@@ -67,7 +52,7 @@ def test_generic_task_completion() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for complete state
-    is_valid_state = wait_for_task_state(
+    is_valid_state = task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
     if not is_valid_state:
@@ -97,7 +82,7 @@ def test_create_generic_task_error() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for error state
-    is_valid_state = wait_for_task_state(
+    is_valid_state = task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.ERROR, timeout=30
     )
     if not is_valid_state:

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 	"golang.org/x/exp/slices"
 
@@ -344,36 +343,7 @@ func (a *apiServer) CreateGenericTask(
 		return nil, err
 	}
 
-	onAllocationExit := func(ae *task.AllocationExited) {
-		syslog := logrus.WithField("component", "genericTask").WithFields(logCtx.Fields())
-		if ae.Err != nil {
-			err = a.m.db.SetErrorState(taskID, time.Now().UTC())
-			if err != nil {
-				syslog.WithError(err).Error("setting task to error state")
-			}
-			if err := tasklist.GroupPriorityChangeRegistry.Delete(jobID); err != nil {
-				syslog.WithError(err).Error("deleting group priority change registry")
-			}
-			return
-		}
-		isPaused, err := a.m.db.IsPaused(ctx, taskID)
-		if err != nil {
-			syslog.WithError(err).Error("checking if a task is paused")
-		}
-		if isPaused {
-			err = a.m.db.SetPausedState(taskID, time.Now().UTC())
-			if err != nil {
-				syslog.WithError(err).Error("setting task to paused state")
-			}
-			return
-		}
-		if err := a.m.db.CompleteGenericTask(taskID, time.Now().UTC()); err != nil {
-			syslog.WithError(err).Error("marking generic task complete")
-		}
-		if err := tasklist.GroupPriorityChangeRegistry.Delete(jobID); err != nil {
-			syslog.WithError(err).Error("deleting group priority change registry")
-		}
-	}
+	onAllocationExit := a.m.getGenericTaskOnAllocationExit(ctx, taskID, jobID, logCtx)
 
 	allocationID := model.AllocationID(fmt.Sprintf("%s.%d", taskID, 1))
 	isSingleNode := genericTaskSpec.GenericTaskConfig.Resources.IsSingleNode() != nil &&
@@ -672,36 +642,7 @@ func (a *apiServer) UnpauseGenericTask(
 			"task-id":   resumingTask.TaskID,
 			"task-type": model.TaskTypeGeneric,
 		}
-		onAllocationExit := func(ae *task.AllocationExited) {
-			syslog := logrus.WithField("component", "genericTask").WithFields(logCtx.Fields())
-			if ae.Err != nil {
-				err = a.m.db.SetErrorState(resumingTask.TaskID, time.Now().UTC())
-				if err != nil {
-					syslog.WithError(err).Error("setting task to error state")
-				}
-				if err := tasklist.GroupPriorityChangeRegistry.Delete(*resumingTask.JobID); err != nil {
-					syslog.WithError(err).Error("deleting group priority change registry")
-				}
-				return
-			}
-			isPaused, err := a.m.db.IsPaused(ctx, resumingTask.TaskID)
-			if err != nil {
-				syslog.WithError(err).Error("checking if a task is paused")
-			}
-			if isPaused {
-				err = a.m.db.SetPausedState(resumingTask.TaskID, time.Now().UTC())
-				if err != nil {
-					syslog.WithError(err).Error("setting task to paused state")
-				}
-				return
-			}
-			if err := a.m.db.CompleteGenericTask(resumingTask.TaskID, time.Now().UTC()); err != nil {
-				syslog.WithError(err).Error("marking generic task complete")
-			}
-			if err := tasklist.GroupPriorityChangeRegistry.Delete(*resumingTask.JobID); err != nil {
-				syslog.WithError(err).Error("deleting group priority change registry")
-			}
-		}
+		onAllocationExit := a.m.getGenericTaskOnAllocationExit(ctx, resumingTask.TaskID, *resumingTask.JobID, logCtx)
 		allocationSpecifier, err := allocationID.GetAllocationSpecifier()
 		if err != nil {
 			return nil, err

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -343,7 +343,7 @@ func (a *apiServer) CreateGenericTask(
 		return nil, err
 	}
 
-	onAllocationExit := a.m.getGenericTaskOnAllocationExit(ctx, taskID, jobID, logCtx)
+	onAllocationExit := getGenericTaskOnAllocationExit(ctx, taskID, jobID, logCtx)
 
 	allocationID := model.AllocationID(fmt.Sprintf("%s.%d", taskID, 1))
 	isSingleNode := genericTaskSpec.GenericTaskConfig.Resources.IsSingleNode() != nil &&
@@ -642,7 +642,7 @@ func (a *apiServer) UnpauseGenericTask(
 			"task-id":   resumingTask.TaskID,
 			"task-type": model.TaskTypeGeneric,
 		}
-		onAllocationExit := a.m.getGenericTaskOnAllocationExit(ctx, resumingTask.TaskID, *resumingTask.JobID, logCtx)
+		onAllocationExit := getGenericTaskOnAllocationExit(ctx, resumingTask.TaskID, *resumingTask.JobID, logCtx)
 		allocationSpecifier, err := allocationID.GetAllocationSpecifier()
 		if err != nil {
 			return nil, err

--- a/master/internal/command/command_service.go
+++ b/master/internal/command/command_service.go
@@ -73,14 +73,18 @@ func (cs *CommandService) RestoreAllCommands(
 	}
 
 	for i := range snapshots {
-		cmd, err := commandFromSnapshot(cs.db, cs.rm, &snapshots[i])
-		if err != nil {
-			cs.syslog.Errorf("failed to restore from snapshot: %s", err)
-			continue
+		if snapshots[i].GenericTaskSpec != nil {
+			//
+		} else {
+			cmd, err := commandFromSnapshot(cs.db, cs.rm, &snapshots[i])
+			if err != nil {
+				cs.syslog.Errorf("failed to restore from snapshot: %s", err)
+				continue
+			}
+			// Restore to the command service registry.
+			cs.commands[cmd.taskID] = cmd
+			cs.syslog.Debugf("restored & started generic command %s", cmd.taskID)
 		}
-		// Restore to the command service registry.
-		cs.commands[cmd.taskID] = cmd
-		cs.syslog.Debugf("restored & started generic command %s", cmd.taskID)
 	}
 	return nil
 }

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1082,6 +1082,8 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 		return err
 	}
 
+	// Restore generic tasks
+
 	if err = m.closeOpenAllocations(ctx); err != nil {
 		return err
 	}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -832,7 +832,7 @@ func (m *Master) restoreGenericTasks(ctx context.Context) error {
 			return err
 		}
 
-		onAllocationExit := m.getGenericTaskOnAllocationExit(ctx, taskID, *jobID, logCtx)
+		onAllocationExit := getGenericTaskOnAllocationExit(ctx, taskID, *jobID, logCtx)
 
 		isSingleNode := snapshots[i].GenericTaskSpec.GenericTaskConfig.Resources.IsSingleNode() != nil &&
 			*snapshots[i].GenericTaskSpec.GenericTaskConfig.Resources.IsSingleNode()

--- a/master/internal/db/postgres_tasks.go
+++ b/master/internal/db/postgres_tasks.go
@@ -103,7 +103,7 @@ func CompleteTask(ctx context.Context, tID model.TaskID, endTime time.Time) erro
 }
 
 // CompleteGenericTask persists the completion of a task of type GENERIC.
-func (db *PgDB) CompleteGenericTask(tID model.TaskID, endTime time.Time) error {
+func CompleteGenericTask(tID model.TaskID, endTime time.Time) error {
 	err := CompleteTask(context.Background(), tID, endTime)
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func (db *PgDB) CompleteGenericTask(tID model.TaskID, endTime time.Time) error {
 }
 
 // KillGenericTask persists the termination of a task of type GENERIC.
-func (db *PgDB) KillGenericTask(tID model.TaskID, endTime time.Time) error {
+func KillGenericTask(tID model.TaskID, endTime time.Time) error {
 	err := CompleteTask(context.Background(), tID, endTime)
 	if err != nil {
 		return err
@@ -140,7 +140,7 @@ func (db *PgDB) KillGenericTask(tID model.TaskID, endTime time.Time) error {
 }
 
 // SetPausedState sets given task to a PAUSED state.
-func (db *PgDB) SetPausedState(taskID model.TaskID, endTime time.Time) error {
+func SetPausedState(taskID model.TaskID, endTime time.Time) error {
 	_, err := Bun().NewUpdate().
 		Table("tasks").
 		Set("task_state = ?", model.TaskStatePaused).
@@ -154,7 +154,7 @@ func (db *PgDB) SetPausedState(taskID model.TaskID, endTime time.Time) error {
 }
 
 // IsPaused returns true if given task is in paused/pausing state.
-func (db *PgDB) IsPaused(ctx context.Context, tID model.TaskID) (bool, error) {
+func IsPaused(ctx context.Context, tID model.TaskID) (bool, error) {
 	count, err := Bun().NewSelect().Table("tasks").
 		Where("task_id = ?", tID).
 		WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
@@ -168,7 +168,7 @@ func (db *PgDB) IsPaused(ctx context.Context, tID model.TaskID) (bool, error) {
 }
 
 // SetErrorState sets given task to a ERROR state.
-func (db *PgDB) SetErrorState(taskID model.TaskID, endTime time.Time) error {
+func SetErrorState(taskID model.TaskID, endTime time.Time) error {
 	_, err := Bun().NewUpdate().
 		Table("tasks").
 		Set("task_state = ?", model.TaskStateError).

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -3,18 +3,23 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8sV1 "k8s.io/api/core/v1"
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	pkgCommand "github.com/determined-ai/determined/master/pkg/command"
+	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -133,4 +138,38 @@ func getTaskSessionToken(ctx context.Context, userModel *model.User) (string, er
 		}
 	}
 	return token, nil
+}
+
+func (m *Master) getGenericTaskOnAllocationExit(ctx context.Context, taskID model.TaskID, jobID model.JobID, logCtx logger.Context) func(ae *task.AllocationExited) {
+	return func(ae *task.AllocationExited) {
+		syslog := logrus.WithField("component", "genericTask").WithFields(logCtx.Fields())
+		if ae.Err != nil {
+			err := m.db.SetErrorState(taskID, time.Now().UTC())
+			if err != nil {
+				syslog.WithError(err).Error("setting task to error state")
+			}
+			if err := tasklist.GroupPriorityChangeRegistry.Delete(jobID); err != nil {
+				syslog.WithError(err).Error("deleting group priority change registry")
+			}
+			return
+		}
+		isPaused, err := m.db.IsPaused(ctx, taskID)
+		if err != nil {
+			syslog.WithError(err).Error("checking if a task is paused")
+		}
+		if isPaused {
+			err = m.db.SetPausedState(taskID, time.Now().UTC())
+			if err != nil {
+				syslog.WithError(err).Error("setting task to paused state")
+			}
+			return
+		}
+		if err := m.db.CompleteGenericTask(taskID, time.Now().UTC()); err != nil {
+			syslog.WithError(err).Error("marking generic task complete")
+		}
+		if err := tasklist.GroupPriorityChangeRegistry.Delete(jobID); err != nil {
+			syslog.WithError(err).Error("deleting group priority change registry")
+		}
+	}
+
 }

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -140,7 +140,12 @@ func getTaskSessionToken(ctx context.Context, userModel *model.User) (string, er
 	return token, nil
 }
 
-func (m *Master) getGenericTaskOnAllocationExit(ctx context.Context, taskID model.TaskID, jobID model.JobID, logCtx logger.Context) func(ae *task.AllocationExited) {
+func (m *Master) getGenericTaskOnAllocationExit(
+	ctx context.Context,
+	taskID model.TaskID,
+	jobID model.JobID,
+	logCtx logger.Context,
+) func(ae *task.AllocationExited) {
 	return func(ae *task.AllocationExited) {
 		syslog := logrus.WithField("component", "genericTask").WithFields(logCtx.Fields())
 		if ae.Err != nil {
@@ -171,5 +176,4 @@ func (m *Master) getGenericTaskOnAllocationExit(ctx context.Context, taskID mode
 			syslog.WithError(err).Error("deleting group priority change registry")
 		}
 	}
-
 }


### PR DESCRIPTION
## Description

Restoring Generic Tasks after master restarts



## Test Plan

1. Create a Task 
`det task create e2e_tests/tests/fixtures/generic_task/test_config.yaml --context e2e_tests/tests/fixtures/generic_task`
2. Restart master before task completes
3. Wait for task to complete and verify task completion via logs & DB task status
`det task logs <task-id>`


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10100

