### PR TITLE
fix: remove possible hang from ship_logs.py [MLG-1565]

### DIFF
--- a/docs/release-notes/8803-ship-logs-hanging.rst
+++ b/docs/release-notes/8803-ship-logs-hanging.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+**Fixes**
+
+-  Since 0.26.2, it was possible to cause Determined Trials and Commands to hang after the main
+   process exited but before the container exited, by starting a non-terminating subprocess from
+   your training script or command that kept an open stdout or stderr file descriptor. Now, logs
+   from subprocesses of your main process are ignored after your main process has exited.


### PR DESCRIPTION
Previously, after the main subprocess exited or was killed, the log shipper would wait without limit for the stdout and stderr readers to finish reading, under the assumption that after the main subprocess died they would be quickly drained.

However, if the main subprocess spun off other, non-terminating child processes, there would remain writers to the stdout and stderr, and this assumption caused a hang.

I named this the "Orphaned Grandchild Problem", and it is concerning because it can cause severe problems for users making fairly innocent mistakes.  It didn't appear earlier because most training scripts that we influence practice structured concurrency.

This fix includes a regression test.

## Test Plan

- [x] fix includes a regression test
- [x] run `det cmd run sh -c 'sleep infinity &'` and make sure the container only runs for a second or two