### PR TITLE
fix: check for models before deleting workspace

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -567,7 +567,8 @@ func (a *apiServer) DeleteWorkspace(
 		return nil, fmt.Errorf("unable to check workspace for models: %w", err)
 	}
 	if modelsExist {
-		return nil, status.Errorf(codes.FailedPrecondition, "workspace (%d) contains models; move or delete models first", req.Id)
+		return nil, status.Errorf(codes.FailedPrecondition, "workspace (%d) contains models; move or delete models first",
+			req.Id)
 	}
 
 	holder := &workspacev1.Workspace{}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -124,7 +124,7 @@ func (a *apiServer) workspaceHasModels(ctx context.Context, workspaceID int32) (
 		Where("workspace_id=?", workspaceID).
 		Exists(ctx)
 	if err != nil {
-		return exists, fmt.Errorf("error while checking workspace for models: %w", err)
+		return false, fmt.Errorf("checking workspace for models: %w", err)
 	}
 	return exists, nil
 }
@@ -563,7 +563,7 @@ func (a *apiServer) DeleteWorkspace(
 
 	modelsExist, err := a.workspaceHasModels(ctx, req.Id)
 	if err != nil {
-		return nil, fmt.Errorf("unable to check workspace for models: %w", err)
+		return nil, err
 	}
 	if modelsExist {
 		return nil, status.Errorf(codes.FailedPrecondition, "workspace (%d) contains models; move or delete models first",
@@ -611,9 +611,6 @@ func (a *apiServer) DeleteWorkspace(
 	go func() {
 		a.deleteWorkspace(ctx, req.Id, projects)
 	}()
-	if err != nil {
-		return nil, fmt.Errorf("error deleting workspace (%d): %w", req.Id, err)
-	}
 	return &apiv1.DeleteWorkspaceResponse{Completed: false}, nil
 }
 

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -123,7 +123,6 @@ func (a *apiServer) workspaceHasModels(ctx context.Context, workspaceID int32) (
 	exists, err := db.Bun().NewSelect().Model((*model.Model)(nil)).
 		Where("workspace_id=?", workspaceID).
 		Exists(ctx)
-
 	if err != nil {
 		return exists, fmt.Errorf("error while checking workspace for models: %w", err)
 	}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -120,7 +120,6 @@ func (a *apiServer) getWorkspaceAndCheckCanDoActions(
 }
 
 func (a *apiServer) workspaceHasModels(ctx context.Context, workspaceID int32) (bool, error) {
-
 	exists, err := db.Bun().NewSelect().Model((*model.Model)(nil)).
 		Where("workspace_id=?", workspaceID).
 		Exists(ctx)
@@ -559,14 +558,14 @@ func (a *apiServer) DeleteWorkspace(
 		return nil, err
 	}
 
-	models_exist, _ := a.workspaceHasModels(ctx, req.Id)
-	if models_exist {
+	modelsExist, _ := a.workspaceHasModels(ctx, req.Id)
+	if modelsExist {
 		return nil, fmt.Errorf("workspace (%d) contains models; move or delete models first", req.Id)
 	}
 
 	holder := &workspacev1.Workspace{}
 	// TODO(kristine): update workspace state in transaction with template delete
-	a.m.db.QueryProto("deletable_workspace", holder, req.Id)
+	_ = a.m.db.QueryProto("deletable_workspace", holder, req.Id)
 	if holder.Id == 0 {
 		return nil, fmt.Errorf("workspace (%d) does not exist or not deletable by this user", req.Id)
 	}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -123,7 +123,11 @@ func (a *apiServer) workspaceHasModels(ctx context.Context, workspaceID int32) (
 	exists, err := db.Bun().NewSelect().Model((*model.Model)(nil)).
 		Where("workspace_id=?", workspaceID).
 		Exists(ctx)
-	return exists, fmt.Errorf("error while checking workspace for models: %w", err)
+
+	if err != nil {
+		return exists, fmt.Errorf("error while checking workspace for models: %w", err)
+	}
+	return exists, nil
 }
 
 func (a *apiServer) GetWorkspace(

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -571,7 +571,7 @@ func (a *apiServer) DeleteWorkspace(
 	}
 
 	holder := &workspacev1.Workspace{}
-	// TODO(kristine): update workspace state in transaction with template delete
+	// TODO(kristine): DET-10138 update workspace state in transaction with template delete
 	err = a.m.db.QueryProto("deletable_workspace", holder, req.Id)
 	if err != nil || holder.Id == 0 {
 		return nil, fmt.Errorf("workspace (%d) does not exist or not deletable by this user: %w", req.Id, err)
@@ -589,7 +589,7 @@ func (a *apiServer) DeleteWorkspace(
 		"",
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error while getting workspace projects: %w", err)
+		return nil, fmt.Errorf("getting workspace projects: %w", err)
 	}
 
 	log.Debugf("deleting workspace %d NTSC", req.Id)

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -553,6 +553,7 @@ func TestDeleteWorkspace(t *testing.T) {
 
 	// set up command service - required for successful DeleteWorkspaceRequest calls
 	cs, err := command.NewService(api.m.db, api.m.rm)
+	require.NoError(t, err)
 	command.SetDefaultService(cs)
 
 	// create workspace

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -525,26 +525,23 @@ func TestAuthzWorkspaceGetThenActionRoutes(t *testing.T) {
 
 func TestWorkspaceHasModels(t *testing.T) {
 	// set up a dB and api server to use for integration testing
-	require.NoError(t, etc.SetRootPath("../static/srv"))
-	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
-	defer cleanup()
-	db.MustMigrateTestPostgres(t, pgDB, "file://../static/migrations")
-	api, _, ctx := setupAPITest(t, pgDB)
+	api, _, ctx := setupAPITest(t, nil)
 
 	// create workspace for test
-	workspaceName := "test-workspace"
+	workspaceName := uuid.New().String()
 	resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: workspaceName})
 	require.NoError(t, err)
 
 	// confirm workspace does not have any models
 	exists, err := api.workspaceHasModels(ctx, resp.Workspace.Id)
-	assert.False(t, exists)
 	require.NoError(t, err)
+	assert.False(t, exists)
 
 	// add model to workspace
-	_, err = api.PostModel(ctx, &apiv1.PostModelRequest{Name: "test-model", WorkspaceName: &workspaceName})
-	assert.Nil(t, err) // no error creating model
+	modelName := uuid.New().String()
+	_, err = api.PostModel(ctx, &apiv1.PostModelRequest{Name: modelName, WorkspaceName: &workspaceName})
+	require.NoError(t, err) // no error creating model
 	exists, err = api.workspaceHasModels(ctx, resp.Workspace.Id)
-	assert.True(t, exists)
 	require.NoError(t, err)
+	assert.True(t, exists)
 }

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -542,7 +542,8 @@ func TestWorkspaceHasModels(t *testing.T) {
 	require.NoError(t, err)
 
 	// add model to workspace
-	api.PostModel(ctx, &apiv1.PostModelRequest{Name: "test-model", WorkspaceName: &workspaceName})
+	_, err = api.PostModel(ctx, &apiv1.PostModelRequest{Name: "test-model", WorkspaceName: &workspaceName})
+	assert.Nil(t, err) // no error creating model
 	exists, err = api.workspaceHasModels(ctx, resp.Workspace.Id)
 	assert.True(t, exists)
 	require.NoError(t, err)

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -354,7 +354,7 @@ func RegisterCheckpointAsModelVersion(t *testing.T, pgDB *db.PgDB, ckptID uuid.U
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		Username:        user.Username,
+		UserID:          int(user.ID),
 		WorkspaceID:     1,
 	}
 	var pmdl modelv1.Model

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -348,13 +348,13 @@ func RegisterCheckpointAsModelVersion(t *testing.T, pgDB *db.PgDB, ckptID uuid.U
 	user := db.RequireMockUser(t, pgDB)
 	// Insert a model.
 	now := time.Now()
-	mdl := model.Model{
+	mdl := db.Model{
 		Name:            uuid.NewString(),
 		Description:     "some important model",
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		UserID:          int(user.ID),
+		UserID:          user.ID,
 		WorkspaceID:     1,
 	}
 	var pmdl modelv1.Model

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -184,13 +184,13 @@ func TestDeleteCheckpoints(t *testing.T) {
 
 	// Insert a model.
 	now := time.Now()
-	mdl := model.Model{
+	mdl := Model{
 		Name:            uuid.NewString(),
 		Description:     "some important model",
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		UserID:          int(user.ID),
+		UserID:          user.ID,
 		WorkspaceID:     1,
 	}
 	mdlNotes := "some notes2"

--- a/master/internal/db/postgres_checkpoints_intg_test.go
+++ b/master/internal/db/postgres_checkpoints_intg_test.go
@@ -190,7 +190,7 @@ func TestDeleteCheckpoints(t *testing.T) {
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		Username:        user.Username,
+		UserID:          int(user.ID),
 		WorkspaceID:     1,
 	}
 	mdlNotes := "some notes2"

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -171,13 +171,13 @@ func TestPgDB_ExperimentCheckpointsToGCRaw(t *testing.T) {
 func addCheckpointToModelRegistry(db *PgDB, checkpointUUID uuid.UUID, user model.User) error {
 	// Insert a model.
 	now := time.Now()
-	mdl := model.Model{
+	mdl := Model{
 		Name:            uuid.NewString(),
 		Description:     "some important model",
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		UserID:          int(user.ID),
+		UserID:          user.ID,
 		WorkspaceID:     1,
 	}
 	mdlNotes := "some notes1"

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -177,7 +177,7 @@ func addCheckpointToModelRegistry(db *PgDB, checkpointUUID uuid.UUID, user model
 		CreationTime:    now,
 		LastUpdatedTime: now,
 		Labels:          []string{"some other label"},
-		Username:        user.Username,
+		UserID:          int(user.ID),
 		WorkspaceID:     1,
 	}
 	mdlNotes := "some notes1"

--- a/master/internal/db/postgres_model_intg_test.go
+++ b/master/internal/db/postgres_model_intg_test.go
@@ -52,13 +52,13 @@ func TestModels(t *testing.T) {
 
 			// Insert a model.
 			now := time.Now()
-			mdl := model.Model{
+			mdl := Model{
 				Name:            uuid.NewString(),
 				Description:     "some important model",
 				CreationTime:    now,
 				LastUpdatedTime: now,
 				Labels:          []string{"some other label"},
-				UserID:          int(user.ID),
+				UserID:          user.ID,
 				WorkspaceID:     1,
 			}
 			mdlNotes := "some notes"

--- a/master/internal/db/postgres_model_intg_test.go
+++ b/master/internal/db/postgres_model_intg_test.go
@@ -58,7 +58,7 @@ func TestModels(t *testing.T) {
 				CreationTime:    now,
 				LastUpdatedTime: now,
 				Labels:          []string{"some other label"},
-				Username:        user.Username,
+				UserID:          int(user.ID),
 				WorkspaceID:     1,
 			}
 			mdlNotes := "some notes"

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -46,6 +46,21 @@ const (
 	DefaultTestSrcPath = "../../../examples/tutorials/mnist_pytorch"
 )
 
+// Model represents a row from the `models` table. Unused except for tests.
+type Model struct {
+	Name            string        `db:"name" json:"name"`
+	Description     string        `db:"description" json:"description"`
+	CreationTime    time.Time     `db:"creation_time" json:"creation_time"`
+	LastUpdatedTime time.Time     `db:"last_updated_time" json:"last_updated_time"`
+	Metadata        model.JSONObj `db:"metadata" json:"metadata"`
+	ID              int           `db:"id" json:"id"`
+	Labels          []string      `db:"labels" json:"labels"`
+	UserID          model.UserID  `db:"user_id" json:"user_id"`
+	Archived        bool          `db:"archived" json:"archived"`
+	Notes           string        `db:"notes" json:"notes"`
+	WorkspaceID     int           `db:"workspace_id" json:"workspace_id"`
+}
+
 // ResolveTestPostgres resolves a connection to a postgres database. To debug tests that use this
 // (or otherwise run the tests outside of the Makefile), make sure to set
 // DET_INTEGRATION_POSTGRES_URL.

--- a/master/pkg/model/model.go
+++ b/master/pkg/model/model.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/google/uuid"
 )
 
-// Model represents a row from the `models` table.
+// Model represents a row from the `models` table. Unused except for tests.
 type Model struct {
 	Name            string    `db:"name" json:"name"`
 	Description     string    `db:"description" json:"description"`
@@ -21,22 +19,6 @@ type Model struct {
 	Archived        bool      `db:"archived" json:"archived"`
 	Notes           string    `db:"notes" json:"notes"`
 	WorkspaceID     int       `db:"workspace_id" json:"workspace_id"`
-}
-
-// ModelVersion represents a row from the `model_versions` table.
-type ModelVersion struct {
-	Version         int       `db:"version" json:"version"`
-	CheckpointUUID  uuid.UUID `db:"checkpoint_uuid" json:"checkpoint_uuid"`
-	CreationTime    time.Time `db:"creation_time" json:"creation_time"`
-	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
-	Metadata        JSONObj   `db:"metadata" json:"metadata"`
-	ModelID         int       `db:"model_id" json:"model_id"`
-	ID              int       `db:"id" json:"id"`
-	Name            string    `db:"name" json:"name"`
-	Comment         string    `db:"comment" json:"comment"`
-	UserID          int       `db:"user_id" json:"user_id"`
-	Labels          []string  `db:"labels" json:"labels"`
-	Notes           string    `db:"readme" json:"notes"`
 }
 
 // InstanceState is an enum type that describes an instance state.

--- a/master/pkg/model/model.go
+++ b/master/pkg/model/model.go
@@ -4,36 +4,39 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Model represents a row from the `models` table.
 type Model struct {
-	ID              int       `db:"id" json:"id"`
 	Name            string    `db:"name" json:"name"`
 	Description     string    `db:"description" json:"description"`
-	Metadata        JSONObj   `db:"metadata" json:"metadata"`
 	CreationTime    time.Time `db:"creation_time" json:"creation_time"`
 	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
+	Metadata        JSONObj   `db:"metadata" json:"metadata"`
+	ID              int       `db:"id" json:"id"`
 	Labels          []string  `db:"labels" json:"labels"`
-	Username        string    `db:"username" json:"username"`
+	UserID          int       `db:"user_id" json:"user_id"`
 	Archived        bool      `db:"archived" json:"archived"`
-	NumVersions     int       `db:"num_versions" json:"num_versions"`
+	Notes           string    `db:"notes" json:"notes"`
 	WorkspaceID     int       `db:"workspace_id" json:"workspace_id"`
 }
 
 // ModelVersion represents a row from the `model_versions` table.
 type ModelVersion struct {
-	ID              int       `db:"id" json:"id"`
 	Version         int       `db:"version" json:"version"`
-	CheckpointID    int       `db:"checkpoint_id" json:"checkpoint_id"`
+	CheckpointUUID  uuid.UUID `db:"checkpoint_uuid" json:"checkpoint_uuid"`
 	CreationTime    time.Time `db:"creation_time" json:"creation_time"`
-	ModelID         int       `db:"model_id" json:"model_id"`
-	Metadata        JSONObj   `db:"metadata" json:"metadata"`
-	Name            string    `db:"name" json:"name"`
 	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
+	Metadata        JSONObj   `db:"metadata" json:"metadata"`
+	ModelID         int       `db:"model_id" json:"model_id"`
+	ID              int       `db:"id" json:"id"`
+	Name            string    `db:"name" json:"name"`
 	Comment         string    `db:"comment" json:"comment"`
+	UserID          int       `db:"user_id" json:"user_id"`
+	Labels          []string  `db:"labels" json:"labels"`
 	Notes           string    `db:"readme" json:"notes"`
-	Username        string    `db:"username" json:"username"`
 }
 
 // InstanceState is an enum type that describes an instance state.

--- a/master/pkg/model/model.go
+++ b/master/pkg/model/model.go
@@ -6,21 +6,6 @@ import (
 	"time"
 )
 
-// Model represents a row from the `models` table. Unused except for tests.
-type Model struct {
-	Name            string    `db:"name" json:"name"`
-	Description     string    `db:"description" json:"description"`
-	CreationTime    time.Time `db:"creation_time" json:"creation_time"`
-	LastUpdatedTime time.Time `db:"last_updated_time" json:"last_updated_time"`
-	Metadata        JSONObj   `db:"metadata" json:"metadata"`
-	ID              int       `db:"id" json:"id"`
-	Labels          []string  `db:"labels" json:"labels"`
-	UserID          int       `db:"user_id" json:"user_id"`
-	Archived        bool      `db:"archived" json:"archived"`
-	Notes           string    `db:"notes" json:"notes"`
-	WorkspaceID     int       `db:"workspace_id" json:"workspace_id"`
-}
-
 // InstanceState is an enum type that describes an instance state.
 type InstanceState string
 


### PR DESCRIPTION
## Description

Details in [DET-9982]. Previously, if a user tried to delete a workspace with models (archived or not), they were met with an SQL error. Most of the workspace contents were deleted and the workspace was left in state "Deleting". 

With this change, we first check if a workspace has models on a delete request. If it does, a human-readable error message is returned and the workspace state is unchanged. Nothing in the workspace is deleted.


## Test Plan

Added integration tests to confirm functionality. Also tested locally using CLI. 


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-9982


[DET-9982]: https://hpe-aiatscale.atlassian.net/browse/DET-9982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ