### PR TITLE
chore: GCP firewall for GKE master service to limit traffic

### DIFF
--- a/helm/charts/determined/templates/master-service.yaml
+++ b/helm/charts/determined/templates/master-service.yaml
@@ -11,6 +11,9 @@ spec:
   - port: {{ required "A valid Values.masterPort entry required!" .Values.masterPort }}
     targetPort: {{- include "determined.masterPort" . | indent 1 }}
     protocol: TCP
+    {{- if .Values.loadBalancerSourceRanges }}
+    loadBalancerSourceRanges: {{ .Values.loadBalancerSourceRanges}}
+    {{- end }}
 
 {{- if ((.Values.openshiftRoute).enabled | default false) }}
   type: ClusterIP

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -389,3 +389,7 @@ genai:
   #   v100:
   #     gpu_type: V100
   #     max_agents: 2
+
+## Configure the set of IP ranges allowed to connect to the Determined master service on a public
+## GKE cluster.
+loadBalancerSourceRanges:


### PR DESCRIPTION
## Description

Script to be run on each CI node in order to ensure that the service on the shared cluster remains firewall'd off from all external IP addresses other than CI instances.

## Test Plan

Helm install determined within a given namespace on shared CI cluster and ensure, execute this script, and ensure that the service, even with a public endpoint, is only accessible from CI IP addresses).

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10135