### PR TITLE
chore: add testing for k8s informer panic

### DIFF
--- a/master/internal/rm/kubernetesrm/informer_intg_test.go
+++ b/master/internal/rm/kubernetesrm/informer_intg_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8sV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -300,6 +302,22 @@ func TestEventListener(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestInformerPanic tests that we panic on unexpected retryWatcher channel close.
+func TestInformerPanic(t *testing.T) {
+	ctx := context.TODO()
+	eventChan := make(chan watch.Event)
+
+	i := informer{
+		syslog:     logrus.WithField("component", "panicInformer"),
+		resultChan: eventChan,
+	}
+
+	close(eventChan)
+	require.Panics(t, func() {
+		i.run(ctx)
+	})
 }
 
 // Methods for mockWatcher.


### PR DESCRIPTION
## Description
#8786 was a release fix that addressed the issue of uncaught retryWatcher failures. This PR adds a test to make sure that the code behaves as expected when the channel the informer reads from is closed.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
No manual testing required. Run the test and make sure it succeeds. 
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
