### PR TITLE
fix: stop truncating log timestamps to avoid missing logs [WEB-1791]

### DIFF
--- a/bindings/generate_bindings_ts.py
+++ b/bindings/generate_bindings_ts.py
@@ -86,7 +86,7 @@ def annotation(anno: swagger_parser.TypeAnno) -> Code:
     if isinstance(anno, swagger_parser.Bool):
         return "boolean"
     if isinstance(anno, swagger_parser.DateTime):
-        return "Date"
+        return "Date | DateString"
     if isinstance(anno, swagger_parser.Ref):
         if not anno.defn:
             return "void"
@@ -265,7 +265,7 @@ def generate_function(api: str, phase: Phase, function: swagger_parser.Function)
             code += f"if ({param.name}{null_check}) {{"
             code.indent()
             if isinstance(param.type, swagger_parser.DateTime):
-                code += f"localVarQueryParameter['{param.serialized_name}'] = {param.name}.toISOString()"
+                code += f"localVarQueryParameter['{param.serialized_name}'] = typeof {param.name} === \"string\" ? {param.name} : {param.name}.toISOString()"
             else:
                 code += f"localVarQueryParameter['{param.serialized_name}'] = {param.name}"
             code.dedent()
@@ -459,7 +459,7 @@ def tsbindings(swagger: swagger_parser.ParseResult) -> str:
  * NOTE: Do not edit the class manually.
  */
 
-
+import {{ DateString }} from "ioTypes";
 import {{ Configuration }} from "./configuration";
 
 type ValueOf<T> = T[keyof T];

--- a/webui/react/src/ioTypes.ts
+++ b/webui/react/src/ioTypes.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { isLeft } from 'fp-ts/lib/Either';
 import * as io from 'io-ts';
 
@@ -70,6 +71,18 @@ class Float extends io.Type<number, number | string, unknown> {
 }
 
 export const float = new Float();
+
+interface DateStringBrand {
+  readonly DateString: unique symbol;
+}
+
+export const DateString = io.brand(
+  io.string,
+  (n): n is io.Branded<string, DateStringBrand> => dayjs(n).isValid(),
+  'DateString',
+);
+
+export type DateString = io.TypeOf<typeof DateString>;
 
 /* Slot */
 

--- a/webui/react/src/pages/JobQueue/JobQueue.table.tsx
+++ b/webui/react/src/pages/JobQueue/JobQueue.table.tsx
@@ -132,7 +132,12 @@ export const columns: ColumnDef<Job>[] = [
     render: createOmitableRenderer<Job, FullJob>(
       'entityId',
       (_, record): ReactNode =>
-        record.submissionTime && relativeTimeRenderer(record.submissionTime),
+        record.submissionTime &&
+        relativeTimeRenderer(
+          typeof record.submissionTime === 'string'
+            ? new Date(record.submissionTime)
+            : record.submissionTime,
+        ),
     ),
     title: 'Submitted',
   },

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -7,6 +7,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import Page from 'components/Page';
 import { commandTypeToLabel } from 'constants/states';
 import { useSettings } from 'hooks/useSettings';
+import { DateString, decode } from 'ioTypes';
 import { paths, serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
@@ -107,8 +108,8 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
         settings.level,
         undefined,
         undefined,
-        options.timestampBefore ? new Date(options.timestampBefore) : undefined,
-        options.timestampAfter ? new Date(options.timestampAfter) : undefined,
+        decode(DateString, options.timestampBefore),
+        decode(DateString, options.timestampAfter),
         options.orderBy as OrderBy,
         settings.searchText,
         { signal: config.canceler.signal },

--- a/webui/react/src/pages/TaskLogs.tsx
+++ b/webui/react/src/pages/TaskLogs.tsx
@@ -7,7 +7,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import Page from 'components/Page';
 import { commandTypeToLabel } from 'constants/states';
 import { useSettings } from 'hooks/useSettings';
-import { DateString, decode } from 'ioTypes';
+import { DateString, decode, optional } from 'ioTypes';
 import { paths, serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
@@ -77,8 +77,8 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
         follow: false,
         limit: config.limit,
         orderBy: 'ORDER_BY_UNSPECIFIED',
-        timestampAfter: '',
-        timestampBefore: '',
+        timestampAfter: undefined as Date | string | undefined,
+        timestampBefore: undefined as Date | string | undefined,
       };
 
       if (type === FetchType.Initial) {
@@ -108,8 +108,8 @@ const TaskLogs: React.FC<Props> = ({ taskId, taskType, onCloseLogs, headerCompon
         settings.level,
         undefined,
         undefined,
-        decode(DateString, options.timestampBefore),
-        decode(DateString, options.timestampAfter),
+        decode(optional(DateString), options.timestampBefore),
+        decode(optional(DateString), options.timestampAfter),
         options.orderBy as OrderBy,
         settings.searchText,
         { signal: config.canceler.signal },

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import useUI from 'components/ThemeProvider';
 import { useSettings } from 'hooks/useSettings';
-import { DateString, decode } from 'ioTypes';
+import { DateString, decode, optional } from 'ioTypes';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
@@ -129,8 +129,8 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
         follow: false,
         limit: config.limit,
         orderBy: 'ORDER_BY_UNSPECIFIED',
-        timestampAfter: '',
-        timestampBefore: '',
+        timestampAfter: undefined as Date | string | undefined,
+        timestampBefore: undefined as Date | string | undefined,
       };
 
       if (type === FetchType.Initial) {
@@ -159,8 +159,8 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
         settings.level,
         undefined,
         undefined,
-        decode(DateString, options.timestampBefore),
-        decode(DateString, options.timestampAfter),
+        decode(optional(DateString), options.timestampBefore),
+        decode(optional(DateString), options.timestampAfter),
         options.orderBy as OrderBy,
         settings.searchText,
         { signal },

--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -8,6 +8,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import useUI from 'components/ThemeProvider';
 import { useSettings } from 'hooks/useSettings';
+import { DateString, decode } from 'ioTypes';
 import { serverAddress } from 'routes/utils';
 import { detApi } from 'services/apiConfig';
 import { mapV1LogsResponse } from 'services/decoder';
@@ -158,8 +159,8 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
         settings.level,
         undefined,
         undefined,
-        options.timestampBefore ? new Date(options.timestampBefore) : undefined,
-        options.timestampAfter ? new Date(options.timestampAfter) : undefined,
+        decode(DateString, options.timestampBefore),
+        decode(DateString, options.timestampAfter),
         options.orderBy as OrderBy,
         settings.searchText,
         { signal },

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -8,7 +8,7 @@
  * NOTE: Do not edit the class manually.
  */
 
-
+import { DateString } from "ioTypes";
 import { Configuration } from "./configuration";
 
 type ValueOf<T> = T[keyof T];
@@ -760,16 +760,16 @@ export interface Trialv1Trial {
     experimentId: number;
     /**
      * The time the trial was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof Trialv1Trial
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The time the trial ended if the trial is stopped.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof Trialv1Trial
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
     /**
      * The current state of the trial.
      * @type {Trialv1State}
@@ -1037,10 +1037,10 @@ export interface V1Agent {
     id: string;
     /**
      * The time when the agent registered with the master.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Agent
      */
-    registeredTime?: Date;
+    registeredTime?: Date | DateString;
     /**
      * A map of slot id to each slot of this agent.
      * @type {{ [key: string]: V1Slot; }}
@@ -1337,10 +1337,10 @@ export interface V1AllocationSummary {
     name?: string;
     /**
      * The registered time of the task.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1AllocationSummary
      */
-    registeredTime?: Date;
+    registeredTime?: Date | DateString;
     /**
      * The name of the resource pool.
      * @type {string}
@@ -1687,10 +1687,10 @@ export interface V1Checkpoint {
     uuid: string;
     /**
      * Timestamp when the checkpoint was reported.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Checkpoint
      */
-    reportTime?: Date;
+    reportTime?: Date | DateString;
     /**
      * Dictionary of file paths to file sizes in bytes of all files in the checkpoint.
      * @type {{ [key: string]: string; }}
@@ -1811,10 +1811,10 @@ export interface V1CheckpointWorkload {
     uuid?: string;
     /**
      * The time the workload finished or was stopped.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1CheckpointWorkload
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
     /**
      * The state of the checkpoint.
      * @type {Checkpointv1State}
@@ -1891,10 +1891,10 @@ export interface V1Command {
     state: Taskv1State;
     /**
      * The time the command was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Command
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The container running the command.
      * @type {V1Container}
@@ -2158,10 +2158,10 @@ export interface V1CreateExperimentRequest {
     gitCommitter?: string;
     /**
      * Git commit date at submission time.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1CreateExperimentRequest
      */
-    gitCommitDate?: Date;
+    gitCommitDate?: Date | DateString;
     /**
      * Unmanaged experiments are detached.
      * @type {boolean}
@@ -2316,10 +2316,10 @@ export interface V1DataPoint {
     values?: any;
     /**
      * The time the measurement is taken.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1DataPoint
      */
-    time: Date;
+    time: Date | DateString;
     /**
      * The epoch this measurement is taken.
      * @type {number}
@@ -2686,16 +2686,16 @@ export interface V1Experiment {
     labels?: Array<string>;
     /**
      * The time the experiment was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Experiment
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The time the experiment ended if the experiment is stopped.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Experiment
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
     /**
      * The current state of the experiment.
      * @type {Experimentv1State}
@@ -3064,10 +3064,10 @@ export interface V1FileNode {
     name?: string;
     /**
      * Modification time of file.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1FileNode
      */
-    modifiedTime?: Date;
+    modifiedTime?: Date | DateString;
     /**
      * Number of bytes in file content.
      * @type {number}
@@ -4807,10 +4807,10 @@ export interface V1Job {
     type: Jobv1Type;
     /**
      * The time when the job was submitted by the user.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Job
      */
-    submissionTime: Date;
+    submissionTime: Date | DateString;
     /**
      * The username of the user who submitted the job.
      * @type {string}
@@ -5498,10 +5498,10 @@ export interface V1LogEntry {
     message: string;
     /**
      * The timestamp.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1LogEntry
      */
-    timestamp: Date;
+    timestamp: Date | DateString;
     /**
      * The log level.
      * @type {V1LogLevel}
@@ -5704,10 +5704,10 @@ export interface V1MetricsReport {
     trialId: number;
     /**
      * End time of when metric was reported.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1MetricsReport
      */
-    endTime: Date;
+    endTime: Date | DateString;
     /**
      * Struct of the reported metrics.
      * @type {any}
@@ -5753,10 +5753,10 @@ export interface V1MetricsReport {
 export interface V1MetricsWorkload {
     /**
      * The time the workload finished or was stopped.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1MetricsWorkload
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
     /**
      * Metrics.
      * @type {V1Metrics}
@@ -5813,16 +5813,16 @@ export interface V1Model {
     metadata: any;
     /**
      * The time the model was created.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Model
      */
-    creationTime: Date;
+    creationTime: Date | DateString;
     /**
      * The time the model was last updated.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Model
      */
-    lastUpdatedTime: Date;
+    lastUpdatedTime: Date | DateString;
     /**
      * The id of this model.
      * @type {number}
@@ -5898,10 +5898,10 @@ export interface V1ModelVersion {
     version: number;
     /**
      * The time the model version was created.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1ModelVersion
      */
-    creationTime: Date;
+    creationTime: Date | DateString;
     /**
      * Unique id for each model version.
      * @type {number}
@@ -5922,10 +5922,10 @@ export interface V1ModelVersion {
     metadata?: any;
     /**
      * The time this model version was last updated.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1ModelVersion
      */
-    lastUpdatedTime: Date;
+    lastUpdatedTime: Date | DateString;
     /**
      * Comment associated with this model version.
      * @type {string}
@@ -6118,10 +6118,10 @@ export interface V1Notebook {
     state: Taskv1State;
     /**
      * The time the notebook was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Notebook
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The container running the notebook.
      * @type {V1Container}
@@ -7509,10 +7509,10 @@ export interface V1Project {
     description?: string;
     /**
      * Time of most recently started experiment within this project.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Project
      */
-    lastExperimentStartedAt?: Date;
+    lastExperimentStartedAt?: Date | DateString;
     /**
      * Notes associated with this project.
      * @type {Array<V1Note>}
@@ -8064,16 +8064,16 @@ export interface V1ResourceAllocationRawEntry {
     kind?: string;
     /**
      * The time at which the allocation began.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1ResourceAllocationRawEntry
      */
-    startTime?: Date;
+    startTime?: Date | DateString;
     /**
      * The time at which the allocation ended.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1ResourceAllocationRawEntry
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
     /**
      * The ID of the experiment the allocation is a part of.
      * @type {number}
@@ -9309,10 +9309,10 @@ export interface V1Shell {
     state: Taskv1State;
     /**
      * The time the shell was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Shell
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The container running the shell.
      * @type {V1Container}
@@ -9537,16 +9537,16 @@ export interface V1Task {
     allocations: Array<V1Allocation>;
     /**
      * Start timestamp.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Task
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * End timestamp if completed.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Task
      */
-    endTime?: Date;
+    endTime?: Date | DateString;
 }
 /**
  * 
@@ -9592,10 +9592,10 @@ export interface V1TaskLog {
     rankId?: number;
     /**
      * The timestamp of the log.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TaskLog
      */
-    timestamp?: Date;
+    timestamp?: Date | DateString;
     /**
      * The level of this log.
      * @type {V1LogLevel}
@@ -9678,10 +9678,10 @@ export interface V1TaskLogsResponse {
     id: string;
     /**
      * The timestamp of the log.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TaskLogsResponse
      */
-    timestamp: Date;
+    timestamp: Date | DateString;
     /**
      * The flat version of the log that UIs have shown historically.
      * @type {string}
@@ -9809,10 +9809,10 @@ export interface V1Tensorboard {
     state: Taskv1State;
     /**
      * The time the tensorboard was started.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Tensorboard
      */
-    startTime: Date;
+    startTime: Date | DateString;
     /**
      * The container running the tensorboard.
      * @type {V1Container}
@@ -9901,28 +9901,28 @@ export interface V1TestWebhookResponse {
 export interface V1TimestampFieldFilter {
     /**
      * Less than.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TimestampFieldFilter
      */
-    lt?: Date;
+    lt?: Date | DateString;
     /**
      * Less than or equal.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TimestampFieldFilter
      */
-    lte?: Date;
+    lte?: Date | DateString;
     /**
      * Greater than.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TimestampFieldFilter
      */
-    gt?: Date;
+    gt?: Date | DateString;
     /**
      * Greater than or equal.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TimestampFieldFilter
      */
-    gte?: Date;
+    gte?: Date | DateString;
 }
 /**
  * TrialClosed is a searcher event triggered when a trial has successfully finished.
@@ -10056,10 +10056,10 @@ export interface V1TrialLogsResponse {
     id: string;
     /**
      * The timestamp of the log.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1TrialLogsResponse
      */
-    timestamp: Date;
+    timestamp: Date | DateString;
     /**
      * The flat version of the log that UIs have shown historically.
      * @type {string}
@@ -10216,10 +10216,10 @@ export interface V1TrialProfilerMetricsBatch {
     batches: Array<number>;
     /**
      * The timestamp at which a reading occurred, repeated for the batch of metrics.
-     * @type {Array<Date>}
+     * @type {Array<Date | DateString>}
      * @memberof V1TrialProfilerMetricsBatch
      */
-    timestamps: Array<Date>;
+    timestamps: Array<Date | DateString>;
     /**
      * The labels for this series.
      * @type {V1TrialProfilerMetricLabels}
@@ -10670,10 +10670,10 @@ export interface V1User {
     displayName?: string;
     /**
      * The version of the user object for caching purposes.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1User
      */
-    modifiedAt?: Date;
+    modifiedAt?: Date | DateString;
     /**
      * Bool denoting whether the user should be able to login with or change a password.
      * @type {boolean}
@@ -10682,10 +10682,10 @@ export interface V1User {
     remote?: boolean;
     /**
      * when the user last authenticated
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1User
      */
-    lastAuthAt?: Date;
+    lastAuthAt?: Date | DateString;
 }
 /**
  * Message for results of individual users in a multi-user action.
@@ -10827,10 +10827,10 @@ export interface V1ValidationHistoryEntry {
     trialId: number;
     /**
      * The time at which the completed validation was reported.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1ValidationHistoryEntry
      */
-    endTime: Date;
+    endTime: Date | DateString;
     /**
      * The value of the `searcher.metric`, indicated by the experiment config, for the validation.
      * @type {number}
@@ -10991,10 +10991,10 @@ export interface V1Workspace {
     checkpointStorageConfig?: any;
     /**
      * Optional date when workspace was pinned.
-     * @type {Date}
+     * @type {Date | DateString}
      * @memberof V1Workspace
      */
-    pinnedAt?: Date;
+    pinnedAt?: Date | DateString;
     /**
      * Name of the default compute pool.
      * @type {string}
@@ -12164,12 +12164,12 @@ export const ClusterApiFetchParamCreator = function (configuration?: Configurati
         /**
          * 
          * @summary Get a detailed view of resource allocation during the given time period.
-         * @param {Date} timestampAfter The start of the period to consider.
-         * @param {Date} timestampBefore The end of the period to consider.
+         * @param {Date | DateString} timestampAfter The start of the period to consider.
+         * @param {Date | DateString} timestampBefore The end of the period to consider.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        resourceAllocationRaw(timestampAfter: Date, timestampBefore: Date, options: any = {}): FetchArgs {
+        resourceAllocationRaw(timestampAfter: Date | DateString, timestampBefore: Date | DateString, options: any = {}): FetchArgs {
             // verify required parameter 'timestampAfter' is not null or undefined
             if (timestampAfter === null || timestampAfter === undefined) {
                 throw new RequiredError('timestampAfter','Required parameter timestampAfter was null or undefined when calling resourceAllocationRaw.');
@@ -12193,11 +12193,11 @@ export const ClusterApiFetchParamCreator = function (configuration?: Configurati
             }
             
             if (timestampAfter) {
-                localVarQueryParameter['timestampAfter'] = timestampAfter.toISOString()
+                localVarQueryParameter['timestampAfter'] = typeof timestampAfter === "string" ? timestampAfter : timestampAfter.toISOString()
             }
             
             if (timestampBefore) {
-                localVarQueryParameter['timestampBefore'] = timestampBefore.toISOString()
+                localVarQueryParameter['timestampBefore'] = typeof timestampBefore === "string" ? timestampBefore : timestampBefore.toISOString()
             }
             
             objToSearchParams(localVarQueryParameter, localVarUrlObj.searchParams);
@@ -12479,12 +12479,12 @@ export const ClusterApiFp = function (configuration?: Configuration) {
         /**
          * 
          * @summary Get a detailed view of resource allocation during the given time period.
-         * @param {Date} timestampAfter The start of the period to consider.
-         * @param {Date} timestampBefore The end of the period to consider.
+         * @param {Date | DateString} timestampAfter The start of the period to consider.
+         * @param {Date | DateString} timestampBefore The end of the period to consider.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        resourceAllocationRaw(timestampAfter: Date, timestampBefore: Date, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1ResourceAllocationRawResponse> {
+        resourceAllocationRaw(timestampAfter: Date | DateString, timestampBefore: Date | DateString, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1ResourceAllocationRawResponse> {
             const localVarFetchArgs = ClusterApiFetchParamCreator(configuration).resourceAllocationRaw(timestampAfter, timestampBefore, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -12649,12 +12649,12 @@ export const ClusterApiFactory = function (configuration?: Configuration, fetch?
         /**
          * 
          * @summary Get a detailed view of resource allocation during the given time period.
-         * @param {Date} timestampAfter The start of the period to consider.
-         * @param {Date} timestampBefore The end of the period to consider.
+         * @param {Date | DateString} timestampAfter The start of the period to consider.
+         * @param {Date | DateString} timestampBefore The end of the period to consider.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        resourceAllocationRaw(timestampAfter: Date, timestampBefore: Date, options?: any) {
+        resourceAllocationRaw(timestampAfter: Date | DateString, timestampBefore: Date | DateString, options?: any) {
             return ClusterApiFp(configuration).resourceAllocationRaw(timestampAfter, timestampBefore, options)(fetch, basePath);
         },
     }
@@ -12837,13 +12837,13 @@ export class ClusterApi extends BaseAPI {
     /**
      * 
      * @summary Get a detailed view of resource allocation during the given time period.
-     * @param {Date} timestampAfter The start of the period to consider.
-     * @param {Date} timestampBefore The end of the period to consider.
+     * @param {Date | DateString} timestampAfter The start of the period to consider.
+     * @param {Date | DateString} timestampBefore The end of the period to consider.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ClusterApi
      */
-    public resourceAllocationRaw(timestampAfter: Date, timestampBefore: Date, options?: any) {
+    public resourceAllocationRaw(timestampAfter: Date | DateString, timestampBefore: Date | DateString, options?: any) {
         return ClusterApiFp(this.configuration).resourceAllocationRaw(timestampAfter, timestampBefore, options)(this.fetch, this.basePath)
     }
     
@@ -13580,14 +13580,14 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
          * @param {number} [timeSeriesFilterIntegerRangeGte] Greater than or equal.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeIncl] In a set. `in` is a reserved word in python.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeNotIn] Not in a set.
-         * @param {Date} [timeSeriesFilterTimeRangeLt] Less than.
-         * @param {Date} [timeSeriesFilterTimeRangeLte] Less than or equal.
-         * @param {Date} [timeSeriesFilterTimeRangeGt] Greater than.
-         * @param {Date} [timeSeriesFilterTimeRangeGte] Greater than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLt] Less than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLte] Less than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGt] Greater than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGte] Greater than or equal.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date, timeSeriesFilterTimeRangeLte?: Date, timeSeriesFilterTimeRangeGt?: Date, timeSeriesFilterTimeRangeGte?: Date, options: any = {}): FetchArgs {
+        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date | DateString, timeSeriesFilterTimeRangeLte?: Date | DateString, timeSeriesFilterTimeRangeGt?: Date | DateString, timeSeriesFilterTimeRangeGte?: Date | DateString, options: any = {}): FetchArgs {
             const localVarPath = `/api/v1/trials/time-series`;
             const localVarUrlObj = new URL(localVarPath, BASE_PATH);
             const localVarRequestOptions = { method: 'GET', ...options };
@@ -13679,19 +13679,19 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
             }
             
             if (timeSeriesFilterTimeRangeLt) {
-                localVarQueryParameter['timeSeriesFilter.timeRange.lt'] = timeSeriesFilterTimeRangeLt.toISOString()
+                localVarQueryParameter['timeSeriesFilter.timeRange.lt'] = typeof timeSeriesFilterTimeRangeLt === "string" ? timeSeriesFilterTimeRangeLt : timeSeriesFilterTimeRangeLt.toISOString()
             }
             
             if (timeSeriesFilterTimeRangeLte) {
-                localVarQueryParameter['timeSeriesFilter.timeRange.lte'] = timeSeriesFilterTimeRangeLte.toISOString()
+                localVarQueryParameter['timeSeriesFilter.timeRange.lte'] = typeof timeSeriesFilterTimeRangeLte === "string" ? timeSeriesFilterTimeRangeLte : timeSeriesFilterTimeRangeLte.toISOString()
             }
             
             if (timeSeriesFilterTimeRangeGt) {
-                localVarQueryParameter['timeSeriesFilter.timeRange.gt'] = timeSeriesFilterTimeRangeGt.toISOString()
+                localVarQueryParameter['timeSeriesFilter.timeRange.gt'] = typeof timeSeriesFilterTimeRangeGt === "string" ? timeSeriesFilterTimeRangeGt : timeSeriesFilterTimeRangeGt.toISOString()
             }
             
             if (timeSeriesFilterTimeRangeGte) {
-                localVarQueryParameter['timeSeriesFilter.timeRange.gte'] = timeSeriesFilterTimeRangeGte.toISOString()
+                localVarQueryParameter['timeSeriesFilter.timeRange.gte'] = typeof timeSeriesFilterTimeRangeGte === "string" ? timeSeriesFilterTimeRangeGte : timeSeriesFilterTimeRangeGte.toISOString()
             }
             
             objToSearchParams(localVarQueryParameter, localVarUrlObj.searchParams);
@@ -14969,14 +14969,14 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'trialId' is not null or undefined
             if (trialId === null || trialId === undefined) {
                 throw new RequiredError('trialId','Required parameter trialId was null or undefined when calling trialLogs.');
@@ -15029,11 +15029,11 @@ export const ExperimentsApiFetchParamCreator = function (configuration?: Configu
             }
             
             if (timestampBefore) {
-                localVarQueryParameter['timestampBefore'] = timestampBefore.toISOString()
+                localVarQueryParameter['timestampBefore'] = typeof timestampBefore === "string" ? timestampBefore : timestampBefore.toISOString()
             }
             
             if (timestampAfter) {
-                localVarQueryParameter['timestampAfter'] = timestampAfter.toISOString()
+                localVarQueryParameter['timestampAfter'] = typeof timestampAfter === "string" ? timestampAfter : timestampAfter.toISOString()
             }
             
             if (orderBy !== undefined) {
@@ -15313,14 +15313,14 @@ export const ExperimentsApiFp = function (configuration?: Configuration) {
          * @param {number} [timeSeriesFilterIntegerRangeGte] Greater than or equal.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeIncl] In a set. `in` is a reserved word in python.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeNotIn] Not in a set.
-         * @param {Date} [timeSeriesFilterTimeRangeLt] Less than.
-         * @param {Date} [timeSeriesFilterTimeRangeLte] Less than or equal.
-         * @param {Date} [timeSeriesFilterTimeRangeGt] Greater than.
-         * @param {Date} [timeSeriesFilterTimeRangeGte] Greater than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLt] Less than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLte] Less than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGt] Greater than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGte] Greater than or equal.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date, timeSeriesFilterTimeRangeLte?: Date, timeSeriesFilterTimeRangeGt?: Date, timeSeriesFilterTimeRangeGte?: Date, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1CompareTrialsResponse> {
+        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date | DateString, timeSeriesFilterTimeRangeLte?: Date | DateString, timeSeriesFilterTimeRangeGt?: Date | DateString, timeSeriesFilterTimeRangeGte?: Date | DateString, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<V1CompareTrialsResponse> {
             const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).compareTrials(trialIds, maxDatapoints, metricNames, startBatches, endBatches, metricType, group, metricIds, timeSeriesFilterName, timeSeriesFilterDoubleRangeLt, timeSeriesFilterDoubleRangeLte, timeSeriesFilterDoubleRangeGt, timeSeriesFilterDoubleRangeGte, timeSeriesFilterIntegerRangeLt, timeSeriesFilterIntegerRangeLte, timeSeriesFilterIntegerRangeGt, timeSeriesFilterIntegerRangeGte, timeSeriesFilterIntegerRangeIncl, timeSeriesFilterIntegerRangeNotIn, timeSeriesFilterTimeRangeLt, timeSeriesFilterTimeRangeLte, timeSeriesFilterTimeRangeGt, timeSeriesFilterTimeRangeGte, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -15921,14 +15921,14 @@ export const ExperimentsApiFp = function (configuration?: Configuration) {
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
             const localVarFetchArgs = ExperimentsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -16089,14 +16089,14 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
          * @param {number} [timeSeriesFilterIntegerRangeGte] Greater than or equal.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeIncl] In a set. `in` is a reserved word in python.
          * @param {Array<number>} [timeSeriesFilterIntegerRangeNotIn] Not in a set.
-         * @param {Date} [timeSeriesFilterTimeRangeLt] Less than.
-         * @param {Date} [timeSeriesFilterTimeRangeLte] Less than or equal.
-         * @param {Date} [timeSeriesFilterTimeRangeGt] Greater than.
-         * @param {Date} [timeSeriesFilterTimeRangeGte] Greater than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLt] Less than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeLte] Less than or equal.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGt] Greater than.
+         * @param {Date | DateString} [timeSeriesFilterTimeRangeGte] Greater than or equal.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date, timeSeriesFilterTimeRangeLte?: Date, timeSeriesFilterTimeRangeGt?: Date, timeSeriesFilterTimeRangeGte?: Date, options?: any) {
+        compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date | DateString, timeSeriesFilterTimeRangeLte?: Date | DateString, timeSeriesFilterTimeRangeGt?: Date | DateString, timeSeriesFilterTimeRangeGte?: Date | DateString, options?: any) {
             return ExperimentsApiFp(configuration).compareTrials(trialIds, maxDatapoints, metricNames, startBatches, endBatches, metricType, group, metricIds, timeSeriesFilterName, timeSeriesFilterDoubleRangeLt, timeSeriesFilterDoubleRangeLte, timeSeriesFilterDoubleRangeGt, timeSeriesFilterDoubleRangeGte, timeSeriesFilterIntegerRangeLt, timeSeriesFilterIntegerRangeLte, timeSeriesFilterIntegerRangeGt, timeSeriesFilterIntegerRangeGte, timeSeriesFilterIntegerRangeIncl, timeSeriesFilterIntegerRangeNotIn, timeSeriesFilterTimeRangeLt, timeSeriesFilterTimeRangeLte, timeSeriesFilterTimeRangeGt, timeSeriesFilterTimeRangeGte, options)(fetch, basePath);
         },
         /**
@@ -16436,14 +16436,14 @@ export const ExperimentsApiFactory = function (configuration?: Configuration, fe
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
             return ExperimentsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
@@ -16581,15 +16581,15 @@ export class ExperimentsApi extends BaseAPI {
      * @param {number} [timeSeriesFilterIntegerRangeGte] Greater than or equal.
      * @param {Array<number>} [timeSeriesFilterIntegerRangeIncl] In a set. `in` is a reserved word in python.
      * @param {Array<number>} [timeSeriesFilterIntegerRangeNotIn] Not in a set.
-     * @param {Date} [timeSeriesFilterTimeRangeLt] Less than.
-     * @param {Date} [timeSeriesFilterTimeRangeLte] Less than or equal.
-     * @param {Date} [timeSeriesFilterTimeRangeGt] Greater than.
-     * @param {Date} [timeSeriesFilterTimeRangeGte] Greater than or equal.
+     * @param {Date | DateString} [timeSeriesFilterTimeRangeLt] Less than.
+     * @param {Date | DateString} [timeSeriesFilterTimeRangeLte] Less than or equal.
+     * @param {Date | DateString} [timeSeriesFilterTimeRangeGt] Greater than.
+     * @param {Date | DateString} [timeSeriesFilterTimeRangeGte] Greater than or equal.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
      */
-    public compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date, timeSeriesFilterTimeRangeLte?: Date, timeSeriesFilterTimeRangeGt?: Date, timeSeriesFilterTimeRangeGte?: Date, options?: any) {
+    public compareTrials(trialIds?: Array<number>, maxDatapoints?: number, metricNames?: Array<string>, startBatches?: number, endBatches?: number, metricType?: V1MetricType, group?: string, metricIds?: Array<string>, timeSeriesFilterName?: string, timeSeriesFilterDoubleRangeLt?: number, timeSeriesFilterDoubleRangeLte?: number, timeSeriesFilterDoubleRangeGt?: number, timeSeriesFilterDoubleRangeGte?: number, timeSeriesFilterIntegerRangeLt?: number, timeSeriesFilterIntegerRangeLte?: number, timeSeriesFilterIntegerRangeGt?: number, timeSeriesFilterIntegerRangeGte?: number, timeSeriesFilterIntegerRangeIncl?: Array<number>, timeSeriesFilterIntegerRangeNotIn?: Array<number>, timeSeriesFilterTimeRangeLt?: Date | DateString, timeSeriesFilterTimeRangeLte?: Date | DateString, timeSeriesFilterTimeRangeGt?: Date | DateString, timeSeriesFilterTimeRangeGte?: Date | DateString, options?: any) {
         return ExperimentsApiFp(this.configuration).compareTrials(trialIds, maxDatapoints, metricNames, startBatches, endBatches, metricType, group, metricIds, timeSeriesFilterName, timeSeriesFilterDoubleRangeLt, timeSeriesFilterDoubleRangeLte, timeSeriesFilterDoubleRangeGt, timeSeriesFilterDoubleRangeGte, timeSeriesFilterIntegerRangeLt, timeSeriesFilterIntegerRangeLte, timeSeriesFilterIntegerRangeGt, timeSeriesFilterIntegerRangeGte, timeSeriesFilterIntegerRangeIncl, timeSeriesFilterIntegerRangeNotIn, timeSeriesFilterTimeRangeLt, timeSeriesFilterTimeRangeLte, timeSeriesFilterTimeRangeGt, timeSeriesFilterTimeRangeGte, options)(this.fetch, this.basePath)
     }
     
@@ -16986,15 +16986,15 @@ export class ExperimentsApi extends BaseAPI {
      * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
      * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
      * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-     * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-     * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+     * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+     * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
      * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ExperimentsApi
      */
-    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
         return ExperimentsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath)
     }
     
@@ -22746,14 +22746,14 @@ export const JobsApiFetchParamCreator = function (configuration?: Configuration)
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'taskId' is not null or undefined
             if (taskId === null || taskId === undefined) {
                 throw new RequiredError('taskId','Required parameter taskId was null or undefined when calling taskLogs.');
@@ -22810,11 +22810,11 @@ export const JobsApiFetchParamCreator = function (configuration?: Configuration)
             }
             
             if (timestampBefore) {
-                localVarQueryParameter['timestampBefore'] = timestampBefore.toISOString()
+                localVarQueryParameter['timestampBefore'] = typeof timestampBefore === "string" ? timestampBefore : timestampBefore.toISOString()
             }
             
             if (timestampAfter) {
-                localVarQueryParameter['timestampAfter'] = timestampAfter.toISOString()
+                localVarQueryParameter['timestampAfter'] = typeof timestampAfter === "string" ? timestampAfter : timestampAfter.toISOString()
             }
             
             if (orderBy !== undefined) {
@@ -22897,14 +22897,14 @@ export const JobsApiFp = function (configuration?: Configuration) {
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
             const localVarFetchArgs = JobsApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -22958,14 +22958,14 @@ export const JobsApiFactory = function (configuration?: Configuration, fetch?: F
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
             return JobsApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
@@ -23002,15 +23002,15 @@ export class JobsApi extends BaseAPI {
      * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
      * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
      * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-     * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-     * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+     * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+     * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
      * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof JobsApi
      */
-    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
         return JobsApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath)
     }
     
@@ -27445,14 +27445,14 @@ export const TasksApiFetchParamCreator = function (configuration?: Configuration
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'taskId' is not null or undefined
             if (taskId === null || taskId === undefined) {
                 throw new RequiredError('taskId','Required parameter taskId was null or undefined when calling taskLogs.');
@@ -27509,11 +27509,11 @@ export const TasksApiFetchParamCreator = function (configuration?: Configuration
             }
             
             if (timestampBefore) {
-                localVarQueryParameter['timestampBefore'] = timestampBefore.toISOString()
+                localVarQueryParameter['timestampBefore'] = typeof timestampBefore === "string" ? timestampBefore : timestampBefore.toISOString()
             }
             
             if (timestampAfter) {
-                localVarQueryParameter['timestampAfter'] = timestampAfter.toISOString()
+                localVarQueryParameter['timestampAfter'] = typeof timestampAfter === "string" ? timestampAfter : timestampAfter.toISOString()
             }
             
             if (orderBy !== undefined) {
@@ -27670,14 +27670,14 @@ export const TasksApiFp = function (configuration?: Configuration) {
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TaskLogsResponse> {
             const localVarFetchArgs = TasksApiFetchParamCreator(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -27769,14 +27769,14 @@ export const TasksApiFactory = function (configuration?: Configuration, fetch?: 
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+        taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
             return TasksApiFp(configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
@@ -27859,15 +27859,15 @@ export class TasksApi extends BaseAPI {
      * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
      * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
      * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-     * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-     * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+     * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+     * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
      * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TasksApi
      */
-    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+    public taskLogs(taskId: string, limit?: number, follow?: boolean, allocationIds?: Array<string>, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
         return TasksApiFp(this.configuration).taskLogs(taskId, limit, follow, allocationIds, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath)
     }
     
@@ -29279,14 +29279,14 @@ export const TrialsApiFetchParamCreator = function (configuration?: Configuratio
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options: any = {}): FetchArgs {
             // verify required parameter 'trialId' is not null or undefined
             if (trialId === null || trialId === undefined) {
                 throw new RequiredError('trialId','Required parameter trialId was null or undefined when calling trialLogs.');
@@ -29339,11 +29339,11 @@ export const TrialsApiFetchParamCreator = function (configuration?: Configuratio
             }
             
             if (timestampBefore) {
-                localVarQueryParameter['timestampBefore'] = timestampBefore.toISOString()
+                localVarQueryParameter['timestampBefore'] = typeof timestampBefore === "string" ? timestampBefore : timestampBefore.toISOString()
             }
             
             if (timestampAfter) {
-                localVarQueryParameter['timestampAfter'] = timestampAfter.toISOString()
+                localVarQueryParameter['timestampAfter'] = typeof timestampAfter === "string" ? timestampAfter : timestampAfter.toISOString()
             }
             
             if (orderBy !== undefined) {
@@ -29573,14 +29573,14 @@ export const TrialsApiFp = function (configuration?: Configuration) {
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<StreamResultOfV1TrialLogsResponse> {
             const localVarFetchArgs = TrialsApiFetchParamCreator(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options);
             return (fetch: FetchAPI = window.fetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
@@ -29718,14 +29718,14 @@ export const TrialsApiFactory = function (configuration?: Configuration, fetch?:
          * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
          * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
          * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-         * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-         * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+         * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+         * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
          * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
          * @param {string} [searchText] Search the logs by whether the text contains a substring.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+        trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
             return TrialsApiFp(configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(fetch, basePath);
         },
         /**
@@ -29860,15 +29860,15 @@ export class TrialsApi extends BaseAPI {
      * @param {Array<V1LogLevel>} [levels] Limit the trial logs to a subset of agents.   - LOG_LEVEL_UNSPECIFIED: Unspecified log level.  - LOG_LEVEL_TRACE: A log level of TRACE.  - LOG_LEVEL_DEBUG: A log level of DEBUG.  - LOG_LEVEL_INFO: A log level of INFO.  - LOG_LEVEL_WARNING: A log level of WARNING.  - LOG_LEVEL_ERROR: A log level of ERROR.  - LOG_LEVEL_CRITICAL: A log level of CRITICAL.
      * @param {Array<string>} [stdtypes] Limit the trial logs to a subset of output streams.
      * @param {Array<string>} [sources] Limit the trial logs to a subset of sources.
-     * @param {Date} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
-     * @param {Date} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
+     * @param {Date | DateString} [timestampBefore] Limit the trial logs to ones with a timestamp before a given time.
+     * @param {Date | DateString} [timestampAfter] Limit the trial logs to ones with a timestamp after a given time.
      * @param {V1OrderBy} [orderBy] Order logs in either ascending or descending order by timestamp.   - ORDER_BY_UNSPECIFIED: Returns records in no specific order.  - ORDER_BY_ASC: Returns records in ascending order.  - ORDER_BY_DESC: Returns records in descending order.
      * @param {string} [searchText] Search the logs by whether the text contains a substring.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TrialsApi
      */
-    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date, timestampAfter?: Date, orderBy?: V1OrderBy, searchText?: string, options?: any) {
+    public trialLogs(trialId: number, limit?: number, follow?: boolean, agentIds?: Array<string>, containerIds?: Array<string>, rankIds?: Array<number>, levels?: Array<V1LogLevel>, stdtypes?: Array<string>, sources?: Array<string>, timestampBefore?: Date | DateString, timestampAfter?: Date | DateString, orderBy?: V1OrderBy, searchText?: string, options?: any) {
         return TrialsApiFp(this.configuration).trialLogs(trialId, limit, follow, agentIds, containerIds, rankIds, levels, stdtypes, sources, timestampBefore, timestampAfter, orderBy, searchText, options)(this.fetch, this.basePath)
     }
     

--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -642,7 +642,7 @@ const decodeDownsampledMetrics = (data: Sdk.V1DownsampledMetrics[]): types.Metri
       data: m.data.map((pt) => ({
         batches: pt.batches,
         epoch: pt.epoch,
-        time: pt.time,
+        time: typeof pt.time === 'string' ? new Date(pt.time) : pt.time,
         values: pt.values,
       })),
       group: m.group,
@@ -799,6 +799,10 @@ export const mapWorkspaceState = (state: Sdk.V1WorkspaceState): types.WorkspaceS
 export const mapV1Project = (data: Sdk.V1Project): types.Project => {
   return {
     ...data,
+    lastExperimentStartedAt:
+      typeof data.lastExperimentStartedAt === 'string'
+        ? new Date(data.lastExperimentStartedAt)
+        : data.lastExperimentStartedAt,
     state: mapWorkspaceState(data.state),
     workspaceName: data.workspaceName ?? '',
   };


### PR DESCRIPTION
## Description
Context: https://hpe-aiatscale.slack.com/archives/C02PV33GSN5/p1706886505065759

TLDR: When web fetches logs from the API we we converting the timestamp from the database to and from a JavaScript Date object. Dates only support millisecond precision, so all significant digits in the microsecond range were truncated. Due to the way we request logs, this led to ~500 microseconds worth of entries not being reported on the web LogViewer. By allowing the timestamp to be passed without a conversion step, this problem should be avoided.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

- Go to any trial logs page
- Download the full logs though the Download Logs modal
- Open the Network tab of your browser's inspector
- Scroll up in the LogViewer until you see a GET request to `/api/v1/trials/{trial_id}/logs?limit=100&...`
- Copy the response to that request into a text file
- Continue to scroll up in LogViewer until you see another similar GET request
- Copy the response into a separate text file
- The last entry from the first API call should be the same as the first entry from the second API call
- Cross reference with full downloaded logs that there aren't any logs missing between the two requests

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
