### PR TITLE
chore: configure agent log level through config file

### DIFF
--- a/agent/internal/core.go
+++ b/agent/internal/core.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/agent/internal/options"
+	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/syncx/errgroupx"
 )
 
@@ -29,6 +30,9 @@ func Run(parent context.Context, version string, opts options.Options) error {
 	wg := errgroupx.WithContext(ctx)
 
 	log.Trace("starting main agent process")
+
+	logger.SetLogrus(opts.Log)
+
 	wg.Go(func(ctx context.Context) error {
 		defer wg.Cancel()
 

--- a/docs/release-notes/log-level-config.rst
+++ b/docs/release-notes/log-level-config.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  Configure log settings for the Determined agent in the configuration file used to launch
+   Determined clusters by setting ``log.level``and ``log.color`` appropriately.

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -70,3 +70,5 @@ stages:
         master_host: 127.0.0.1
         master_port: 8080
         container_master_host: $DOCKER_LOCALHOST
+        log:
+          level: trace


### PR DESCRIPTION
## Description

Agent log level can now be set via agent config.

## Test Plan

- Change the value of `log.level` (and `log.color`) in the `agent` stage of `.../determined/tools/devcluster.yaml`:
```
- agent:
    ...
    config_file:
        log:
            level: <input_level>
            color: <input_color>    
```

- Run `make devcluster` and verify that the output of `agent configuration` in the build logs includes `"log":{"level":<input_level>, "color":<input_color>}`. 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-8884