### PR TITLE
chore: remove unused SetAllocationName

### DIFF
--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -486,19 +486,6 @@ func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slot
 	return name, nil
 }
 
-// SetAllocationName implements rm.ResourceManager.
-func (a *ResourceManager) SetAllocationName(msg sproto.SetAllocationName) {
-	pool, err := a.poolByName(msg.ResourcePool)
-	if err != nil {
-		a.syslog.WithError(err).Warnf("set allocation name found no resource pool with name %s",
-			msg.ResourcePool)
-		return
-	}
-	// In the actor system, this was a tell before, so the `go` is to keep the same structure.  I'm not changing it
-	// out of principle during the refactor but removing it is very likely fine, just check for deadlocks.
-	go pool.SetAllocationName(msg)
-}
-
 // SetGroupMaxSlots implements rm.ResourceManager.
 func (a *ResourceManager) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	pool, err := a.poolByName(msg.ResourcePool)

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -229,18 +229,6 @@ func (rp *resourcePool) restoreResources(
 	return nil
 }
 
-func (rp *resourcePool) SetAllocationName(msg sproto.SetAllocationName) {
-	rp.mu.Lock()
-	defer rp.mu.Unlock()
-	rp.receiveSetTaskName(msg)
-}
-
-func (rp *resourcePool) receiveSetTaskName(msg sproto.SetAllocationName) {
-	if task, found := rp.taskList.TaskByID(msg.AllocationID); found {
-		task.Name = msg.Name
-	}
-}
-
 func (rp *resourcePool) ResourcesReleased(msg sproto.ResourcesReleased) {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -331,17 +331,6 @@ func (k *ResourceManager) Release(msg sproto.ResourcesReleased) {
 	rp.ResourcesReleased(msg)
 }
 
-// SetAllocationName implements rm.ResourceManager.
-func (k *ResourceManager) SetAllocationName(msg sproto.SetAllocationName) {
-	rp, err := k.poolByName(msg.ResourcePool)
-	if err != nil {
-		k.syslog.WithError(err).Warnf("set allocation name found no resource pool with name %s",
-			msg.ResourcePool)
-		return
-	}
-	rp.SetAllocationName(msg)
-}
-
 // SetGroupMaxSlots implements rm.ResourceManager.
 func (k *ResourceManager) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	rp, err := k.poolByName(msg.ResourcePool)

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -90,14 +90,6 @@ func (k *kubernetesResourcePool) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	k.getOrCreateGroup(msg.JobID).MaxSlots = msg.MaxSlots
 }
 
-func (k *kubernetesResourcePool) SetAllocationName(msg sproto.SetAllocationName) {
-	k.mu.Lock()
-	defer k.mu.Unlock()
-	k.reschedule = true
-
-	k.receiveSetAllocationName(msg)
-}
-
 func (k *kubernetesResourcePool) AllocateRequest(msg sproto.AllocateRequest) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -462,14 +454,6 @@ func (k *kubernetesResourcePool) jobQInfo() map[model.JobID]*sproto.RMJobInfo {
 	jobQInfo := tasklist.ReduceToJobQInfo(reqs)
 	correctedJobQInfo := k.correctJobQInfo(reqs, jobQInfo)
 	return correctedJobQInfo
-}
-
-func (k *kubernetesResourcePool) receiveSetAllocationName(
-	msg sproto.SetAllocationName,
-) {
-	if task, found := k.reqList.TaskByID(msg.AllocationID); found {
-		task.Name = msg.Name
-	}
 }
 
 func (k *kubernetesResourcePool) assignResources(

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -13,7 +13,6 @@ type ResourceManager interface {
 	// Basic functionality
 	GetAllocationSummary(sproto.GetAllocationSummary) (*sproto.AllocationSummary, error)
 	GetAllocationSummaries(sproto.GetAllocationSummaries) (map[model.AllocationID]sproto.AllocationSummary, error)
-	SetAllocationName(sproto.SetAllocationName)
 	Allocate(sproto.AllocateRequest) (*sproto.ResourcesSubscription, error)
 	Release(sproto.ResourcesReleased)
 	ValidateCommandResources(sproto.ValidateCommandResourcesRequest) (sproto.ValidateCommandResourcesResponse, error)

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -93,12 +93,6 @@ type (
 		Priority       *int               `json:"priority"`
 		ProxyPorts     []*ProxyPortConfig `json:"proxy_ports,omitempty"`
 	}
-	// SetAllocationName sets the name of the task.
-	SetAllocationName struct {
-		Name         string
-		AllocationID model.AllocationID
-		ResourcePool string
-	}
 
 	// ValidateCommandResourcesRequest is a message asking resource manager whether the given
 	// resource pool can (or, rather, if it's not impossible to) fulfill the command request


### PR DESCRIPTION
## Description
The `SetAllocationMethod` in the ResourceManager interface is not used anywhere, just defined. 
Remove all definitions to this method -- best practice for tech debt, only keep code that we use in the codebase.

## Test Plan
N/a, just don't break existing intg or e2e tests.


## Commentary (optional)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-10149
