### PR TITLE
docs: Update slurm install

### DIFF
--- a/docs/setup-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/slurm/slurm-requirements.rst
@@ -13,7 +13,6 @@ To deploy the Determined HPC Launcher on Slurm/PBS, the following requirements m
 -  The login node, admin node, and compute nodes must be installed and configured with one of the
    following Linux distributions:
 
-   -  Red Hat® Enterprise Linux (RHEL) or CentOS 7.9
    -  RHEL or Rocky Linux® 8.5, 8.6
    -  RHEL 9
    -  SUSE® Linux Enterprise Server (SLES) 12 SP3 , 15 SP3, 15 SP4


### PR DESCRIPTION
Update Slurm installation requirements, removing reference to the following distribution: Red Hat® Enterprise Linux (RHEL) or CentOS 7.9
