### PR TITLE
fix: stop allowing multi-container allocations to launch in single agent config[DET-9911]

### DIFF
--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -61,14 +61,16 @@ func MockRM() *mocks.ResourceManager {
 		},
 		nil,
 	)
-	mockRM.On("ValidateResources", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockRM.On("ValidateResources", mock.Anything).Return(
+		func(sproto.ValidateResourcesRequest) sproto.ValidateResourcesResponse {
+			return sproto.ValidateResourcesResponse{}
+		}, nil, nil)
 	mockRM.On("TaskContainerDefaults", mock.Anything, mock.Anything).Return(
 		func(name string, def model.TaskContainerDefaultsConfig) model.TaskContainerDefaultsConfig {
 			return def
 		},
 		nil,
 	)
-	mockRM.On("ValidateResourcePoolAvailability", mock.Anything).Return(nil, nil)
 	mockRM.On("SetGroupMaxSlots", mock.Anything).Return()
 	mockRM.On("SetGroupWeight", mock.Anything).Return(nil)
 	mockRM.On("Allocate", mock.Anything).Return(func(msg sproto.AllocateRequest) *sproto.ResourcesSubscription {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -299,9 +299,6 @@ func (m *Master) parseCreateExperiment(req *apiv1.CreateExperimentRequest, owner
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
-	if err = m.rm.ValidateResources(poolName, resources.SlotsPerTrial(), isSingleNode); err != nil {
-		return nil, nil, config, nil, nil, errors.Wrapf(err, "error validating resources")
-	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
 		poolName,
 		m.config.TaskContainerDefaults,

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -116,18 +116,12 @@ func newExperiment(
 
 	var launchWarnings []command.LaunchWarning
 	if expModel.ID == 0 {
-		err := m.rm.ValidateResources(poolName, resources.SlotsPerTrial(), false)
-		if err != nil {
+		if _, launchWarnings, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
+			ResourcePool: poolName,
+			Slots:        resources.SlotsPerTrial(),
+			IsSingleNode: resources.IsSingleNode() != nil && *resources.IsSingleNode(),
+		}); err != nil {
 			return nil, nil, fmt.Errorf("validating resources: %v", err)
-		}
-		launchWarnings, err = m.rm.ValidateResourcePoolAvailability(
-			&sproto.ValidateResourcePoolAvailabilityRequest{
-				Name:  poolName,
-				Slots: resources.SlotsPerTrial(),
-			},
-		)
-		if err != nil {
-			return nil, launchWarnings, fmt.Errorf("getting resource availability: %w", err)
 		}
 		if m.config.ResourceManager.AgentRM != nil && m.config.LaunchError && len(launchWarnings) > 0 {
 			return nil, nil, errors.New("slots requested exceeds cluster capacity")

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/determined-ai/determined/master/internal/experiment"
+	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/workspace"
 
 	"github.com/pkg/errors"
@@ -98,10 +99,11 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	if err != nil {
 		return fmt.Errorf("invalid resource configuration: %w", err)
 	}
-	if err = m.rm.ValidateResources(
-		poolName,
-		activeConfig.Resources().SlotsPerTrial(),
-		false); err != nil {
+	if _, _, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
+		ResourcePool: poolName,
+		Slots:        activeConfig.Resources().SlotsPerTrial(),
+		IsSingleNode: false,
+	}); err != nil {
 		return fmt.Errorf("validating resources: %v", err)
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -201,8 +201,8 @@ func (a *ResourceManager) handlePatchSlotState(
 }
 
 // CheckMaxSlotsExceeded checks if the job exceeded the maximum number of slots.
-func (a *ResourceManager) CheckMaxSlotsExceeded(v *sproto.ValidateResourcePoolAvailabilityRequest) (bool, error) {
-	pool, err := a.poolByName(v.Name)
+func (a *ResourceManager) CheckMaxSlotsExceeded(v *sproto.ValidateResourcesRequest) (bool, error) {
+	pool, err := a.poolByName(v.ResourcePool)
 	if err != nil {
 		return false, err
 	}
@@ -524,16 +524,36 @@ func (a *ResourceManager) TaskContainerDefaults(
 	return result, nil
 }
 
-// ValidateCommandResources implements rm.ResourceManager.
-func (a *ResourceManager) ValidateCommandResources(
-	msg sproto.ValidateCommandResourcesRequest,
-) (sproto.ValidateCommandResourcesResponse, error) {
-	pool, err := a.poolByName(msg.ResourcePool)
-	if err != nil {
-		a.syslog.WithError(err).Error("recovering job position")
-		return sproto.ValidateCommandResourcesResponse{}, err
+// ValidateResources implements rm.ResourceManager.
+func (a *ResourceManager) ValidateResources(
+	msg sproto.ValidateResourcesRequest,
+) (sproto.ValidateResourcesResponse, []command.LaunchWarning, error) {
+	if msg.Slots == 0 {
+		return sproto.ValidateResourcesResponse{}, nil, nil
 	}
-	return pool.ValidateCommandResources(msg), nil
+
+	if msg.IsSingleNode {
+		pool, err := a.poolByName(msg.ResourcePool)
+		if err != nil {
+			a.syslog.WithError(err).Error("recovering job position")
+			return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf(
+				"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
+		}
+		resp := pool.ValidateResources(msg)
+		if !resp.Fulfillable {
+			return resp, nil, errors.New("request unfulfillable, please try requesting less slots")
+		}
+		return sproto.ValidateResourcesResponse{}, nil, nil
+	}
+	switch exceeded, err := a.CheckMaxSlotsExceeded(&msg); {
+	case err != nil:
+		return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf(
+			"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
+	case exceeded:
+		return sproto.ValidateResourcesResponse{}, []command.LaunchWarning{command.CurrentSlotsExceeded}, nil
+	default:
+		return sproto.ValidateResourcesResponse{}, nil, nil
+	}
 }
 
 // ValidateResourcePool implements rm.ResourceManager.
@@ -541,42 +561,6 @@ func (a *ResourceManager) ValidateResourcePool(name string) error {
 	_, err := a.poolByName(name)
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-// ValidateResourcePoolAvailability implements rm.ResourceManager.
-func (a *ResourceManager) ValidateResourcePoolAvailability(
-	v *sproto.ValidateResourcePoolAvailabilityRequest,
-) ([]command.LaunchWarning, error) {
-	if v.Slots == 0 {
-		return nil, nil
-	}
-
-	switch exceeded, err := a.CheckMaxSlotsExceeded(v); {
-	case err != nil:
-		return nil, fmt.Errorf("validating request for (%s, %d): %w", v.Name, v.Slots, err)
-	case exceeded:
-		return []command.LaunchWarning{command.CurrentSlotsExceeded}, nil
-	default:
-		return nil, nil
-	}
-}
-
-// ValidateResources implements rm.ResourceManager.
-func (a *ResourceManager) ValidateResources(name string, slots int, command bool) error {
-	// TODO: Replace this function usage with ValidateCommandResources
-	if slots > 0 && command {
-		switch resp, err := a.ValidateCommandResources(
-			sproto.ValidateCommandResourcesRequest{
-				ResourcePool: name,
-				Slots:        slots,
-			}); {
-		case err != nil:
-			return fmt.Errorf("validating request for (%s, %d): %w", name, slots, err)
-		case !resp.Fulfillable:
-			return errors.New("request unfulfillable, please try requesting less slots")
-		}
 	}
 	return nil
 }

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -567,9 +567,9 @@ func (rp *resourcePool) GetAllocationSummaries(
 	return rp.taskList.TaskSummaries(rp.groups, rp.config.Scheduler.GetType())
 }
 
-func (rp *resourcePool) ValidateCommandResources(
-	msg sproto.ValidateCommandResourcesRequest,
-) sproto.ValidateCommandResourcesResponse {
+func (rp *resourcePool) ValidateResources(
+	msg sproto.ValidateResourcesRequest,
+) sproto.ValidateResourcesResponse {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 
@@ -591,7 +591,7 @@ func (rp *resourcePool) ValidateCommandResources(
 		fulfillable = maxSlots >= msg.Slots
 	}
 
-	return sproto.ValidateCommandResourcesResponse{Fulfillable: fulfillable}
+	return sproto.ValidateResourcesResponse{Fulfillable: fulfillable}
 }
 
 // GetResourceSummary requests a summary of the resources used by the resource pool (agents, slots, cpu containers).

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -262,15 +262,15 @@ func (k *kubernetesResourcePool) getResourceSummary(msg getResourceSummary) (*re
 	}, nil
 }
 
-func (k *kubernetesResourcePool) ValidateCommandResources(
-	msg sproto.ValidateCommandResourcesRequest,
-) sproto.ValidateCommandResourcesResponse {
+func (k *kubernetesResourcePool) ValidateResources(
+	msg sproto.ValidateResourcesRequest,
+) sproto.ValidateResourcesResponse {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	k.reschedule = true
 
 	fulfillable := k.maxSlotsPerPod >= msg.Slots
-	return sproto.ValidateCommandResourcesResponse{Fulfillable: fulfillable}
+	return sproto.ValidateResourcesResponse{Fulfillable: fulfillable}
 }
 
 func (k *kubernetesResourcePool) Schedule() {

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -14,8 +14,7 @@ type ResourceManager interface {
 	GetAllocationSummaries(sproto.GetAllocationSummaries) (map[model.AllocationID]sproto.AllocationSummary, error)
 	Allocate(sproto.AllocateRequest) (*sproto.ResourcesSubscription, error)
 	Release(sproto.ResourcesReleased)
-	ValidateCommandResources(sproto.ValidateCommandResourcesRequest) (sproto.ValidateCommandResourcesResponse, error)
-	ValidateResources(name string, slots int, command bool) error
+	ValidateResources(sproto.ValidateResourcesRequest) (sproto.ValidateResourcesResponse, []command.LaunchWarning, error)
 	DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, error)
 	NotifyContainerRunning(sproto.NotifyContainerRunning) error
 
@@ -34,7 +33,6 @@ type ResourceManager interface {
 	GetDefaultAuxResourcePool(sproto.GetDefaultAuxResourcePoolRequest) (sproto.GetDefaultAuxResourcePoolResponse, error)
 	ValidateResourcePool(name string) error
 	ResolveResourcePool(name string, workspace, slots int) (string, error)
-	ValidateResourcePoolAvailability(v *sproto.ValidateResourcePoolAvailabilityRequest) ([]command.LaunchWarning, error)
 	TaskContainerDefaults(
 		resourcePoolName string,
 		fallbackConfig model.TaskContainerDefaultsConfig,

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -40,18 +40,13 @@ func (m *Master) ResolveResources(
 	if err != nil {
 		return "", nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
-	if err = m.rm.ValidateResources(poolName, slots, isSingleNode); err != nil {
-		return "", nil, fmt.Errorf("validating resources: %v", err)
-	}
-
-	launchWarnings, err := m.rm.ValidateResourcePoolAvailability(
-		&sproto.ValidateResourcePoolAvailabilityRequest{
-			Name:  poolName,
-			Slots: slots,
-		},
-	)
+	_, launchWarnings, err := m.rm.ValidateResources(sproto.ValidateResourcesRequest{
+		ResourcePool: poolName,
+		Slots:        slots,
+		IsSingleNode: isSingleNode,
+	})
 	if err != nil {
-		return "", launchWarnings, fmt.Errorf("checking resource availability: %v", err.Error())
+		return "", nil, fmt.Errorf("validating resources: %v", err)
 	}
 	if m.config.ResourceManager.AgentRM != nil &&
 		m.config.LaunchError &&

--- a/master/internal/spec_util_intg_test.go
+++ b/master/internal/spec_util_intg_test.go
@@ -22,11 +22,11 @@ import (
 func getMockResourceManager(poolName string) *mocks.ResourceManager {
 	rm := &mocks.ResourceManager{}
 	rm.On("ResolveResourcePool", "/", 0, 1).Return(poolName, nil)
-	rm.On("ValidateResourcePoolAvailability", &sproto.ValidateResourcePoolAvailabilityRequest{
-		Name:  poolName,
-		Slots: 1,
-	}).Return(nil, nil)
-	rm.On("ValidateResources", poolName, 1, true).Return(nil)
+	rm.On("ValidateResources", sproto.ValidateResourcesRequest{
+		ResourcePool: poolName,
+		Slots:        1,
+		IsSingleNode: true,
+	}).Return(sproto.ValidateResourcesResponse{}, nil, nil)
 	return rm
 }
 

--- a/master/internal/sproto/agent_resource_manager.go
+++ b/master/internal/sproto/agent_resource_manager.go
@@ -94,12 +94,3 @@ func (t TerminateDecision) String() string {
 	}
 	return strings.Join(item, ",")
 }
-
-// ValidateResourcePoolAvailabilityRequest contains the params for ValidateResourcePoolAvailability().
-type ValidateResourcePoolAvailabilityRequest struct {
-	Name  string
-	Slots int
-	// Optional. If it is provided, ValidateResourcePoolAvailability() validates resource pool
-	// availability for a specific task.
-	TaskID *model.TaskID
-}

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -92,16 +92,18 @@ type (
 		ProxyPorts     []*ProxyPortConfig `json:"proxy_ports,omitempty"`
 	}
 
-	// ValidateCommandResourcesRequest is a message asking resource manager whether the given
-	// resource pool can (or, rather, if it's not impossible to) fulfill the command request
+	// ValidateResourcesRequest is a message asking resource manager whether the given
+	// resource pool can (or, rather, if it's not impossible to) fulfill the request
 	// for the given amount of slots.
-	ValidateCommandResourcesRequest struct {
+	ValidateResourcesRequest struct {
 		ResourcePool string
 		Slots        int
+		IsSingleNode bool
+		TaskID       *model.TaskID
 	}
 
-	// ValidateCommandResourcesResponse is the response to ValidateCommandResourcesRequest.
-	ValidateCommandResourcesResponse struct {
+	// ValidateResourcesResponse is the response to ValidateResourcesRequest.
+	ValidateResourcesResponse struct {
 		// Fulfillable values:
 		// - false: impossible to fulfill
 		// - true: ok or unknown

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -803,11 +803,12 @@ func (t *trial) maybeRestoreAllocation() (*model.Allocation, error) {
 }
 
 func (t *trial) checkResourcePoolRemainingCapacity() error {
-	launchWarnings, err := t.rm.ValidateResourcePoolAvailability(
-		&sproto.ValidateResourcePoolAvailabilityRequest{
-			Name:   t.config.Resources().ResourcePool(),
-			Slots:  t.config.Resources().SlotsPerTrial(),
-			TaskID: &t.taskID,
+	_, launchWarnings, err := t.rm.ValidateResources(
+		sproto.ValidateResourcesRequest{
+			ResourcePool: t.config.Resources().ResourcePool(),
+			Slots:        t.config.Resources().SlotsPerTrial(),
+			IsSingleNode: t.config.Resources().IsSingleNode() != nil && *t.config.Resources().IsSingleNode(),
+			TaskID:       &t.taskID,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->

The system can launch multi-container notebooks but accesses only a single container’s instance from the Web UI (as expected). There is no validation on slot requests in config when launching notebooks in CLI or Web UI. Fixed it using ValidateCommandResources instead of ValidateResources in the codebase. Also removed the ValidateResources function.
## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->

1. Set max_slots_per_pod in devcluster.yaml as a small number like 1 or 2. 
2. Start a notebook using the CLI, with resources.slot as higher than the max slots per pod. Eg. max_slots_per_pod = 2 and CLI command: `det notebook start --config resources.slots=4`
3. The CLI should show this error:

> Failed to start a new notebook: failed to prepare launch params: validating resources: request unfulfillable, please try requesting less slots

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
[DET-9911]

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[DET-9911]: https://hpe-aiatscale.atlassian.net/browse/DET-9911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ