### PR TITLE
ci: fix performance feature branch using wrong db

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2205,7 +2205,7 @@ jobs:
             - run:
                 name: Get db instance host
                 command: |
-                  echo "export RDS_HOST=$(aws rds describe-db-instances \
+                  echo "export PERF_DB_HOST=$(aws rds describe-db-instances \
                     --region us-west-2 \
                     --db-instance-identifier "ci-perf-db-${CIRCLE_BUILD_NUM}" \
                     --query "DBInstances[0].Endpoint.Address" \
@@ -2281,17 +2281,18 @@ jobs:
           name: Upload result of performance test to Postgres result db
           command: python .circleci/scripts/upload_perf_results.py ./performance/reports/latest.results.json
 
-      - when:
-          condition: <<parameters.deploy-db>>
+      - run:
+          name: Delete RDS instance
           when: always
-          steps:
-            - run:
-                name: Delete RDS instance
-                command: |
-                  aws rds delete-db-instance \
-                    --region="us-west-2" \
-                    --db-instance-identifier="ci-perf-db-${CIRCLE_BUILD_NUM}" \
-                    --skip-final-snapshot
+          command: |
+            if [ -n "$PERF_SNAPSHOT_TO_USE" ]; then
+              aws rds delete-db-instance \
+                --region="us-west-2" \
+                --db-instance-identifier="ci-perf-db-${CIRCLE_BUILD_NUM}" \
+                --skip-final-snapshot
+            else
+              echo "PERF_SNAPSHOT_TO_USE is not set. Skipping deletion."
+            fi
 
       - slack/status:
           fail_only: true

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2203,6 +2203,13 @@ jobs:
                     --vpc-security-group-ids="${PERF_DB_SECURITY_GROUP_ID}" \
                 no_output_timeout: 30m
             - run:
+                name: Wait for database to be ready
+                command: |
+                  aws rds wait db-instance-available \
+                    --region="us-west-2" \
+                    --db-instance-identifier="ci-perf-db-${CIRCLE_BUILD_NUM}"
+                no_output_timeout: 30m
+            - run:
                 name: Get db instance host
                 command: |
                   echo "export PERF_DB_HOST=$(aws rds describe-db-instances \
@@ -2212,13 +2219,6 @@ jobs:
                     --output text)" >> "$BASH_ENV"
                   source $BASH_ENV
                   echo "perf db host ${PERF_DB_HOST}"
-            - run:
-                name: Wait for database to be ready
-                command: |
-                  aws rds wait db-instance-available \
-                    --region="us-west-2" \
-                    --db-instance-identifier="ci-perf-db-${CIRCLE_BUILD_NUM}"
-                no_output_timeout: 30m
 
       - run:
           name: Add SSH key

--- a/master/static/migrations/20240213090511_testsleep.tx.up.sql
+++ b/master/static/migrations/20240213090511_testsleep.tx.up.sql
@@ -1,1 +1,0 @@
-SELECT pg_sleep(10);

--- a/master/static/migrations/20240213090511_testsleep.tx.up.sql
+++ b/master/static/migrations/20240213090511_testsleep.tx.up.sql
@@ -1,0 +1,1 @@
+SELECT pg_sleep(10);


### PR DESCRIPTION
## Description

Fixes two issues with performance tests.

1. The feature branch was accidentally using the main database because of a bug.

2. Sometimes the feature branch would fail and not run the db cleanup command.



## Test Plan

Run a migration on a perf feature branch and check main database isn't updated


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
