### PR TITLE
feat: generic tasks: support startup hooks

### DIFF
--- a/master/static/srv/generic-task-entrypoint.sh
+++ b/master/static/srv/generic-task-entrypoint.sh
@@ -4,6 +4,23 @@ source /run/determined/task-setup.sh
 
 set -e
 
+STARTUP_HOOK="startup-hook.sh"
+export PATH="/run/determined/pythonuserbase/bin:$PATH"
+
+# If HOME is not explicitly set for a container, libcontainer (Docker) will
+# try to guess it by reading /etc/password directly, which will not work with
+# our libnss_determined plugin (or any user-defined NSS plugin in a container).
+# The default is "/", but HOME must be a writable location for distributed
+# training, so we try to query the user system for a valid HOME, or default to
+# the working directory otherwise.
+if [ "$HOME" = "/" ]; then
+    HOME="$(
+        set -o pipefail
+        getent passwd "$(whoami)" | cut -d: -f6
+    )" || HOME="$PWD"
+    export HOME
+fi
+
 if [ -z "$DET_PYTHON_EXECUTABLE" ]; then
     export DET_PYTHON_EXECUTABLE="python3"
 fi
@@ -13,6 +30,10 @@ fi
 # which contains the "determined/exec/prep_container.py" script that's needed
 # to register the proxy with the Determined master.
 "$DET_PYTHON_EXECUTABLE" -m determined.exec.prep_container --proxy --download_context_directory
+
+set -x
+test -f "${STARTUP_HOOK}" && source "${STARTUP_HOOK}"
+set +x
 
 if [ "$#" -eq 1 ]; then
     exec /bin/sh -c "$@"


### PR DESCRIPTION
## Description

Add support for startup hooks in generic task entrypoint, and add `pythonuserbase` to make `pip install`s work.

## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
