### PR TITLE
fix: job queue test failures

### DIFF
--- a/e2e_tests/tests/cluster/test_job_queue.py
+++ b/e2e_tests/tests/cluster/test_job_queue.py
@@ -53,8 +53,8 @@ def get_raw_data() -> Tuple[List[Dict[str, str]], List[str]]:
         for i, field in enumerate(line.split("|")):
             if keys[i] == "ID":
                 ordered_ids.append(field.strip())
-            if keys[i] == "Type" and field == "TYPE_GENERIC":
-                del ordered_ids[-1]
+            # if keys[i] == "Type" and field == "TYPE_GENERIC":
+            #     del ordered_ids[-1]
             line_dict[keys[i]] = field.strip()
         data.append(line_dict)
 

--- a/e2e_tests/tests/cluster/test_job_queue.py
+++ b/e2e_tests/tests/cluster/test_job_queue.py
@@ -53,6 +53,8 @@ def get_raw_data() -> Tuple[List[Dict[str, str]], List[str]]:
         for i, field in enumerate(line.split("|")):
             if keys[i] == "ID":
                 ordered_ids.append(field.strip())
+            if keys[i] == "Type" and field == "TYPE_GENERIC":
+                del ordered_ids[-1]
             line_dict[keys[i]] = field.strip()
         data.append(line_dict)
 

--- a/e2e_tests/tests/cluster/test_job_queue.py
+++ b/e2e_tests/tests/cluster/test_job_queue.py
@@ -53,8 +53,6 @@ def get_raw_data() -> Tuple[List[Dict[str, str]], List[str]]:
         for i, field in enumerate(line.split("|")):
             if keys[i] == "ID":
                 ordered_ids.append(field.strip())
-            # if keys[i] == "Type" and field == "TYPE_GENERIC":
-            #     del ordered_ids[-1]
             line_dict[keys[i]] = field.strip()
         data.append(line_dict)
 

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -103,12 +103,10 @@ def test_master_restart_generic_task(managed_cluster_restarts: ManagedCluster) -
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Wait for task to start
-    task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
+    task.wait_for_task_start(test_session, task_resp.taskId)
     managed_cluster_restarts.kill_master()
     managed_cluster_restarts.restart_master()
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)
 
 
 @pytest.mark.managed_devcluster
@@ -131,20 +129,16 @@ def test_master_restart_generic_task_pause(managed_cluster_restarts: ManagedClus
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Wait for task to start
-    task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
+    task.wait_for_task_start(test_session, task_resp.taskId)
     # Pause task
     bindings.post_PauseGenericTask(test_session, taskId=task_resp.taskId)
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.PAUSED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.PAUSED)
     managed_cluster_restarts.kill_master()
     managed_cluster_restarts.restart_master()
 
     # Unpause task
     bindings.post_UnpauseGenericTask(test_session, taskId=task_resp.taskId)
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)
 
 
 @pytest.mark.managed_devcluster

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -103,17 +103,12 @@ def test_master_restart_generic_task(managed_cluster_restarts: ManagedCluster) -
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Wait for task to start
-    started = task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
-    if not started:
-        pytest.fail("task failed to started")
+    task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
     managed_cluster_restarts.kill_master()
     managed_cluster_restarts.restart_master()
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.managed_devcluster
@@ -136,26 +131,20 @@ def test_master_restart_generic_task_pause(managed_cluster_restarts: ManagedClus
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Wait for task to start
-    started = task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
-    if not started:
-        pytest.fail("task failed to started")
+    task.wait_for_task_start(test_session, task_resp.taskId, timeout=30)
     # Pause task
     bindings.post_PauseGenericTask(test_session, taskId=task_resp.taskId)
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.PAUSED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
     managed_cluster_restarts.kill_master()
     managed_cluster_restarts.restart_master()
 
     # Unpause task
     bindings.post_UnpauseGenericTask(test_session, taskId=task_resp.taskId)
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.managed_devcluster

--- a/e2e_tests/tests/task/task.py
+++ b/e2e_tests/tests/task/task.py
@@ -9,7 +9,7 @@ def wait_for_task_state(
     test_session: api.Session,
     task_id: str,
     expected_state: api.bindings.v1GenericTaskState,
-    timeout: int,
+    timeout: int = 30,
 ) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -23,7 +23,7 @@ def wait_for_task_state(
 def wait_for_task_start(
     test_session: api.Session,
     task_id: str,
-    timeout: int,
+    timeout: int = 30,
 ) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:

--- a/e2e_tests/tests/task/task.py
+++ b/e2e_tests/tests/task/task.py
@@ -1,5 +1,7 @@
 import time
 
+import pytest
+
 from determined.common import api
 
 
@@ -8,25 +10,25 @@ def wait_for_task_state(
     task_id: str,
     expected_state: api.bindings.v1GenericTaskState,
     timeout: int,
-) -> bool:
+) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         resp = api.bindings.get_GetTask(test_session, taskId=task_id)
         if expected_state == resp.task.taskState:
-            return True
+            return
         time.sleep(0.1)
-    return False
+    pytest.fail(f"task failed to complete after {timeout} seconds")
 
 
 def wait_for_task_start(
     test_session: api.Session,
     task_id: str,
     timeout: int,
-) -> bool:
+) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
         resp = api.bindings.get_GetTask(test_session, taskId=task_id)
         if resp.task.allocations[0].state == api.bindings.taskv1State.RUNNING:
-            return True
+            return
         time.sleep(0.1)
-    return False
+    pytest.fail(f"task failed to start after {timeout} seconds")

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -32,9 +32,7 @@ def test_create_generic_task() -> None:
     task_id = res.stdout[id_index + len("Created task ") :].strip()
 
     test_session = api_utils.determined_test_session()
-    task.wait_for_task_state(
-        test_session, task_id, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_id, bindings.v1GenericTaskState.COMPLETED)
 
 
 @pytest.mark.e2e_cpu
@@ -60,9 +58,7 @@ def test_generic_task_completion() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for complete state
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)
 
 
 @pytest.mark.e2e_cpu
@@ -88,9 +84,7 @@ def test_create_generic_task_error() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for error state
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.ERROR, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.ERROR)
 
 
 @pytest.mark.e2e_cpu
@@ -124,9 +118,7 @@ def test_generic_task_config() -> None:
     expected_config = {"entrypoint": ["echo", "task ran"]}
     assert result_config == expected_config
 
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)
 
 
 @pytest.mark.e2e_cpu
@@ -176,11 +168,9 @@ def test_generic_task_create_with_fork() -> None:
     expected_config = {"entrypoint": ["echo", "forked"]}
     assert result_config == expected_config
 
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)
     task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
-    task.wait_for_task_state(
-        test_session, fork_task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+        test_session, fork_task_resp.taskId, bindings.v1GenericTaskState.COMPLETED
     )
 
 
@@ -213,9 +203,7 @@ def test_kill_generic_task() -> None:
     subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
 
     bindings.get_GetTask(test_session, taskId=task_resp.taskId)
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.CANCELED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.CANCELED)
 
 
 @pytest.mark.e2e_cpu
@@ -257,6 +245,4 @@ def test_pause_and_unpause_generic_task() -> None:
     unpause_resp = bindings.get_GetTask(test_session, taskId=task_resp.taskId)
     assert unpause_resp.task.taskState == bindings.v1GenericTaskState.ACTIVE
 
-    task.wait_for_task_state(
-        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
-    )
+    task.wait_for_task_state(test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -26,7 +26,17 @@ def test_create_generic_task() -> None:
         conf.fixtures_path("generic_task"),
     ]
 
-    subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
+    res = subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
+
+    id_index = res.stdout.find("Created task ")
+    task_id = res.stdout[id_index + len("Created task ") :].strip()
+
+    test_session = api_utils.determined_test_session()
+    is_valid_state = task.wait_for_task_state(
+        test_session, task_id, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -120,6 +130,12 @@ def test_generic_task_config() -> None:
     expected_config = {"entrypoint": ["echo", "task ran"]}
     assert result_config == expected_config
 
+    is_valid_state = task.wait_for_task_state(
+        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")
+
 
 @pytest.mark.e2e_cpu
 def test_generic_task_create_with_fork() -> None:
@@ -167,6 +183,18 @@ def test_generic_task_create_with_fork() -> None:
     result_config = util.yaml_safe_load(res.stdout)
     expected_config = {"entrypoint": ["echo", "forked"]}
     assert result_config == expected_config
+
+    is_valid_state = task.wait_for_task_state(
+        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")
+
+    is_valid_state = task.wait_for_task_state(
+        test_session, fork_task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -239,3 +267,9 @@ def test_pause_and_unpause_generic_task() -> None:
 
     unpause_resp = bindings.get_GetTask(test_session, taskId=task_resp.taskId)
     assert unpause_resp.task.taskState == bindings.v1GenericTaskState.ACTIVE
+
+    is_valid_state = task.wait_for_task_state(
+        test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
+    )
+    if not is_valid_state:
+        pytest.fail("task failed to complete after 30 seconds")

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -32,11 +32,9 @@ def test_create_generic_task() -> None:
     task_id = res.stdout[id_index + len("Created task ") :].strip()
 
     test_session = api_utils.determined_test_session()
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_id, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -62,11 +60,9 @@ def test_generic_task_completion() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for complete state
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -92,11 +88,9 @@ def test_create_generic_task_error() -> None:
     task_resp = bindings.post_CreateGenericTask(test_session, body=req)
 
     # Check for error state
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.ERROR, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -130,11 +124,9 @@ def test_generic_task_config() -> None:
     expected_config = {"entrypoint": ["echo", "task ran"]}
     assert result_config == expected_config
 
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -184,17 +176,12 @@ def test_generic_task_create_with_fork() -> None:
     expected_config = {"entrypoint": ["echo", "forked"]}
     assert result_config == expected_config
 
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
-
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, fork_task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")
 
 
 @pytest.mark.e2e_cpu
@@ -225,8 +212,10 @@ def test_kill_generic_task() -> None:
 
     subprocess.run(command, universal_newlines=True, stdout=subprocess.PIPE, check=True)
 
-    kill_resp = bindings.get_GetTask(test_session, taskId=task_resp.taskId)
-    assert kill_resp.task.taskState == bindings.v1GenericTaskState.CANCELED
+    bindings.get_GetTask(test_session, taskId=task_resp.taskId)
+    task.wait_for_task_state(
+        test_session, task_resp.taskId, bindings.v1GenericTaskState.CANCELED, timeout=30
+    )
 
 
 @pytest.mark.e2e_cpu
@@ -268,8 +257,6 @@ def test_pause_and_unpause_generic_task() -> None:
     unpause_resp = bindings.get_GetTask(test_session, taskId=task_resp.taskId)
     assert unpause_resp.task.taskState == bindings.v1GenericTaskState.ACTIVE
 
-    is_valid_state = task.wait_for_task_state(
+    task.wait_for_task_state(
         test_session, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED, timeout=30
     )
-    if not is_valid_state:
-        pytest.fail("task failed to complete after 30 seconds")


### PR DESCRIPTION
## Description

Fixing generic task tests that cause the job queue test to fail

## Test Plan

e2e tests should pass, specifically `test_job_queue.py` & `test_generic_tasks.py`

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
