### PR TITLE
chore: use npm build for hew

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.16.1",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.30",
+        "hew": "npm:@hpe.com/hew@^0.6.30",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.20",
@@ -7333,8 +7333,10 @@
       }
     },
     "node_modules/hew": {
+      "name": "@hpe.com/hew",
       "version": "0.6.30",
-      "resolved": "git+https://git@github.com/determined-ai/hew.git#7f8ad42bf2a1a96016c775f748266227c56ee513",
+      "resolved": "https://registry.npmjs.org/@hpe.com/hew/-/hew-0.6.30.tgz",
+      "integrity": "sha512-GdoYn4XDMyWfs3Abf/K7+O3smxwDOVHBbNMnBsQlHv+C1p+JFAzxL+4+BQ5sMIUhkZzYliChOP7niS+vswEsEA==",
       "dependencies": {
         "@ant-design/icons": "^5.0.1",
         "@codemirror/lang-markdown": "^6.2.1",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -46,7 +46,7 @@
     "fp-ts": "^2.16.1",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "git+https://git@github.com/determined-ai/hew.git#v0.6.30",
+    "hew": "npm:@hpe.com/hew@^0.6.30",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.20",


### PR DESCRIPTION


## Description

This uses the npm build for hew. previously, we used the github build, which required us to grab hew's dependencies and build on install. this should improve build times as the package is built ahead of time.



## Test Plan

no testing needed -- build should succeed


## Commentary (optional)

`hew` was already a preexisting package in npm, so this is published under the `@hpe.com` scope. Because of that, the package is aliased back to `hew` to make the pr smaller. we can look at switching to `@hpe.com/hew` later.



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
no ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
