### PR TITLE
chore: refactor ResourceManager interface for multirm

### DIFF
--- a/master/internal/api_agents.go
+++ b/master/internal/api_agents.go
@@ -19,7 +19,7 @@ import (
 func (a *apiServer) GetAgents(
 	ctx context.Context, req *apiv1.GetAgentsRequest,
 ) (*apiv1.GetAgentsResponse, error) {
-	resp, err := a.m.rm.GetAgents(req)
+	resp, err := a.m.rm.GetAgents()
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (a *apiServer) GetAgent(
 		return nil, err
 	}
 
-	resp, err := a.m.rm.GetAgent(req)
+	resp, err := a.m.rm.GetAgent(req.ResourceManager, req)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (a *apiServer) GetSlots(
 		return nil, err
 	}
 
-	resp, err := a.m.rm.GetSlots(req)
+	resp, err := a.m.rm.GetSlots(req.ResourceManager, req)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (a *apiServer) GetSlot(
 		return nil, err
 	}
 
-	resp, err := a.m.rm.GetSlot(req)
+	resp, err := a.m.rm.GetSlot(req.ResourceManager, req)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (a *apiServer) EnableAgent(
 	if err := a.canUpdateAgents(ctx); err != nil {
 		return nil, err
 	}
-	return a.m.rm.EnableAgent(req)
+	return a.m.rm.EnableAgent(req.ResourceManager, req)
 }
 
 func (a *apiServer) DisableAgent(
@@ -153,7 +153,7 @@ func (a *apiServer) DisableAgent(
 	if err := a.canUpdateAgents(ctx); err != nil {
 		return nil, err
 	}
-	return a.m.rm.DisableAgent(req)
+	return a.m.rm.DisableAgent(req.ResourceManager, req)
 }
 
 func (a *apiServer) EnableSlot(
@@ -163,7 +163,7 @@ func (a *apiServer) EnableSlot(
 		return nil, err
 	}
 
-	resp, err = a.m.rm.EnableSlot(req)
+	resp, err = a.m.rm.EnableSlot(req.ResourceManager, req)
 	switch {
 	case errors.Is(err, rmerrors.ErrNotSupported):
 		return resp, status.Error(codes.Unimplemented, err.Error())
@@ -181,7 +181,7 @@ func (a *apiServer) DisableSlot(
 		return nil, err
 	}
 
-	resp, err = a.m.rm.DisableSlot(req)
+	resp, err = a.m.rm.DisableSlot(req.ResourceManager, req)
 	switch {
 	case errors.Is(err, rmerrors.ErrNotSupported):
 		return resp, status.Error(codes.Unimplemented, err.Error())

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -374,7 +374,7 @@ func (a *apiServer) CheckpointsRemoveFiles(
 
 			for _, g := range groups {
 				err = runCheckpointGCTask(
-					a.m.rm, a.m.db, taskID, jobID, jobSubmissionTime, taskSpec, exps[i].ID,
+					exps[i].Config.ResourceManager, a.m.rm, a.m.db, taskID, jobID, jobSubmissionTime, taskSpec, exps[i].ID,
 					exps[i].Config, g.StorageID, g.Checkpoints, req.CheckpointGlobs,
 					false, agentUserGroup, curUser, nil,
 				)

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -374,7 +374,7 @@ func (a *apiServer) CheckpointsRemoveFiles(
 
 			for _, g := range groups {
 				err = runCheckpointGCTask(
-					exps[i].Config.ResourceManager, a.m.rm, a.m.db, taskID, jobID, jobSubmissionTime, taskSpec, exps[i].ID,
+					a.m.rm, a.m.db, taskID, jobID, jobSubmissionTime, taskSpec, exps[i].ID,
 					exps[i].Config, g.StorageID, g.Checkpoints, req.CheckpointGlobs,
 					false, agentUserGroup, curUser, nil,
 				)

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -96,7 +96,8 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 		resources.Slots = 0
 	}
 
-	poolName, launchWarnings, err := a.m.ResolveResources(
+	managerName, poolName, launchWarnings, err := a.m.ResolveResources(
+		resources.ResourceManager,
 		resources.ResourcePool,
 		resources.Slots,
 		int(cmdSpec.Metadata.WorkspaceID),
@@ -107,7 +108,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Get the base TaskSpec.
-	taskSpec, err := a.m.fillTaskSpec(poolName, agentUserGroup, userModel)
+	taskSpec, err := a.m.fillTaskSpec(managerName, poolName, agentUserGroup, userModel)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -489,7 +489,7 @@ func (a *apiServer) deleteExperiments(exps []*model.Experiment, userModel *model
 			}
 			if len(checkpoints) > 0 {
 				if err := runCheckpointGCForCheckpoints(
-					exp.Config.ResourceManager, a.m.rm, a.m.db, exp.JobID, exp.StartTime,
+					a.m.rm, a.m.db, exp.JobID, exp.StartTime,
 					&taskSpec, exp.ID, exp.Config, checkpoints,
 					[]string{fullDeleteGlob}, true, agentUserGroup, userModel, nil,
 				); err != nil {
@@ -1288,7 +1288,7 @@ func (a *apiServer) PatchExperiment(
 
 			go func() {
 				if err := runCheckpointGCForCheckpoints(
-					modelExp.Config.ResourceManager, a.m.rm, a.m.db, modelExp.JobID, modelExp.StartTime,
+					a.m.rm, a.m.db, modelExp.JobID, modelExp.StartTime,
 					&taskSpec, modelExp.ID, modelExp.Config, checkpoints,
 					[]string{fullDeleteGlob}, true, agentUserGroup, user, nil,
 				); err != nil {
@@ -3031,7 +3031,7 @@ func (a *apiServer) DeleteTensorboardFiles(
 
 	var uuidList []uuid.UUID
 	err = runCheckpointGCTask(
-		exp.Config.ResourceManager, a.m.rm, a.m.db, model.NewTaskID(), exp.JobID, exp.StartTime, *a.m.taskSpec, exp.ID,
+		a.m.rm, a.m.db, model.NewTaskID(), exp.JobID, exp.StartTime, *a.m.taskSpec, exp.ID,
 		exp.Config, nil, uuidList, nil, true, agentUserGroup, curUser,
 		nil,
 	)

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -489,7 +489,7 @@ func (a *apiServer) deleteExperiments(exps []*model.Experiment, userModel *model
 			}
 			if len(checkpoints) > 0 {
 				if err := runCheckpointGCForCheckpoints(
-					a.m.rm, a.m.db, exp.JobID, exp.StartTime,
+					exp.Config.ResourceManager, a.m.rm, a.m.db, exp.JobID, exp.StartTime,
 					&taskSpec, exp.ID, exp.Config, checkpoints,
 					[]string{fullDeleteGlob}, true, agentUserGroup, userModel, nil,
 				); err != nil {
@@ -1288,7 +1288,7 @@ func (a *apiServer) PatchExperiment(
 
 			go func() {
 				if err := runCheckpointGCForCheckpoints(
-					a.m.rm, a.m.db, modelExp.JobID, modelExp.StartTime,
+					modelExp.Config.ResourceManager, a.m.rm, a.m.db, modelExp.JobID, modelExp.StartTime,
 					&taskSpec, modelExp.ID, modelExp.Config, checkpoints,
 					[]string{fullDeleteGlob}, true, agentUserGroup, user, nil,
 				); err != nil {
@@ -3031,7 +3031,7 @@ func (a *apiServer) DeleteTensorboardFiles(
 
 	var uuidList []uuid.UUID
 	err = runCheckpointGCTask(
-		a.m.rm, a.m.db, model.NewTaskID(), exp.JobID, exp.StartTime, *a.m.taskSpec, exp.ID,
+		exp.Config.ResourceManager, a.m.rm, a.m.db, model.NewTaskID(), exp.JobID, exp.StartTime, *a.m.taskSpec, exp.ID,
 		exp.Config, nil, uuidList, nil, true, agentUserGroup, curUser,
 		nil,
 	)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1907,6 +1907,8 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 		errC <- errors.New("something real bad")
 		return sproto.DeleteJobResponse{Err: errC}
 	}, nil)
+	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything).Return(
+		mock.Anything, mock.Anything, nil)
 
 	api, curUser, ctx := setupAPITest(t, nil, &mockRM)
 

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -103,7 +103,9 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 		return nil, nil, nil, fmt.Errorf("resource slots must be >= 0")
 	}
 	isSingleNode := resources.IsSingleNode != nil && *resources.IsSingleNode
-	poolName, launchWarnings, err := a.m.ResolveResources(resources.ResourcePool,
+	managerName, poolName, launchWarnings, err := a.m.ResolveResources(
+		resources.ResourceManager,
+		resources.ResourcePool,
 		resources.Slots,
 		int(proj.WorkspaceId),
 		isSingleNode)
@@ -111,7 +113,7 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 		return nil, nil, nil, err
 	}
 	// Get the base TaskSpec.
-	taskSpec, err := a.m.fillTaskSpec(poolName, agentUserGroup, userModel)
+	taskSpec, err := a.m.fillTaskSpec(managerName, poolName, agentUserGroup, userModel)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -126,6 +128,7 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 	// Copy discovered (default) resource pool name and slot count.
 
 	fillTaskConfig(resources.Slots, taskSpec, &taskConfig.Environment)
+	taskConfig.Resources.RawResourceManager = &resources.ResourceManager
 	taskConfig.Resources.RawResourcePool = &poolName
 	taskConfig.Resources.RawSlots = &resources.Slots
 
@@ -356,8 +359,9 @@ func (a *apiServer) CreateGenericTask(
 		IsUserVisible:     true,
 		Name:              fmt.Sprintf("Generic Task %s", taskID),
 
-		SlotsNeeded:  *genericTaskSpec.GenericTaskConfig.Resources.Slots(),
-		ResourcePool: genericTaskSpec.GenericTaskConfig.Resources.ResourcePool(),
+		SlotsNeeded:     *genericTaskSpec.GenericTaskConfig.Resources.Slots(),
+		ResourceManager: genericTaskSpec.GenericTaskConfig.Resources.ResourceManager(),
+		ResourcePool:    genericTaskSpec.GenericTaskConfig.Resources.ResourcePool(),
 		FittingRequirements: sproto.FittingRequirements{
 			SingleAgent: isSingleNode,
 		},
@@ -660,6 +664,7 @@ func (a *apiServer) UnpauseGenericTask(
 				IsUserVisible:     true,
 				Name:              fmt.Sprintf("Generic Task %s", resumingTask.TaskID),
 				SlotsNeeded:       *genericTaskSpec.GenericTaskConfig.Resources.Slots(),
+				ResourceManager:   genericTaskSpec.GenericTaskConfig.Resources.ResourceManager(),
 				ResourcePool:      genericTaskSpec.GenericTaskConfig.Resources.ResourcePool(),
 				FittingRequirements: sproto.FittingRequirements{
 					SingleAgent: isSingleNode,

--- a/master/internal/api_job.go
+++ b/master/internal/api_job.go
@@ -99,7 +99,7 @@ func (a *apiServer) GetJobsV2(
 func (a *apiServer) GetJobQueueStats(
 	_ context.Context, req *apiv1.GetJobQueueStatsRequest,
 ) (*apiv1.GetJobQueueStatsResponse, error) {
-	resp, err := a.m.rm.GetJobQueueStatsRequest(req)
+	resp, err := a.m.rm.GetJobQueueStatsRequest(req.ResourceManager, req)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -11,7 +11,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/rm"
-	"github.com/determined-ai/determined/master/internal/sproto"
 	workspaceauth "github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/set"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
@@ -50,7 +49,7 @@ func (a *apiServer) GetResourcePools(
 	if err != nil {
 		return nil, err
 	}
-	resp, err := a.m.rm.GetResourcePools(req)
+	resp, err := a.m.rm.GetResourcePools()
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +89,7 @@ func (a *apiServer) GetResourcePools(
 func (a *apiServer) BindRPToWorkspace(
 	ctx context.Context, req *apiv1.BindRPToWorkspaceRequest,
 ) (*apiv1.BindRPToWorkspaceResponse, error) {
-	err := a.checkIfPoolIsDefault(req.ResourcePoolName)
+	err := a.checkIfPoolIsDefault(req.ResourceManagerName, req.ResourcePoolName)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func (a *apiServer) BindRPToWorkspace(
 func (a *apiServer) OverwriteRPWorkspaceBindings(
 	ctx context.Context, req *apiv1.OverwriteRPWorkspaceBindingsRequest,
 ) (*apiv1.OverwriteRPWorkspaceBindingsResponse, error) {
-	err := a.checkIfPoolIsDefault(req.ResourcePoolName)
+	err := a.checkIfPoolIsDefault(req.ResourceManagerName, req.ResourcePoolName)
 	if err != nil {
 		return nil, err
 	}
@@ -212,16 +211,13 @@ func (a *apiServer) ListWorkspacesBoundToRP(
 	}, nil
 }
 
-func (a *apiServer) checkIfPoolIsDefault(poolName string) error {
-	defaultComputePool, err := a.m.rm.GetDefaultComputeResourcePool(
-		sproto.GetDefaultComputeResourcePoolRequest{})
+func (a *apiServer) checkIfPoolIsDefault(managerName string, poolName string) error {
+	defaultComputePool, err := a.m.rm.GetDefaultComputeResourcePool(managerName)
 	if err != nil {
 		return err
 	}
 
-	defaultAuxPool, err := a.m.rm.GetDefaultAuxResourcePool(
-		sproto.GetDefaultAuxResourcePoolRequest{},
-	)
+	defaultAuxPool, err := a.m.rm.GetDefaultAuxResourcePool(managerName)
 	if err != nil {
 		return err
 	}
@@ -254,7 +250,7 @@ func (a *apiServer) canUserModifyWorkspaces(ctx context.Context, ids []int32) er
 }
 
 func (a *apiServer) resourcePoolsAsConfigs() ([]config.ResourcePoolConfig, error) {
-	resp, err := a.m.rm.GetResourcePools(&apiv1.GetResourcePoolsRequest{})
+	resp, err := a.m.rm.GetResourcePools()
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_resourcepool_intg_test.go
+++ b/master/internal/api_resourcepool_intg_test.go
@@ -58,9 +58,9 @@ func TestPostBindingFails(t *testing.T) {
 
 	// TODO (eliu): add some tests for workspaceIDs
 	// test resource pools on workspaces that do not exist
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Once()
 	_, err := api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
 		ResourcePoolName: testPoolName,
@@ -69,11 +69,11 @@ func TestPostBindingFails(t *testing.T) {
 	require.ErrorContains(t, err, "the following workspaces do not exist: [nonexistent_workspace]")
 
 	// test resource pool doesn't exist
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Twice()
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{},
 		}, nil).Once()
@@ -85,7 +85,7 @@ func TestPostBindingFails(t *testing.T) {
 	require.ErrorContains(t, err, "pool with name testRP doesn't exist")
 
 	// test resource pool is a default resource pool
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{PoolName: testPoolName}, nil).Twice()
 
 	_, err = api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
@@ -95,7 +95,7 @@ func TestPostBindingFails(t *testing.T) {
 
 	require.ErrorContains(t, err, "default resource pool testRP cannot be bound to any workspace")
 
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{PoolName: testPoolName}, nil).Once()
 
 	_, err = api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
@@ -106,11 +106,11 @@ func TestPostBindingFails(t *testing.T) {
 	require.ErrorContains(t, err, "default resource pool testRP cannot be bound to any workspace")
 
 	// test no resource pool specified
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{PoolName: testPoolName}, nil).Once()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{PoolName: testPoolName}, nil).Once()
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Once()
@@ -134,11 +134,11 @@ func TestPostBindingSucceeds(t *testing.T) {
 	_ = setupWorkspaces(ctx, t, api)
 
 	// bind first resource pool
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Twice()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Twice()
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Twice()
@@ -170,11 +170,11 @@ func TestListWorkspacesBoundToRPFails(t *testing.T) {
 	_ = setupWorkspaces(ctx, t, api)
 
 	// bind first workspace
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Times(3)
@@ -207,11 +207,11 @@ func TestListWorkspacesBoundToRPSucceeds(t *testing.T) {
 	workspaceIDs := setupWorkspaces(ctx, t, api)
 
 	// test bind resource pool to workspace
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Once()
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Twice()
@@ -231,7 +231,7 @@ func TestListWorkspacesBoundToRPSucceeds(t *testing.T) {
 	require.Equal(t, workspaceIDs[0], resp.WorkspaceIds[0])
 
 	// test listing on resource pool that has no bindings
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{
 				{Name: testPoolName}, {Name: testPool2Name},
@@ -256,11 +256,11 @@ func TestPatchBindingsSucceeds(t *testing.T) {
 	workspaceIDs := setupWorkspaces(ctx, t, api)
 
 	// setup first binding
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Times(4)
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Times(4)
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Times(7)
@@ -328,11 +328,11 @@ func TestDeleteBindingsSucceeds(t *testing.T) {
 
 	// TODO: fix all comments
 	// setup first binding
-	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultComputeResourcePool", mock.Anything).
 		Return(sproto.GetDefaultComputeResourcePoolResponse{}, nil).Times(1)
-	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
+	mockRM.On("GetDefaultAuxResourcePool", mock.Anything).
 		Return(sproto.GetDefaultAuxResourcePoolResponse{}, nil).Times(1)
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
+	mockRM.On("GetResourcePools").
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
 		}, nil).Times(3)

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -23,7 +23,6 @@ import (
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/logpattern"
-	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/internal/webhooks"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -551,7 +550,7 @@ func (a *apiServer) GetActiveTasksCount(
 func (a *apiServer) GetTasks(
 	ctx context.Context, req *apiv1.GetTasksRequest,
 ) (resp *apiv1.GetTasksResponse, err error) {
-	summary, err := a.m.rm.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	summary, err := a.m.rm.GetAllocationSummaries()
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_tasks_intg_test.go
+++ b/master/internal/api_tasks_intg_test.go
@@ -148,9 +148,7 @@ func TestGetTasksAuthZ(t *testing.T) {
 	var allocations map[model.AllocationID]sproto.AllocationSummary
 
 	mockRM := MockRM()
-	mockRM.On("GetAllocationSummaries", mock.Anything).Return(func(
-		_ sproto.GetAllocationSummaries,
-	) map[model.AllocationID]sproto.AllocationSummary {
+	mockRM.On("GetAllocationSummaries").Return(func() map[model.AllocationID]sproto.AllocationSummary {
 		return allocations
 	}, nil)
 

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -1192,7 +1192,7 @@ func (a *apiServer) AllocationPendingPreemptionSignal(
 		return nil, err
 	}
 
-	if err := a.m.rm.ExternalPreemptionPending(req.ResourceManager, model.AllocationID(req.AllocationId)); err != nil {
+	if err := a.m.rm.ExternalPreemptionPending(model.AllocationID(req.AllocationId)); err != nil {
 		return nil, err
 	}
 
@@ -1207,7 +1207,7 @@ func (a *apiServer) NotifyContainerRunning(
 		return nil, err
 	}
 
-	if err := a.m.rm.NotifyContainerRunning(req.ResourceManager,
+	if err := a.m.rm.NotifyContainerRunning(
 		sproto.NotifyContainerRunning{
 			AllocationID: model.AllocationID(req.AllocationId),
 			NumPeers:     req.NumPeers,

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -1192,9 +1192,7 @@ func (a *apiServer) AllocationPendingPreemptionSignal(
 		return nil, err
 	}
 
-	if err := a.m.rm.ExternalPreemptionPending(
-		sproto.PendingPreemption{AllocationID: model.AllocationID(req.AllocationId)},
-	); err != nil {
+	if err := a.m.rm.ExternalPreemptionPending(req.ResourceManager, model.AllocationID(req.AllocationId)); err != nil {
 		return nil, err
 	}
 
@@ -1209,7 +1207,7 @@ func (a *apiServer) NotifyContainerRunning(
 		return nil, err
 	}
 
-	if err := a.m.rm.NotifyContainerRunning(
+	if err := a.m.rm.NotifyContainerRunning(req.ResourceManager,
 		sproto.NotifyContainerRunning{
 			AllocationID: model.AllocationID(req.AllocationId),
 			NumPeers:     req.NumPeers,

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/logpattern"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/user"
+	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -55,27 +56,18 @@ func MockRM() *mocks.ResourceManager {
 	mockRM.On("DeleteJob", mock.Anything).Return(func(sproto.DeleteJob) sproto.DeleteJobResponse {
 		return sproto.EmptyDeleteJobResponse()
 	}, nil)
-	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).Return(
-		func(name string, _, _ int) string {
-			return name
-		},
-		nil,
-	)
-	mockRM.On("ValidateResources", mock.Anything).Return(
-		func(sproto.ValidateResourcesRequest) sproto.ValidateResourcesResponse {
-			return sproto.ValidateResourcesResponse{}
-		}, nil, nil)
-	mockRM.On("TaskContainerDefaults", mock.Anything, mock.Anything).Return(
-		func(name string, def model.TaskContainerDefaultsConfig) model.TaskContainerDefaultsConfig {
-			return def
-		},
-		nil,
-	)
-	mockRM.On("SetGroupMaxSlots", mock.Anything).Return()
+	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything).Return(
+		mock.Anything, mock.Anything, nil)
+	mockRM.On("ValidateResources", mock.Anything, mock.Anything).Return([]command.LaunchWarning{}, nil)
+	mockRM.On("TaskContainerDefaults", mock.Anything, mock.Anything, mock.Anything).Return(
+		model.TaskContainerDefaultsConfig{}, nil)
+	mockRM.On("ValidateResourcePoolAvailability", mock.Anything).Return(nil, nil)
+	mockRM.On("SetGroupMaxSlots", mock.Anything, mock.Anything).Return()
 	mockRM.On("SetGroupWeight", mock.Anything, mock.Anything).Return(nil)
-	mockRM.On("Allocate", mock.Anything).Return(func(msg sproto.AllocateRequest) *sproto.ResourcesSubscription {
-		return rmevents.Subscribe(msg.AllocationID)
-	}, nil)
+	mockRM.On("Allocate", mock.Anything, mock.Anything).Return(
+		func(name string, msg sproto.AllocateRequest) *sproto.ResourcesSubscription {
+			return rmevents.Subscribe(msg.AllocationID)
+		}, nil)
 	return &mockRM
 }
 

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -29,7 +29,6 @@ import (
 const fullDeleteGlob = "**/*"
 
 func runCheckpointGCForCheckpoints(
-	rmName string,
 	rm rm.ResourceManager,
 	db *db.PgDB,
 	jobID model.JobID,
@@ -55,7 +54,7 @@ func runCheckpointGCForCheckpoints(
 		wg.Go(func() error {
 			taskID := model.TaskID(fmt.Sprintf("%d.%s", expID, uuid.New()))
 			if err := runCheckpointGCTask(
-				rmName, rm, db, taskID, jobID, jobSubmissionTime, *taskSpec,
+				rm, db, taskID, jobID, jobSubmissionTime, *taskSpec,
 				expID, legacyConfig, g.StorageID, g.Checkpoints,
 				checkpointGlobs, deleteTensorboards,
 				agentUserGroup, owner, logCtx,
@@ -75,7 +74,6 @@ func runCheckpointGCForCheckpoints(
 }
 
 func runCheckpointGCTask(
-	rmName string,
 	rm rm.ResourceManager,
 	pgDB *db.PgDB,
 	taskID model.TaskID,
@@ -101,7 +99,7 @@ func runCheckpointGCTask(
 		return nil
 	}
 
-	resolvedRM, rp, err := rm.ResolveResourcePool(rmName,
+	resolvedRM, rp, err := rm.ResolveResourcePool("", // todo (multirm)
 		sproto.ResolveResourcesRequest{
 			ResourcePool: "",
 			Workspace:    -1,

--- a/master/internal/checkpoint_gc_test.go
+++ b/master/internal/checkpoint_gc_test.go
@@ -136,7 +136,7 @@ func TestRunCheckpointGCTask(t *testing.T) {
 
 			jobID := db.RequireMockJob(t, pgDB, &user.ID)
 
-			if err := runCheckpointGCTask("",
+			if err := runCheckpointGCTask(
 				tt.args.rm,
 				pgDB,
 				model.NewTaskID(),

--- a/master/internal/checkpoint_gc_test.go
+++ b/master/internal/checkpoint_gc_test.go
@@ -56,11 +56,10 @@ func TestRunCheckpointGCTask(t *testing.T) {
 			args: args{
 				rm: func() *mocks.ResourceManager {
 					var rm mocks.ResourceManager
+					rm.On("ResolveResourcePool", mock.Anything, mock.Anything).
+						Return("", "default", nil)
 
-					rm.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).
-						Return("default", nil)
-
-					rm.On("TaskContainerDefaults", mock.Anything, mock.Anything).
+					rm.On("TaskContainerDefaults", mock.Anything, mock.Anything, mock.Anything).
 						Return(model.TaskContainerDefaultsConfig{}, nil)
 
 					return &rm
@@ -116,8 +115,8 @@ func TestRunCheckpointGCTask(t *testing.T) {
 				rm: func() *mocks.ResourceManager {
 					var rm mocks.ResourceManager
 
-					rm.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).
-						Return("", errors.New("rm is down or something"))
+					rm.On("ResolveResourcePool", mock.Anything, mock.Anything).
+						Return("", "", errors.New("rm is down or something"))
 
 					return &rm
 				}(),
@@ -137,7 +136,7 @@ func TestRunCheckpointGCTask(t *testing.T) {
 
 			jobID := db.RequireMockJob(t, pgDB, &user.ID)
 
-			if err := runCheckpointGCTask(
+			if err := runCheckpointGCTask("",
 				tt.args.rm,
 				pgDB,
 				model.NewTaskID(),

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -155,6 +155,7 @@ func (c *Command) Start(ctx context.Context) error {
 			IsUserVisible:       true,
 			Name:                c.Config.Description,
 			SlotsNeeded:         c.Config.Resources.Slots,
+			ResourceManager:     c.Config.Resources.ResourceManager,
 			ResourcePool:        c.Config.Resources.ResourcePool,
 			FittingRequirements: sproto.FittingRequirements{SingleAgent: true},
 			ProxyPorts:          sproto.NewProxyPortConfig(c.GenericCommandSpec.ProxyPorts(), c.taskID),

--- a/master/internal/command/command_intg_test.go
+++ b/master/internal/command/command_intg_test.go
@@ -171,7 +171,7 @@ func setupTest(t *testing.T) *db.PgDB {
 	// First init the new Command Service
 	var mockRM mocks.ResourceManager
 	sub := sproto.NewAllocationSubscription(queue.New[sproto.ResourcesEvent](), func() {})
-	mockRM.On("Allocate", mock.Anything, mock.Anything).Return(sub, nil)
+	mockRM.On("Allocate", mock.Anything, mock.Anything, mock.Anything).Return(sub, nil)
 	mockRM.On("Release", mock.Anything, mock.Anything).Return(nil)
 	mockRM.On("SetGroupPriority", mock.Anything, mock.Anything).Return(nil)
 

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -293,12 +293,13 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
 	isSingleNode := resources.IsSingleNode() != nil && *resources.IsSingleNode()
-	poolName, _, err := m.ResolveResources(resources.ResourcePool(), resources.SlotsPerTrial(), workspaceID, isSingleNode)
+	managerName, poolName, _, err := m.ResolveResources(resources.ResourceManager(),
+		resources.ResourcePool(), resources.SlotsPerTrial(), workspaceID, isSingleNode)
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
-		poolName,
+		managerName, poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/core_observability.go
+++ b/master/internal/core_observability.go
@@ -7,11 +7,10 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/internal/prom"
-	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
 func (m *Master) getPrometheusTargets(c echo.Context) (interface{}, error) {
-	resp, err := m.rm.GetAgents(&apiv1.GetAgentsRequest{})
+	resp, err := m.rm.GetAgents()
 	if err != nil {
 		return nil, fmt.Errorf("gather agent statuses: %w", err)
 	}

--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -6,11 +6,10 @@ import (
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/context"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
-	"github.com/determined-ai/determined/master/internal/sproto"
 )
 
 func (m *Master) getTasks(c echo.Context) (interface{}, error) {
-	summary, err := m.rm.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	summary, err := m.rm.GetAllocationSummaries()
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -107,26 +107,31 @@ func newExperiment(
 		return nil, nil, err
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
-	poolName, err := m.rm.ResolveResourcePool(
-		resources.ResourcePool(), workspaceID, resources.SlotsPerTrial(),
-	)
+	managerName, poolName, err := m.rm.ResolveResourcePool(resources.ResourceManager(),
+		sproto.ResolveResourcesRequest{
+			ResourcePool: resources.ResourcePool(),
+			Workspace:    workspaceID,
+			Slots:        resources.SlotsPerTrial(),
+		})
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create an experiment: %w", err)
 	}
 
 	var launchWarnings []command.LaunchWarning
 	if expModel.ID == 0 {
-		if _, launchWarnings, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-			ResourcePool: poolName,
-			Slots:        resources.SlotsPerTrial(),
-			IsSingleNode: resources.IsSingleNode() != nil && *resources.IsSingleNode(),
-		}); err != nil {
+		if launchWarnings, err = m.rm.ValidateResources(managerName,
+			sproto.ValidateResourcesRequest{
+				ResourcePool: poolName,
+				Slots:        resources.SlotsPerTrial(),
+				IsSingleNode: resources.IsSingleNode() != nil && *resources.IsSingleNode(),
+			}); err != nil {
 			return nil, nil, fmt.Errorf("validating resources: %v", err)
 		}
 		if m.config.LaunchError && len(launchWarnings) > 0 {
 			return nil, nil, errors.New("slots requested exceeds cluster capacity")
 		}
 	}
+	resources.SetResourceManager(managerName)
 	resources.SetResourcePool(poolName)
 
 	activeConfig.SetResources(resources)
@@ -252,11 +257,12 @@ func (e *internalExperiment) start() error {
 		return err
 	}
 
-	e.rm.SetGroupMaxSlots(sproto.SetGroupMaxSlots{
-		MaxSlots:     e.activeConfig.Resources().MaxSlots(),
-		ResourcePool: e.activeConfig.Resources().ResourcePool(),
-		JobID:        e.JobID,
-	})
+	e.rm.SetGroupMaxSlots(e.activeConfig.Resources().ResourceManager(),
+		sproto.SetGroupMaxSlots{
+			MaxSlots:     e.activeConfig.Resources().MaxSlots(),
+			ResourcePool: e.activeConfig.Resources().ResourcePool(),
+			JobID:        e.JobID,
+		})
 	if err := e.setWeight(e.activeConfig.Resources().Weight()); err != nil {
 		e.updateState(model.StateWithReason{
 			State:               model.StoppingErrorState,
@@ -407,7 +413,7 @@ func (e *internalExperiment) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	e.activeConfig.SetResources(resources)
 	msg.JobID = e.JobID
 	msg.ResourcePool = e.activeConfig.Resources().ResourcePool()
-	e.rm.SetGroupMaxSlots(msg)
+	e.rm.SetGroupMaxSlots(e.activeConfig.Resources().ResourceManager(), msg)
 }
 
 func (e *internalExperiment) SetGroupWeight(weight float64) error {
@@ -482,7 +488,7 @@ func (e *internalExperiment) stop() error {
 	if len(checkpoints) > 0 {
 		go func() {
 			if err := runCheckpointGCForCheckpoints(
-				e.rm, e.db, e.JobID, e.StartTime, taskSpec,
+				e.activeConfig.Resources().ResourceManager(), e.rm, e.db, e.JobID, e.StartTime, taskSpec,
 				e.Experiment.ID, e.activeConfig.AsLegacy(), checkpoints,
 				[]string{fullDeleteGlob},
 				false, taskSpec.AgentUserGroup, taskSpec.Owner, e.logCtx,
@@ -1047,10 +1053,10 @@ func (e *internalExperiment) setPriority(priority *int, forward bool) (err error
 	}
 
 	if forward {
-		switch err := e.rm.SetGroupPriority(resources.ResourceManager(),
+		switch err := e.rm.SetGroupPriority(e.activeConfig.Resources().ResourceManager(),
 			sproto.SetGroupPriority{
 				Priority:     *priority,
-				ResourcePool: resources.ResourcePool(),
+				ResourcePool: e.activeConfig.Resources().ResourcePool(),
 				JobID:        e.JobID,
 			}).(type) {
 		case nil:
@@ -1075,10 +1081,10 @@ func (e *internalExperiment) setWeight(weight float64) error {
 		return fmt.Errorf("setting experiment %d weight: %w", e.ID, err)
 	}
 
-	switch err := e.rm.SetGroupWeight(resources.ResourceManager(),
+	switch err := e.rm.SetGroupWeight(e.activeConfig.Resources().ResourceManager(),
 		sproto.SetGroupWeight{
 			Weight:       weight,
-			ResourcePool: resources.ResourcePool(),
+			ResourcePool: e.activeConfig.Resources().ResourcePool(),
 			JobID:        e.JobID,
 		}).(type) {
 	case nil:
@@ -1100,9 +1106,12 @@ func (e *internalExperiment) setRP(resourceManager string, resourcePool string) 
 		return err
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
-	rp, err := e.rm.ResolveResourcePool(
-		resourcePool, workspaceID, e.activeConfig.Resources().SlotsPerTrial(),
-	)
+	rm, rp, err := e.rm.ResolveResourcePool(resourceManager,
+		sproto.ResolveResourcesRequest{
+			ResourcePool: resourcePool,
+			Workspace:    workspaceID,
+			Slots:        resources.SlotsPerTrial(),
+		})
 	switch {
 	case err != nil:
 		return fmt.Errorf("invalid resource pool name %s", resourcePool)
@@ -1110,6 +1119,7 @@ func (e *internalExperiment) setRP(resourceManager string, resourcePool string) 
 		return fmt.Errorf("resource pool is unchanged (%s == %s)", oldRP, rp)
 	}
 
+	resources.SetResourceManager(rm)
 	resources.SetResourcePool(rp)
 	e.activeConfig.SetResources(resources)
 
@@ -1124,7 +1134,7 @@ func (e *internalExperiment) setRP(resourceManager string, resourcePool string) 
 	for _, t := range e.trials {
 		t := t
 		g.Go(func() error {
-			t.PatchRP(rp)
+			t.PatchRP(rm, rp)
 			return nil
 		})
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -488,7 +488,7 @@ func (e *internalExperiment) stop() error {
 	if len(checkpoints) > 0 {
 		go func() {
 			if err := runCheckpointGCForCheckpoints(
-				e.activeConfig.Resources().ResourceManager(), e.rm, e.db, e.JobID, e.StartTime, taskSpec,
+				e.rm, e.db, e.JobID, e.StartTime, taskSpec,
 				e.Experiment.ID, e.activeConfig.AsLegacy(), checkpoints,
 				[]string{fullDeleteGlob},
 				false, taskSpec.AgentUserGroup, taskSpec.Owner, e.logCtx,

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -91,23 +91,25 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 		return err
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
-	poolName, err := m.rm.ResolveResourcePool(
-		activeConfig.Resources().ResourcePool(),
-		workspaceID,
-		activeConfig.Resources().SlotsPerTrial(),
-	)
+	managerName, poolName, err := m.rm.ResolveResourcePool(activeConfig.Resources().ResourceManager(),
+		sproto.ResolveResourcesRequest{
+			ResourcePool: activeConfig.Resources().ResourcePool(),
+			Workspace:    workspaceID,
+			Slots:        activeConfig.Resources().SlotsPerTrial(),
+		})
 	if err != nil {
 		return fmt.Errorf("invalid resource configuration: %w", err)
 	}
-	if _, _, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-		ResourcePool: poolName,
-		Slots:        activeConfig.Resources().SlotsPerTrial(),
-		IsSingleNode: false,
-	}); err != nil {
+	if _, err = m.rm.ValidateResources(activeConfig.Resources().ResourceManager(),
+		sproto.ValidateResourcesRequest{
+			ResourcePool: poolName,
+			Slots:        activeConfig.Resources().SlotsPerTrial(),
+			IsSingleNode: false,
+		}); err != nil {
 		return fmt.Errorf("validating resources: %v", err)
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
-		poolName,
+		managerName, poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -107,7 +107,7 @@ func newAgentResourceManager(
 }
 
 // Allocate implements rm.ResourceManager.
-func (a *ResourceManager) Allocate(msg sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
+func (a *ResourceManager) Allocate(_ string, msg sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
 	// this code exists to handle the case where an experiment does not have
 	// an explicit resource pool specified in the config. This should never happen
 	// for newly created/forked experiments as the default pool is filled in to the
@@ -138,7 +138,7 @@ func (*ResourceManager) DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, e
 }
 
 // DisableAgent implements rm.ResourceManager.
-func (a *ResourceManager) DisableAgent(msg *apiv1.DisableAgentRequest) (*apiv1.DisableAgentResponse, error) {
+func (a *ResourceManager) DisableAgent(_ string, msg *apiv1.DisableAgentRequest) (*apiv1.DisableAgentResponse, error) {
 	agent, ok := a.agentService.get(agentID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
@@ -147,7 +147,7 @@ func (a *ResourceManager) DisableAgent(msg *apiv1.DisableAgentRequest) (*apiv1.D
 }
 
 // DisableSlot implements rm.ResourceManager.
-func (a *ResourceManager) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error) {
+func (a *ResourceManager) DisableSlot(_ string, req *apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error) {
 	deviceIDStr, err := strconv.Atoi(req.SlotId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid slot id: %s", req.SlotId)
@@ -167,7 +167,7 @@ func (a *ResourceManager) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Dis
 }
 
 // EnableAgent implements rm.ResourceManager.
-func (a *ResourceManager) EnableAgent(msg *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error) {
+func (a *ResourceManager) EnableAgent(_ string, msg *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error) {
 	agent, ok := a.agentService.get(agentID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
@@ -176,7 +176,7 @@ func (a *ResourceManager) EnableAgent(msg *apiv1.EnableAgentRequest) (*apiv1.Ena
 }
 
 // EnableSlot implements rm.ResourceManager.
-func (a *ResourceManager) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error) {
+func (a *ResourceManager) EnableSlot(_ string, req *apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error) {
 	deviceIDStr, err := strconv.Atoi(req.SlotId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid slot id: %s", req.SlotId)
@@ -219,12 +219,12 @@ func (a *ResourceManager) CheckMaxSlotsExceeded(v *sproto.ValidateResourcesReque
 }
 
 // ExternalPreemptionPending implements rm.ResourceManager.
-func (*ResourceManager) ExternalPreemptionPending(sproto.PendingPreemption) error {
+func (*ResourceManager) ExternalPreemptionPending(string, model.AllocationID) error {
 	return rmerrors.ErrNotSupported
 }
 
 // GetAgent implements rm.ResourceManager.
-func (a *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
+func (a *ResourceManager) GetAgent(_ string, msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
 	agent, ok := a.agentService.get(agentID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
@@ -233,26 +233,22 @@ func (a *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentR
 }
 
 // GetAgents implements rm.ResourceManager.
-func (a *ResourceManager) GetAgents(msg *apiv1.GetAgentsRequest) (*apiv1.GetAgentsResponse, error) {
-	return a.agentService.getAgents(msg), nil
+func (a *ResourceManager) GetAgents() (*apiv1.GetAgentsResponse, error) {
+	return a.agentService.getAgents(), nil
 }
 
 // GetAllocationSummaries implements rm.ResourceManager.
-func (a *ResourceManager) GetAllocationSummaries(
-	msg sproto.GetAllocationSummaries,
-) (map[model.AllocationID]sproto.AllocationSummary, error) {
+func (a *ResourceManager) GetAllocationSummaries() (map[model.AllocationID]sproto.AllocationSummary, error) {
 	summaries := make(map[model.AllocationID]sproto.AllocationSummary)
 	for _, pool := range a.pools {
-		rpSummaries := pool.GetAllocationSummaries(msg)
+		rpSummaries := pool.GetAllocationSummaries()
 		maps.Copy(summaries, rpSummaries)
 	}
 	return summaries, nil
 }
 
 // GetDefaultAuxResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) GetDefaultAuxResourcePool(
-	sproto.GetDefaultAuxResourcePoolRequest,
-) (sproto.GetDefaultAuxResourcePoolResponse, error) {
+func (a *ResourceManager) GetDefaultAuxResourcePool(string) (sproto.GetDefaultAuxResourcePoolResponse, error) {
 	if a.config.DefaultAuxResourcePool == "" {
 		return sproto.GetDefaultAuxResourcePoolResponse{}, rmerrors.ErrNoDefaultResourcePool
 	}
@@ -260,9 +256,7 @@ func (a *ResourceManager) GetDefaultAuxResourcePool(
 }
 
 // GetDefaultComputeResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) GetDefaultComputeResourcePool(
-	sproto.GetDefaultComputeResourcePoolRequest,
-) (sproto.GetDefaultComputeResourcePoolResponse, error) {
+func (a *ResourceManager) GetDefaultComputeResourcePool(string) (sproto.GetDefaultComputeResourcePoolResponse, error) {
 	if a.config.DefaultComputeResourcePool == "" {
 		return sproto.GetDefaultComputeResourcePoolResponse{}, rmerrors.ErrNoDefaultResourcePool
 	}
@@ -291,7 +285,7 @@ func (a *ResourceManager) GetJobQ(_, resourcePool string) (map[model.JobID]*spro
 
 // GetJobQueueStatsRequest implements rm.ResourceManager.
 func (a *ResourceManager) GetJobQueueStatsRequest(
-	msg *apiv1.GetJobQueueStatsRequest,
+	_ string, msg *apiv1.GetJobQueueStatsRequest,
 ) (*apiv1.GetJobQueueStatsResponse, error) {
 	resp := &apiv1.GetJobQueueStatsResponse{
 		Results: make([]*apiv1.RPQueueStat, 0),
@@ -321,9 +315,7 @@ func (a *ResourceManager) GetJobQueueStatsRequest(
 }
 
 // GetResourcePools implements rm.ResourceManager.
-func (a *ResourceManager) GetResourcePools(
-	msg *apiv1.GetResourcePoolsRequest,
-) (*apiv1.GetResourcePoolsResponse, error) {
+func (a *ResourceManager) GetResourcePools() (*apiv1.GetResourcePoolsResponse, error) {
 	summaries := make([]*resourcepoolv1.ResourcePool, 0, len(a.poolsConfig))
 	for _, pool := range a.poolsConfig {
 		summary, err := a.createResourcePoolSummary(pool.PoolName)
@@ -346,7 +338,7 @@ func (a *ResourceManager) GetResourcePools(
 }
 
 // GetSlot implements rm.ResourceManager.
-func (a *ResourceManager) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
+func (a *ResourceManager) GetSlot(_ string, req *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
 	deviceIDStr, err := strconv.Atoi(req.SlotId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid slot id: %s", req.SlotId)
@@ -361,7 +353,7 @@ func (a *ResourceManager) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResp
 }
 
 // GetSlots implements rm.ResourceManager.
-func (a *ResourceManager) GetSlots(msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
+func (a *ResourceManager) GetSlots(_ string, msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
 	agent, ok := a.agentService.get(agentID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
@@ -370,7 +362,7 @@ func (a *ResourceManager) GetSlots(msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsR
 }
 
 // IsReattachableOnlyAfterStarted implements rm.ResourceManager.
-func (*ResourceManager) IsReattachableOnlyAfterStarted() bool {
+func (*ResourceManager) IsReattachableOnlyAfterStarted(string) bool {
 	return true
 }
 
@@ -384,7 +376,7 @@ func (a *ResourceManager) MoveJob(_ string, msg sproto.MoveJob) error {
 }
 
 // NotifyContainerRunning implements rm.ResourceManager.
-func (*ResourceManager) NotifyContainerRunning(sproto.NotifyContainerRunning) error {
+func (*ResourceManager) NotifyContainerRunning(string, sproto.NotifyContainerRunning) error {
 	// Agent Resource Manager does not implement a handler for the
 	// NotifyContainerRunning message, as it is only used on HPC
 	// (High Performance Computing).
@@ -402,7 +394,7 @@ func (a *ResourceManager) RecoverJobPosition(_ string, msg sproto.RecoverJobPosi
 }
 
 // Release implements rm.ResourceManager.
-func (a *ResourceManager) Release(msg sproto.ResourcesReleased) {
+func (a *ResourceManager) Release(_ string, msg sproto.ResourcesReleased) {
 	pool, err := a.poolByName(msg.ResourcePool)
 	if err != nil {
 		a.syslog.WithError(err).Warnf("release found no resource pool with name %s",
@@ -413,68 +405,68 @@ func (a *ResourceManager) Release(msg sproto.ResourcesReleased) {
 }
 
 // ResolveResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slots int) (string, error) {
+func (a *ResourceManager) ResolveResourcePool(_ string, req sproto.ResolveResourcesRequest) (
+	rmName string, poolName string, err error,
+) {
 	ctx := context.TODO()
-	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, workspaceID)
+	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, req.Workspace)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	// If the resource pool isn't set, fill in the default at creation time.
-	if name == "" && slots == 0 {
+	if req.ResourcePool == "" && req.Slots == 0 {
 		if defaultAuxPool == "" {
-			req := sproto.GetDefaultAuxResourcePoolRequest{}
-			resp, err := a.GetDefaultAuxResourcePool(req)
+			resp, err := a.GetDefaultAuxResourcePool("")
 			if err != nil {
-				return "", fmt.Errorf("defaulting to aux pool: %w", err)
+				return "", "", fmt.Errorf("defaulting to aux pool: %w", err)
 			}
-			return resp.PoolName, nil
+			return "", resp.PoolName, nil
 		}
-		name = defaultAuxPool
+		req.ResourcePool = defaultAuxPool
 	}
 
-	if name == "" && slots >= 0 {
+	if req.ResourcePool == "" && req.Slots >= 0 {
 		if defaultComputePool == "" {
-			req := sproto.GetDefaultComputeResourcePoolRequest{}
-			resp, err := a.GetDefaultComputeResourcePool(req)
+			resp, err := a.GetDefaultComputeResourcePool("")
 			if err != nil {
-				return "", fmt.Errorf("defaulting to compute pool: %w", err)
+				return "", "", fmt.Errorf("defaulting to compute pool: %w", err)
 			}
-			return resp.PoolName, nil
+			return "", resp.PoolName, nil
 		}
-		name = defaultComputePool
+		req.ResourcePool = defaultComputePool
 	}
 
-	resp, err := a.GetResourcePools(&apiv1.GetResourcePoolsRequest{})
+	resp, err := a.GetResourcePools()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	poolNames, _, err := db.ReadRPsAvailableToWorkspace(
-		ctx, int32(workspaceID), 0, -1, rmutils.ResourcePoolsToConfig(resp.ResourcePools))
+		ctx, int32(req.Workspace), 0, -1, rmutils.ResourcePoolsToConfig(resp.ResourcePools))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if name == poolName {
+		if req.ResourcePool == poolName {
 			found = true
 			break
 		}
 	}
 	if !found {
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"resource pool %s does not exist or is not available to workspace id %d",
-			name, workspaceID)
+			req.ResourcePool, req.Workspace)
 	}
 
-	if err := a.ValidateResourcePool(name); err != nil {
-		return "", fmt.Errorf("validating pool: %w", err)
+	if err := a.ValidateResourcePool("", req.ResourcePool); err != nil {
+		return "", "", fmt.Errorf("validating pool: %w", err)
 	}
-	return name, nil
+	return "", req.ResourcePool, nil
 }
 
 // SetGroupMaxSlots implements rm.ResourceManager.
-func (a *ResourceManager) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
+func (a *ResourceManager) SetGroupMaxSlots(_ string, msg sproto.SetGroupMaxSlots) {
 	pool, err := a.poolByName(msg.ResourcePool)
 	if err != nil {
 		a.syslog.WithError(err).Warnf("set group max slots found no resource pool with name %s",
@@ -509,7 +501,7 @@ func (a *ResourceManager) SetGroupWeight(_ string, msg sproto.SetGroupWeight) er
 
 // TaskContainerDefaults implements rm.ResourceManager.
 func (a *ResourceManager) TaskContainerDefaults(
-	resourcePoolName string,
+	_, resourcePoolName string,
 	fallbackConfig model.TaskContainerDefaultsConfig,
 ) (model.TaskContainerDefaultsConfig, error) {
 	result := fallbackConfig
@@ -527,38 +519,38 @@ func (a *ResourceManager) TaskContainerDefaults(
 
 // ValidateResources implements rm.ResourceManager.
 func (a *ResourceManager) ValidateResources(
-	msg sproto.ValidateResourcesRequest,
-) (sproto.ValidateResourcesResponse, []command.LaunchWarning, error) {
+	_ string, msg sproto.ValidateResourcesRequest,
+) ([]command.LaunchWarning, error) {
 	if msg.Slots == 0 {
-		return sproto.ValidateResourcesResponse{}, nil, nil
+		return nil, nil
 	}
 
 	if msg.IsSingleNode {
 		pool, err := a.poolByName(msg.ResourcePool)
 		if err != nil {
 			a.syslog.WithError(err).Error("recovering job position")
-			return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
 		}
 		resp := pool.ValidateResources(msg)
-		if !resp.Fulfillable {
-			return resp, nil, errors.New("request unfulfillable, please try requesting less slots")
+		if !resp {
+			return nil, errors.New("request unfulfillable, please try requesting less slots")
 		}
-		return sproto.ValidateResourcesResponse{}, nil, nil
+		return nil, nil
 	}
 	switch exceeded, err := a.CheckMaxSlotsExceeded(&msg); {
 	case err != nil:
-		return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
 	case exceeded:
-		return sproto.ValidateResourcesResponse{}, []command.LaunchWarning{command.CurrentSlotsExceeded}, nil
+		return []command.LaunchWarning{command.CurrentSlotsExceeded}, nil
 	default:
-		return sproto.ValidateResourcesResponse{}, nil, nil
+		return nil, nil
 	}
 }
 
 // ValidateResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) ValidateResourcePool(name string) error {
+func (a *ResourceManager) ValidateResourcePool(_, name string) error {
 	_, err := a.poolByName(name)
 	if err != nil {
 		return err

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -219,7 +219,7 @@ func (a *ResourceManager) CheckMaxSlotsExceeded(v *sproto.ValidateResourcesReque
 }
 
 // ExternalPreemptionPending implements rm.ResourceManager.
-func (*ResourceManager) ExternalPreemptionPending(string, model.AllocationID) error {
+func (*ResourceManager) ExternalPreemptionPending(model.AllocationID) error {
 	return rmerrors.ErrNotSupported
 }
 
@@ -376,7 +376,7 @@ func (a *ResourceManager) MoveJob(_ string, msg sproto.MoveJob) error {
 }
 
 // NotifyContainerRunning implements rm.ResourceManager.
-func (*ResourceManager) NotifyContainerRunning(string, sproto.NotifyContainerRunning) error {
+func (*ResourceManager) NotifyContainerRunning(sproto.NotifyContainerRunning) error {
 	// Agent Resource Manager does not implement a handler for the
 	// NotifyContainerRunning message, as it is only used on HPC
 	// (High Performance Computing).

--- a/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
+++ b/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
@@ -60,7 +60,7 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	}
 
 	// Check if there are tasks.
-	taskSummaries, err := agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries, err := agentRM.GetAllocationSummaries()
 	require.NoError(t, err)
 	assert.Equal(t, len(taskSummaries), 0)
 
@@ -81,13 +81,13 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	gpuTask2 := &MockTask{ID: "gpu-task2", SlotsNeeded: 4}
 
 	// Let the CPU task actors request resources.
-	_, err = agentRM.Allocate(sproto.AllocateRequest{
+	_, err = agentRM.Allocate("", sproto.AllocateRequest{
 		AllocationID: cpuTask1.ID,
 		SlotsNeeded:  cpuTask1.SlotsNeeded,
 		ResourcePool: cpuTask1.ResourcePool,
 	})
 	require.NoError(t, err)
-	_, err = agentRM.Allocate(sproto.AllocateRequest{
+	_, err = agentRM.Allocate("", sproto.AllocateRequest{
 		AllocationID: cpuTask2.ID,
 		SlotsNeeded:  cpuTask2.SlotsNeeded,
 		ResourcePool: cpuTask2.ResourcePool,
@@ -95,7 +95,7 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource pools of the tasks are correct.
-	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries, err = agentRM.GetAllocationSummaries()
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -104,13 +104,13 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	)
 
 	// Let the GPU task actors request resources.
-	_, err = agentRM.Allocate(sproto.AllocateRequest{
+	_, err = agentRM.Allocate("", sproto.AllocateRequest{
 		AllocationID: gpuTask1.ID,
 		SlotsNeeded:  gpuTask1.SlotsNeeded,
 		ResourcePool: gpuTask1.ResourcePool,
 	})
 	require.NoError(t, err)
-	_, err = agentRM.Allocate(sproto.AllocateRequest{
+	_, err = agentRM.Allocate("", sproto.AllocateRequest{
 		AllocationID: gpuTask2.ID,
 		SlotsNeeded:  gpuTask2.SlotsNeeded,
 		ResourcePool: gpuTask2.ResourcePool,
@@ -118,39 +118,38 @@ func TestAgentRMRoutingTaskRelatedMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the resource pools of the tasks are correct.
-	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries, err = agentRM.GetAllocationSummaries()
 	require.NoError(t, err)
 	assert.Equal(
 		t,
 		taskSummaries[gpuTask1.ID].ResourcePool,
 		taskSummaries[gpuTask2.ID].ResourcePool,
 	)
-
 	// Let the CPU task actors release resources.
-	agentRM.Release(
+	agentRM.Release("",
 		sproto.ResourcesReleased{
 			AllocationID: cpuTask1.ID,
 			ResourcePool: taskSummaries[cpuTask1.ID].ResourcePool,
 		},
 	)
-	agentRM.Release(sproto.ResourcesReleased{
+	agentRM.Release("", sproto.ResourcesReleased{
 		AllocationID: cpuTask2.ID,
 		ResourcePool: taskSummaries[cpuTask2.ID].ResourcePool,
 	})
-	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries, err = agentRM.GetAllocationSummaries()
 	require.NoError(t, err)
 	assert.Equal(t, len(taskSummaries), 2)
 
 	// Let the GPU task actors release resources.
-	agentRM.Release(sproto.ResourcesReleased{
+	agentRM.Release("", sproto.ResourcesReleased{
 		AllocationID: gpuTask1.ID,
 		ResourcePool: taskSummaries[gpuTask1.ID].ResourcePool,
 	})
-	agentRM.Release(sproto.ResourcesReleased{
+	agentRM.Release("", sproto.ResourcesReleased{
 		AllocationID: gpuTask2.ID,
 		ResourcePool: taskSummaries[gpuTask2.ID].ResourcePool,
 	})
-	taskSummaries, err = agentRM.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries, err = agentRM.GetAllocationSummaries()
 	require.NoError(t, err)
 	assert.Equal(t, len(taskSummaries), 0)
 

--- a/master/internal/rm/agentrm/agents.go
+++ b/master/internal/rm/agentrm/agents.go
@@ -182,7 +182,7 @@ func (a *agents) HandleWebsocketConnection(msg webSocketRequest) error {
 	return nil
 }
 
-func (a *agents) getAgents(msg *apiv1.GetAgentsRequest) *apiv1.GetAgentsResponse {
+func (a *agents) getAgents() *apiv1.GetAgentsResponse {
 	var response apiv1.GetAgentsResponse
 	for _, a := range a.summarize() {
 		response.Agents = append(response.Agents, a.ToProto())

--- a/master/internal/rm/agentrm/resource_managers_test.go
+++ b/master/internal/rm/agentrm/resource_managers_test.go
@@ -37,7 +37,7 @@ func TestResourceManagerForwardMessage(t *testing.T) {
 
 	rm := New(nil, echo.New(), conf.ResourceManagers()[0], nil, nil)
 
-	taskSummary, err := rm.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummary, err := rm.GetAllocationSummaries()
 	assert.NilError(t, err)
 	assert.DeepEqual(t, taskSummary, make(map[model.AllocationID]sproto.AllocationSummary))
 	rm.stop()

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -559,17 +559,13 @@ func (rp *resourcePool) NotifyAgentUpdated() {
 	rp.reschedule = true
 }
 
-func (rp *resourcePool) GetAllocationSummaries(
-	msg sproto.GetAllocationSummaries,
-) map[model.AllocationID]sproto.AllocationSummary {
+func (rp *resourcePool) GetAllocationSummaries() map[model.AllocationID]sproto.AllocationSummary {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 	return rp.taskList.TaskSummaries(rp.groups, rp.config.Scheduler.GetType())
 }
 
-func (rp *resourcePool) ValidateResources(
-	msg sproto.ValidateResourcesRequest,
-) sproto.ValidateResourcesResponse {
+func (rp *resourcePool) ValidateResources(msg sproto.ValidateResourcesRequest) bool {
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 
@@ -591,7 +587,7 @@ func (rp *resourcePool) ValidateResources(
 		fulfillable = maxSlots >= msg.Slots
 	}
 
-	return sproto.ValidateResourcesResponse{Fulfillable: fulfillable}
+	return fulfillable
 }
 
 // GetResourceSummary requests a summary of the resources used by the resource pool (agents, slots, cpu containers).

--- a/master/internal/rm/agentrm/resource_pool_test.go
+++ b/master/internal/rm/agentrm/resource_pool_test.go
@@ -25,7 +25,7 @@ func TestCleanUpTaskWhenTaskActorStopsWithError(t *testing.T) {
 	rp := setupResourcePool(t, nil, nil, tasks, nil, agents)
 
 	rp.Allocate(sproto.AllocateRequest{AllocationID: tasks[0].ID, SlotsNeeded: tasks[0].SlotsNeeded})
-	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries := rp.GetAllocationSummaries()
 	assert.Equal(t, len(taskSummaries), 1)
 
 	rp.ResourcesReleased(sproto.ResourcesReleased{
@@ -38,7 +38,7 @@ func TestCleanUpTaskWhenTaskActorStopsWithError(t *testing.T) {
 	}
 
 	rp.stop()
-	assert.Equal(t, len(rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})), 0)
+	assert.Equal(t, len(rp.GetAllocationSummaries()), 0)
 }
 
 func TestCleanUpTaskWhenTaskActorPanics(t *testing.T) {
@@ -47,7 +47,7 @@ func TestCleanUpTaskWhenTaskActorPanics(t *testing.T) {
 	rp := setupResourcePool(t, nil, nil, tasks, nil, agents)
 
 	rp.Allocate(sproto.AllocateRequest{AllocationID: tasks[0].ID, SlotsNeeded: tasks[0].SlotsNeeded})
-	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries := rp.GetAllocationSummaries()
 	assert.Equal(t, len(taskSummaries), 1)
 
 	rp.ResourcesReleased(sproto.ResourcesReleased{
@@ -60,7 +60,7 @@ func TestCleanUpTaskWhenTaskActorPanics(t *testing.T) {
 	}
 
 	rp.stop()
-	assert.Equal(t, len(rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})), 0)
+	assert.Equal(t, len(rp.GetAllocationSummaries()), 0)
 }
 
 func TestCleanUpTaskWhenTaskActorStopsNormally(t *testing.T) {
@@ -69,7 +69,7 @@ func TestCleanUpTaskWhenTaskActorStopsNormally(t *testing.T) {
 	rp := setupResourcePool(t, nil, nil, tasks, nil, agents)
 
 	rp.Allocate(sproto.AllocateRequest{AllocationID: tasks[0].ID, SlotsNeeded: tasks[0].SlotsNeeded})
-	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries := rp.GetAllocationSummaries()
 	assert.Equal(t, len(taskSummaries), 1)
 
 	rp.ResourcesReleased(sproto.ResourcesReleased{
@@ -82,7 +82,7 @@ func TestCleanUpTaskWhenTaskActorStopsNormally(t *testing.T) {
 	}
 
 	rp.stop()
-	assert.Equal(t, len(rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})), 0)
+	assert.Equal(t, len(rp.GetAllocationSummaries()), 0)
 }
 
 func TestCleanUpTaskWhenTaskActorReleaseResources(t *testing.T) {
@@ -91,7 +91,7 @@ func TestCleanUpTaskWhenTaskActorReleaseResources(t *testing.T) {
 	rp := setupResourcePool(t, nil, nil, tasks, nil, agents)
 
 	rp.Allocate(sproto.AllocateRequest{AllocationID: tasks[0].ID, SlotsNeeded: tasks[0].SlotsNeeded})
-	taskSummaries := rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})
+	taskSummaries := rp.GetAllocationSummaries()
 	assert.Equal(t, len(taskSummaries), 1)
 
 	rp.ResourcesReleased(sproto.ResourcesReleased{
@@ -100,7 +100,7 @@ func TestCleanUpTaskWhenTaskActorReleaseResources(t *testing.T) {
 	})
 
 	rp.stop()
-	assert.Equal(t, len(rp.GetAllocationSummaries(sproto.GetAllocationSummaries{})), 0)
+	assert.Equal(t, len(rp.GetAllocationSummaries()), 0)
 }
 
 func TestScalingInfoAgentSummary(t *testing.T) {

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -136,7 +136,7 @@ func New(
 }
 
 // Allocate implements rm.ResourceManager.
-func (k *ResourceManager) Allocate(msg sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
+func (k *ResourceManager) Allocate(_ string, msg sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
 	// This code exists to handle the case where an experiment does not have
 	// an explicit resource pool specified in the config. This should never happen
 	// for newly created/forked experiments as the default pool is filled in to the
@@ -167,50 +167,48 @@ func (ResourceManager) DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, er
 }
 
 // ExternalPreemptionPending implements rm.ResourceManager.
-func (ResourceManager) ExternalPreemptionPending(sproto.PendingPreemption) error {
+func (ResourceManager) ExternalPreemptionPending(string, model.AllocationID) error {
 	return rmerrors.ErrNotSupported
 }
 
 // GetAgent implements rm.ResourceManager.
-func (k *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
+func (k *ResourceManager) GetAgent(_ string, msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
 	return k.podsService.GetAgent(msg), nil
 }
 
 // GetAgents implements rm.ResourceManager.
-func (k *ResourceManager) GetAgents(msg *apiv1.GetAgentsRequest) (*apiv1.GetAgentsResponse, error) {
-	return k.podsService.GetAgents(msg), nil
+func (k *ResourceManager) GetAgents() (*apiv1.GetAgentsResponse, error) {
+	return k.podsService.GetAgents(), nil
 }
 
 // GetAllocationSummaries implements rm.ResourceManager.
-func (k *ResourceManager) GetAllocationSummaries(
-	msg sproto.GetAllocationSummaries,
-) (map[model.AllocationID]sproto.AllocationSummary, error) {
+func (k *ResourceManager) GetAllocationSummaries() (map[model.AllocationID]sproto.AllocationSummary, error) {
 	summaries := make(map[model.AllocationID]sproto.AllocationSummary)
 	for _, rp := range k.pools {
-		rpSummaries := rp.GetAllocationSummaries(msg)
+		rpSummaries := rp.GetAllocationSummaries()
 		maps.Copy(summaries, rpSummaries)
 	}
 	return summaries, nil
 }
 
 // GetDefaultAuxResourcePool implements rm.ResourceManager.
-func (k *ResourceManager) GetDefaultAuxResourcePool(
-	sproto.GetDefaultAuxResourcePoolRequest,
-) (sproto.GetDefaultAuxResourcePoolResponse, error) {
+func (k *ResourceManager) GetDefaultAuxResourcePool(string) (sproto.GetDefaultAuxResourcePoolResponse, error) {
 	if k.config.DefaultComputeResourcePool == "" {
 		return sproto.GetDefaultAuxResourcePoolResponse{}, rmerrors.ErrNoDefaultResourcePool
 	}
-	return sproto.GetDefaultAuxResourcePoolResponse{PoolName: k.config.DefaultAuxResourcePool}, nil
+	return sproto.GetDefaultAuxResourcePoolResponse{
+		PoolName: k.config.DefaultAuxResourcePool,
+	}, nil
 }
 
 // GetDefaultComputeResourcePool implements rm.ResourceManager.
-func (k *ResourceManager) GetDefaultComputeResourcePool(
-	sproto.GetDefaultComputeResourcePoolRequest,
-) (sproto.GetDefaultComputeResourcePoolResponse, error) {
+func (k *ResourceManager) GetDefaultComputeResourcePool(string) (sproto.GetDefaultComputeResourcePoolResponse, error) {
 	if k.config.DefaultComputeResourcePool == "" {
 		return sproto.GetDefaultComputeResourcePoolResponse{}, rmerrors.ErrNoDefaultResourcePool
 	}
-	return sproto.GetDefaultComputeResourcePoolResponse{PoolName: k.config.DefaultComputeResourcePool}, nil
+	return sproto.GetDefaultComputeResourcePoolResponse{
+		PoolName: k.config.DefaultComputeResourcePool,
+	}, nil
 }
 
 // GetExternalJobs implements rm.ResourceManager.
@@ -234,7 +232,7 @@ func (k *ResourceManager) GetJobQ(_, resourcePool string) (map[model.JobID]*spro
 
 // GetJobQueueStatsRequest implements rm.ResourceManager.
 func (k *ResourceManager) GetJobQueueStatsRequest(
-	*apiv1.GetJobQueueStatsRequest,
+	_ string, msg *apiv1.GetJobQueueStatsRequest,
 ) (*apiv1.GetJobQueueStatsResponse, error) {
 	resp := &apiv1.GetJobQueueStatsResponse{
 		Results: make([]*apiv1.RPQueueStat, 0),
@@ -259,7 +257,7 @@ func (k *ResourceManager) GetJobQueueStatsRequest(
 }
 
 // GetResourcePools implements rm.ResourceManager.
-func (k *ResourceManager) GetResourcePools(*apiv1.GetResourcePoolsRequest) (*apiv1.GetResourcePoolsResponse, error) {
+func (k *ResourceManager) GetResourcePools() (*apiv1.GetResourcePoolsResponse, error) {
 	summaries := make([]*resourcepoolv1.ResourcePool, 0, len(k.poolsConfig))
 	for _, pool := range k.poolsConfig {
 		summary, err := k.createResourcePoolSummary(pool.PoolName)
@@ -281,12 +279,12 @@ func (k *ResourceManager) GetResourcePools(*apiv1.GetResourcePoolsRequest) (*api
 }
 
 // GetSlot implements rm.ResourceManager.
-func (k *ResourceManager) GetSlot(msg *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
+func (k *ResourceManager) GetSlot(_ string, msg *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
 	return k.podsService.GetSlot(msg), nil
 }
 
 // GetSlots implements rm.ResourceManager.
-func (k *ResourceManager) GetSlots(msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
+func (k *ResourceManager) GetSlots(_ string, msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
 	return k.podsService.GetSlots(msg), nil
 }
 
@@ -310,7 +308,7 @@ func (k *ResourceManager) RecoverJobPosition(_ string, msg sproto.RecoverJobPosi
 }
 
 // Release implements rm.ResourceManager.
-func (k *ResourceManager) Release(msg sproto.ResourcesReleased) {
+func (k *ResourceManager) Release(_ string, msg sproto.ResourcesReleased) {
 	rp, err := k.poolByName(msg.ResourcePool)
 	if err != nil {
 		k.syslog.WithError(err).Warnf("release found no resource pool with name %s",
@@ -321,7 +319,7 @@ func (k *ResourceManager) Release(msg sproto.ResourcesReleased) {
 }
 
 // SetGroupMaxSlots implements rm.ResourceManager.
-func (k *ResourceManager) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
+func (k *ResourceManager) SetGroupMaxSlots(_ string, msg sproto.SetGroupMaxSlots) {
 	rp, err := k.poolByName(msg.ResourcePool)
 	if err != nil {
 		k.syslog.WithError(err).Warnf("set group max slots found no resource pool with name %s",
@@ -353,34 +351,34 @@ func (k *ResourceManager) SetGroupWeight(_ string, msg sproto.SetGroupWeight) er
 
 // ValidateResources implements rm.ResourceManager.
 func (k *ResourceManager) ValidateResources(
-	msg sproto.ValidateResourcesRequest,
-) (sproto.ValidateResourcesResponse, []command.LaunchWarning, error) {
+	_ string, msg sproto.ValidateResourcesRequest,
+) ([]command.LaunchWarning, error) {
 	if msg.Slots == 0 {
-		return sproto.ValidateResourcesResponse{}, nil, nil
+		return nil, nil
 	}
 
 	if msg.IsSingleNode {
 		rp, err := k.poolByName(msg.ResourcePool)
 		if err != nil {
-			return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
 		}
 		resp := rp.ValidateResources(msg)
-		if !resp.Fulfillable {
-			return resp, nil, errors.New("request unfulfillable, please try requesting less slots")
+		if !resp {
+			return nil, errors.New("request unfulfillable, please try requesting less slots")
 		}
-		return sproto.ValidateResourcesResponse{}, nil, nil
+		return nil, nil
 	} else if err := k.resourcePoolExists(msg.ResourcePool); err != nil {
-		return sproto.ValidateResourcesResponse{}, nil, fmt.Errorf("%s is an invalid resource pool", msg.ResourcePool)
+		return nil, fmt.Errorf("%s is an invalid resource pool", msg.ResourcePool)
 	}
-	return sproto.ValidateResourcesResponse{}, nil, nil
+	return nil, nil
 }
 
 // getResourcePoolRef gets an actor ref to a resource pool by name.
 func (k ResourceManager) resourcePoolExists(
 	name string,
 ) error {
-	resp, err := k.GetResourcePools(&apiv1.GetResourcePoolsRequest{})
+	resp, err := k.GetResourcePools()
 	if err != nil {
 		return err
 	}
@@ -394,79 +392,75 @@ func (k ResourceManager) resourcePoolExists(
 }
 
 // ResolveResourcePool resolves the resource pool completely.
-func (k ResourceManager) ResolveResourcePool(
-	name string,
-	workspaceID int,
-	slots int,
-) (string, error) {
+func (k ResourceManager) ResolveResourcePool(_ string, req sproto.ResolveResourcesRequest) (
+	rmName string, poolName string, err error,
+) {
 	ctx := context.TODO()
-	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, workspaceID)
+	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, req.Workspace)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	// If the resource pool isn't set, fill in the default at creation time.
-	if name == "" && slots == 0 {
+	if req.ResourcePool == "" && req.Slots == 0 {
 		if defaultAuxPool == "" {
-			req := sproto.GetDefaultAuxResourcePoolRequest{}
-			resp, err := k.GetDefaultAuxResourcePool(req)
+			resp, err := k.GetDefaultAuxResourcePool("")
 			if err != nil {
-				return "", fmt.Errorf("defaulting to aux pool: %w", err)
+				return "", "", fmt.Errorf("defaulting to aux pool: %w", err)
 			}
-			return resp.PoolName, nil
+			return "", resp.PoolName, nil
 		}
-		name = defaultAuxPool
+		req.ResourcePool = defaultAuxPool
 	}
 
-	if name == "" && slots >= 0 {
+	if req.ResourcePool == "" && req.Slots >= 0 {
 		if defaultComputePool == "" {
-			req := sproto.GetDefaultComputeResourcePoolRequest{}
-			resp, err := k.GetDefaultComputeResourcePool(req)
+			resp, err := k.GetDefaultComputeResourcePool("")
 			if err != nil {
-				return "", fmt.Errorf("defaulting to compute pool: %w", err)
+				return "", "", fmt.Errorf("defaulting to compute pool: %w", err)
 			}
-			return resp.PoolName, nil
+			return "", resp.PoolName, nil
 		}
-		name = defaultComputePool
+		req.ResourcePool = defaultComputePool
 	}
 
-	resp, err := k.GetResourcePools(&apiv1.GetResourcePoolsRequest{})
+	resp, err := k.GetResourcePools()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	poolNames, _, err := db.ReadRPsAvailableToWorkspace(
-		ctx, int32(workspaceID), 0, -1, rmutils.ResourcePoolsToConfig(resp.ResourcePools))
+		ctx, int32(req.Workspace), 0, -1, rmutils.ResourcePoolsToConfig(resp.ResourcePools))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if name == poolName {
+		if req.ResourcePool == poolName {
 			found = true
 			break
 		}
 	}
 	if !found {
-		return "", fmt.Errorf(
+		return "", "", fmt.Errorf(
 			"resource pool %s does not exist or is not available to workspace ID %d",
-			name, workspaceID)
+			req.ResourcePool, req.Workspace)
 	}
 
-	if err := k.ValidateResourcePool(name); err != nil {
-		return "", fmt.Errorf("validating pool: %w", err)
+	if err := k.ValidateResourcePool("", req.ResourcePool); err != nil {
+		return "", "", fmt.Errorf("validating pool: %w", err)
 	}
-	return name, nil
+	return "", req.ResourcePool, nil
 }
 
 // ValidateResourcePool validates that the named resource pool exists.
-func (k ResourceManager) ValidateResourcePool(name string) error {
+func (k ResourceManager) ValidateResourcePool(_, name string) error {
 	return k.resourcePoolExists(name)
 }
 
 // NotifyContainerRunning receives a notification from the container to let
 // the master know that the container is running.
 func (k ResourceManager) NotifyContainerRunning(
-	msg sproto.NotifyContainerRunning,
+	_ string, msg sproto.NotifyContainerRunning,
 ) error {
 	// Kubernetes Resource Manager does not implement a handler for the
 	// NotifyContainerRunning message, as it is only used on HPC
@@ -476,16 +470,16 @@ func (k ResourceManager) NotifyContainerRunning(
 }
 
 // IsReattachableOnlyAfterStarted always returns false for the k8s resource manager.
-func (k ResourceManager) IsReattachableOnlyAfterStarted() bool {
+func (k ResourceManager) IsReattachableOnlyAfterStarted(string) bool {
 	return false
 }
 
 // TaskContainerDefaults returns TaskContainerDefaults for the specified pool.
-func (k ResourceManager) TaskContainerDefaults(
-	pool string,
-	fallbackConfig model.TaskContainerDefaultsConfig,
+func (k ResourceManager) TaskContainerDefaults(_, pool string, fallbackConfig model.TaskContainerDefaultsConfig,
 ) (result model.TaskContainerDefaultsConfig, err error) {
-	return k.getTaskContainerDefaults(taskContainerDefaults{fallbackDefault: fallbackConfig, resourcePool: pool}), nil
+	return k.getTaskContainerDefaults(
+		taskContainerDefaults{fallbackDefault: fallbackConfig, resourcePool: pool},
+	), nil
 }
 
 func (k *ResourceManager) podStatusUpdateCallback(msg sproto.UpdatePodStatus) {
@@ -498,11 +492,11 @@ func (k *ResourceManager) poolByName(resourcePool string) (*kubernetesResourcePo
 	if resourcePool == "" {
 		return nil, errors.New("invalid call: cannot get a resource pool with no name")
 	}
-	rp, ok := k.pools[resourcePool]
+	res, ok := k.pools[resourcePool]
 	if !ok {
 		return nil, fmt.Errorf("cannot find resource pool %s", resourcePool)
 	}
-	return rp, nil
+	return res, nil
 }
 
 func (k *ResourceManager) createResourcePoolSummary(
@@ -657,28 +651,28 @@ func (k *ResourceManager) getTaskContainerDefaults(
 
 // EnableAgent allows scheduling on a node that has been disabled.
 func (k *ResourceManager) EnableAgent(
-	req *apiv1.EnableAgentRequest,
+	_ string, req *apiv1.EnableAgentRequest,
 ) (resp *apiv1.EnableAgentResponse, err error) {
 	return k.podsService.EnableAgent(req)
 }
 
 // DisableAgent prevents scheduling on a node and has the option to kill running jobs.
 func (k *ResourceManager) DisableAgent(
-	req *apiv1.DisableAgentRequest,
+	_ string, req *apiv1.DisableAgentRequest,
 ) (resp *apiv1.DisableAgentResponse, err error) {
 	return k.podsService.DisableAgent(req)
 }
 
 // EnableSlot implements 'det slot enable...' functionality.
 func (k ResourceManager) EnableSlot(
-	req *apiv1.EnableSlotRequest,
+	_ string, req *apiv1.EnableSlotRequest,
 ) (resp *apiv1.EnableSlotResponse, err error) {
 	return nil, rmerrors.ErrNotSupported
 }
 
 // DisableSlot implements 'det slot disable...' functionality.
 func (k ResourceManager) DisableSlot(
-	req *apiv1.DisableSlotRequest,
+	_ string, req *apiv1.DisableSlotRequest,
 ) (resp *apiv1.DisableSlotResponse, err error) {
 	return nil, rmerrors.ErrNotSupported
 }

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -167,7 +167,7 @@ func (ResourceManager) DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, er
 }
 
 // ExternalPreemptionPending implements rm.ResourceManager.
-func (ResourceManager) ExternalPreemptionPending(string, model.AllocationID) error {
+func (ResourceManager) ExternalPreemptionPending(model.AllocationID) error {
 	return rmerrors.ErrNotSupported
 }
 
@@ -459,9 +459,7 @@ func (k ResourceManager) ValidateResourcePool(_, name string) error {
 
 // NotifyContainerRunning receives a notification from the container to let
 // the master know that the container is running.
-func (k ResourceManager) NotifyContainerRunning(
-	_ string, msg sproto.NotifyContainerRunning,
-) error {
+func (k ResourceManager) NotifyContainerRunning(msg sproto.NotifyContainerRunning) error {
 	// Kubernetes Resource Manager does not implement a handler for the
 	// NotifyContainerRunning message, as it is only used on HPC
 	// (High Performance Computing).

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -291,7 +291,7 @@ func (p *pods) GetSlot(msg *apiv1.GetSlotRequest) *apiv1.GetSlotResponse {
 	return p.handleGetSlotRequest(msg.AgentId, msg.SlotId)
 }
 
-func (p *pods) GetAgents(msg *apiv1.GetAgentsRequest) *apiv1.GetAgentsResponse {
+func (p *pods) GetAgents() *apiv1.GetAgentsResponse {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.handleGetAgentsRequest()

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -128,7 +128,7 @@ func (k *kubernetesResourcePool) UpdatePodStatus(msg sproto.UpdatePodStatus) {
 	}
 }
 
-func (k *kubernetesResourcePool) PendingPreemption(msg sproto.PendingPreemption) error {
+func (k *kubernetesResourcePool) PendingPreemption(model.AllocationID) error {
 	return rmerrors.ErrNotSupported
 }
 
@@ -221,9 +221,7 @@ func (k *kubernetesResourcePool) RecoverJobPosition(msg sproto.RecoverJobPositio
 	k.queuePositions.RecoverJobPosition(msg.JobID, msg.JobPosition)
 }
 
-func (k *kubernetesResourcePool) GetAllocationSummaries(
-	msg sproto.GetAllocationSummaries,
-) map[model.AllocationID]sproto.AllocationSummary {
+func (k *kubernetesResourcePool) GetAllocationSummaries() map[model.AllocationID]sproto.AllocationSummary {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
@@ -254,15 +252,13 @@ func (k *kubernetesResourcePool) getResourceSummary(msg getResourceSummary) (*re
 	}, nil
 }
 
-func (k *kubernetesResourcePool) ValidateResources(
-	msg sproto.ValidateResourcesRequest,
-) sproto.ValidateResourcesResponse {
+func (k *kubernetesResourcePool) ValidateResources(msg sproto.ValidateResourcesRequest) bool {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	k.reschedule = true
 
 	fulfillable := k.maxSlotsPerPod >= msg.Slots
-	return sproto.ValidateResourcesResponse{Fulfillable: fulfillable}
+	return fulfillable
 }
 
 func (k *kubernetesResourcePool) Schedule() {

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -11,47 +11,43 @@ import (
 // ResourceManager is an interface for a resource manager, which can allocate and manage resources.
 type ResourceManager interface {
 	// Basic functionality
-	GetAllocationSummaries(sproto.GetAllocationSummaries) (map[model.AllocationID]sproto.AllocationSummary, error)
-	Allocate(sproto.AllocateRequest) (*sproto.ResourcesSubscription, error)
-	Release(sproto.ResourcesReleased)
-	ValidateResources(sproto.ValidateResourcesRequest) (sproto.ValidateResourcesResponse, []command.LaunchWarning, error)
-	DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, error)
-	NotifyContainerRunning(sproto.NotifyContainerRunning) error
+	GetAllocationSummaries() (map[model.AllocationID]sproto.AllocationSummary, error)
+	Allocate(rmName string, req sproto.AllocateRequest) (*sproto.ResourcesSubscription, error)
+	Release(rmName string, req sproto.ResourcesReleased)
+	ValidateResources(rmName string, req sproto.ValidateResourcesRequest) ([]command.LaunchWarning, error)
+	DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, error) // only used in dispatcherrm
+	NotifyContainerRunning(rmName string, req sproto.NotifyContainerRunning) error
 
 	// Scheduling related stuff
-	SetGroupMaxSlots(sproto.SetGroupMaxSlots)
+	SetGroupMaxSlots(rmName string, req sproto.SetGroupMaxSlots)
 	SetGroupWeight(rmName string, req sproto.SetGroupWeight) error
 	SetGroupPriority(rmName string, req sproto.SetGroupPriority) error
-	ExternalPreemptionPending(sproto.PendingPreemption) error
-	IsReattachableOnlyAfterStarted() bool
+	ExternalPreemptionPending(rmName string, allocID model.AllocationID) error
+	IsReattachableOnlyAfterStarted(rmName string) bool
 
-	// Resource pool stuff.
-	GetResourcePools(*apiv1.GetResourcePoolsRequest) (*apiv1.GetResourcePoolsResponse, error)
-	GetDefaultComputeResourcePool(
-		sproto.GetDefaultComputeResourcePoolRequest,
-	) (sproto.GetDefaultComputeResourcePoolResponse, error)
-	GetDefaultAuxResourcePool(sproto.GetDefaultAuxResourcePoolRequest) (sproto.GetDefaultAuxResourcePoolResponse, error)
-	ValidateResourcePool(name string) error
-	ResolveResourcePool(name string, workspace, slots int) (string, error)
-	TaskContainerDefaults(
-		resourcePoolName string,
-		fallbackConfig model.TaskContainerDefaultsConfig,
-	) (model.TaskContainerDefaultsConfig, error)
+	// Resource pool stuff
+	GetResourcePools() (*apiv1.GetResourcePoolsResponse, error)
+	GetDefaultComputeResourcePool(rmName string) (sproto.GetDefaultComputeResourcePoolResponse, error)
+	GetDefaultAuxResourcePool(rmName string) (sproto.GetDefaultAuxResourcePoolResponse, error)
+	ValidateResourcePool(rmName string, rpName string) error
+	ResolveResourcePool(rmName string, req sproto.ResolveResourcesRequest) (rm string, rp string, err error)
+	TaskContainerDefaults(rmName string, rpName string, fallbackConfig model.TaskContainerDefaultsConfig) (
+		model.TaskContainerDefaultsConfig, error)
 
 	// Job queue
 	GetJobQ(rmName string, rpName string) (map[model.JobID]*sproto.RMJobInfo, error)
-	GetJobQueueStatsRequest(*apiv1.GetJobQueueStatsRequest) (*apiv1.GetJobQueueStatsResponse, error)
+	GetJobQueueStatsRequest(rmName string, req *apiv1.GetJobQueueStatsRequest) (*apiv1.GetJobQueueStatsResponse, error)
 	MoveJob(rmName string, req sproto.MoveJob) error
 	RecoverJobPosition(rmName string, req sproto.RecoverJobPosition)
 	GetExternalJobs(rmName string, rpName string) ([]*jobv1.Job, error)
 
 	// Cluster Management APIs
-	GetAgents(*apiv1.GetAgentsRequest) (*apiv1.GetAgentsResponse, error)
-	GetAgent(*apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error)
-	EnableAgent(*apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error)
-	DisableAgent(*apiv1.DisableAgentRequest) (*apiv1.DisableAgentResponse, error)
-	GetSlots(*apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error)
-	GetSlot(*apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error)
-	EnableSlot(*apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error)
-	DisableSlot(*apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error)
+	GetAgents() (*apiv1.GetAgentsResponse, error)
+	GetAgent(rmName string, req *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error)
+	EnableAgent(rmName string, req *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error)
+	DisableAgent(rmName string, req *apiv1.DisableAgentRequest) (*apiv1.DisableAgentResponse, error)
+	GetSlots(rmName string, req *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error)
+	GetSlot(rmName string, req *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error)
+	EnableSlot(rmName string, req *apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error)
+	DisableSlot(rmName string, req *apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error)
 }

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -15,14 +15,14 @@ type ResourceManager interface {
 	Allocate(rmName string, req sproto.AllocateRequest) (*sproto.ResourcesSubscription, error)
 	Release(rmName string, req sproto.ResourcesReleased)
 	ValidateResources(rmName string, req sproto.ValidateResourcesRequest) ([]command.LaunchWarning, error)
-	DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, error) // only used in dispatcherrm
-	NotifyContainerRunning(rmName string, req sproto.NotifyContainerRunning) error
+	DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, error)   // only used in dispatcherrm
+	NotifyContainerRunning(req sproto.NotifyContainerRunning) error // only used in dispatcherrm
 
 	// Scheduling related stuff
 	SetGroupMaxSlots(rmName string, req sproto.SetGroupMaxSlots)
 	SetGroupWeight(rmName string, req sproto.SetGroupWeight) error
 	SetGroupPriority(rmName string, req sproto.SetGroupPriority) error
-	ExternalPreemptionPending(rmName string, allocID model.AllocationID) error
+	ExternalPreemptionPending(allocID model.AllocationID) error // only used in dispatcherrm
 	IsReattachableOnlyAfterStarted(rmName string) bool
 
 	// Resource pool stuff

--- a/master/internal/rm/tasklist/job.go
+++ b/master/internal/rm/tasklist/job.go
@@ -59,11 +59,11 @@ func JobStats(taskList *TaskList) *jobv1.QueueStats {
 }
 
 // JobStatsByPool returns quick job-related stats about the TaskList, by resource pool.
-func JobStatsByPool(taskList *TaskList, resourcePool string) *jobv1.QueueStats {
+func JobStatsByPool(taskList *TaskList, resourceManager string, resourcePool string) *jobv1.QueueStats {
 	reqs := make(AllocReqs, 0)
 	for it := taskList.Iterator(); it.Next(); {
 		req := it.Value()
-		if !req.IsUserVisible || req.ResourcePool != resourcePool {
+		if !req.IsUserVisible || req.ResourcePool != resourcePool || req.ResourceManager != resourceManager {
 			continue
 		}
 		reqs = append(reqs, req)

--- a/master/internal/rm/tasklist/task_list.go
+++ b/master/internal/rm/tasklist/task_list.go
@@ -102,20 +102,6 @@ func (l *TaskList) RemoveAllocation(id model.AllocationID) {
 	l.taskByID[id].State = sproto.SchedulingStateQueued
 }
 
-// ForResourcePool returns a new TaskList filtered by resource pool.
-func (l *TaskList) ForResourcePool(name string) *TaskList {
-	newTaskList := New()
-	for it := l.Iterator(); it.Next(); {
-		task := it.Value()
-		if task.ResourcePool != name {
-			continue
-		}
-
-		newTaskList.AddTask(it.Value())
-	}
-	return newTaskList
-}
-
 // TaskSummary returns a summary for an allocation in the TaskList.
 func (l *TaskList) TaskSummary(
 	id model.AllocationID,
@@ -171,15 +157,16 @@ func newTaskSummary(
 		}
 	}
 	summary := sproto.AllocationSummary{
-		TaskID:         request.TaskID,
-		AllocationID:   request.AllocationID,
-		Name:           request.Name,
-		RegisteredTime: request.RequestTime,
-		ResourcePool:   request.ResourcePool,
-		SlotsNeeded:    request.SlotsNeeded,
-		Resources:      resourcesSummaries,
-		SchedulerType:  schedulerType,
-		ProxyPorts:     request.ProxyPorts,
+		TaskID:          request.TaskID,
+		AllocationID:    request.AllocationID,
+		Name:            request.Name,
+		RegisteredTime:  request.RequestTime,
+		ResourceManager: request.ResourceManager,
+		ResourcePool:    request.ResourcePool,
+		SlotsNeeded:     request.SlotsNeeded,
+		Resources:       resourcesSummaries,
+		SchedulerType:   schedulerType,
+		ProxyPorts:      request.ProxyPorts,
 	}
 
 	if group, ok := groups[request.JobID]; ok {

--- a/master/internal/sproto/globals.go
+++ b/master/internal/sproto/globals.go
@@ -1,22 +1,9 @@
 package sproto
 
 type (
-	// GetDefaultComputeResourcePoolRequest is a message asking for the name of the default
-	// GPU resource pool.
-	GetDefaultComputeResourcePoolRequest struct{}
-
-	// GetDefaultComputeResourcePoolResponse is the response to
-	// GetDefaultComputeResourcePoolRequest.
-	GetDefaultComputeResourcePoolResponse struct {
-		PoolName string
-	}
-
-	// GetDefaultAuxResourcePoolRequest is a message asking for the name of the default
-	// CPU resource pool.
-	GetDefaultAuxResourcePoolRequest struct{}
+	// GetDefaultComputeResourcePoolResponse is the response to GetDefaultComputeResourcePool().
+	GetDefaultComputeResourcePoolResponse struct{ PoolName string }
 
 	// GetDefaultAuxResourcePoolResponse is the response to GetDefaultAuxResourcePoolRequest.
-	GetDefaultAuxResourcePoolResponse struct {
-		PoolName string
-	}
+	GetDefaultAuxResourcePoolResponse struct{ PoolName string }
 )

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -37,6 +37,7 @@ type (
 
 		// Resource configuration.
 		SlotsNeeded         int
+		ResourceManager     string
 		ResourcePool        string
 		FittingRequirements FittingRequirements
 
@@ -80,16 +81,17 @@ type (
 	GetAllocationSummaries struct{}
 	// AllocationSummary contains information about a task for external display.
 	AllocationSummary struct {
-		TaskID         model.TaskID       `json:"task_id"`
-		AllocationID   model.AllocationID `json:"allocation_id"`
-		Name           string             `json:"name"`
-		RegisteredTime time.Time          `json:"registered_time"`
-		ResourcePool   string             `json:"resource_pool"`
-		SlotsNeeded    int                `json:"slots_needed"`
-		Resources      []ResourcesSummary `json:"resources"`
-		SchedulerType  string             `json:"scheduler_type"`
-		Priority       *int               `json:"priority"`
-		ProxyPorts     []*ProxyPortConfig `json:"proxy_ports,omitempty"`
+		TaskID          model.TaskID       `json:"task_id"`
+		AllocationID    model.AllocationID `json:"allocation_id"`
+		Name            string             `json:"name"`
+		RegisteredTime  time.Time          `json:"registered_time"`
+		ResourceManager string             `json:"resource_manager"`
+		ResourcePool    string             `json:"resource_pool"`
+		SlotsNeeded     int                `json:"slots_needed"`
+		Resources       []ResourcesSummary `json:"resources"`
+		SchedulerType   string             `json:"scheduler_type"`
+		Priority        *int               `json:"priority"`
+		ProxyPorts      []*ProxyPortConfig `json:"proxy_ports,omitempty"`
 	}
 
 	// ValidateResourcesRequest is a message asking resource manager whether the given
@@ -102,12 +104,11 @@ type (
 		TaskID       *model.TaskID
 	}
 
-	// ValidateResourcesResponse is the response to ValidateResourcesRequest.
-	ValidateResourcesResponse struct {
-		// Fulfillable values:
-		// - false: impossible to fulfill
-		// - true: ok or unknown
-		Fulfillable bool
+	// ResolveResourcesRequest is ...
+	ResolveResourcesRequest struct {
+		ResourcePool string
+		Workspace    int
+		Slots        int
 	}
 )
 
@@ -239,10 +240,6 @@ func (a *AllocationSummary) Proto() *taskv1.AllocationSummary {
 
 // Incoming task actor messages; task actors must accept these messages.
 type (
-	// ChangeRP notifies the task actor that to set itself for a new resource pool.
-	ChangeRP struct {
-		ResourcePool string
-	}
 	// ResourcesAllocated notifies the task actor of assigned resources.
 	ResourcesAllocated struct {
 		ID                model.AllocationID
@@ -250,11 +247,6 @@ type (
 		Resources         ResourceList
 		JobSubmissionTime time.Time
 		Recovered         bool
-	}
-	// PendingPreemption notifies the task actor that it should release
-	// resources due to a pending system-triggered preemption.
-	PendingPreemption struct {
-		AllocationID model.AllocationID
 	}
 
 	// NotifyContainerRunning notifies the launcher (dispatcher) resource

--- a/master/internal/task/allocation_service_test.go
+++ b/master/internal/task/allocation_service_test.go
@@ -179,9 +179,9 @@ func TestGracefullyTerminateAfterRestart(t *testing.T) {
 	var rm mocks.ResourceManager
 	subq := queue.New[sproto.ResourcesEvent]()
 	sub := sproto.NewAllocationSubscription(subq, func() {})
-	rm.On("Allocate", mock.Anything).Return(sub, nil).Once()
-	rm.On("Release", mock.Anything).Return().Run(func(args mock.Arguments) {
-		msg := args[0].(sproto.ResourcesReleased)
+	rm.On("Allocate", mock.Anything, mock.Anything).Return(sub, nil).Once()
+	rm.On("Release", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
+		msg := args[1].(sproto.ResourcesReleased)
 		if msg.ResourcesID == nil {
 			subq.Put(sproto.ResourcesReleasedEvent{})
 		}
@@ -239,7 +239,7 @@ func TestGracefullyTerminateAfterRestart(t *testing.T) {
 
 	t.Log("restore the allocation")
 	ar.Restore = true
-	rm.On("Allocate", mock.MatchedBy(func(req sproto.AllocateRequest) bool {
+	rm.On("Allocate", mock.Anything, mock.MatchedBy(func(req sproto.AllocateRequest) bool {
 		return req.Restore
 	})).Return(sub, nil).Once()
 	err = DefaultService.StartAllocation(
@@ -557,9 +557,9 @@ func requireStarted(t *testing.T, opts ...func(*sproto.AllocateRequest)) (
 	q := queue.New[sproto.ResourcesEvent]()
 	sub := sproto.NewAllocationSubscription(q, func() { subClosed.Store(true) })
 
-	rm.On("Allocate", mock.Anything).Return(sub, nil)
-	rm.On("Release", mock.Anything).Return().Run(func(args mock.Arguments) {
-		msg := args[0].(sproto.ResourcesReleased)
+	rm.On("Allocate", mock.Anything, mock.Anything).Return(sub, nil)
+	rm.On("Release", mock.Anything, mock.Anything).Return().Run(func(args mock.Arguments) {
+		msg := args[1].(sproto.ResourcesReleased)
 		if msg.ResourcesID == nil {
 			q.Put(sproto.ResourcesReleasedEvent{})
 		}
@@ -595,15 +595,19 @@ func requireStarted(t *testing.T, opts ...func(*sproto.AllocateRequest)) (
 
 func stubAllocateRequest(task *model.Task) sproto.AllocateRequest {
 	return sproto.AllocateRequest{
-		TaskID:       task.TaskID,
-		AllocationID: model.AllocationID(fmt.Sprintf("%s.0", task.TaskID)),
-		SlotsNeeded:  2,
-		Preemptible:  true,
-		ResourcePool: stubResourcePoolName,
+		TaskID:          task.TaskID,
+		AllocationID:    model.AllocationID(fmt.Sprintf("%s.0", task.TaskID)),
+		SlotsNeeded:     2,
+		Preemptible:     true,
+		ResourceManager: stubResourceManagerName,
+		ResourcePool:    stubResourcePoolName,
 	}
 }
 
-var stubResourcePoolName = "default"
+var (
+	stubResourcePoolName    = "default"
+	stubResourceManagerName = "default"
+)
 
 var stubAgentName = aproto.ID("agentx")
 

--- a/master/internal/telemetry/reports.go
+++ b/master/internal/telemetry/reports.go
@@ -27,9 +27,7 @@ const (
 
 // telemetryRPFetcher exists mainly to avoid an annoying import cycle.
 type telemetryRPFetcher interface {
-	GetResourcePools(
-		*apiv1.GetResourcePoolsRequest,
-	) (*apiv1.GetResourcePoolsResponse, error)
+	GetResourcePools() (*apiv1.GetResourcePoolsResponse, error)
 }
 
 // PeriodicallyReportMasterTick periodically reports various telemetry information about the
@@ -58,7 +56,7 @@ func reportMasterTickDelay() time.Duration {
 
 // reportMasterTick reports the master snapshot on a periodic tick.
 func reportMasterTick(db db.DB, rm telemetryRPFetcher) {
-	resp, err := rm.GetResourcePools(&apiv1.GetResourcePoolsRequest{})
+	resp, err := rm.GetResourcePools()
 	if err != nil {
 		// TODO(Brad): Make this routine more accepting of failures.
 		syslog.WithError(err).Error("failed to receive resource pool telemetry information")

--- a/master/internal/telemetry/telemetry_test.go
+++ b/master/internal/telemetry/telemetry_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/segmentio/analytics-go.v3"
 
@@ -120,7 +119,7 @@ func (m *mockClient) resetQueue() {
 // initMockedTelemetry() does what Init() does, but for tests.
 func initMockedTelemetry(t *testing.T) (*mockClient, *mocks.ResourceManager) {
 	mockRM := &mocks.ResourceManager{}
-	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).Return(
+	mockRM.On("GetResourcePools").Return(
 		&apiv1.GetResourcePoolsResponse{ResourcePools: []*resourcepoolv1.ResourcePool{}},
 		nil,
 	)

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -241,11 +241,12 @@ func (t *trial) PatchSearcherState(req experiment.TrialSearcherState) error {
 	return nil
 }
 
-func (t *trial) PatchRP(rp string) {
+func (t *trial) PatchRP(rm, rp string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	resources := t.config.Resources()
+	resources.SetResourceManager(rm)
 	resources.SetResourcePool(rp)
 	t.config.SetResources(resources)
 	if t.allocationID != nil {
@@ -401,6 +402,7 @@ func (t *trial) maybeAllocateTask() error {
 			IsUserVisible:     true,
 			Name:              name,
 			SlotsNeeded:       t.config.Resources().SlotsPerTrial(),
+			ResourceManager:   t.config.Resources().ResourceManager(),
 			ResourcePool:      t.config.Resources().ResourcePool(),
 			FittingRequirements: sproto.FittingRequirements{
 				SingleAgent: isSingleNode,
@@ -445,8 +447,9 @@ func (t *trial) maybeAllocateTask() error {
 		IsUserVisible:     true,
 		Name:              name,
 
-		SlotsNeeded:  t.config.Resources().SlotsPerTrial(),
-		ResourcePool: t.config.Resources().ResourcePool(),
+		SlotsNeeded:     t.config.Resources().SlotsPerTrial(),
+		ResourceManager: t.config.Resources().ResourceManager(),
+		ResourcePool:    t.config.Resources().ResourcePool(),
 		FittingRequirements: sproto.FittingRequirements{
 			SingleAgent: isSingleNode,
 		},
@@ -766,7 +769,7 @@ func (t *trial) maybeRestoreAllocation() (*model.Allocation, error) {
 		Where("end_time IS NULL").
 		Where("state != ?", model.AllocationStateTerminated)
 
-	if t.rm.IsReattachableOnlyAfterStarted() {
+	if t.rm.IsReattachableOnlyAfterStarted(t.config.Resources().ResourceManager()) {
 		selectQuery.Where("start_time IS NOT NULL")
 	}
 
@@ -803,7 +806,7 @@ func (t *trial) maybeRestoreAllocation() (*model.Allocation, error) {
 }
 
 func (t *trial) checkResourcePoolRemainingCapacity() error {
-	_, launchWarnings, err := t.rm.ValidateResources(
+	launchWarnings, err := t.rm.ValidateResources(t.config.Resources().ResourceManager(),
 		sproto.ValidateResourcesRequest{
 			ResourcePool: t.config.Resources().ResourcePool(),
 			Slots:        t.config.Resources().SlotsPerTrial(),

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -95,6 +95,7 @@ func (e ExperimentConfig) AsLegacy() LegacyConfig {
 		Environment:       schemas.Copy(e.Environment()),
 		Hyperparameters:   schemas.Copy(e.Hyperparameters()),
 		Searcher:          e.Searcher().AsLegacy(),
+		ResourceManager:   e.Resources().ResourceManager(),
 	}
 }
 

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -95,7 +95,6 @@ func (e ExperimentConfig) AsLegacy() LegacyConfig {
 		Environment:       schemas.Copy(e.Environment()),
 		Hyperparameters:   schemas.Copy(e.Hyperparameters()),
 		Searcher:          e.Searcher().AsLegacy(),
-		ResourceManager:   e.Resources().ResourceManager(),
 	}
 }
 

--- a/master/pkg/schemas/expconf/legacy.go
+++ b/master/pkg/schemas/expconf/legacy.go
@@ -24,7 +24,6 @@ type LegacyConfig struct {
 	Environment       EnvironmentConfig
 	Hyperparameters   Hyperparameters
 	Searcher          LegacySearcher
-	ResourceManager   string
 }
 
 // LegacySearcher represents a subset of the SearcherConfig which can be expected to be available
@@ -223,16 +222,6 @@ func getLegacySearcher(raw map[string]interface{}) (LegacySearcher, error) {
 	}, nil
 }
 
-func getResourceManager(raw map[string]interface{}) (string, error) {
-	rm := raw["resource_manager"]
-	if rm == nil {
-		// Not error-ing if not found, as the RM field is optional.
-		return "", nil
-	}
-
-	return rm.(string), nil
-}
-
 // ParseLegacyConfigJSON parses bytes that represent an experiment config that was once valid
 // but might no longer be shimmable to the current version of ExperimentConfig.
 func ParseLegacyConfigJSON(byts []byte) (LegacyConfig, error) {
@@ -279,12 +268,6 @@ func ParseLegacyConfigJSON(byts []byte) (LegacyConfig, error) {
 		return out, err
 	}
 	out.Searcher = searcher
-
-	rm, err := getResourceManager(raw)
-	if err != nil {
-		return out, err
-	}
-	out.ResourceManager = rm
 
 	return out, nil
 }

--- a/master/pkg/schemas/expconf/legacy.go
+++ b/master/pkg/schemas/expconf/legacy.go
@@ -24,6 +24,7 @@ type LegacyConfig struct {
 	Environment       EnvironmentConfig
 	Hyperparameters   Hyperparameters
 	Searcher          LegacySearcher
+	ResourceManager   string
 }
 
 // LegacySearcher represents a subset of the SearcherConfig which can be expected to be available
@@ -222,6 +223,16 @@ func getLegacySearcher(raw map[string]interface{}) (LegacySearcher, error) {
 	}, nil
 }
 
+func getResourceManager(raw map[string]interface{}) (string, error) {
+	rm := raw["resource_manager"]
+	if rm == nil {
+		// Not error-ing if not found, as the RM field is optional.
+		return "", nil
+	}
+
+	return rm.(string), nil
+}
+
 // ParseLegacyConfigJSON parses bytes that represent an experiment config that was once valid
 // but might no longer be shimmable to the current version of ExperimentConfig.
 func ParseLegacyConfigJSON(byts []byte) (LegacyConfig, error) {
@@ -268,6 +279,12 @@ func ParseLegacyConfigJSON(byts []byte) (LegacyConfig, error) {
 		return out, err
 	}
 	out.Searcher = searcher
+
+	rm, err := getResourceManager(raw)
+	if err != nil {
+		return out, err
+	}
+	out.ResourceManager = rm
 
 	return out, nil
 }


### PR DESCRIPTION
## Description
Refactor the requests/responses in `ResourceManager` interface, as a pre-requisite for the multiRM project, remove sproto message types where necessary.

Add a `ResourceManager` field to `sproto.AllocateRequest{}` and `expconf.ResourceConfigV0`.

## Test Plan
Pass existing tests.

## Commentary (optional)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-44