### PR TITLE
fix: correctly source bucket region when using minio

### DIFF
--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -68,7 +68,7 @@ func genLongString(approxLength int) string {
 }
 
 func createMockCheckpointS3(bucket string, prefix string) error {
-	region, err := dets3.GetS3BucketRegion(context.TODO(), bucket)
+	region, err := dets3.GetS3BucketRegion(context.TODO(), bucket, nil)
 	if err != nil {
 		return err
 	}

--- a/master/pkg/checkpoints/checkpoints.go
+++ b/master/pkg/checkpoints/checkpoints.go
@@ -49,7 +49,7 @@ func NewDownloader(
 	switch storage := storageConfig.GetUnionMember().(type) {
 	case expconf.S3Config:
 		prefix := idPrefixRef(storage.Prefix())
-		return s3.NewS3Downloader(ctx, aw, storage.Bucket(), prefix)
+		return s3.NewS3Downloader(ctx, aw, storage.Bucket(), prefix, storage.EndpointURL())
 
 	case expconf.GCSConfig:
 		prefix := idPrefixRef(storage.Prefix())

--- a/master/pkg/checkpoints/s3/s3checkpoints.go
+++ b/master/pkg/checkpoints/s3/s3checkpoints.go
@@ -113,29 +113,25 @@ func NewS3Downloader(
 	// the existing AWS credentials.
 	var region string
 	var err error
+	var sess *session.Session
 	if endpointURL != nil {
 		endpointFormat := fmt.Sprint(*endpointURL, "/%s")
 		region, err = GetS3BucketRegion(ctx, bucket, &endpointFormat)
-	} else {
-		region, err = GetS3BucketRegion(ctx, bucket, nil)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	var sess *session.Session
-	if endpointURL != nil {
+		if err != nil {
+			return nil, err
+		}
 		sess, err = session.NewSession(&aws.Config{
 			Region:           aws.String(region),
 			Endpoint:         endpointURL,
 			DisableSSL:       aws.Bool(false),
 			S3ForcePathStyle: aws.Bool(true),
 		})
+	} else {
+		region, err = GetS3BucketRegion(ctx, bucket, nil)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+
 		sess, err = session.NewSession(&aws.Config{
 			Region: &region,
 		})

--- a/master/pkg/checkpoints/s3/s3checkpoints.go
+++ b/master/pkg/checkpoints/s3/s3checkpoints.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	AWSEndpointURL = "https://%s.s3.amazonaws.com"
+	// awsEndpointURL is the AWS endpoint format for getting bucket regions.
+	awsEndpointURL = "https://%s.s3.amazonaws.com"
 )
 
 // S3Downloader implements downloading a checkpoint from S3
@@ -167,7 +168,7 @@ func GetS3BucketRegion(ctx context.Context, bucket string, endpointURL *string) 
 	if endpointURL != nil {
 		url = fmt.Sprintf(*endpointURL, bucket)
 	} else {
-		url = fmt.Sprintf(AWSEndpointURL, bucket)
+		url = fmt.Sprintf(awsEndpointURL, bucket)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)

--- a/master/pkg/checkpoints/s3/s3checkpoints.go
+++ b/master/pkg/checkpoints/s3/s3checkpoints.go
@@ -156,7 +156,6 @@ func NewS3Downloader(
 // GetS3BucketRegion returns the region name of the specified bucket.
 // It does so by making an API call to AWS.
 func GetS3BucketRegion(ctx context.Context, bucket string, endpointURL string) (string, error) {
-	// TODO this won't work on non aws s3 APIs.
 	// We can't use the AWS SDK for getting bucket region
 	// because we get a 403 when the region in the client is different
 	// than the bucket (defeating the whole point of calling bucket location).


### PR DESCRIPTION
## Description
Instead of hardcoding the AWS URL whenever attempting to retrieve a bucket's region, instead leverage the endpoint URL when specified, ensuring that when MinIO is used for checkpoint storage the correct endpoint is used.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- Launch a MinIO server locally
- Create a bucket & an access key 
- Configure devcluster.yaml to use MinIO for checkpoint storage
- Confirm that checkpoints are able to successfully be stored & retrieved via master
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
Automated testing around the use of MinIO as an S3 checkpoint storage option should be put in place.

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
