### PR TITLE
ci: fix broken ci due to queue version change

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2144,6 +2144,9 @@ jobs:
       image: <<pipeline.parameters.machine-image>>
     resource_class: xlarge
     steps:
+      - queue/until_front_of_line:
+          only-on-branch: main
+          time: "120" # Wait two hours at most. Adjust this over time.
       - checkout
       - attach_workspace:
           at: .

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -7,7 +7,7 @@ orbs:
   gh: circleci/github-cli@2.0
   helm: circleci/helm@1.2.0
   kubernetes: circleci/kubernetes@0.11.0
-  queue: eddiewebb/queue@2.2.2
+  queue: eddiewebb/queue@2.2.1
   slack: circleci/slack@3.4.2
   win: circleci/windows@5.0.0
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2144,9 +2144,6 @@ jobs:
       image: <<pipeline.parameters.machine-image>>
     resource_class: xlarge
     steps:
-      - queue/until_front_of_line:
-          only-on-branch: main
-          time: "120" # Wait two hours at most. Adjust this over time.
       - checkout
       - attach_workspace:
           at: .

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -7,7 +7,7 @@ orbs:
   gh: circleci/github-cli@2.0
   helm: circleci/helm@1.2.0
   kubernetes: circleci/kubernetes@0.11.0
-  queue: eddiewebb/queue@volatile
+  queue: eddiewebb/queue@2.2.2
   slack: circleci/slack@3.4.2
   win: circleci/windows@5.0.0
 


### PR DESCRIPTION
## Description

Our queue orb had a breaking change and we had the version as volatile.

https://github.com/eddiewebb/circleci-queue/blame/main/src/%40orb.yml

Just downgrade for the time being, we can think about upgrading later.

## Test Plan

CI passes


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
