### PR TITLE
chore: bunify postgres_jobs.go

### DIFF
--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/shopspring/decimal"
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -95,7 +94,6 @@ type DB interface {
 	RecordInstanceStats(a *model.InstanceStats) error
 	EndInstanceStats(a *model.InstanceStats) error
 	EndAllInstanceStats() error
-	UpdateJobPosition(jobID model.JobID, position decimal.Decimal) error
 }
 
 var (

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -35,7 +35,7 @@ func TestClusterAPI(t *testing.T) {
 		OwnerID: &user.ID,
 	}
 
-	err = db.AddJob(jIn)
+	err = AddJob(jIn)
 	require.NoError(t, err, "failed to add job")
 
 	// Add a task

--- a/master/internal/db/postgres_jobs.go
+++ b/master/internal/db/postgres_jobs.go
@@ -25,31 +25,34 @@ func AddJobTx(ctx context.Context, idb bun.IDB, j *model.Job) error {
 }
 
 // AddJob persists the existence of a job.
-func (db *PgDB) AddJob(j *model.Job) error {
+func AddJob(j *model.Job) error {
 	return AddJobTx(context.TODO(), Bun(), j)
 }
 
 // JobByID retrieves a job by ID.
-func (db *PgDB) JobByID(jID model.JobID) (*model.Job, error) {
+func JobByID(ctx context.Context, jobID model.JobID) (*model.Job, error) {
 	var j model.Job
-	if err := db.query(`
-SELECT *
-FROM jobs
-WHERE job_id = $1
-`, &j, jID); err != nil {
-		return nil, errors.Wrap(err, "querying job")
+	err := Bun().NewSelect().Model(&j).
+		Where("job_id = ?", jobID).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying job: %w", err)
 	}
 	return &j, nil
 }
 
 // UpdateJobPosition propagates the new queue position to the job.
-func (db *PgDB) UpdateJobPosition(jobID model.JobID, position decimal.Decimal) error {
+func UpdateJobPosition(ctx context.Context, jobID model.JobID, position decimal.Decimal) error {
 	if jobID.String() == "" {
 		return errors.Errorf("error modifying job with empty id")
 	}
-	_, err := db.sql.Exec(`
-UPDATE jobs
-SET q_position = $2
-WHERE job_id = $1`, jobID, position)
+	j := model.Job{JobID: jobID, QPos: position}
+	_, err := Bun().NewUpdate().Model(&j).
+		Column("q_position").
+		Where("job_id = ?", jobID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("updating job position: %w", err)
+	}
 	return err
 }

--- a/master/internal/db/postgres_jobs_intg_test.go
+++ b/master/internal/db/postgres_jobs_intg_test.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"context"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -15,39 +16,39 @@ import (
 )
 
 func TestAddJob(t *testing.T) {
-	db := setupDBForTest(t)
+	setupDBForTest(t)
 
 	t.Run("add job", func(t *testing.T) {
-		_, err := createAndAddJob(0, db)
+		_, err := createAndAddJob(0)
 		require.NoError(t, err)
 	})
 
 	t.Run("add job with duplicate id", func(t *testing.T) {
-		j, err := createAndAddJob(0, db)
+		j, err := createAndAddJob(0)
 		require.NoError(t, err)
 
 		// change job type and re-add job
 		j.JobType = model.JobTypeExperiment
-		err = db.AddJob(&j)
+		err = AddJob(&j)
 		require.Error(t, err)
 	})
 
 	t.Run("add job with no job type", func(t *testing.T) {
-		err := db.AddJob(&model.Job{JobID: model.NewJobID()})
+		err := AddJob(&model.Job{JobID: model.NewJobID()})
 		require.Error(t, err)
 	})
 }
 
 func TestJobByID(t *testing.T) {
-	db := setupDBForTest(t)
+	setupDBForTest(t)
 
 	t.Run("add and retrieve job", func(t *testing.T) {
 		// create and send job
-		sendJob, err := createAndAddJob(10, db)
+		sendJob, err := createAndAddJob(10)
 		require.NoError(t, err)
 
 		// retrieve job and test for equality
-		recvJob, err := db.JobByID(sendJob.JobID)
+		recvJob, err := JobByID(context.Background(), sendJob.JobID)
 		require.NoError(t, err)
 		assert.Equal(t, sendJob.JobID, recvJob.JobID)
 		assert.Equal(t, sendJob.JobType, recvJob.JobType)
@@ -57,89 +58,96 @@ func TestJobByID(t *testing.T) {
 
 	t.Run("retrieve non-existent job", func(t *testing.T) {
 		// attempt to retrieve job that does not exist
-		recvJob, err := db.JobByID(model.NewJobID())
+		recvJob, err := JobByID(context.Background(), model.NewJobID())
 		require.Error(t, err)
 		require.Nil(t, recvJob)
 	})
 }
 
 func TestUpdateJobPosition(t *testing.T) {
-	db := setupDBForTest(t)
+	setupDBForTest(t)
 
 	t.Run("update position", func(t *testing.T) {
 		// create and send job
-		sendJob, err := createAndAddJob(10, db)
+		sendJob, err := createAndAddJob(10)
 		require.NoError(t, err)
 
 		// update job position
 		newPos := decimal.NewFromInt(5)
-		err = db.UpdateJobPosition(sendJob.JobID, newPos)
+		err = UpdateJobPosition(context.Background(), sendJob.JobID, newPos)
 		require.NoError(t, err)
 
 		// retrieve job and confirm pos update
-		recvJob, err := db.JobByID(sendJob.JobID)
+		recvJob, err := JobByID(context.Background(), sendJob.JobID)
 		require.NoError(t, err)
 		assert.Equal(t, newPos.Equal(recvJob.QPos), true)
+		// expect other fields to remain the same
+		assert.Equal(t, sendJob.JobID, recvJob.JobID)
+		assert.Equal(t, sendJob.JobType, recvJob.JobType)
+		assert.Equal(t, sendJob.OwnerID, recvJob.OwnerID)
 	})
 
 	t.Run("update position - negative value", func(t *testing.T) {
 		// create and send job
-		sendJob, err := createAndAddJob(10, db)
+		sendJob, err := createAndAddJob(10)
 		require.NoError(t, err)
 
 		// update job position
 		newPos := decimal.NewFromInt(-5)
-		err = db.UpdateJobPosition(sendJob.JobID, newPos)
+		err = UpdateJobPosition(context.Background(), sendJob.JobID, newPos)
 		require.NoError(t, err)
 
 		// retrieve job and confirm pos update
-		recvJob, err := db.JobByID(sendJob.JobID)
+		recvJob, err := JobByID(context.Background(), sendJob.JobID)
 		require.NoError(t, err)
 		assert.Equal(t, newPos.Equal(recvJob.QPos), true)
+		// expect other fields to remain the same
+		assert.Equal(t, sendJob.JobID, recvJob.JobID)
+		assert.Equal(t, sendJob.JobType, recvJob.JobType)
+		assert.Equal(t, sendJob.OwnerID, recvJob.OwnerID)
 	})
 
 	t.Run("update position - empty ID", func(t *testing.T) {
-		sendJob, err := createAndAddJob(10, db)
+		sendJob, err := createAndAddJob(10)
 		require.NoError(t, err)
 
 		// update job position
 		newPos := decimal.NewFromInt(5)
-		err = db.UpdateJobPosition(model.JobID(""), newPos)
+		err = UpdateJobPosition(context.Background(), model.JobID(""), newPos)
 		require.Error(t, err)
 
 		// retrieve job and ensure queue pos not updated
-		recvJob, err := db.JobByID(sendJob.JobID)
+		recvJob, err := JobByID(context.Background(), sendJob.JobID)
 		require.NoError(t, err)
 		assert.Equal(t, sendJob.QPos.Equal(recvJob.QPos), true)
 	})
 
 	t.Run("update position - ID does not exist", func(t *testing.T) {
 		// create and send job
-		_, err := createAndAddJob(10, db)
+		_, err := createAndAddJob(10)
 		require.NoError(t, err)
 
 		// update job position for a job that doesn't exist
 		newPos := decimal.NewFromInt(5)
-		err = db.UpdateJobPosition(model.NewJobID(), newPos)
+		err = UpdateJobPosition(context.Background(), model.NewJobID(), newPos)
 		require.NoError(t, err)
 	})
 }
 
 // TODO [RM-27] initialize db in a TestMain(...) when there's enough package isolation.
-func setupDBForTest(t *testing.T) *PgDB {
+func setupDBForTest(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
 
 	db := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
-	return db
 }
 
-func createAndAddJob(pos int64, db *PgDB) (model.Job, error) {
+func createAndAddJob(pos int64) (model.Job, error) {
 	sendJob := model.Job{
 		JobID:   model.NewJobID(),
 		JobType: model.JobTypeExperiment,
 		QPos:    decimal.NewFromInt(pos),
 	}
-	err := db.AddJob(&sendJob)
+	err := AddJob(&sendJob)
 	return sendJob, err
 }

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -69,11 +69,11 @@ func TestJobTaskAndAllocationAPI(t *testing.T) {
 		OwnerID: &user.ID,
 		QPos:    decimal.New(0, 0),
 	}
-	err := db.AddJob(jIn)
+	err := AddJob(jIn)
 	require.NoError(t, err, "failed to add job")
 
 	// Retrieve it back and make sure the mapping is exhaustive.
-	jOut, err := db.JobByID(jID)
+	jOut, err := JobByID(context.Background(), jID)
 	require.NoError(t, err, "failed to retrieve job")
 	require.True(t, reflect.DeepEqual(jIn, jOut), pprintedExpect(jIn, jOut))
 

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -19,7 +19,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/checkpoints"
 	"github.com/determined-ai/determined/master/internal/config"
-	"github.com/determined-ai/determined/master/internal/db"
+	internaldb "github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
 	"github.com/determined-ai/determined/master/internal/rm"
@@ -62,7 +62,7 @@ type (
 
 		*model.Experiment
 		activeConfig        expconf.ExperimentConfig
-		db                  *db.PgDB
+		db                  *internaldb.PgDB
 		rm                  rm.ResourceManager
 		syslog              *logrus.Entry
 		searcher            *searcher.Searcher
@@ -212,7 +212,7 @@ func newUnmanagedExperiment(
 	expModel.State = model.PausedState
 	expModel.Unmanaged = true
 
-	if err := db.AddExperimentTx(ctx, idb, expModel, modelDef, activeConfig, true); err != nil {
+	if err := internaldb.AddExperimentTx(ctx, idb, expModel, modelDef, activeConfig, true); err != nil {
 		return nil, nil, err
 	}
 	telemetry.ReportExperimentCreated(expModel.ID, activeConfig)
@@ -281,7 +281,7 @@ func (e *internalExperiment) start() error {
 	jobservice.DefaultService.RegisterJob(e.JobID, e)
 
 	if e.restored {
-		j, err := e.db.JobByID(e.JobID)
+		j, err := internaldb.JobByID(context.TODO(), e.JobID)
 		if err != nil {
 			e.updateState(model.StateWithReason{
 				State:               model.StoppingErrorState,
@@ -735,7 +735,7 @@ func (e *internalExperiment) restoreTrials() {
 func (e *internalExperiment) handleContinueExperiment(reqID model.RequestID) (*int, bool) {
 	var continueFromTrialID *int
 	if e.continueTrials {
-		switch trial, err := db.TrialByExperimentAndRequestID(context.TODO(), e.ID, reqID); {
+		switch trial, err := internaldb.TrialByExperimentAndRequestID(context.TODO(), e.ID, reqID); {
 		case errors.Is(err, sql.ErrNoRows):
 		// Trial doesn't exist, don't do anything
 		case err != nil:
@@ -892,7 +892,7 @@ var errIsNotTrialTaskID = fmt.Errorf("taskID is not a trial task ID")
 
 func experimentIDFromTrialTaskID(taskID model.TaskID) (int, error) {
 	var experimentID int
-	err := db.Bun().NewSelect().
+	err := internaldb.Bun().NewSelect().
 		Table("run_id_task_id").
 		Column("experiment_id").
 		Join("LEFT JOIN trials ON trials.id = run_id_task_id.run_id").
@@ -911,7 +911,7 @@ func (e *internalExperiment) checkpointForCreate(op searcher.Create) (*model.Che
 	checkpoint := e.warmStartCheckpoint
 	// If the Create specifies a checkpoint, ignore the experiment-wide one.
 	if op.Checkpoint != nil {
-		trial, err := db.TrialByExperimentAndRequestID(context.TODO(), e.ID, op.Checkpoint.RequestID)
+		trial, err := internaldb.TrialByExperimentAndRequestID(context.TODO(), e.ID, op.Checkpoint.RequestID)
 		if err != nil {
 			return nil, errors.Wrapf(err,
 				"invalid request ID in Create operation: %d", op.Checkpoint.RequestID)
@@ -992,7 +992,7 @@ func (e *internalExperiment) restore(experimentSnapshot json.RawMessage) error {
 }
 
 func checkpointFromTrialIDOrUUID(
-	db *db.PgDB, trialID *int, checkpointUUIDStr *string,
+	db *internaldb.PgDB, trialID *int, checkpointUUIDStr *string,
 ) (*model.Checkpoint, error) {
 	var checkpoint *model.Checkpoint
 	var err error

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/internal/config"
-	"github.com/determined-ai/determined/master/internal/db"
+	internaldb "github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/logpattern"
 	"github.com/determined-ai/determined/master/internal/rm/agentrm/provisioner"
 	"github.com/determined-ai/determined/master/internal/rm/rmevents"
@@ -55,7 +55,7 @@ type resourcePool struct {
 	saveNotifications bool
 	notifications     []<-chan struct{}
 
-	db db.DB
+	db internaldb.DB
 }
 
 // actionCoolDown is the rate limit for scheduler action.
@@ -64,7 +64,7 @@ const actionCoolDown = 500 * time.Millisecond
 // newResourcePool initializes a new empty default resource provider.
 func newResourcePool(
 	config *config.ResourcePoolConfig,
-	db db.DB,
+	db internaldb.DB,
 	cert *tls.Certificate,
 	scheduler Scheduler,
 	fittingMethod SoftConstraint,
@@ -178,7 +178,7 @@ func (rp *resourcePool) restoreResources(
 	allocationID := req.AllocationID
 
 	containerSnapshots := []containerSnapshot{}
-	err := db.Bun().NewSelect().Model(&containerSnapshots).
+	err := internaldb.Bun().NewSelect().Model(&containerSnapshots).
 		Relation("ResourcesWithState").
 		Where("resources_with_state.allocation_id = ?", allocationID).
 		Scan(context.TODO())
@@ -759,7 +759,7 @@ func (rp *resourcePool) moveJob(
 	if err != nil {
 		return err
 	}
-	if err := rp.db.UpdateJobPosition(jobID, jobPosition); err != nil {
+	if err := internaldb.UpdateJobPosition(context.TODO(), jobID, jobPosition); err != nil {
 		return err
 	}
 

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -1,6 +1,7 @@
 package kubernetesrm
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/internal/config"
-	"github.com/determined-ai/determined/master/internal/db"
+	internaldb "github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/rm/rmevents"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
@@ -53,7 +54,7 @@ type kubernetesResourcePool struct {
 	queuePositions tasklist.JobSortState
 	reschedule     bool
 
-	db *db.PgDB
+	db *internaldb.PgDB
 
 	syslog *logrus.Entry
 }
@@ -62,7 +63,7 @@ func newResourcePool(
 	maxSlotsPerPod int,
 	poolConfig *config.ResourcePoolConfig,
 	podsService *pods,
-	db *db.PgDB,
+	db *internaldb.PgDB,
 ) *kubernetesResourcePool {
 	return &kubernetesResourcePool{
 		maxSlotsPerPod:            maxSlotsPerPod,
@@ -399,7 +400,7 @@ func (k *kubernetesResourcePool) moveJob(
 	if err != nil {
 		return err
 	}
-	if err := k.db.UpdateJobPosition(jobID, jobPosition); err != nil {
+	if err := internaldb.UpdateJobPosition(context.TODO(), jobID, jobPosition); err != nil {
 		return err
 	}
 

--- a/master/internal/trial_intg_test.go
+++ b/master/internal/trial_intg_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/determined-ai/determined/master/internal/db"
+	internaldb "github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/mocks/allocationmocks"
 	"github.com/determined-ai/determined/master/internal/task"
@@ -59,7 +59,7 @@ func TestTrial(t *testing.T) {
 		Closed:   true,
 	}))
 
-	dbTrial, err := db.TrialByID(context.TODO(), tr.id)
+	dbTrial, err := internaldb.TrialByID(context.Background(), tr.id)
 	require.NoError(t, err)
 	require.Equal(t, dbTrial.State, model.StoppingCompletedState)
 
@@ -72,7 +72,7 @@ func TestTrial(t *testing.T) {
 	}
 	require.True(t, model.TerminalStates[tr.state])
 
-	dbTrial, err = db.TrialByID(context.TODO(), tr.id)
+	dbTrial, err = internaldb.TrialByID(context.Background(), tr.id)
 	require.NoError(t, err)
 	require.Equal(t, dbTrial.State, model.CompletedState)
 }
@@ -99,7 +99,7 @@ func TestTrialRestarts(t *testing.T) {
 		tr.AllocationExitedCallback(&task.AllocationExited{Err: errors.New("bad stuff went down")})
 
 		if i == tr.config.MaxRestarts() {
-			dbTrial, err := db.TrialByID(context.TODO(), tr.id)
+			dbTrial, err := internaldb.TrialByID(context.Background(), tr.id)
 			require.NoError(t, err)
 			require.Equal(t, dbTrial.State, model.ErrorState)
 		} else {
@@ -118,7 +118,7 @@ func TestTrialRestarts(t *testing.T) {
 }
 
 func setup(t *testing.T) (
-	*db.PgDB,
+	*internaldb.PgDB,
 	model.RequestID,
 	*trial,
 	*allocationmocks.AllocationService,
@@ -139,7 +139,7 @@ func setup(t *testing.T) (
 
 	a, _, _ := setupAPITest(t, nil)
 	j := &model.Job{JobID: model.NewJobID(), JobType: model.JobTypeExperiment}
-	require.NoError(t, a.m.db.AddJob(j))
+	require.NoError(t, internaldb.AddJob(j))
 
 	// instantiate the trial
 	rID := model.NewRequestID(rand.Reader)


### PR DESCRIPTION
## Description
[DET-10134](https://hpe-aiatscale.atlassian.net/browse/DET-10134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) Convert all SQL commands in postgres_jobs.go to Bun SQL commands.

## Test Plan

## Commentary (optional)
Moving to bun means that we are also slowly simplifying (deprecating?) the db interface, allowing code to move out of the db package and be organized in a more modular way.

I also named /master/internal/db import as internaldb to differentiate between db as a type and db as a package - especially since it was sometimes used in both contexts in the same file.

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[DET-10134](https://determinedai.atlassian.net/browse/DET-10134)


[DET-10134]: https://hpe-aiatscale.atlassian.net/browse/DET-10134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-10134]: https://hpe-aiatscale.atlassian.net/browse/DET-10134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ