### PR TITLE
chore: make UpdateUserGroupMembershipTx work at read committed 

### DIFF
--- a/master/internal/usergroup/postgres_groups.go
+++ b/master/internal/usergroup/postgres_groups.go
@@ -511,8 +511,8 @@ func UpdateUserGroupMembershipTx(ctx context.Context, tx bun.IDB, u *model.User,
 WITH deleted_rows AS (
   DELETE FROM user_group_membership WHERE user_id = ? AND group_id IN (
     SELECT groups.id FROM groups
-	JOIN user_group_membership ON groups.id = user_group_membership.group_id
-	WHERE group_name NOT IN (?) AND user_group_membership.user_id = ?
+    JOIN user_group_membership ON groups.id = user_group_membership.group_id
+    WHERE group_name NOT IN (?) AND user_group_membership.user_id = ?
   )
 )
 INSERT INTO user_group_membership (user_id, group_id)


### PR DESCRIPTION
## Description

Make ```UpdateUserGroupMembershipTx``` work at read committed. We run this in serializable isolation level which means we have to deal with retries and all of that.

Instead try to make this work at read committed using CTEs. We should look at a consistent view of the database. 

## Test Plan

intg tests


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
