### PR TITLE
chore: api's default retry now session's default retry

### DIFF
--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -21,7 +21,7 @@ def make_session(username: str, password: str) -> api.Session:
     master_url = conf.make_master_url()
     # Use login instead of login_with_cache() to not touch auth.json on the filesystem.
     utp = authentication.login(master_url, username, password, cert())
-    return api.Session(master_url, utp, cert())
+    return api.Session(master_url, utp, cert(), max_retries=None)
 
 
 _user_session: Optional[api.Session] = None
@@ -269,6 +269,7 @@ def is_hpc() -> bool:
     return st in (bindings.v1SchedulerType.SLURM, bindings.v1SchedulerType.PBS)
 
 
+_master_is_reachable: Optional[bool] = None
 _is_ee: Optional[bool] = None
 
 

--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -277,7 +277,7 @@ def _get_ee() -> Optional[bool]:
 
     if _is_ee is None:
         try:
-            sess = api.UnauthSession(conf.make_master_url(), cert())
+            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
             info = sess.get("info").json()
             _is_ee = "sso_providers" in info
         except (errors.APIException, errors.MasterNotFoundException):
@@ -318,7 +318,7 @@ def _get_scim_enabled() -> Optional[bool]:
 
     if _scim_enabled is None:
         try:
-            sess = api.UnauthSession(conf.make_master_url(), cert())
+            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
             info = sess.get("info").json()
             _scim_enabled = bool(info.get("sso_providers") and len(info["sso_providers"]) > 0)
         except (errors.APIException, errors.MasterNotFoundException):
@@ -347,7 +347,7 @@ def _get_rbac_enabled() -> Optional[bool]:
 
     if _rbac_enabled is None:
         try:
-            sess = api.UnauthSession(conf.make_master_url(), cert())
+            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
             _rbac_enabled = bindings.get_GetMaster(sess).rbacEnabled
         except (errors.APIException, errors.MasterNotFoundException):
             pass

--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -1,3 +1,4 @@
+import functools
 import uuid
 from typing import Callable, Optional, Sequence, Tuple, TypeVar
 
@@ -21,27 +22,17 @@ def make_session(username: str, password: str) -> api.Session:
     master_url = conf.make_master_url()
     # Use login instead of login_with_cache() to not touch auth.json on the filesystem.
     utp = authentication.login(master_url, username, password, cert())
-    return api.Session(master_url, utp, cert(), max_retries=None)
+    return api.Session(master_url, utp, cert(), max_retries=0)
 
 
-_user_session: Optional[api.Session] = None
-
-
+@functools.lru_cache(maxsize=1)
 def user_session() -> api.Session:
-    global _user_session
-    if _user_session is None:
-        _user_session = make_session("determined", "")
-    return _user_session
+    return make_session("determined", "")
 
 
-_admin_session: Optional[api.Session] = None
-
-
+@functools.lru_cache(maxsize=1)
 def admin_session() -> api.Session:
-    global _admin_session
-    if _admin_session is None:
-        _admin_session = make_session("admin", "")
-    return _admin_session
+    return make_session("admin", "")
 
 
 def get_random_string() -> str:
@@ -175,21 +166,16 @@ def list_ntsc(
 F = TypeVar("F", bound=Callable)
 
 
-_is_k8s: Optional[bool] = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_is_k8s() -> Optional[bool]:
-    global _is_k8s
-
-    if _is_k8s is None:
-        try:
-            admin = admin_session()
-            resp = bindings.get_GetMasterConfig(admin)
-            _is_k8s = resp.config["resource_manager"]["type"] == "kubernetes"
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-
-    return _is_k8s
+    try:
+        admin = admin_session()
+        resp = bindings.get_GetMasterConfig(admin)
+        is_k8s = resp.config["resource_manager"]["type"] == "kubernetes"
+        assert isinstance(is_k8s, bool)
+        return is_k8s
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_not_k8s(reason: str = "test is k8s-specific") -> Callable[[F], F]:
@@ -204,26 +190,20 @@ def skipif_not_k8s(reason: str = "test is k8s-specific") -> Callable[[F], F]:
     return decorator
 
 
-_scheduler_type: Optional[bindings.v1SchedulerType] = None
-
-
 # Queries the determined master for resource pool information to determine if agent is used
 # Currently we are assuming that all resource pools are of the same scheduler type
 # which is why only the first resource pool's type is checked.
+@functools.lru_cache(maxsize=1)
 def _get_scheduler_type() -> Optional[bindings.v1SchedulerType]:
-    global _scheduler_type
-    if _scheduler_type is None:
-        try:
-            sess = user_session()
-            resourcePool = bindings.get_GetResourcePools(sess).resourcePools
-            if not resourcePool:
-                raise ValueError(
-                    "Resource Pool returned no value. Make sure the resource pool is set."
-                )
-            _scheduler_type = resourcePool[0].schedulerType
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-    return _scheduler_type
+    scheduler_type: Optional[bindings.v1SchedulerType]
+    try:
+        sess = user_session()
+        resourcePool = bindings.get_GetResourcePools(sess).resourcePools
+        if not resourcePool:
+            raise ValueError("Resource Pool returned no value. Make sure the resource pool is set.")
+        return resourcePool[0].schedulerType
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_not_hpc(reason: str = "test is hpc-specific") -> Callable[[F], F]:
@@ -269,22 +249,14 @@ def is_hpc() -> bool:
     return st in (bindings.v1SchedulerType.SLURM, bindings.v1SchedulerType.PBS)
 
 
-_master_is_reachable: Optional[bool] = None
-_is_ee: Optional[bool] = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_ee() -> Optional[bool]:
-    global _is_ee
-
-    if _is_ee is None:
-        try:
-            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
-            info = sess.get("info").json()
-            _is_ee = "sso_providers" in info
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-
-    return _is_ee
+    try:
+        sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=0)
+        info = sess.get("info").json()
+        return "sso_providers" in info
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_ee(reason: str = "test is oss-specific") -> Callable[[F], F]:
@@ -311,21 +283,14 @@ def skipif_not_ee(reason: str = "test is ee-specific") -> Callable[[F], F]:
     return decorator
 
 
-_scim_enabled: Optional[bool] = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_scim_enabled() -> Optional[bool]:
-    global _scim_enabled
-
-    if _scim_enabled is None:
-        try:
-            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
-            info = sess.get("info").json()
-            _scim_enabled = bool(info.get("sso_providers") and len(info["sso_providers"]) > 0)
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-
-    return _scim_enabled
+    try:
+        sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=0)
+        info = sess.get("info").json()
+        return bool(info.get("sso_providers") and len(info["sso_providers"]) > 0)
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_scim_not_enabled(reason: str = "scim is required for this test") -> Callable[[F], F]:
@@ -340,20 +305,13 @@ def skipif_scim_not_enabled(reason: str = "scim is required for this test") -> C
     return decorator
 
 
-_rbac_enabled: Optional[bool] = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_rbac_enabled() -> Optional[bool]:
-    global _rbac_enabled
-
-    if _rbac_enabled is None:
-        try:
-            sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=None)
-            _rbac_enabled = bindings.get_GetMaster(sess).rbacEnabled
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-
-    return _rbac_enabled
+    try:
+        sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=0)
+        return bindings.get_GetMaster(sess).rbacEnabled
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_rbac_not_enabled(reason: str = "ee is required for this test") -> Callable[[F], F]:
@@ -368,21 +326,14 @@ def skipif_rbac_not_enabled(reason: str = "ee is required for this test") -> Cal
     return decorator
 
 
-_strict_q: Optional[bool] = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_strict_q() -> Optional[bool]:
-    global _strict_q
-
-    if _strict_q is None:
-        try:
-            sess = api.UnauthSession(conf.make_master_url(), cert())
-            resp = bindings.get_GetMaster(sess)
-            _strict_q = resp.rbacEnabled and resp.strictJobQueueControl
-        except (errors.APIException, errors.MasterNotFoundException):
-            pass
-
-    return _strict_q
+    try:
+        sess = api.UnauthSession(conf.make_master_url(), cert(), max_retries=0)
+        resp = bindings.get_GetMaster(sess)
+        return resp.rbacEnabled and resp.strictJobQueueControl
+    except (errors.APIException, errors.MasterNotFoundException):
+        return None
 
 
 def skipif_strict_q_control_not_enabled(

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -86,7 +86,7 @@ default_pagination_args = make_pagination_args()
 
 def unauth_session(args: argparse.Namespace) -> api.UnauthSession:
     master_url = args.master
-    return api.UnauthSession(master=master_url, cert=cli.cert)
+    return api.UnauthSession(master=master_url, cert=cli.cert, max_retries=0)
 
 
 def setup_session(args: argparse.Namespace) -> api.Session:

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -97,7 +97,7 @@ def setup_session(args: argparse.Namespace) -> api.Session:
         password=None,
         cert=cli.cert,
     )
-    return api.Session(master_url, utp, cli.cert, api.default_retry())
+    return api.Session(master_url, utp, cli.cert)
 
 
 def require_feature_flag(feature_flag: str, error_message: str) -> Callable[..., Any]:

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -2,7 +2,6 @@ from determined.common.api import authentication, errors, metric, bindings
 from determined.common.api._session import BaseSession, UnauthSession, Session
 from determined.common.api._util import (
     PageOpts,
-    default_retry,
     get_ntsc_details,
     canonicalize_master_url,
     get_default_master_url,

--- a/harness/determined/common/api/_session.py
+++ b/harness/determined/common/api/_session.py
@@ -10,6 +10,8 @@ from determined.common import api
 from determined.common import requests as det_requests
 from determined.common.api import authentication, certs, errors
 
+GeneralizedRetry = Union[urllib3.util.retry.Retry, int]
+
 # Default retry logic
 DEFAULT_MAX_RETRIES = urllib3.util.retry.Retry(
     total=5,
@@ -22,7 +24,7 @@ def _do_request(
     method: str,
     host: str,
     path: str,
-    max_retries: Union[urllib3.util.retry.Retry, int],
+    max_retries: Optional[GeneralizedRetry],
     params: Optional[Dict[str, Any]] = None,
     json: Any = None,
     data: Optional[str] = None,
@@ -95,7 +97,7 @@ class BaseSession(metaclass=abc.ABCMeta):
 
     master: str
     cert: Optional[certs.Cert]
-    _max_retries: Union[urllib3.util.retry.Retry, int]
+    _max_retries: Optional[GeneralizedRetry]
 
     @abc.abstractmethod
     def _do_request(
@@ -178,7 +180,7 @@ class UnauthSession(BaseSession):
         self,
         master: str,
         cert: Optional[certs.Cert],
-        max_retries: Union[urllib3.util.retry.Retry, int] = DEFAULT_MAX_RETRIES,
+        max_retries: Optional[GeneralizedRetry] = DEFAULT_MAX_RETRIES,
     ) -> None:
         if master != api.canonicalize_master_url(master):
             # This check is targeting developers of Determined, not users of Determined.
@@ -229,7 +231,7 @@ class Session(BaseSession):
         master: str,
         utp: authentication.UsernameTokenPair,
         cert: Optional[certs.Cert],
-        max_retries: Union[urllib3.util.retry.Retry, int] = DEFAULT_MAX_RETRIES,
+        max_retries: Optional[GeneralizedRetry] = DEFAULT_MAX_RETRIES,
     ) -> None:
         if master != api.canonicalize_master_url(master):
             # This check is targeting developers of Determined, not users of Determined.

--- a/harness/determined/common/api/_util.py
+++ b/harness/determined/common/api/_util.py
@@ -3,8 +3,6 @@ import os
 from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union
 from urllib import parse
 
-import urllib3
-
 from determined.common import api, util
 from determined.common.api import bindings
 
@@ -13,12 +11,6 @@ class PageOpts(str, enum.Enum):
     single = "1"
     all = "all"
 
-
-# HTTP status codes that will force request retries.
-RETRY_STATUSES = [502, 503, 504]  # Bad Gateway, Service Unavailable, Gateway Timeout
-
-# Default max number of times to retry a request.
-MAX_RETRIES = 5
 
 # Default seconds for an NTSC task to become ready before timeout.
 DEFAULT_NTSC_TIMEOUT = 60 * 5
@@ -116,15 +108,6 @@ def read_paginated(
             break
         assert pagination.endIndex is not None
         offset = pagination.endIndex
-
-
-def default_retry(max_retries: int = MAX_RETRIES) -> urllib3.util.retry.Retry:
-    retry = urllib3.util.retry.Retry(
-        total=max_retries,
-        backoff_factor=0.5,  # {backoff factor} * (2 ** ({number of total retries} - 1))
-        status_forcelist=RETRY_STATUSES,
-    )
-    return retry
 
 
 # Literal["notebook", "tensorboard", "shell", "command"]

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -52,7 +52,7 @@ def login(
     TokenStore.
     """
     password = api.salt_and_hash(password)
-    unauth_session = api.UnauthSession(master=master_address, cert=cert)
+    unauth_session = api.UnauthSession(master=master_address, cert=cert, max_retries=0)
     login = bindings.v1LoginRequest(username=username, password=password, isHashed=True)
     r = bindings.post_Login(session=unauth_session, body=login)
     return UsernameTokenPair(username, r.token)

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -56,8 +56,7 @@ class Determined:
         )
 
         utp = authentication.login_with_cache(self._master, user, password, cert=cert)
-        retry = api.default_retry()
-        self._session = api.Session(self._master, utp, cert, retry)
+        self._session = api.Session(self._master, utp, cert)
 
     @classmethod
     def _from_session(cls, session: api.Session) -> "Determined":


### PR DESCRIPTION
Pre-patch, a `Session` that was constructed without a `max_retries` had its `_max_retries` assigned to `None`. If you wanted to use the default retry, you had to explicitly pass it a `Retry` constructed from `api.default_retry`.

If we're claiming that `api.default_retry` is a default, then it should actually be default when constructing Sessions. It's a reasonable default to use, so let's do it.

It's still possible to create a Session with a `_max_retries = None`, now you just have to do that explicitly (`None` is not the default).

In summary:

* Remove `default_retry` from `api.default_retry`, because why does anyone need it
* Make a single default `urllib3` `Retry` object to be used as the default for Sessions where the retry isn't specified
* Give `*Session` constructors the default retry (was previously no retry)
* [bonus] Allow `Sessions` to typecheck when constructed with either a `Retry` or an `int`, mirroring the interface in `requests`.
* unauthenticated sessions in the CLI explicitly have no retries
* unauthenticated session used to login explicitly has no retries
* e2e-tests explicitly create sessions with no retries when testing master for presence features
* e2e-tests use functools caching instead of self-managing it when testing master for presence of features

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
