### PR TITLE
ci: more e2e test fixes

### DIFF
--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -55,11 +55,10 @@ def create_test_user(
     Returns a tuple of (Session, password).
     """
     session = admin_session()
-    username = get_random_string()
-    user = user or bindings.v1User(username=username, admin=False, active=True)
+    user = user or bindings.v1User(username=get_random_string(), admin=False, active=True)
     password = get_random_string()
     bindings.post_PostUser(session, body=bindings.v1PostUserRequest(user=user, password=password))
-    sess = make_session(username, password)
+    sess = make_session(user.username, password)
     return sess, password
 
 


### PR DESCRIPTION
create_test_user was returning a nonsense username in some cases.