### PR TITLE
chore: logins return Sessions

### DIFF
--- a/.circleci/scripts/wait_for_perf_migration_upload_results.py
+++ b/.circleci/scripts/wait_for_perf_migration_upload_results.py
@@ -35,8 +35,7 @@ def _wait_for_master() -> None:
 
 def _upload_migration_length(conn: extensions.connection) -> None:
     cert = certs.Cert(noverify=True)
-    utp = authentication.login("http://127.0.0.1:8080", "admin", "", cert)
-    sess = api.Session("http://127.0.0.1:8080", utp, cert)
+    sess = authentication.login("http://127.0.0.1:8080", "admin", "", cert)
 
     migration_start_log = None
     migration_end_log = None

--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -21,8 +21,7 @@ def cert() -> certs.Cert:
 def make_session(username: str, password: str) -> api.Session:
     master_url = conf.make_master_url()
     # Use login instead of login_with_cache() to not touch auth.json on the filesystem.
-    utp = authentication.login(master_url, username, password, cert())
-    return api.Session(master_url, utp, cert(), max_retries=0)
+    return authentication.login(master_url, username, password, cert())
 
 
 @functools.lru_cache(maxsize=1)

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -28,8 +28,7 @@ def mksess(host: str, port: int, username: str = "determined", password: str = "
     """Since this file frequently creates new masters, always create a fresh Session."""
 
     master_url = api.canonicalize_master_url(f"http://{host}:{port}")
-    utp = authentication.login(master_url, username=username, password=password)
-    return api.Session(master_url, utp, cert=None, max_retries=0)
+    return authentication.login(master_url, username=username, password=password)
 
 
 def det_deploy(subcommand: List) -> None:

--- a/harness/determined/cli/_util.py
+++ b/harness/determined/cli/_util.py
@@ -91,13 +91,12 @@ def unauth_session(args: argparse.Namespace) -> api.UnauthSession:
 
 def setup_session(args: argparse.Namespace) -> api.Session:
     master_url = args.master
-    utp = authentication.login_with_cache(
+    return authentication.login_with_cache(
         master_address=master_url,
         requested_user=args.user,
         password=None,
         cert=cli.cert,
     )
-    return api.Session(master_url, utp, cli.cert)
 
 
 def require_feature_flag(feature_flag: str, error_message: str) -> Callable[..., Any]:

--- a/harness/determined/cli/tunnel.py
+++ b/harness/determined/cli/tunnel.py
@@ -32,8 +32,9 @@ if __name__ == "__main__":
     cert = certs.default_load(args.master_url, cert_file, args.cert_name, noverify)
 
     if args.auth:
-        utp = authentication.login_with_cache(args.master_url, args.user, cert=cert)
-        sess: api.BaseSession = api.Session(args.master_url, utp, cert)
+        sess: api.BaseSession = authentication.login_with_cache(
+            args.master_url, args.user, cert=cert
+        )
     else:
         sess = api.UnauthSession(args.master_url, cert)
 

--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -76,9 +76,9 @@ def log_in_user(args: Namespace) -> None:
     password = getpass.getpass(message)
 
     token_store = authentication.TokenStore(args.master)
-    utp = authentication.login(args.master, username, password, cli.cert)
-    token_store.set_token(utp.username, utp.token)
-    token_store.set_active(utp.username)
+    sess = authentication.login(args.master, username, password, cli.cert)
+    token_store.set_token(sess.username, sess.token)
+    token_store.set_active(sess.username)
 
 
 def log_out_user(args: Namespace) -> None:
@@ -127,9 +127,9 @@ def change_password(args: Namespace) -> None:
     # password change so that the user doesn't have to do so manually.
     if args.target_user is None:
         token_store = authentication.TokenStore(args.master)
-        utp = authentication.login(args.master, username, password, cli.cert)
-        token_store.set_token(utp.username, utp.token)
-        token_store.set_active(utp.username)
+        sess = authentication.login(args.master, username, password, cli.cert)
+        token_store.set_token(sess.username, sess.token)
+        token_store.set_active(sess.username)
 
 
 def link_with_agent_user(args: Namespace) -> None:

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -21,7 +21,7 @@ from determined.common.api._rbac import (
     workspace_by_name,
     not_found_errs,
 )
-from determined.common.api.authentication import UsernameTokenPair, salt_and_hash
+from determined.common.api.authentication import salt_and_hash
 from determined.common.api.logs import (
     pprint_logs,
     trial_logs,

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -34,18 +34,12 @@ def get_det_password_from_env() -> Optional[str]:
     return os.environ.get("DET_PASS")
 
 
-class UsernameTokenPair:
-    def __init__(self, username: str, token: str):
-        self.username = username
-        self.token = token
-
-
 def login(
     master_address: str,
     username: str,
     password: str,
     cert: Optional[certs.Cert] = None,
-) -> UsernameTokenPair:
+) -> "api.Session":
     """
     Log in without considering or affecting the TokenStore on the file system.
 
@@ -56,7 +50,7 @@ def login(
     unauth_session = api.UnauthSession(master=master_address, cert=cert, max_retries=0)
     login = bindings.v1LoginRequest(username=username, password=password, isHashed=True)
     r = bindings.post_Login(session=unauth_session, body=login)
-    return UsernameTokenPair(username, r.token)
+    return api.Session(master=master_address, username=username, token=r.token, cert=cert)
 
 
 def default_load_user_password(
@@ -110,7 +104,7 @@ def login_with_cache(
     requested_user: Optional[str] = None,
     password: Optional[str] = None,
     cert: Optional[certs.Cert] = None,
-) -> UsernameTokenPair:
+) -> "api.Session":
     """
     Log in, preferring cached credentials in the TokenStore, if possible.
 
@@ -140,7 +134,7 @@ def login_with_cache(
         token = None
 
     if token is not None:
-        return UsernameTokenPair(user, token)
+        return api.Session(master=master_address, username=user, token=token, cert=cert)
 
     # Special case: use token provided from the container environment if:
     # - No token was obtained from the token store already,
@@ -156,14 +150,14 @@ def login_with_cache(
         assert env_user
         env_token = get_det_user_token_from_env()
         assert env_token
-        return UsernameTokenPair(env_user, env_token)
+        return api.Session(master=master_address, username=env_user, token=env_token, cert=cert)
 
     if password is None:
         password = getpass.getpass(f"Password for user '{user}': ")
 
     try:
-        utp = login(master_address, user, password, cert)
-        user, token = utp.username, utp.token
+        sess = login(master_address, user, password, cert)
+        user, token = sess.username, sess.token
     except api.errors.ForbiddenException:
         # Master will return a 403 if the user is not found, or if the password is incorrect.
         # This is the right response to a failed explicit login attempt. But in the "fallback" case,
@@ -175,7 +169,7 @@ def login_with_cache(
 
     token_store.set_token(user, token)
 
-    return UsernameTokenPair(user, token)
+    return sess
 
 
 def logout(
@@ -210,8 +204,7 @@ def logout(
 
     token_store.drop_user(user)
 
-    utp = UsernameTokenPair(user, token)
-    sess = api.Session(master=master_address, utp=utp, cert=cert)
+    sess = api.Session(master=master_address, username=user, token=token, cert=cert)
     try:
         bindings.post_Logout(sess)
     except (api.errors.UnauthenticatedException, api.errors.APIException):
@@ -235,8 +228,7 @@ def _is_token_valid(master_address: str, token: str, cert: Optional[certs.Cert])
     Find out whether the given token is valid by attempting to use it
     on the "api/v1/me" endpoint.
     """
-    utp = UsernameTokenPair("username-doesnt-matter", token)
-    sess = api.Session(master_address, utp, cert)
+    sess = api.Session(master_address, username="ignored", token=token, cert=cert)
     try:
         r = sess.get("api/v1/me")
     except (api.errors.UnauthenticatedException, api.errors.APIException):

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -119,7 +119,7 @@ def login_with_cache(
     the password is only used in a cache miss.
 
     Returns:
-        The username and token of the logged in user.
+        A new, logged-in Session (one that has a valid token).
     """
 
     token_store = TokenStore(master_address)

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -120,7 +120,7 @@ def login_with_cache(
     Unlike ``login``, this function may not send a login request to the master. It will instead
     first attempt to find a valid token in the TokenStore, and only if that fails will it post a
     login request to the master to generate a new one. As with ``login``, the token is then baked
-    into a new api.Session object to sign future communication with master.
+    into a new ``api.Session`` object to sign future communication with master.
 
     There is also a special case for checking if the DET_USER_TOKEN is set in the environment (by
     the determined-master).  That must happen in this function because it is only used when no other

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -55,8 +55,7 @@ class Determined:
             explicit_noverify=noverify,
         )
 
-        utp = authentication.login_with_cache(self._master, user, password, cert=cert)
-        self._session = api.Session(self._master, utp, cert)
+        self._session = authentication.login_with_cache(self._master, user, password, cert=cert)
 
     @classmethod
     def _from_session(cls, session: api.Session) -> "Determined":

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -98,6 +98,11 @@ class Determined:
         return self._session.username
 
     def logout(self) -> None:
+        """Log out of the current session.
+
+        This results in dropping any cached credentials and sending a request to master to
+        invalidate the session's token.
+        """
         authentication.logout(self._session.master, self._session.username, self._session.cert)
 
     def list_users(self, active: Optional[bool] = None) -> List[user.User]:

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -226,8 +226,9 @@ def init(
 
     # We are on the cluster.
     cert = certs.default_load(info.master_url)
-    utp = authentication.login_with_cache(info.master_url, cert=cert)
-    session = api.Session(info.master_url, utp, cert, max_retries=util.get_max_retries_config())
+    session = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+        util.get_max_retries_config()
+    )
 
     if distributed is None:
         if len(info.container_addrs) > 1 or len(info.slot_ids) > 1:

--- a/harness/determined/deploy/healthcheck.py
+++ b/harness/determined/deploy/healthcheck.py
@@ -50,8 +50,7 @@ def wait_for_genai_url(
     start_time = time.time()
 
     # Hopefully we have an active session to this master, or we can make a default one.
-    utp = authentication.login_with_cache(master_url, cert=cert)
-    sess = api.Session(master_url, utp, cert)
+    sess = authentication.login_with_cache(master_url, cert=cert)
 
     try:
         while time.time() - start_time < timeout:

--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -1,6 +1,7 @@
 """
 The entrypoint for the GC checkpoints job container.
 """
+
 import argparse
 import json
 import logging
@@ -12,7 +13,7 @@ import urllib3
 
 import determined as det
 from determined import errors, tensorboard
-from determined.common import api, constants, storage
+from determined.common import constants, storage
 from determined.common.api import authentication, bindings, certs
 
 logger = logging.getLogger("determined")
@@ -25,10 +26,10 @@ def patch_checkpoints(storage_ids_to_resources: Dict[str, Dict[str, int]]) -> No
         info._to_file()
 
     cert = certs.default_load(info.master_url)
-    utp = authentication.login_with_cache(info.master_url, cert=cert)
     # With backoff retries for 64 seconds
-    max_retries = urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
-    sess = api.Session(info.master_url, utp, cert, max_retries)
+    sess = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+        urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
+    )
 
     checkpoints = []
     for storage_id, resources in storage_ids_to_resources.items():

--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -7,7 +7,7 @@ import sys
 import types
 
 import determined as det
-from determined.common import api, constants, storage
+from determined.common import constants, storage
 from determined.common.api import authentication, certs
 from determined.exec import prep_container
 
@@ -22,8 +22,7 @@ def trigger_preemption(signum: int, frame: types.FrameType) -> None:
         logger.info("SIGTERM: Preemption imminent.")
         # Notify the master that we need to be preempted
         cert = certs.default_load(info.master_url)
-        utp = authentication.login_with_cache(info.master_url, cert=cert)
-        sess = api.Session(info.master_url, utp, cert)
+        sess = authentication.login_with_cache(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/signals/pending_preemption")
 
 

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -310,10 +310,10 @@ if __name__ == "__main__":
         )
 
     cert = certs.default_load(info.master_url)
-    utp = authentication.login_with_cache(info.master_url, cert=cert)
     # With backoff retries for 64 seconds
-    max_retries = urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
-    sess = api.Session(info.master_url, utp, cert, max_retries)
+    sess = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+        urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
+    )
 
     # Notify the Determined Master that the container is running.
     # This should only be used on HPC clusters.

--- a/harness/determined/experimental/core_v2/_core_context_v2.py
+++ b/harness/determined/experimental/core_v2/_core_context_v2.py
@@ -6,7 +6,7 @@ import appdirs
 
 import determined as det
 from determined import core, experimental, tensorboard
-from determined.common import api, constants, storage, util
+from determined.common import constants, storage, util
 from determined.common.api import authentication, certs
 
 logger = logging.getLogger("determined.core")
@@ -43,15 +43,16 @@ def _make_v2_context(
 
         # We are on the cluster.
         cert = certs.default_load(info.master_url)
-        utp = authentication.login_with_cache(info.master_url, cert=cert)
-        session = api.Session(info.master_url, utp, cert, util.get_max_retries_config())
+        session = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+            util.get_max_retries_config()
+        )
     else:
         unmanaged = True
 
         info = unmanaged_info
 
         if client is None:
-            session = det.experimental.client._get_singleton_session()
+            session = experimental.client._get_singleton_session()
         else:
             session = client._session
 

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -3,6 +3,7 @@ deepspeed.py is the launch layer for DeepSpeedTrial in Determined.
 
 It launches the entrypoint script using DeepSpeed's launch process.
 """
+
 import argparse
 import logging
 import os
@@ -21,7 +22,6 @@ from packaging import version
 import determined as det
 import determined.common
 from determined import constants, util
-from determined.common import api
 from determined.common.api import authentication, certs
 
 hostfile_path = None
@@ -287,8 +287,7 @@ def main(script: List[str]) -> int:
         # Mark sshd containers as daemon containers that the master should kill when all non-daemon
         # containers (deepspeed launcher, in this case) have exited.
         cert = certs.default_load(info.master_url)
-        utp = authentication.login_with_cache(info.master_url, cert=cert)
-        sess = api.Session(info.master_url, utp, cert)
+        sess = authentication.login_with_cache(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/resources/{resources_id}/daemon")
 
         # Wrap it in a pid_server to ensure that we can't hang if a worker fails.

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -4,6 +4,7 @@ autohorovod.py is the default launch layer for Determined.
 It launches the entrypoint script under horovodrun when slots_per_trial>1, or as a regular
 subprocess otherwise.
 """
+
 import argparse
 import logging
 import os
@@ -14,7 +15,6 @@ from typing import List, Tuple
 
 import determined as det
 from determined import horovod, util
-from determined.common import api
 from determined.common.api import authentication, certs
 from determined.constants import DTRAIN_SSH_PORT
 
@@ -129,8 +129,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
         # Mark sshd containers as daemon resources that the master should kill when all non-daemon
         # containers (horovodrun, in this case) have exited.
         cert = certs.default_load(info.master_url)
-        utp = authentication.login_with_cache(info.master_url, cert=cert)
-        sess = api.Session(info.master_url, utp, cert)
+        sess = authentication.login_with_cache(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/resources/{resources_id}/daemon")
 
         pid_server_cmd, run_sshd_command = create_sshd_worker_cmd(

--- a/harness/tests/checkpoints/test_checkpoint.py
+++ b/harness/tests/checkpoints/test_checkpoint.py
@@ -6,7 +6,6 @@ import responses
 from responses import matchers
 
 from determined.common import api
-from determined.common.api import authentication
 from determined.experimental import client
 
 
@@ -79,9 +78,8 @@ def test_checkpoint_download_via_master(tmp_path: Path) -> None:
     )
 
     checkpoint_path = tmp_path / uuid_tgz
-    utp = authentication.UsernameTokenPair("username", "token")
     client.Checkpoint._download_via_master(
-        api.Session("https://dummy-master.none:443", utp, cert=None),
+        api.Session("https://dummy-master.none:443", "username", "token", cert=None),
         uuid_tgz,
         checkpoint_path,
     )

--- a/harness/tests/cli/test_experiment.py
+++ b/harness/tests/cli/test_experiment.py
@@ -6,7 +6,8 @@ import requests_mock as mock
 
 import determined
 import determined.cli
-from determined.common.api import authentication, bindings
+from determined.common import api
+from determined.common.api import bindings
 from tests.fixtures import api_responses
 
 
@@ -24,9 +25,10 @@ def test_wait_returns_error_code_when_experiment_errors(
     login_with_cache_mock: unittest.mock.MagicMock,
     requests_mock: mock.Mocker,
 ) -> None:
-    login_with_cache_mock.return_value = authentication.UsernameTokenPair("username", "token")
+    master = "http://localhost:8888"
+    login_with_cache_mock.return_value = api.Session(master, "test", "test", None)
     exp = api_responses.sample_get_experiment(id=1, state=bindings.experimentv1State.COMPLETED)
-    args = CliArgs(master="http://localhost:8888", experiment_id=1)
+    args = CliArgs(master=master, experiment_id=1)
     exp.experiment.state = bindings.experimentv1State.ERROR
     requests_mock.get(
         f"/api/v1/experiments/{args.experiment_id}",

--- a/harness/tests/determined/common/experimental/test_checkpoint.py
+++ b/harness/tests/determined/common/experimental/test_checkpoint.py
@@ -7,7 +7,6 @@ import pytest
 import responses
 
 from determined.common import api, storage
-from determined.common.api import authentication
 from determined.common.experimental import checkpoint
 from tests.fixtures import api_responses
 
@@ -18,8 +17,7 @@ StorageConfig = Dict[str, Optional[Union[str, int]]]
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_determined.py
+++ b/harness/tests/determined/common/experimental/test_determined.py
@@ -5,7 +5,8 @@ from unittest import mock
 import pytest
 import responses
 
-from determined.common.api import authentication, errors
+from determined.common import api
+from determined.common.api import errors
 from determined.experimental import client as _client
 from tests.fixtures import api_responses
 
@@ -14,7 +15,7 @@ _MASTER = "http://localhost:8080"
 
 def make_client() -> _client.Determined:
     with mock.patch("determined.common.api.authentication.login_with_cache") as mock_login:
-        mock_login.return_value = authentication.UsernameTokenPair("username", "token")
+        mock_login.return_value = api.Session(_MASTER, "username", "token", None)
         return _client.Determined(_MASTER)
 
 

--- a/harness/tests/determined/common/experimental/test_experiment.py
+++ b/harness/tests/determined/common/experimental/test_experiment.py
@@ -9,7 +9,7 @@ import requests
 import responses
 
 from determined.common import api
-from determined.common.api import authentication, bindings
+from determined.common.api import bindings
 from determined.common.experimental import checkpoint, determined, experiment
 from tests.fixtures import api_responses
 
@@ -18,8 +18,7 @@ _MASTER = "http://localhost:8080"
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_model.py
+++ b/harness/tests/determined/common/experimental/test_model.py
@@ -4,7 +4,6 @@ import pytest
 import responses
 
 from determined.common import api
-from determined.common.api import authentication
 from determined.common.experimental import model
 from tests.fixtures import api_responses
 
@@ -13,8 +12,7 @@ _MASTER = "http://localhost:8080"
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_project.py
+++ b/harness/tests/determined/common/experimental/test_project.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 
 from determined.common import api
-from determined.common.api import authentication, bindings
+from determined.common.api import bindings
 from determined.common.experimental import project
 from tests.fixtures import api_responses
 
@@ -13,8 +13,7 @@ _MASTER = "http://localhost:8080"
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_resource_pool.py
+++ b/harness/tests/determined/common/experimental/test_resource_pool.py
@@ -1,16 +1,9 @@
 import pytest
 
-from determined.common import api
-from determined.common.api import authentication, bindings
+from determined.common.api import bindings
 from tests.fixtures import api_responses
 
 _MASTER = "http://localhost:8080"
-
-
-@pytest.fixture
-def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_trial.py
+++ b/harness/tests/determined/common/experimental/test_trial.py
@@ -6,7 +6,6 @@ import pytest
 import responses
 
 from determined.common import api
-from determined.common.api import authentication
 from determined.common.experimental import checkpoint, determined, trial
 from tests.fixtures import api_responses
 
@@ -15,8 +14,7 @@ _MASTER = "http://localhost:8080"
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/determined/common/experimental/test_workspace.py
+++ b/harness/tests/determined/common/experimental/test_workspace.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 
 from determined.common import api
-from determined.common.api import authentication, bindings, errors
+from determined.common.api import bindings, errors
 from determined.common.experimental import workspace
 from tests.fixtures import api_responses
 
@@ -11,8 +11,7 @@ _MASTER = "http://localhost:8080"
 
 @pytest.fixture
 def standard_session() -> api.Session:
-    utp = authentication.UsernameTokenPair("username", "token")
-    return api.Session(_MASTER, utp, cert=None)
+    return api.Session(_MASTER, "username", "token", cert=None)
 
 
 @pytest.fixture

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -6,8 +6,8 @@ from unittest import mock
 import pytest
 from deepspeed.launcher.runner import DEEPSPEED_ENVIRONMENT_NAME
 
-import determined.launch.deepspeed as launch_deepspeed
-from determined import constants
+import determined.launch.deepspeed  # noqa: F401
+from determined import constants, launch
 from tests.launch import test_util
 
 
@@ -33,7 +33,7 @@ def test_parse_args() -> None:
     }
 
     test_util.parse_args_check(
-        positive_test_cases, negative_test_cases, launch_deepspeed.parse_args
+        positive_test_cases, negative_test_cases, launch.deepspeed.parse_args
     )
 
 
@@ -52,18 +52,18 @@ def test_launch_multi_slot_chief(
     mock_start_time = time.time()
     mock_time.return_value = mock_start_time
     script = ["s1", "s2"]
-    sshd_cmd = launch_deepspeed.create_sshd_cmd()
-    pid_server_cmd = launch_deepspeed.create_pid_server_cmd(
+    sshd_cmd = launch.deepspeed.create_sshd_cmd()
+    pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch_deepspeed.create_run_command(
+    deepspeed_cmd = launch.deepspeed.create_run_command(
         cluster_info.container_addrs[0],
-        launch_deepspeed.get_hostfile_path(
+        launch.deepspeed.get_hostfile_path(
             multi_machine=True, allocation_id=cluster_info.allocation_id
         ),
     )
-    pid_client_cmd = launch_deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
-    log_redirect_cmd = launch_deepspeed.create_log_redirect_cmd()
+    pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
+    log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
 
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
@@ -80,7 +80,7 @@ def test_launch_multi_slot_chief(
     mock_subprocess.side_effect = mock_process
 
     with test_util.set_resources_id_env_var():
-        launch_deepspeed.main(script)
+        launch.deepspeed.main(script)
 
     mock_cluster_info.assert_called_once()
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
@@ -105,7 +105,7 @@ def test_launch_multi_slot_chief(
     sshd_proc_mock().kill.assert_called_once()
     sshd_proc_mock().wait.assert_called_once()
 
-    # Cleanup deepspeed environment file created in launch_deepspeed.main
+    # Cleanup deepspeed environment file created in launch.deepspeed.main
     deepspeed_env_path = os.path.join(os.getcwd(), DEEPSPEED_ENVIRONMENT_NAME)
     if os.path.isfile(deepspeed_env_path):
         os.remove(deepspeed_env_path)
@@ -128,18 +128,18 @@ def test_launch_multi_slot_fail(
     mock_check_sshd.side_effect = ValueError("no sshd greeting")
 
     script = ["s1", "s2"]
-    sshd_cmd = launch_deepspeed.create_sshd_cmd()
-    pid_server_cmd = launch_deepspeed.create_pid_server_cmd(
+    sshd_cmd = launch.deepspeed.create_sshd_cmd()
+    pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch_deepspeed.create_run_command(
+    deepspeed_cmd = launch.deepspeed.create_run_command(
         cluster_info.container_addrs[0],
-        launch_deepspeed.get_hostfile_path(
+        launch.deepspeed.get_hostfile_path(
             multi_machine=True, allocation_id=cluster_info.allocation_id
         ),
     )
-    pid_client_cmd = launch_deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
-    log_redirect_cmd = launch_deepspeed.create_log_redirect_cmd()
+    pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
+    log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
 
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
@@ -157,7 +157,7 @@ def test_launch_multi_slot_fail(
 
     with test_util.set_resources_id_env_var():
         with pytest.raises(ValueError, match="no sshd greeting"):
-            launch_deepspeed.main(script)
+            launch.deepspeed.main(script)
 
     mock_cluster_info.assert_called_once()
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
@@ -176,7 +176,7 @@ def test_launch_multi_slot_fail(
     sshd_proc_mock().kill.assert_called_once()
     sshd_proc_mock().wait.assert_called_once()
 
-    # Cleanup deepspeed environment file created in launch_deepspeed.main
+    # Cleanup deepspeed environment file created in launch.deepspeed.main
     deepspeed_env_path = os.path.join(os.getcwd(), DEEPSPEED_ENVIRONMENT_NAME)
     if os.path.isfile(deepspeed_env_path):
         os.remove(deepspeed_env_path)
@@ -190,21 +190,21 @@ def test_launch_one_slot(
     cluster_info = test_util.make_mock_cluster_info(["0.0.0.0"], 0, 4)
     mock_cluster_info.return_value = cluster_info
     script = ["s1", "s2"]
-    pid_server_cmd = launch_deepspeed.create_pid_server_cmd(
+    pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch_deepspeed.create_run_command(
+    deepspeed_cmd = launch.deepspeed.create_run_command(
         "localhost",
-        launch_deepspeed.get_hostfile_path(
+        launch.deepspeed.get_hostfile_path(
             multi_machine=False, allocation_id=cluster_info.allocation_id
         ),
     )
-    pid_client_cmd = launch_deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
-    log_redirect_cmd = launch_deepspeed.create_log_redirect_cmd()
+    pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
+    log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
     with test_util.set_resources_id_env_var():
-        launch_deepspeed.main(script)
+        launch.deepspeed.main(script)
 
     mock_cluster_info.assert_called_once()
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
@@ -220,21 +220,21 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
     mock_cluster_info.return_value = cluster_info
     mock_subprocess.return_value.wait.return_value = 1
     script = ["s1", "s2"]
-    pid_server_cmd = launch_deepspeed.create_pid_server_cmd(
+    pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    deepspeed_cmd = launch_deepspeed.create_run_command(
+    deepspeed_cmd = launch.deepspeed.create_run_command(
         "localhost",
-        launch_deepspeed.get_hostfile_path(
+        launch.deepspeed.get_hostfile_path(
             multi_machine=False, allocation_id=cluster_info.allocation_id
         ),
     )
-    pid_client_cmd = launch_deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
-    log_redirect_cmd = launch_deepspeed.create_log_redirect_cmd()
+    pid_client_cmd = launch.deepspeed.create_pid_client_cmd(cluster_info.allocation_id)
+    log_redirect_cmd = launch.deepspeed.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
     with test_util.set_resources_id_env_var():
-        assert launch_deepspeed.main(script) == 1
+        assert launch.deepspeed.main(script) == 1
 
     mock_cluster_info.assert_called_once()
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
@@ -256,7 +256,7 @@ def test_launch_worker(
     mock_session = mock.MagicMock()
     mock_login.return_value = mock_session
     with test_util.set_resources_id_env_var():
-        launch_deepspeed.main(["script"])
+        launch.deepspeed.main(["script"])
 
     mock_cluster_info.assert_called_once()
     assert os.environ["DET_CHIEF_IP"] == cluster_info.container_addrs[0]
@@ -264,10 +264,10 @@ def test_launch_worker(
     mock_login.assert_called_once()
     mock_session.post.assert_called_once()
 
-    pid_server_cmd = launch_deepspeed.create_pid_server_cmd(
+    pid_server_cmd = launch.deepspeed.create_pid_server_cmd(
         cluster_info.allocation_id, len(cluster_info.slot_ids)
     )
-    sshd_cmd = launch_deepspeed.create_sshd_cmd()
+    sshd_cmd = launch.deepspeed.create_sshd_cmd()
 
     expected_cmd = pid_server_cmd + sshd_cmd
     mock_subprocess.assert_called_once_with(expected_cmd)
@@ -288,6 +288,6 @@ def test_filter_env_vars() -> None:
         "DET_SESSION_TOKEN": "keep",
         "RANDOM_USER_VAR": "keep",
     }
-    env_out = launch_deepspeed.filter_env_vars(env_in)
+    env_out = launch.deepspeed.filter_env_vars(env_in)
     env_exp = {k: v for k, v in env_in.items() if v == "keep"}
     assert env_out == env_exp

--- a/harness/tests/launch/test_horovod.py
+++ b/harness/tests/launch/test_horovod.py
@@ -117,15 +117,15 @@ def test_horovod_chief(
 @mock.patch("subprocess.Popen")
 @mock.patch("determined.get_cluster_info")
 @mock.patch("determined.common.api.authentication.login_with_cache")
-@mock.patch("determined.common.api._session.Session.post")
 def test_sshd_worker(
-    mock_post: mock.MagicMock,
     mock_login: mock.MagicMock,
     mock_cluster_info: mock.MagicMock,
     mock_popen: mock.MagicMock,
 ) -> None:
     info = test_util.make_mock_cluster_info(["0.0.0.0", "0.0.0.1"], 1, num_slots=1)
     mock_cluster_info.return_value = info
+    mock_session = mock.MagicMock()
+    mock_login.return_value = mock_session
     hvd_args = ["ds1", "ds2"]
     script = ["s1", "s2"]
 
@@ -153,7 +153,7 @@ def test_sshd_worker(
     mock_popen.assert_has_calls([mock.call(launch_cmd)])
 
     mock_login.assert_called_once()
-    mock_post.assert_has_calls(
+    mock_session.post.assert_has_calls(
         [mock.call(f"/api/v1/allocations/{info.allocation_id}/resources/resourcesId/daemon")]
     )
 

--- a/master/static/srv/check_idle.py
+++ b/master/static/srv/check_idle.py
@@ -75,8 +75,7 @@ def main():
     notebook_server = f"https://127.0.0.1:{port}/proxy/{notebook_id}"
     master_url = api.canonicalize_master_url(os.environ["DET_MASTER"])
     cert = certs.default_load(master_url)
-    utp = authentication.login_with_cache(info.master_url, cert=cert)
-    sess = api.Session(master_url, utp, cert)
+    sess = authentication.login_with_cache(master_url, cert=cert)
     try:
         idle_type = IdleType[os.environ["NOTEBOOK_IDLE_TYPE"].upper()]
     except KeyError:
@@ -92,7 +91,7 @@ def main():
             idle = is_idle(notebook_server, idle_type)
             sess.put(
                 f"/api/v1/notebooks/{notebook_id}/report_idle",
-                {"notebook_id": notebook_id, "idle": idle},
+                params={"notebook_id": notebook_id, "idle": idle},
             )
         except Exception:
             logging.warning("ignoring error communicating with master", exc_info=True)

--- a/master/static/srv/check_ready_logs.py
+++ b/master/static/srv/check_ready_logs.py
@@ -2,6 +2,7 @@
 check_ready_logs.py accepts a task's logs as STDIN, runs a regex to determine and report readiness.
 Callers should be aware it may terminate early, and stop reading from STDIN.
 """
+
 import argparse
 import os
 import re
@@ -36,8 +37,7 @@ def main(ready: Pattern, waiting: Optional[Pattern] = None):
     cert = certs.default_load(master_url)
     # This only runs on-cluster, so it is expected the username and session token are present in the
     # environment.
-    utp = authentication.login_with_cache(master_url, cert=cert)
-    sess = api.Session(master_url, utp, cert)
+    sess = authentication.login_with_cache(master_url, cert=cert)
     allocation_id = str(os.environ["DET_ALLOCATION_ID"])
     for line in sys.stdin:
         if ready.match(line):
@@ -46,6 +46,7 @@ def main(ready: Pattern, waiting: Optional[Pattern] = None):
         if waiting and waiting.match(line):
             post_ready(sess, allocation_id, "waiting")
             return
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Read STDIN for a match and mark a task as ready")


### PR DESCRIPTION
Logins used to return an intermediate `UsernameTokenPair` that itself was used to create Sessions. We did it this way because the job of `login` is to find/create a valid token. But because `login` itself is a user-facing command, and tokens are an implementation detail most people don't care about, this patch updates the login API to just return a Session (the thing most users cared about in the first place).

If a user really wants to get a token, they can always access the token in the Session.

Additionally as a part of this patch, the `UsernameTokenPair` class has been removed -- it was kind of an in-between abstraction to make it easier for callers of login to create sessions.

This change also contains new `BaseSession.with_retry` to modify retries (by creating new sessions). We needed some mechanism for users to set retry to something other than the default, and passing retry into login would have been a weird interface (what does the retry of the eventual session have to do with logging in?).

[MD-283]

## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MD-283]: https://hpe-aiatscale.atlassian.net/browse/MD-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ