### PR TITLE
chore: delete unused functions [RM-41]

### DIFF
--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -18,8 +18,6 @@ type DB interface {
 	Migrate(migrationURL string, actions []string) error
 	Close() error
 	GetOrCreateClusterID(telemetryID string) (string, error)
-	CheckExperimentExists(id int) (bool, error)
-	CheckTrialExists(id int) (bool, error)
 	TrialExperimentAndRequestID(id int) (int, model.RequestID, error)
 	AddExperiment(experiment *model.Experiment, modelDef []byte, activeConfig expconf.ExperimentConfig) error
 	ExperimentIDByTrialID(trialID int) (int, error)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -395,32 +395,6 @@ LIMIT 1`, metricOrdering), exp.Config.Searcher.Metric, id).Scan(ctx, &metric); e
 	return metric, nil
 }
 
-// CheckExperimentExists checks if the experiment exists.
-func (db *PgDB) CheckExperimentExists(id int) (bool, error) {
-	var exists bool
-	err := db.sql.QueryRow(`
-SELECT
-EXISTS(
-  select id
-  FROM experiments
-  WHERE id = $1
-)`, id).Scan(&exists)
-	return exists, err
-}
-
-// CheckTrialExists checks if the trial exists.
-func (db *PgDB) CheckTrialExists(id int) (bool, error) {
-	var exists bool
-	err := db.sql.QueryRow(`
-SELECT
-EXISTS(
-  select id
-  FROM trials
-  WHERE id = $1
-)`, id).Scan(&exists)
-	return exists, err
-}
-
 // TrialExperimentAndRequestID returns the trial's experiment and request ID.
 func (db *PgDB) TrialExperimentAndRequestID(id int) (int, model.RequestID, error) {
 	var eID int


### PR DESCRIPTION
## Description
chore: delete unused functions [RM-41]

`CheckExperimentExists` and `CheckTrialExists` are not used in the codebase. Rather than bunifying them, we can delete them; they can be added back in if we ever need them

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[RM-41]

<!---
## Title
chore: delete unused functions [RM-41]
-->


[RM-41]: https://hpe-aiatscale.atlassian.net/browse/RM-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-41]: https://hpe-aiatscale.atlassian.net/browse/RM-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-41]: https://hpe-aiatscale.atlassian.net/browse/RM-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ