### PR TITLE
test: Add e2e test for streaming updates python client

### DIFF
--- a/e2e_tests/tests/streaming/test_client.py
+++ b/e2e_tests/tests/streaming/test_client.py
@@ -4,33 +4,32 @@ import pytest
 
 from determined.common import streams
 from determined.common.api import bindings
-from determined.common.streams import _client
 from tests import api_utils
 
 
 @pytest.mark.e2e_cpu
 def test_client_connection() -> None:
     sess = api_utils.admin_session()
-    ws = _client.LomondStreamWebSocket(sess)
-    stream = _client.Stream(ws)
+    ws = streams._client.LomondStreamWebSocket(sess)
+    stream = streams._client.Stream(ws)
     syncId = "sync1"
-    stream.subscribe(sync_id=syncId, projects=_client.ProjectSpec(workspace_id=1))
+    stream.subscribe(sync_id=syncId, projects=streams._client.ProjectSpec(workspace_id=1))
     event = next(stream)
-    assert event == _client.Sync(syncId, False)
+    assert event == streams._client.Sync(syncId, False)
 
     event = next(stream)
     assert isinstance(event, streams.wire.ProjectMsg)
     assert event.id == 1
     assert event.immutable is True
     event = next(stream)
-    assert event == _client.Sync(syncId, True)
+    assert event == streams._client.Sync(syncId, True)
 
 
 @pytest.mark.e2e_cpu
 def test_client_subscribe() -> None:
     sess = api_utils.admin_session()
-    ws = _client.LomondStreamWebSocket(sess)
-    stream = _client.Stream(ws)
+    ws = streams._client.LomondStreamWebSocket(sess)
+    stream = streams._client.Stream(ws)
 
     syncId = "sync1"
     projectName = "streaming_project"
@@ -50,16 +49,16 @@ def test_client_subscribe() -> None:
     )
     p = resp_p.project
 
-    stream.subscribe(sync_id=syncId, projects=_client.ProjectSpec(workspace_id=w.id))
+    stream.subscribe(sync_id=syncId, projects=streams._client.ProjectSpec(workspace_id=w.id))
     event = next(stream)
-    assert event == _client.Sync(syncId, False)
+    assert event == streams._client.Sync(syncId, False)
     event = next(stream)
     assert isinstance(event, streams.wire.ProjectMsg)
     assert event.id == p.id
     assert event.name == projectName
     seq = event.seq
     event = next(stream)
-    assert event == _client.Sync(syncId, True)
+    assert event == streams._client.Sync(syncId, True)
 
     bindings.patch_PatchProject(sess, body=bindings.v1PatchProject(name=newProjectName), id=p.id)
     event = next(stream)

--- a/e2e_tests/tests/streaming/test_client.py
+++ b/e2e_tests/tests/streaming/test_client.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from determined.common import streams
@@ -17,6 +19,7 @@ def test_client_connection() -> None:
     assert event == _client.Sync(syncId, False)
 
     event = next(stream)
+    assert isinstance(event, streams.wire.ProjectMsg)
     assert event.id == 1
     assert event.immutable is True
     event = next(stream)
@@ -34,7 +37,7 @@ def test_client_subscribe() -> None:
     newProjectName = "streaming_project_1"
 
     resp_w = bindings.post_PostWorkspace(
-        sess, body=bindings.v1PostWorkspaceRequest(name="streaming_workspace")
+        sess, body=bindings.v1PostWorkspaceRequest(name=f"streaming_workspace_{random.random()}")
     )
     w = resp_w.workspace
     resp_p = bindings.post_PostProject(
@@ -51,6 +54,7 @@ def test_client_subscribe() -> None:
     event = next(stream)
     assert event == _client.Sync(syncId, False)
     event = next(stream)
+    assert isinstance(event, streams.wire.ProjectMsg)
     assert event.id == p.id
     assert event.name == projectName
     seq = event.seq
@@ -59,6 +63,7 @@ def test_client_subscribe() -> None:
 
     bindings.patch_PatchProject(sess, body=bindings.v1PatchProject(name=newProjectName), id=p.id)
     event = next(stream)
+    assert isinstance(event, streams.wire.ProjectMsg)
     assert event.id == p.id
     assert event.name == newProjectName
     assert event.seq > seq

--- a/e2e_tests/tests/streaming/test_client.py
+++ b/e2e_tests/tests/streaming/test_client.py
@@ -1,0 +1,74 @@
+import pytest
+
+from determined.common import streams
+from determined.common.api import bindings
+from determined.common.streams import _client
+from tests import api_utils
+
+
+@pytest.mark.e2e_cpu
+def test_client_connection() -> None:
+    sess = api_utils.admin_session()
+    ws = _client.LomondStreamWebSocket(sess)
+    stream = _client.Stream(ws)
+    syncId = "sync1"
+    stream.subscribe(sync_id=syncId, projects=_client.ProjectSpec(workspace_id=1))
+    event = next(stream)
+    assert event == _client.Sync(syncId, False)
+
+    event = next(stream)
+    assert event.id == 1
+    assert event.immutable == True
+    event = next(stream)
+    assert event == _client.Sync(syncId, True)
+
+
+@pytest.mark.e2e_cpu
+def test_client_connection() -> None:
+    sess = api_utils.admin_session()
+    ws = _client.LomondStreamWebSocket(sess)
+    stream = _client.Stream(ws)
+
+    syncId = "sync1"
+    projectName = "streaming_project"
+    newProjectName = "streaming_project_1"
+
+    resp_w = bindings.post_PostWorkspace(
+        sess, body=bindings.v1PostWorkspaceRequest(name="streaming_workspace")
+    )
+    w = resp_w.workspace
+    resp_p = bindings.post_PostProject(
+        sess,
+        body=bindings.v1PostProjectRequest(
+            name=projectName,
+            workspaceId=w.id,
+        ),
+        workspaceId=w.id,
+    )
+    p = resp_p.project
+
+    stream.subscribe(sync_id=syncId, projects=_client.ProjectSpec(workspace_id=w.id))
+    event = next(stream)
+    assert event == _client.Sync(syncId, False)
+    event = next(stream)
+    assert event.id == p.id
+    assert event.name == projectName
+    seq = event.seq
+    event = next(stream)
+    assert event == _client.Sync(syncId, True)
+
+    bindings.patch_PatchProject(sess, body=bindings.v1PatchProject(name=newProjectName), id=p.id)
+    event = next(stream)
+    assert event.id == p.id
+    assert event.name == newProjectName
+    assert event.seq > seq
+
+    bindings.delete_DeleteProject(sess, id=p.id)
+    for event in stream:
+        if isinstance(event, streams.wire.ProjectMsg):
+            assert event.state == "DELETING"
+        elif isinstance(event, streams.wire.ProjectsDeleted):
+            assert event == streams.wire.ProjectsDeleted(str(p.id))
+            break
+        else:
+            raise ValueError(f"Unexpected message from stream. {event}")

--- a/e2e_tests/tests/streaming/test_client.py
+++ b/e2e_tests/tests/streaming/test_client.py
@@ -18,13 +18,13 @@ def test_client_connection() -> None:
 
     event = next(stream)
     assert event.id == 1
-    assert event.immutable == True
+    assert event.immutable is True
     event = next(stream)
     assert event == _client.Sync(syncId, True)
 
 
 @pytest.mark.e2e_cpu
-def test_client_connection() -> None:
+def test_client_subscribe() -> None:
     sess = api_utils.admin_session()
     ws = _client.LomondStreamWebSocket(sess)
     stream = _client.Stream(ws)


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
Add e2e test for streaming updates python client


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->
e2e tests pass


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->
[MD-282](https://hpe-aiatscale.atlassian.net/browse/MD-282)

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[MD-282]: https://hpe-aiatscale.atlassian.net/browse/MD-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ