### PR TITLE
test: fix failing det deploy local tests by incorrect cache

### DIFF
--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -192,7 +192,6 @@ def skipif_not_k8s(reason: str = "test is k8s-specific") -> Callable[[F], F]:
 # Queries the determined master for resource pool information to determine if agent is used
 # Currently we are assuming that all resource pools are of the same scheduler type
 # which is why only the first resource pool's type is checked.
-@functools.lru_cache(maxsize=1)
 def _get_scheduler_type() -> Optional[bindings.v1SchedulerType]:
     scheduler_type: Optional[bindings.v1SchedulerType]
     try:

--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -25,12 +25,10 @@ def make_session(username: str, password: str) -> api.Session:
     return api.Session(master_url, utp, cert(), max_retries=0)
 
 
-@functools.lru_cache(maxsize=1)
 def user_session() -> api.Session:
     return make_session("determined", conf.USER_PASSWORD)
 
 
-@functools.lru_cache(maxsize=1)
 def admin_session() -> api.Session:
     return make_session("admin", conf.USER_PASSWORD)
 


### PR DESCRIPTION
## Description

Fix failing det deploy local tests.

```_get_scheduler_type``` was caching None from

```
tests/cluster/test_slurm.py:55: in <module>
    def test_unsupported_option() -> None:
tests/api_utils.py:212: in decorator
    st = _get_scheduler_type()
tests/api_utils.py:197: in _get_scheduler_type
```

The scheduler returned None since no cluster was deployed.

## Test Plan

```test_det_deploy_local``` passes

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
