### PR TITLE
test:  upload test results to datadog

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -613,12 +613,6 @@ commands:
             --junit-xml="<<parameters.junit-path>>" \
             <<parameters.extra-pytest-flags>> \
             $(< /tmp/tests-to-run)
-      - run:
-          name: Upload results to DataDog
-          command: |
-            curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" \
-              --output "./datadog-ci" && chmod +x "./datadog-ci"
-            ls -lf # DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true     
       - upload-test-job:
           only_on_branch: main
           test_results_path: <<parameters.junit-path>>
@@ -2074,7 +2068,6 @@ jobs:
       # Ensure Determined cli can run without installing cli test requirements
       - run: det --help
       - run: pip install setuptools_scm
-      - run: pip install -U ddtrace
       - run: pip install -r harness/tests/requirements/requirements-cli.txt
       - run: pip freeze --all
       - run: sh -c "pip check || true"

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -600,10 +600,13 @@ commands:
           working_directory: ~/project/e2e_tests
           no_output_timeout: 30m
           command: |
+            pip install -U ddtrace
+            DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com DD_ENV=ci DD_SERVICE='test-e2e-<<parameters.mark>>' \
             DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
             pytest -vv -s \
             -m '<<parameters.mark>>' \
             --durations=0 \
+            --ddtrace
             --master-scheme="<<parameters.master-scheme>>" \
             --master-host="<<parameters.master-host>>" \
             --master-port="<<parameters.master-port>>" \
@@ -616,7 +619,7 @@ commands:
           command: |
             curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" \
               --output "./datadog-ci" && chmod +x "./datadog-ci"
-            DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true
+            ls -lf # DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true     
       - upload-test-job:
           only_on_branch: main
           test_results_path: <<parameters.junit-path>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -611,6 +611,12 @@ commands:
             --junit-xml="<<parameters.junit-path>>" \
             <<parameters.extra-pytest-flags>> \
             $(< /tmp/tests-to-run)
+      - upload-dd-results:
+        name: Upload results to DataDog
+        command: |
+          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" \
+            --output "./datadog-ci" && chmod +x "./datadog-ci"
+          DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true
       - upload-test-job:
           only_on_branch: main
           test_results_path: <<parameters.junit-path>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -606,7 +606,7 @@ commands:
             pytest -vv -s \
             -m '<<parameters.mark>>' \
             --durations=0 \
-            --ddtrace
+            --ddtrace \
             --master-scheme="<<parameters.master-scheme>>" \
             --master-host="<<parameters.master-host>>" \
             --master-port="<<parameters.master-port>>" \

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -611,12 +611,12 @@ commands:
             --junit-xml="<<parameters.junit-path>>" \
             <<parameters.extra-pytest-flags>> \
             $(< /tmp/tests-to-run)
-      - upload-dd-results:
-        name: Upload results to DataDog
-        command: |
-          curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" \
-            --output "./datadog-ci" && chmod +x "./datadog-ci"
-          DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true
+      - run:
+          name: Upload results to DataDog
+          command: |
+            curl -L --fail "https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64" \
+              --output "./datadog-ci" && chmod +x "./datadog-ci"
+            DD_ENV=ci datadog-ci junit upload --service pachyderm /tmp/test-results/e2e/ || true
       - upload-test-job:
           only_on_branch: main
           test_results_path: <<parameters.junit-path>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -600,8 +600,6 @@ commands:
           working_directory: ~/project/e2e_tests
           no_output_timeout: 30m
           command: |
-            pip install -U ddtrace
-
             DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com' DD_ENV=ci DD_SERVICE='pytest-<<parameters.mark>>' \
             DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
             pytest -vv -s \
@@ -2076,6 +2074,7 @@ jobs:
       # Ensure Determined cli can run without installing cli test requirements
       - run: det --help
       - run: pip install setuptools_scm
+      - run: pip install -U ddtrace
       - run: pip install -r harness/tests/requirements/requirements-cli.txt
       - run: pip freeze --all
       - run: sh -c "pip check || true"

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -601,7 +601,8 @@ commands:
           no_output_timeout: 30m
           command: |
             pip install -U ddtrace
-            DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com DD_ENV=ci DD_SERVICE='test-e2e-<<parameters.mark>>' \
+
+            DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com' DD_ENV=ci DD_SERVICE='pytest-<<parameters.mark>>' \
             DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
             pytest -vv -s \
             -m '<<parameters.mark>>' \

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -20,3 +20,5 @@ ray[default,tune]
 pyarrow
 # Pydantic V2 has changes that break existing ray tests
 pydantic<2
+# DataDog tracing and result upload utility
+ddtrace


### PR DESCRIPTION
## Description

INFRAENG-363 is exploring test metrics for Determined-AI. We have a running trial for data dog right now. 


## Test Plan

Test results flow to DataDog for this branch - Pass


## Commentary (optional)

Followed setup instruction but set ddtrace in the requirements rather than doing an ad-hoc pip install. 
https://app.datadoghq.com/ci/setup/test?framework=pytest&language=python



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

INFRAENG-363



