### PR TITLE
chore: cover and bunify project functions in postgres_experiments.go

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1631,7 +1631,6 @@ func (a *apiServer) CreateExperiment(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get the user: %s", err)
 	}
-
 	if req.ParentId != 0 {
 		// Can't use getExperimentAndCheckDoActions since model.Experiment doesn't have ParentArchived.
 		var parentExp *experimentv1.Experiment

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1319,11 +1319,6 @@ func TestAuthZCreateExperiment(t *testing.T) {
 	})
 
 	t.Run("can't view project; project does not exist", func(t *testing.T) {
-		fmt.Println("*****")
-		fmt.Println()
-		fmt.Println("beginning failng test")
-		fmt.Println()
-		fmt.Println("*****")
 		var workspaceName string
 		err := db.Bun().NewSelect().
 			Table("workspaces").

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1262,81 +1262,109 @@ func TestAuthZGetExperimentLabels(t *testing.T) {
 func TestAuthZCreateExperiment(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
 	forkFrom := createTestExp(t, api, curUser)
-	_, projectID := createProjectAndWorkspace(ctx, t, api)
+	workspaceID, projectID := createProjectAndWorkspace(ctx, t, api)
 
 	// user is logged in again during experiment creation, meaning args don't match
 	mockUserArg := mock.MatchedBy(func(u model.User) bool {
 		return u.ID == curUser.ID
 	})
 
-	// Can't view forked experiment.
-	authZExp.On("CanGetExperiment", mock.Anything, mockUserArg,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
-	_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		ParentId: int32(forkFrom.ID),
+	t.Run("can't view forked experiment", func(t *testing.T) {
+		authZExp.On("CanGetExperiment", mock.Anything, mockUserArg,
+			mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			ParentId: int32(forkFrom.ID),
+		})
+		require.Equal(t, apiPkg.NotFoundErrs("experiment",
+			fmt.Sprint(forkFrom.ID), true), err)
 	})
-	require.Equal(t, apiPkg.NotFoundErrs("experiment",
-		fmt.Sprint(forkFrom.ID), true), err)
 
-	// Can't fork from experiment.
-	expectedErr := status.Errorf(codes.PermissionDenied, "canForkExperimentError")
-	authZExp.On("CanGetExperiment", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
-	authZExp.On("CanForkFromExperiment", mock.Anything, mockUserArg, mock.Anything).
-		Return(fmt.Errorf("canForkExperimentError")).Once()
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		ParentId: int32(forkFrom.ID),
+	t.Run("can't fork from experiment", func(t *testing.T) {
+		expectedErr := status.Errorf(codes.PermissionDenied, "canForkExperimentError")
+		authZExp.On("CanGetExperiment", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
+		authZExp.On("CanForkFromExperiment", mock.Anything, mockUserArg, mock.Anything).
+			Return(fmt.Errorf("canForkExperimentError")).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			ParentId: int32(forkFrom.ID),
+		})
+		require.Equal(t, expectedErr, err)
 	})
-	require.Equal(t, expectedErr, err)
 
-	// Can't view project passed in.
-	pAuthZ.On("CanGetProject", mock.Anything, mockUserArg,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		ProjectId: int32(projectID),
-		Config:    minExpConfToYaml(t),
+	t.Run("can't view project passed in", func(t *testing.T) {
+		pAuthZ.On("CanGetProject", mock.Anything, mockUserArg,
+			mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			ProjectId: int32(projectID),
+			Config:    minExpConfToYaml(t),
+		})
+		require.Equal(t, apiPkg.NotFoundErrs("project", fmt.Sprint(projectID), true), err)
 	})
-	require.Equal(t, apiPkg.NotFoundErrs("project", fmt.Sprint(projectID), true), err)
 
-	// Can't view project passed in from config.
-	pAuthZ.On("CanGetProject", mock.Anything, mockUserArg,
-		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		Config: minExpConfToYaml(t) + "project: Uncategorized\nworkspace: Uncategorized",
+	t.Run("can't view project passed in from config", func(t *testing.T) {
+		pAuthZ.On("CanGetProject", mock.Anything, mockUserArg,
+			mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			Config: minExpConfToYaml(t) + "project: Uncategorized\nworkspace: Uncategorized",
+		})
+		require.Equal(t,
+			apiPkg.NotFoundErrs("workspace/project", "Uncategorized/Uncategorized", true), err)
 	})
-	require.Equal(t,
-		apiPkg.NotFoundErrs("workspace/project", "Uncategorized/Uncategorized", true), err)
-	// Same as passing in a non existent project.
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		Config: minExpConfToYaml(t) + "project: doesntexist123\nworkspace: doesntexist123",
-	})
-	require.Equal(t,
-		apiPkg.NotFoundErrs("workspace/project", "doesntexist123/doesntexist123", true), err)
 
-	// Can't create experiment deny.
-	expectedErr = status.Errorf(codes.PermissionDenied, "canCreateExperimentError")
-	pAuthZ.On("CanGetProject", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, mockUserArg, mock.Anything).
-		Return(fmt.Errorf("canCreateExperimentError")).Once()
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		ProjectId:       int32(projectID),
-		Config:          minExpConfToYaml(t),
-		ModelDefinition: []*utilv1.File{{Content: []byte{1, 2, 3}}},
+	t.Run("can't view project; workspace does not exist", func(t *testing.T) {
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			Config: minExpConfToYaml(t) + "project: doesntexist123\nworkspace: doesntexist123",
+		})
+		require.Equal(t,
+			apiPkg.NotFoundErrs("workspace/project", "doesntexist123/doesntexist123", true), err)
 	})
-	require.Equal(t, expectedErr, err)
 
-	// Can't activate experiment deny.
-	expectedErr = status.Errorf(codes.PermissionDenied, "canActivateExperimentError")
-	pAuthZ.On("CanGetProject", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
-	authZExp.On("CanCreateExperiment", mock.Anything, mockUserArg, mock.Anything).
-		Return(nil).Once()
-	authZExp.On("CanEditExperiment", mock.Anything, mockUserArg, mock.Anything, mock.Anything).Return(
-		fmt.Errorf("canActivateExperimentError")).Once()
-	_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
-		Activate:        true,
-		Config:          minExpConfToYaml(t),
-		ModelDefinition: []*utilv1.File{{Content: []byte{1, 2, 3}}},
+	t.Run("can't view project; project does not exist", func(t *testing.T) {
+		fmt.Println("*****")
+		fmt.Println()
+		fmt.Println("beginning failng test")
+		fmt.Println()
+		fmt.Println("*****")
+		var workspaceName string
+		err := db.Bun().NewSelect().
+			Table("workspaces").
+			Column("name").
+			Where("id = ?", workspaceID).
+			Scan(ctx, &workspaceName)
+		require.NoError(t, err)
+		_, err = api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			Config: minExpConfToYaml(t) + "project: doesntexist123\nworkspace: " + workspaceName,
+		})
+		require.Equal(t,
+			apiPkg.NotFoundErrs("workspace/project", workspaceName+"/doesntexist123", true), err)
 	})
-	require.Equal(t, expectedErr, err)
+
+	t.Run("can't create experiment deny", func(t *testing.T) {
+		expectedErr := status.Errorf(codes.PermissionDenied, "canCreateExperimentError")
+		pAuthZ.On("CanGetProject", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
+		authZExp.On("CanCreateExperiment", mock.Anything, mockUserArg, mock.Anything).
+			Return(fmt.Errorf("canCreateExperimentError")).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			ProjectId:       int32(projectID),
+			Config:          minExpConfToYaml(t),
+			ModelDefinition: []*utilv1.File{{Content: []byte{1, 2, 3}}},
+		})
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("can't activate experiment deny", func(t *testing.T) {
+		expectedErr := status.Errorf(codes.PermissionDenied, "canActivateExperimentError")
+		pAuthZ.On("CanGetProject", mock.Anything, mockUserArg, mock.Anything).Return(nil).Once()
+		authZExp.On("CanCreateExperiment", mock.Anything, mockUserArg, mock.Anything).
+			Return(nil).Once()
+		authZExp.On("CanEditExperiment", mock.Anything, mockUserArg, mock.Anything, mock.Anything).Return(
+			fmt.Errorf("canActivateExperimentError")).Once()
+		_, err := api.CreateExperiment(ctx, &apiv1.CreateExperimentRequest{
+			Activate:        true,
+			Config:          minExpConfToYaml(t),
+			ModelDefinition: []*utilv1.File{{Content: []byte{1, 2, 3}}},
+		})
+		require.Equal(t, expectedErr, err)
+	})
 }
 
 func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -664,7 +664,7 @@ func (a *apiServer) DeleteProject(
 			req.Id)
 	}
 
-	expList, err := db.ProjectExperiments(ctx, int(req.Id))
+	expList, err := db.ProjectExperiments(context.TODO(), int(req.Id))
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -664,7 +664,7 @@ func (a *apiServer) DeleteProject(
 			req.Id)
 	}
 
-	expList, err := a.m.db.ProjectExperiments(int(req.Id))
+	expList, err := db.ProjectExperiments(ctx, int(req.Id))
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -527,7 +527,7 @@ func (a *apiServer) deleteWorkspace(
 	log.Debugf("deleting workspace %d projects", workspaceID)
 	holder := &workspacev1.Workspace{}
 	for _, pj := range projects {
-		expList, err := db.ProjectExperiments(ctx, int(pj.Id))
+		expList, err := db.ProjectExperiments(context.TODO(), int(pj.Id))
 		if err != nil {
 			log.WithError(err).Errorf("error fetching experiments on project %d while deleting workspace %d",
 				pj.Id, workspaceID)

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -527,7 +527,7 @@ func (a *apiServer) deleteWorkspace(
 	log.Debugf("deleting workspace %d projects", workspaceID)
 	holder := &workspacev1.Workspace{}
 	for _, pj := range projects {
-		expList, err := a.m.db.ProjectExperiments(int(pj.Id))
+		expList, err := db.ProjectExperiments(ctx, int(pj.Id))
 		if err != nil {
 			log.WithError(err).Errorf("error fetching experiments on project %d while deleting workspace %d",
 				pj.Id, workspaceID)

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -77,7 +77,7 @@ func ParseExperimentsQuery(apiCtx echo.Context) (*ExperimentRequestQuery, error)
 	return &queries, nil
 }
 
-func echoGetExperimentAndCheckCanDoActions(ctx context.Context, c echo.Context, m *Master,
+func echoGetExperimentAndCheckCanDoActions(ctx context.Context, c echo.Context,
 	expID int, actions ...func(context.Context, model.User, *model.Experiment) error,
 ) (*model.Experiment, model.User, error) {
 	user := c.(*detContext.DetContext).MustGetUser()
@@ -111,7 +111,7 @@ func (m *Master) getExperimentCheckpointsToGC(c echo.Context) (interface{}, erro
 		return nil, err
 	}
 	exp, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID,
+		c.Request().Context(), c, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
 	)
 	if err != nil {
@@ -155,7 +155,7 @@ func (m *Master) getExperimentModelFile(c echo.Context) error {
 		return err
 	}
 	if _, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID,
+		c.Request().Context(), c, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
 	); err != nil {
 		return err
@@ -183,7 +183,7 @@ func (m *Master) getExperimentModelDefinition(c echo.Context) error {
 		return err
 	}
 	if _, _, err := echoGetExperimentAndCheckCanDoActions(
-		c.Request().Context(), c, m, args.ExperimentID,
+		c.Request().Context(), c, args.ExperimentID,
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts,
 	); err != nil {
 		return err

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -240,7 +240,7 @@ func getCreateExperimentsProject(
 			errProjectNotFound = api.NotFoundErrs("workspace/project",
 				config.Workspace()+"/"+config.Project(), true)
 
-			projectID, err = m.db.ProjectByName(config.Workspace(), config.Project())
+			projectID, err = project.ProjectByName(context.TODO(), config.Workspace(), config.Project())
 			if errors.Is(err, db.ErrNotFound) {
 				return nil, errProjectNotFound
 			} else if err != nil {

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -58,8 +58,6 @@ type DB interface {
 	GetTrialProfilerMetricsBatches(
 		labelsJSON []byte, offset, limit int,
 	) (model.TrialProfilerMetricsBatchBatch, error)
-	ProjectByName(workspaceName string, projectName string) (projectID int, err error)
-	ProjectExperiments(id int) (experiments []*model.Experiment, err error)
 	ExperimentLabelUsage(projectID int32) (labelUsage map[string]int, err error)
 	GetExperimentStatus(experimentID int) (state model.State, progress float64,
 		err error)

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -21,8 +21,6 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 	"github.com/determined-ai/determined/proto/pkg/modelv1"
-	"github.com/determined-ai/determined/proto/pkg/projectv1"
-	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
 
 const (
@@ -32,47 +30,40 @@ const (
 	min  = "min"
 )
 
-// ProjectByName returns a project's ID if it exists in the given workspace.
-func (db *PgDB) ProjectByName(workspaceName string, projectName string) (int, error) {
-	w := workspacev1.Workspace{}
-	err := db.Query("get_workspace_from_name", &w, workspaceName)
-	if err != nil {
-		return 1, err
-	}
-	p := projectv1.Project{}
-	err = db.Query("get_project_from_name", &p, w.Id, projectName)
-	if err != nil {
-		return 1, err
-	}
-	if p.Id < 1 {
-		return 1, ErrNotFound
-	}
-	if p.Archived {
-		return 1, fmt.Errorf("given workspace or project is archived and cannot add new experiments")
-	}
-	return int(p.Id), nil
-}
-
 // ProjectExperiments returns a list of experiments within a project.
-func (db *PgDB) ProjectExperiments(id int) (experiments []*model.Experiment, err error) {
-	rows, err := db.sql.Queryx(`
-SELECT e.id, state, config, start_time, end_time, archived, owner_id, notes,
-		 job_id, u.username as username, project_id, unmanaged
-FROM experiments e
-JOIN users u ON (e.owner_id = u.id)
-WHERE e.project_id = $1`, id)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+func ProjectExperiments(ctx context.Context, id int) (experiments []*model.Experiment, err error) {
+	rows, err := Bun().NewSelect().
+		Model((*model.Experiment)(nil)).
+		Column("e.id").
+		Column("state").
+		Column("config").
+		Column("start_time").
+		Column("end_time").
+		Column("archived").
+		Column("owner_id").
+		Column("notes").
+		Column("job_id").
+		Column("project_id").
+		Column("unmanaged").
+		ColumnExpr("u.username as username").
+		TableExpr("experiments AS e").
+		Join("JOIN users AS u ON (e.owner_id = u.id)").
+		Where("e.project_id = ?", id).
+		Rows(ctx)
 
+	if err != nil {
+		return nil, fmt.Errorf("selecting project experiments: %w", err)
+	}
+
+	defer rows.Close()
 	for rows.Next() {
 		var exp model.Experiment
-		if err = rows.StructScan(&exp); err != nil {
-			return nil, errors.Wrap(err, "unable to read experiment from db")
+		if err := Bun().ScanRow(ctx, rows, exp); err != nil {
+			return nil, fmt.Errorf("reading experiment from db: %w", err)
 		}
 		experiments = append(experiments, &exp)
 	}
+
 	return experiments, nil
 }
 

--- a/master/internal/db/postgres_experiments.go
+++ b/master/internal/db/postgres_experiments.go
@@ -50,7 +50,6 @@ func ProjectExperiments(ctx context.Context, id int) (experiments []*model.Exper
 		Join("JOIN users AS u ON (e.owner_id = u.id)").
 		Where("e.project_id = ?", id).
 		Rows(ctx)
-
 	if err != nil {
 		return nil, fmt.Errorf("selecting project experiments: %w", err)
 	}

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -216,7 +217,7 @@ func TestExperimentByIDs(t *testing.T) {
 	externalID := uuid.New().String()
 	exp := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		ExternalExperimentID: &externalID,
-	})
+	}, DefaultProjectID)
 	trial, task := RequireMockTrial(t, db, exp)
 
 	for _, c := range []struct {
@@ -390,15 +391,16 @@ func TestProjectHyperparameters(t *testing.T) {
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
-	projectID := RequireMockProjectID(t, db)
+	workspaceID, _ := RequireMockWorkspaceID(t, db)
+	projectID, _ := RequireMockProjectID(t, db, workspaceID, false)
 	exp0 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		HParamNames: &[]string{"a", "b", "c"},
 		ProjectID:   &projectID,
-	})
+	}, DefaultProjectID)
 	exp1 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		HParamNames: &[]string{"b", "c", "d"},
 		ProjectID:   &projectID,
-	})
+	}, DefaultProjectID)
 
 	require.ElementsMatch(t, []string{"a", "b", "c", "d"},
 		RequireGetProjectHParams(t, db, projectID))
@@ -491,21 +493,21 @@ func TestGetNonTerminalExperimentCount(t *testing.T) {
 
 	e0 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		State: ptrs.Ptr(model.ActiveState),
-	})
+	}, DefaultProjectID)
 	c, err = GetNonTerminalExperimentCount(ctx, []int32{int32(e0.ID)})
 	require.NoError(t, err)
 	require.Equal(t, 1, c)
 
 	e1 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		State: ptrs.Ptr(model.CompletedState),
-	})
+	}, DefaultProjectID)
 	c, err = GetNonTerminalExperimentCount(ctx, []int32{int32(e1.ID)})
 	require.NoError(t, err)
 	require.Equal(t, 0, c)
 
 	e2 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		State: ptrs.Ptr(model.PausedState),
-	})
+	}, DefaultProjectID)
 	c, err = GetNonTerminalExperimentCount(ctx, []int32{int32(e2.ID)})
 	require.NoError(t, err)
 	require.Equal(t, 1, c)
@@ -898,4 +900,78 @@ func TestDeleteExperiments(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, oldAllocs, newAllocs)
+}
+
+func TestProjectExperiments(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(RootFromDB))
+	db := MustResolveTestPostgres(t)
+	MustMigrateTestPostgres(t, db, MigrationsFromDB)
+
+	// add a workspace, and project
+	workspaceID, _ := RequireMockWorkspaceID(t, db)
+	projectID, _ := RequireMockProjectID(t, db, workspaceID, false)
+
+	t.Run("valid project with zero experiments", func(t *testing.T) {
+		actualExps, err := ProjectExperiments(context.Background(), projectID)
+		require.NoError(t, err)
+		assert.Equal(t, len(actualExps), 0)
+	})
+
+	t.Run("valid project with experiments", func(t *testing.T) {
+		// add 3 experiments
+		user := RequireMockUser(t, db)
+		expectedExps := make([]*model.Experiment, 0)
+		for i := 0; i < 3; i++ {
+			exp := RequireMockExperimentProject(t, db, user, projectID)
+			expectedExps = append(expectedExps, exp)
+		}
+		actualExps, err := ProjectExperiments(context.Background(), projectID)
+		require.NoError(t, err)
+		assert.Equal(t, len(expectedExps), len(actualExps))
+		validateExperimentMatch(t, expectedExps, actualExps)
+	})
+
+	t.Run("invalid project", func(t *testing.T) {
+		actualExps, err := ProjectExperiments(context.Background(), -11)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(actualExps))
+	})
+
+	t.Run("archived project", func(t *testing.T) {
+		// add archvied project to workspace
+		archivedProjectID, _ := RequireMockProjectID(t, db, workspaceID, true)
+		// add 3 experiments
+		user := RequireMockUser(t, db)
+		expectedExps := make([]*model.Experiment, 0)
+		for i := 0; i < 3; i++ {
+			exp := RequireMockExperimentProject(t, db, user, archivedProjectID)
+			expectedExps = append(expectedExps, exp)
+		}
+		actualExps, err := ProjectExperiments(context.Background(), archivedProjectID)
+		require.NoError(t, err)
+		assert.Equal(t, len(expectedExps), len(actualExps))
+		validateExperimentMatch(t, expectedExps, actualExps)
+	})
+}
+
+func validateExperimentMatch(t *testing.T, expected []*model.Experiment, actual []*model.Experiment) {
+	// validate that both sets of experiments are the same using jobID
+	// add all expected jobIDs to a map
+	m := make(map[string]*model.Experiment)
+	for _, exp := range expected {
+		m[string(exp.JobID)] = exp
+	}
+
+	// remove all actual jobIDs from map
+	for _, actual := range actual {
+		expected, ok := m[string(actual.JobID)]
+		require.True(t, ok)
+		require.Equal(t, expected.ProjectID, actual.ProjectID)
+		require.Equal(t, expected.Username, actual.Username)
+		require.Equal(t, expected.OwnerID, actual.OwnerID)
+		delete(m, string(actual.JobID))
+	}
+
+	// map should be empty
+	require.Equal(t, len(m), 0)
 }

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -910,6 +910,7 @@ func TestProjectExperiments(t *testing.T) {
 	// add a workspace, and project
 	workspaceID, _ := RequireMockWorkspaceID(t, db)
 	projectID, _ := RequireMockProjectID(t, db, workspaceID, false)
+	RequireMockUser(t, db)
 
 	t.Run("valid project with zero experiments", func(t *testing.T) {
 		actualExps, err := ProjectExperiments(context.Background(), projectID)

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -219,7 +219,6 @@ func RequireMockWorkspaceID(t *testing.T, db *PgDB) (int, string) {
 
 // RequireMockProjectID returns a mock project ID and name
 func RequireMockProjectID(t *testing.T, db *PgDB, workspaceID int, archived bool) (int, string) {
-
 	mockProject := struct {
 		bun.BaseModel `bun:"table:projects"`
 

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -44,7 +44,8 @@ const (
 	defaultSearcherMetric = "okness"
 	// DefaultTestSrcPath returns src to the mnsit_pytorch model example.
 	DefaultTestSrcPath = "../../../examples/tutorials/mnist_pytorch"
-	DefaultProjectID   = 1
+	// DefaultProjectID is the project used when none is specified.
+	DefaultProjectID = 1
 )
 
 // Model represents a row from the `models` table. Unused except for tests.
@@ -201,7 +202,7 @@ func RequireMockJob(t *testing.T, db *PgDB, userID *model.UserID) model.JobID {
 	return jID
 }
 
-// RequireMockWorkspaceID returns a mock workspace ID and name
+// RequireMockWorkspaceID returns a mock workspace ID and name.
 func RequireMockWorkspaceID(t *testing.T, db *PgDB) (int, string) {
 	mockWorkspace := struct {
 		bun.BaseModel `bun:"table:workspaces"`
@@ -217,7 +218,7 @@ func RequireMockWorkspaceID(t *testing.T, db *PgDB) (int, string) {
 	return mockWorkspace.ID, mockWorkspace.Name
 }
 
-// RequireMockProjectID returns a mock project ID and name
+// RequireMockProjectID returns a mock project ID and name.
 func RequireMockProjectID(t *testing.T, db *PgDB, workspaceID int, archived bool) (int, string) {
 	mockProject := struct {
 		bun.BaseModel `bun:"table:projects"`
@@ -288,7 +289,7 @@ func RequireMockExperiment(t *testing.T, db *PgDB, user model.User) *model.Exper
 	return RequireMockExperimentParams(t, db, user, MockExperimentParams{}, DefaultProjectID)
 }
 
-// RequireMockExperimentProject returns a mock experiment attached to a specific project
+// RequireMockExperimentProject returns a mock experiment attached to a specific project.
 func RequireMockExperimentProject(t *testing.T, db *PgDB, user model.User, projectID int) *model.Experiment {
 	return RequireMockExperimentParams(t, db, user, MockExperimentParams{}, projectID)
 }

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -44,6 +44,7 @@ const (
 	defaultSearcherMetric = "okness"
 	// DefaultTestSrcPath returns src to the mnsit_pytorch model example.
 	DefaultTestSrcPath = "../../../examples/tutorials/mnist_pytorch"
+	DefaultProjectID   = 1
 )
 
 // Model represents a row from the `models` table. Unused except for tests.
@@ -200,8 +201,8 @@ func RequireMockJob(t *testing.T, db *PgDB, userID *model.UserID) model.JobID {
 	return jID
 }
 
-// RequireMockWorkspaceID returns a mock workspace ID.
-func RequireMockWorkspaceID(t *testing.T, db *PgDB) int {
+// RequireMockWorkspaceID returns a mock workspace ID and name
+func RequireMockWorkspaceID(t *testing.T, db *PgDB) (int, string) {
 	mockWorkspace := struct {
 		bun.BaseModel `bun:"table:workspaces"`
 
@@ -213,12 +214,11 @@ func RequireMockWorkspaceID(t *testing.T, db *PgDB) int {
 	_, err := Bun().NewInsert().Model(&mockWorkspace).Returning("id").Exec(context.TODO())
 	require.NoError(t, err)
 
-	return mockWorkspace.ID
+	return mockWorkspace.ID, mockWorkspace.Name
 }
 
-// RequireMockProjectID returns a mock project ID.
-func RequireMockProjectID(t *testing.T, db *PgDB) int {
-	wID := RequireMockWorkspaceID(t, db)
+// RequireMockProjectID returns a mock project ID and name
+func RequireMockProjectID(t *testing.T, db *PgDB, workspaceID int, archived bool) (int, string) {
 
 	mockProject := struct {
 		bun.BaseModel `bun:"table:projects"`
@@ -226,14 +226,18 @@ func RequireMockProjectID(t *testing.T, db *PgDB) int {
 		ID          int `bun:"id,pk,autoincrement"`
 		WorkspaceID int
 		Name        string
+		Archived    bool
+		Description string
 	}{
-		WorkspaceID: wID,
+		WorkspaceID: workspaceID,
 		Name:        uuid.New().String(),
+		Archived:    archived,
+		Description: "description text",
 	}
 	_, err := Bun().NewInsert().Model(&mockProject).Returning("id").Exec(context.TODO())
 	require.NoError(t, err)
 
-	return mockProject.ID
+	return mockProject.ID, mockProject.Name
 }
 
 // RequireGetProjectHParams returns projects hparams.
@@ -282,7 +286,12 @@ func RequireMockUser(t *testing.T, db *PgDB) model.User {
 
 // RequireMockExperiment returns a mock experiment.
 func RequireMockExperiment(t *testing.T, db *PgDB, user model.User) *model.Experiment {
-	return RequireMockExperimentParams(t, db, user, MockExperimentParams{})
+	return RequireMockExperimentParams(t, db, user, MockExperimentParams{}, DefaultProjectID)
+}
+
+// RequireMockExperimentProject returns a mock experiment attached to a specific project
+func RequireMockExperimentProject(t *testing.T, db *PgDB, user model.User, projectID int) *model.Experiment {
+	return RequireMockExperimentParams(t, db, user, MockExperimentParams{}, projectID)
 }
 
 // MockExperimentParams is the parameters for mock experiment.
@@ -300,6 +309,7 @@ func RequireMockExperimentParams(
 	db *PgDB,
 	user model.User,
 	p MockExperimentParams,
+	projectID int,
 ) *model.Experiment {
 	notDefaulted := expconf.ExperimentConfigV0{
 		RawCheckpointStorage: &expconf.CheckpointStorageConfigV0{
@@ -347,7 +357,7 @@ func RequireMockExperimentParams(
 		StartTime:            time.Now().Add(-time.Hour).Truncate(time.Millisecond),
 		OwnerID:              &user.ID,
 		Username:             user.Username,
-		ProjectID:            1,
+		ProjectID:            projectID,
 		ExternalExperimentID: p.ExternalExperimentID,
 	}
 	if p.ProjectID != nil {

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -27,11 +28,11 @@ func ProjectByName(ctx context.Context, workspaceName string, projectName string
 		Where("workspace_id = ?", workspace.ID).
 		Where("name = ?", projectName).
 		Scan(ctx, &pID, &archived)
+	if err == sql.ErrNoRows {
+		return 1, db.ErrNotFound
+	}
 	if err != nil {
 		return 1, err
-	}
-	if pID < 1 {
-		return 1, db.ErrNotFound
 	}
 	if archived {
 		return 1, fmt.Errorf("project is archived and cannot add new experiments")

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -1,0 +1,51 @@
+package project
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/workspace"
+)
+
+// ProjectByName returns a project's ID if it exists in the given workspace and is not archived.
+func ProjectByName(ctx context.Context, workspaceName string, projectName string) (int, error) {
+	workspace, err := workspace.WorkspaceByName(ctx, workspaceName)
+	if err != nil {
+		return 1, err
+	}
+	if workspace.Archived {
+		return 1, fmt.Errorf("workspace is archived and cannot add new experiments")
+	}
+
+	var pID int
+	var archived bool
+	err = db.Bun().NewSelect().
+		Table("projects").
+		Column("id").
+		Column("archived").
+		Where("workspace_id = ?", workspace.ID).
+		Where("name = ?", projectName).
+		Scan(ctx, &pID, &archived)
+	if err != nil {
+		return 1, err
+	}
+	if pID < 1 {
+		return 1, db.ErrNotFound
+	}
+	if archived {
+		return 1, fmt.Errorf("project is archived and cannot add new experiments")
+	}
+	return int(pID), nil
+}
+
+// ProjectIDByName returns a project's ID if it exists in the given workspace.
+func ProjectIDByName(ctx context.Context, workspaceID int, projectName string) (*int, error) {
+	var pID int
+	err := db.Bun().NewRaw("SELECT id FROM projects WHERE name = ? AND workspace_id = ?",
+		projectName, workspaceID).Scan(ctx, &pID)
+	if err != nil {
+		return nil, err
+	}
+	return &pID, nil
+}

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -36,7 +36,7 @@ func ProjectByName(ctx context.Context, workspaceName string, projectName string
 	if archived {
 		return 1, fmt.Errorf("project is archived and cannot add new experiments")
 	}
-	return int(pID), nil
+	return pID, nil
 }
 
 // ProjectIDByName returns a project's ID if it exists in the given workspace.

--- a/master/internal/project/postgres_project_intg_test.go
+++ b/master/internal/project/postgres_project_intg_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+// +build integration
+
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	internaldb "github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/etc"
+)
+
+func TestProjectByName(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(internaldb.RootFromDB))
+	db := internaldb.MustResolveTestPostgres(t)
+	internaldb.MustMigrateTestPostgres(t, db, internaldb.MigrationsFromDB)
+
+	// add a workspace, and project
+	workspaceID, workspaceName := internaldb.RequireMockWorkspaceID(t, db)
+	projectID, projectName := internaldb.RequireMockProjectID(t, db, workspaceID, false)
+
+	t.Run("valid project name", func(t *testing.T) {
+		actualProjectID, err := ProjectByName(context.Background(), workspaceName, projectName)
+		require.NoError(t, err)
+		assert.Equal(t, projectID, actualProjectID)
+	})
+
+	t.Run("invalid project name", func(t *testing.T) {
+		_, err := ProjectByName(context.Background(), workspaceName, "bogus")
+		require.Error(t, err)
+	})
+
+	t.Run("archived project", func(t *testing.T) {
+		// add archvied project to workspace
+		_, archivedProjectName := internaldb.RequireMockProjectID(t, db, workspaceID, true)
+		_, err := ProjectByName(context.Background(), workspaceName, archivedProjectName)
+		require.Error(t, err)
+	})
+}

--- a/master/internal/webhooks/postgres_webhook.go
+++ b/master/internal/webhooks/postgres_webhook.go
@@ -14,6 +14,7 @@ import (
 
 	conf "github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/project"
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -474,7 +475,7 @@ func generateSlackPayload(
 		}
 		wID = w.ID
 
-		pID, err := workspace.ProjectIDByName(ctx, wID, pName)
+		pID, err := project.ProjectIDByName(ctx, wID, pName)
 		if pID != nil {
 			projectID = *pID
 		}

--- a/master/internal/workspace/postgres_workspace.go
+++ b/master/internal/workspace/postgres_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -16,8 +17,11 @@ import (
 func WorkspaceByName(ctx context.Context, workspaceName string) (*model.Workspace, error) {
 	var w model.Workspace
 	err := db.Bun().NewSelect().Model(&w).Where("name = ?", workspaceName).Scan(ctx)
+	if err == sql.ErrNoRows {
+		return nil, db.ErrNotFound
+	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting workspace: %w", err)
 	}
 	return &w, nil
 }

--- a/master/internal/workspace/postgres_workspace.go
+++ b/master/internal/workspace/postgres_workspace.go
@@ -70,17 +70,6 @@ func WorkspaceIDsFromNames(ctx context.Context, workspaceNames []string) (
 	return workspaceIDs, nil
 }
 
-// ProjectIDByName returns a project's ID if it exists in the given workspace.
-func ProjectIDByName(ctx context.Context, workspaceID int, projectName string) (*int, error) {
-	var pID int
-	err := db.Bun().NewRaw("SELECT id FROM projects WHERE name = ? AND workspace_id = ?",
-		projectName, workspaceID).Scan(ctx, &pID)
-	if err != nil {
-		return nil, err
-	}
-	return &pID, nil
-}
-
 // WorkspaceByProjectID returns a workspace given a project ID.
 func WorkspaceByProjectID(ctx context.Context, projectID int) (*model.Workspace, error) {
 	var w model.Workspace


### PR DESCRIPTION
## Description
[RM-48] chore: cover and bunify project functions in postgres_experiments.go

## Test Plan
ensure all unit/integration tests pass; there should be no change in behavior

`ProjectExperiments` is called when deleting a workspace. Create a workspace, add a project, and an experiment. Then, delete it. It completes without error.

Repeat above with deleting a project from a workspace.

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-48

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[RM-48]: https://hpe-aiatscale.atlassian.net/browse/RM-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ