### PR TITLE
fix: tolerate strange cases in container addressing

### DIFF
--- a/master/pkg/aproto/master_message_test.go
+++ b/master/pkg/aproto/master_message_test.go
@@ -19,7 +19,7 @@ func TestContainerStarted_Addresses(t *testing.T) {
 		want  []cproto.Address
 	}{
 		{
-			name:  "ipv4 only",
+			name:  "ipv4 docker and agent addrs",
 			input: mustUnmarshal[ContainerStarted](t, mustReadFile(t, "testdata/ipv4_only.input.json")),
 			want:  mustUnmarshal[[]cproto.Address](t, mustReadFile(t, "testdata/ipv4_only.output.json")),
 		},

--- a/master/pkg/aproto/master_message_test.go
+++ b/master/pkg/aproto/master_message_test.go
@@ -1,0 +1,59 @@
+package aproto
+
+import (
+	"cmp"
+	"encoding/json"
+	"os"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/determined-ai/determined/master/pkg/cproto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerStarted_Addresses(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ContainerStarted
+		want  []cproto.Address
+	}{
+		{
+			name:  "ipv4 only",
+			input: mustUnmarshal[ContainerStarted](t, mustReadFile(t, "testdata/ipv4_only.input.json")),
+			want:  mustUnmarshal[[]cproto.Address](t, mustReadFile(t, "testdata/ipv4_only.output.json")),
+		},
+		{
+			name:  "ipv4 and ipv6",
+			input: mustUnmarshal[ContainerStarted](t, mustReadFile(t, "testdata/ipv6_ipv4_mix.input.json")),
+			want:  mustUnmarshal[[]cproto.Address](t, mustReadFile(t, "testdata/ipv6_ipv4_mix.output.json")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.Addresses()
+			slices.SortFunc(got, cmpAddress)
+			slices.SortFunc(tt.want, cmpAddress)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ContainerStarted.Addresses() = %s, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func cmpAddress(x, y cproto.Address) int {
+	return cmp.Compare(x.String(), y.String())
+}
+
+func mustReadFile(t *testing.T, name string) []byte {
+	bs, err := os.ReadFile(name)
+	require.NoError(t, err, "failed to read file %s", name)
+	return bs
+}
+
+func mustUnmarshal[T any](t *testing.T, input []byte) T {
+	var out T
+	err := json.Unmarshal(input, &out)
+	require.NoError(t, err, "failed to marshal into %T", out)
+	return out
+}

--- a/master/pkg/aproto/testdata/ipv4_only.input.json
+++ b/master/pkg/aproto/testdata/ipv4_only.input.json
@@ -1,0 +1,108 @@
+{
+    "ProxyAddress": "127.0.0.1",
+    "ContainerInfo": {
+        "Id": "290ca3fd78410c7a66c06f3b9b1a64642560641b37fd7109b2b1bee821fb41a3",
+        "HostConfig": {
+            "NetworkMode": "bridge",
+            "PortBindings": null
+        },
+        "Config": {
+            "Hostname": "290ca3fd7841",
+            "Domainname": "",
+            "ExposedPorts": {
+                "12351/tcp": {},
+                "12361/tcp": {},
+                "12366/tcp": {},
+                "1734/tcp": {},
+                "29401/tcp": {}
+            }
+        },
+        "NetworkSettings": {
+            "Bridge": "",
+            "SandboxID": "25b9c42c12d8673f8c88db4252cfbdc453767937594b1688f238533d54f70dd6",
+            "HairpinMode": false,
+            "LinkLocalIPv6Address": "",
+            "LinkLocalIPv6PrefixLen": 0,
+            "Ports": {
+                "12351/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32806"
+                    },
+                    {
+                        "HostIp": "::",
+                        "HostPort": "32806"
+                    }
+                ],
+                "12361/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32805"
+                    },
+                    {
+                        "HostIp": "::",
+                        "HostPort": "32805"
+                    }
+                ],
+                "12366/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32804"
+                    },
+                    {
+                        "HostIp": "::",
+                        "HostPort": "32804"
+                    }
+                ],
+                "1734/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32807"
+                    },
+                    {
+                        "HostIp": "::",
+                        "HostPort": "32807"
+                    }
+                ],
+                "29401/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32803"
+                    },
+                    {
+                        "HostIp": "::",
+                        "HostPort": "32803"
+                    }
+                ]
+            },
+            "SandboxKey": "/var/run/docker/netns/25b9c42c12d8",
+            "SecondaryIPAddresses": null,
+            "SecondaryIPv6Addresses": null,
+            "EndpointID": "71868308c817579a691408e0afc3efa9ead3caa7408300221662873aeafa1dd1",
+            "Gateway": "172.17.0.1",
+            "GlobalIPv6Address": "",
+            "GlobalIPv6PrefixLen": 0,
+            "IPAddress": "172.17.0.4",
+            "IPPrefixLen": 16,
+            "IPv6Gateway": "",
+            "MacAddress": "02:42:ac:11:00:04",
+            "Networks": {
+                "bridge": {
+                    "IPAMConfig": null,
+                    "Links": null,
+                    "Aliases": null,
+                    "NetworkID": "637f0e831f9611fa66e32196fdd2d5b7ca38af95324520c358750e6ee843cce9",
+                    "EndpointID": "71868308c817579a691408e0afc3efa9ead3caa7408300221662873aeafa1dd1",
+                    "Gateway": "172.17.0.1",
+                    "IPAddress": "172.17.0.4",
+                    "IPPrefixLen": 16,
+                    "IPv6Gateway": "",
+                    "GlobalIPv6Address": "",
+                    "GlobalIPv6PrefixLen": 0,
+                    "MacAddress": "02:42:ac:11:00:04",
+                    "DriverOpts": null
+                }
+            }
+        }
+    }
+}

--- a/master/pkg/aproto/testdata/ipv4_only.output.json
+++ b/master/pkg/aproto/testdata/ipv4_only.output.json
@@ -1,0 +1,32 @@
+[
+    {
+        "container_ip": "172.17.0.4",
+        "container_port": 12351,
+        "host_ip": "127.0.0.1",
+        "host_port": 32806
+    },
+    {
+        "container_ip": "172.17.0.4",
+        "container_port": 12361,
+        "host_ip": "127.0.0.1",
+        "host_port": 32805
+    },
+    {
+        "container_ip": "172.17.0.4",
+        "container_port": 12366,
+        "host_ip": "127.0.0.1",
+        "host_port": 32804
+    },
+    {
+        "container_ip": "172.17.0.4",
+        "container_port": 1734,
+        "host_ip": "127.0.0.1",
+        "host_port": 32807
+    },
+    {
+        "container_ip": "172.17.0.4",
+        "container_port": 29401,
+        "host_ip": "127.0.0.1",
+        "host_port": 32803
+    }
+]

--- a/master/pkg/aproto/testdata/ipv6_ipv4_mix.input.json
+++ b/master/pkg/aproto/testdata/ipv6_ipv4_mix.input.json
@@ -1,0 +1,88 @@
+{
+    "ProxyAddress": "[::1]",
+    "ContainerInfo": {
+        "Id": "e806fd21e063a3d1d35174b86fd1a56ab8d9fb8f4292d48657803ae731b313df",
+        "HostConfig": {
+            "NetworkMode": "bridge",
+            "PortBindings": null
+        },
+        "Config": {
+            "Hostname": "e806fd21e063",
+            "Domainname": "",
+            "ExposedPorts": {
+                "12350/tcp": {},
+                "12360/tcp": {},
+                "12365/tcp": {},
+                "1734/tcp": {},
+                "29400/tcp": {}
+            }
+        },
+        "NetworkSettings": {
+            "Bridge": "",
+            "SandboxID": "f840a6d7b73f414c10eeb769542fc2dab8c9eaf83f66d9364c0ef84ec71042ef",
+            "HairpinMode": false,
+            "LinkLocalIPv6Address": "",
+            "LinkLocalIPv6PrefixLen": 0,
+            "Ports": {
+                "12350/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32901"
+                    }
+                ],
+                "12360/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32900"
+                    }
+                ],
+                "12365/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32899"
+                    }
+                ],
+                "1734/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32902"
+                    }
+                ],
+                "29400/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32898"
+                    }
+                ]
+            },
+            "SandboxKey": "/var/run/docker/netns/f840a6d7b73f",
+            "SecondaryIPAddresses": null,
+            "SecondaryIPv6Addresses": null,
+            "EndpointID": "bb75a35d4990e2489549f5a661a708e28aea6feeaa30ef38858a780477570bfe",
+            "Gateway": "172.17.0.1",
+            "GlobalIPv6Address": "",
+            "GlobalIPv6PrefixLen": 0,
+            "IPAddress": "172.17.0.3",
+            "IPPrefixLen": 16,
+            "IPv6Gateway": "",
+            "MacAddress": "02:42:ac:11:00:03",
+            "Networks": {
+                "bridge": {
+                    "IPAMConfig": null,
+                    "Links": null,
+                    "Aliases": null,
+                    "NetworkID": "be47d444aaf5efae2aa2007cba0c753d667271f25b0bf277a13e6c942b0f9546",
+                    "EndpointID": "bb75a35d4990e2489549f5a661a708e28aea6feeaa30ef38858a780477570bfe",
+                    "Gateway": "172.17.0.1",
+                    "IPAddress": "172.17.0.3",
+                    "IPPrefixLen": 16,
+                    "IPv6Gateway": "",
+                    "GlobalIPv6Address": "",
+                    "GlobalIPv6PrefixLen": 0,
+                    "MacAddress": "02:42:ac:11:00:03",
+                    "DriverOpts": null
+                }
+            }
+        }
+    }
+}

--- a/master/pkg/aproto/testdata/ipv6_ipv4_mix.output.json
+++ b/master/pkg/aproto/testdata/ipv6_ipv4_mix.output.json
@@ -1,0 +1,32 @@
+[
+    {
+        "container_ip": "172.17.0.3",
+        "container_port": 12360,
+        "host_ip": "[::1]",
+        "host_port": 32900
+    },
+    {
+        "container_ip": "172.17.0.3",
+        "container_port": 12365,
+        "host_ip": "[::1]",
+        "host_port": 32899
+    },
+    {
+        "container_ip": "172.17.0.3",
+        "container_port": 1734,
+        "host_ip": "[::1]",
+        "host_port": 32902
+    },
+    {
+        "container_ip": "172.17.0.3",
+        "container_port": 29400,
+        "host_ip": "[::1]",
+        "host_port": 32898
+    },
+    {
+        "container_ip": "172.17.0.3",
+        "container_port": 12350,
+        "host_ip": "[::1]",
+        "host_port": 32901
+    }
+]

--- a/master/pkg/cproto/address.go
+++ b/master/pkg/cproto/address.go
@@ -8,7 +8,8 @@ import (
 
 // Address represents an exposed port on a container.
 type Address struct {
-	// ContainerIP is the IP address from inside the container.
+	// ContainerIP is the IP address from inside the container. Will be "missing" if we cannot find a network with a
+	// name matching the network configured via `task_container_defaults.network_mode`.
 	ContainerIP string `json:"container_ip"`
 	// ContainerPort is the port from inside the container.
 	ContainerPort int `json:"container_port"`


### PR DESCRIPTION
## Description
A lot time ago, Docker started returning 2 port bindings for each port, one for ipv4 and one for ipv6. This caused the rendezvous code to explode because suddenly it was getting 2 addresses for each binding where it expected one. To fix this, we preferred the binding that matched the what the agent was using to talk to us.

Three years later, @wes-turner's dev machine has the agent connecting through `::1` and Docker only publishing ipv4 port bindings, and so his experiment fail to find any rendezvous addresses. This reverts back to the old logic then adds a dedup instead, so wes's machine should find some address either way (fyi this doesn't really matter at all, because the trial doesn't use these rendezvous addresses anyway since it is a single trial experiment, it just explodes without them anyway.. but at least now some folks dev machines will work). 
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
- [x] has tests, dont manually test
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-52


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
