### PR TITLE
chore: fix mp.pool test_streaming_metrics_api

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -1,6 +1,5 @@
 import json
-import multiprocessing as mp
-import multiprocessing.pool
+from multiprocessing import pool
 from typing import Dict, List, Set, Union
 
 import pytest
@@ -16,7 +15,7 @@ from tests import experiment as exp
 @pytest.mark.timeout(600)
 def test_streaming_metrics_api() -> None:
     sess = api_utils.user_session()
-    pool = mp.pool.ThreadPool(processes=7)
+    thread_pool = pool.ThreadPool(processes=7)
 
     experiment_id = exp.create_experiment(
         sess,
@@ -30,13 +29,25 @@ def test_streaming_metrics_api() -> None:
     # The HP importance portion of this test is commented out until the feature is enabled by
     # default
 
-    metric_names_thread = pool.apply_async(request_metric_names, (experiment_id,))
-    train_metric_batches_thread = pool.apply_async(request_train_metric_batches, (experiment_id,))
-    valid_metric_batches_thread = pool.apply_async(request_valid_metric_batches, (experiment_id,))
-    train_trials_snapshot_thread = pool.apply_async(request_train_trials_snapshot, (experiment_id,))
-    valid_trials_snapshot_thread = pool.apply_async(request_valid_trials_snapshot, (experiment_id,))
-    train_trials_sample_thread = pool.apply_async(request_train_trials_sample, (experiment_id,))
-    valid_trials_sample_thread = pool.apply_async(request_valid_trials_sample, (experiment_id,))
+    metric_names_thread = thread_pool.apply_async(request_metric_names, (experiment_id,))
+    train_metric_batches_thread = thread_pool.apply_async(
+        request_train_metric_batches, (experiment_id,)
+    )
+    valid_metric_batches_thread = thread_pool.apply_async(
+        request_valid_metric_batches, (experiment_id,)
+    )
+    train_trials_snapshot_thread = thread_pool.apply_async(
+        request_train_trials_snapshot, (experiment_id,)
+    )
+    valid_trials_snapshot_thread = thread_pool.apply_async(
+        request_valid_trials_snapshot, (experiment_id,)
+    )
+    train_trials_sample_thread = thread_pool.apply_async(
+        request_train_trials_sample, (experiment_id,)
+    )
+    valid_trials_sample_thread = thread_pool.apply_async(
+        request_valid_trials_sample, (experiment_id,)
+    )
 
     metric_names_results = metric_names_thread.get()
     train_metric_batches_results = train_metric_batches_thread.get()

--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -1,5 +1,6 @@
 import json
 import multiprocessing as mp
+import multiprocessing.pool
 from typing import Dict, List, Set, Union
 
 import pytest


### PR DESCRIPTION
## Description

Fix test flake seen on main

https://app.circleci.com/pipelines/github/determined-ai/determined/51614/workflows/903b01d9-94ec-4bff-99d0-7b91ab67ba68/jobs/2297652


## Test Plan

e2e_cpu passes


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
