### PR TITLE
fix: don't access agentState when it may be nil

### DIFF
--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -297,7 +297,7 @@ func (a *agent) stop(cause error) {
 		}
 	}
 
-	a.syslog.Infof("removing agent: %s", a.agentState.agentID())
+	a.syslog.Infof("removing agent: %s", a.id)
 	err := a.updateAgentEndStats(string(a.id))
 	if err != nil {
 		a.syslog.WithError(err).Error("failed to update agent end stats")

--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -885,16 +885,18 @@ func (a *agent) socketDisconnected() {
 	timer := time.AfterFunc(a.agentReconnectWait, a.HandleReconnectTimeout)
 	a.reconnectTimers = append(a.reconnectTimers, timer)
 
-	a.preDisconnectEnabled = a.agentState.enabled
-	a.preDisconnectDraining = a.agentState.draining
-	// Mark ourselves as draining to avoid action on ourselves while we recover. While the
-	// system is technically correct without this, it's better because we avoid any waste
-	// effort scheduling things only to have them suffer AgentErrors later.
-	a.agentState.disable(true)
-	a.agentState.patchAllSlotsState(patchAllSlotsState{
-		enabled: &a.agentState.enabled,
-		drain:   &a.agentState.draining,
-	})
+	if a.agentState != nil { // This is nil for a bit after `a.socket` is connected but before `a.started` is true.
+		a.preDisconnectEnabled = a.agentState.enabled
+		a.preDisconnectDraining = a.agentState.draining
+		// Mark ourselves as draining to avoid action on ourselves while we recover. While the
+		// system is technically correct without this, it's better because we avoid any waste
+		// effort scheduling things only to have them suffer AgentErrors later.
+		a.agentState.disable(true)
+		a.agentState.patchAllSlotsState(patchAllSlotsState{
+			enabled: &a.agentState.enabled,
+			drain:   &a.agentState.draining,
+		})
+	}
 	a.notifyListeners()
 }
 

--- a/master/internal/rm/agentrm/agent_test.go
+++ b/master/internal/rm/agentrm/agent_test.go
@@ -1,0 +1,26 @@
+package agentrm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/determined-ai/determined/master/internal/config"
+	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/syncx/queue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentFastFailAfterFirstConnect(t *testing.T) {
+	a := newAgent(
+		"test",
+		queue.New[agentUpdatedEvent](),
+		"default",
+		&config.ResourcePoolConfig{},
+		&aproto.MasterSetAgentOptions{},
+		nil,
+		func() {},
+	)
+	require.NotPanics(t, func() {
+		a.stop(errors.New("agent immediately failed for some weird reason"))
+	})
+}

--- a/master/internal/rm/agentrm/agent_test.go
+++ b/master/internal/rm/agentrm/agent_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/syncx/queue"
 	"github.com/determined-ai/determined/master/pkg/ws"
-	"github.com/gorilla/websocket"
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAgentFastFailAfterFirstConnect2(t *testing.T) {
@@ -39,13 +40,14 @@ func TestAgentFastFailAfterFirstConnect2(t *testing.T) {
 	// Connect a fake websocket.
 	e := echo.New()
 	e.GET("/", func(c echo.Context) error {
-		a.HandleWebsocketConnection(webSocketRequest{echoCtx: c})
+		err := a.HandleWebsocketConnection(webSocketRequest{echoCtx: c})
+		require.NoError(t, err)
 		return nil
 	})
 	server := httptest.NewServer(e.Server.Handler)
 
 	var dialer websocket.Dialer
-	conn, _, err := dialer.Dial(fmt.Sprintf("ws://%s", strings.TrimLeft(server.URL, "http://")), nil)
+	conn, _, err := dialer.Dial(fmt.Sprintf("ws://%s", strings.TrimPrefix(server.URL, "http://")), nil)
 	require.NoError(t, err)
 	_, err = ws.Wrap[*aproto.MasterMessage, aproto.AgentMessage]("test", conn)
 	require.NoError(t, err)

--- a/master/internal/rm/agentrm/agent_test.go
+++ b/master/internal/rm/agentrm/agent_test.go
@@ -1,26 +1,64 @@
 package agentrm
 
 import (
-	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/pkg/aproto"
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/syncx/queue"
+	"github.com/determined-ai/determined/master/pkg/ws"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAgentFastFailAfterFirstConnect(t *testing.T) {
+func TestAgentFastFailAfterFirstConnect2(t *testing.T) {
+	var closed atomic.Bool
 	a := newAgent(
 		"test",
 		queue.New[agentUpdatedEvent](),
 		"default",
 		&config.ResourcePoolConfig{},
-		&aproto.MasterSetAgentOptions{},
+		&aproto.MasterSetAgentOptions{
+			MasterInfo: aproto.MasterInfo{},
+			LoggingOptions: model.LoggingConfig{
+				DefaultLoggingConfig: &model.DefaultLoggingConfig{},
+			},
+			ContainersToReattach: []aproto.ContainerReattach{},
+		},
 		nil,
-		func() {},
+		func() { closed.Store(true) },
 	)
-	require.NotPanics(t, func() {
-		a.stop(errors.New("agent immediately failed for some weird reason"))
+
+	// Connect a fake websocket.
+	e := echo.New()
+	e.GET("/", func(c echo.Context) error {
+		a.HandleWebsocketConnection(webSocketRequest{echoCtx: c})
+		return nil
 	})
+	server := httptest.NewServer(e.Server.Handler)
+
+	var dialer websocket.Dialer
+	conn, _, err := dialer.Dial(fmt.Sprintf("ws://%s", strings.TrimLeft(server.URL, "http://")), nil)
+	require.NoError(t, err)
+	_, err = ws.Wrap[*aproto.MasterMessage, aproto.AgentMessage]("test", conn)
+	require.NoError(t, err)
+
+	// Close the underlying conn to simulate a failure.
+	err = conn.UnderlyingConn().Close()
+	require.NoError(t, err)
+
+	for {
+		if closed.Load() {
+			// The agent should close without a panic. A panic in the agent would bubble up and fail this test.
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Description
AgentState is only set on the agent master-side whenever it is "started", which is when we've made it through all the initialization messages. But an agent can crash while it is starting, and then this access into AgentState causes a NPE, which probably ends up being a convincing red herring when debugging.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
I'll follow up to add tests in a bit.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)
Yep.
<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-53


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
