### PR TITLE
fix: det deploy gcp down shouldn't check quotas

### DIFF
--- a/harness/determined/deploy/gcp/cli.py
+++ b/harness/determined/deploy/gcp/cli.py
@@ -142,7 +142,6 @@ def deploy_gcp(command: str, args: argparse.Namespace) -> None:
             "tf_state_gcs_bucket_name": args.project_id + "-determined-deploy",
         }
 
-        gcp.dry_run(det_configs, env, variables_to_exclude)
         gcp.delete(det_configs, env, args.yes)
         print("Delete Successful")
         return


### PR DESCRIPTION
## Description
For some reason `down` calls `dry_run`, which checks quotas. The output of dry_run isn't relevant to a delete, and we don't need to check quotas when destroying a cluster.
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
Tested when written, don't worry about it for release party. 

What I did: `det deploy gcp down` while a GCP project is at capacity. It should work.
<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
