### PR TITLE
fix: [RM-6] remove global max-slots-per-pod default when multiple RMs…

### DIFF
--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -426,12 +426,11 @@ task_container_defaults:
 	for _, c := range []struct {
 		config   string
 		expected int
-		count    int
 	}{
-		{rm, 17, 1},
-		{rmZero, 0, 2},
-		{taskDefaults, 17, 3},
-		{taskDefaultsZero, 0, 4},
+		{rm, 17},
+		{rmZero, 0},
+		{taskDefaults, 17},
+		{taskDefaultsZero, 0},
 	} {
 		var unmarshaled Config
 		err := yaml.Unmarshal([]byte(c.config), &unmarshaled, yaml.DisallowUnknownFields)
@@ -440,7 +439,6 @@ task_container_defaults:
 		require.Equal(t, c.expected,
 			*unmarshaled.RootManagerInternal.KubernetesRM.MaxSlotsPerPod)
 		require.Equal(t, c.expected,
-			// FIXME kristine - task default is not set
 			*unmarshaled.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod)
 	}
 }


### PR DESCRIPTION
… defined

## Description
fix: [RM-6] remove global max-slots-per-pod default when multiple RMs defined

- if only one RM is defined, allow a global default defined in task_container_defaults.max_slots_per_pod
- if multiple RMs are defined, do not allow a global default; only use max_slots_per_pod as defined in resource_manger

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
confirm unit and integration tests pass; add additional unit tests to cover multi RM use cases

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-6


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->


[RM-6]: https://hpe-aiatscale.atlassian.net/browse/RM-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ