### PR TITLE
chore: add stream.Supervisor tests

### DIFF
--- a/master/internal/stream/supervisor.go
+++ b/master/internal/stream/supervisor.go
@@ -9,12 +9,15 @@ import (
 	"github.com/labstack/echo/v4"
 	log "github.com/sirupsen/logrus"
 
+	detContext "github.com/determined-ai/determined/master/internal/context"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/stream"
 	"github.com/determined-ai/determined/master/pkg/syncx/errgroupx"
 )
 
 // Supervisor manages the context for underlying PublisherSet.
 type Supervisor struct {
-	lock      sync.Mutex
+	cond      sync.Cond
 	dbAddress string
 
 	// this context is responsible for monitoring the life time of the
@@ -28,15 +31,9 @@ type Supervisor struct {
 
 // NewSupervisor creates a new Supervisor.
 func NewSupervisor(dbAddress string) *Supervisor {
-	// initialize with a valid PublisherSet and canceled publisherSetCtx,
-	// so connections prior to runOne() can at least send offline messages.
-	ctx, cancelFn := context.WithCancel(context.Background())
-	cancelFn()
-
 	return &Supervisor{
-		dbAddress:       dbAddress,
-		ps:              NewPublisherSet(dbAddress),
-		publisherSetCtx: ctx,
+		cond:      *sync.NewCond(&sync.Mutex{}),
+		dbAddress: dbAddress,
 	}
 }
 
@@ -45,8 +42,10 @@ func (ssup *Supervisor) runOne(ctx context.Context) error {
 	group := errgroupx.WithContext(ctx)
 	subctx := group.Context()
 	func() {
-		ssup.lock.Lock()
-		defer ssup.lock.Unlock()
+		ssup.cond.L.Lock()
+		defer ssup.cond.L.Unlock()
+		// Broadcast in case this is the first PublisherSet for this supervisor.
+		defer ssup.cond.Broadcast()
 		ssup.publisherSetCtx = subctx
 		ssup.ps = NewPublisherSet(ssup.dbAddress)
 
@@ -57,7 +56,7 @@ func (ssup *Supervisor) runOne(ctx context.Context) error {
 			},
 		)
 		// start up all publishers
-		group.Go(ssup.ps.Start)
+		group.Go(ssup.ps.Run)
 	}()
 	return group.Wait()
 }
@@ -79,22 +78,61 @@ func (ssup *Supervisor) Run(ctx context.Context) error {
 	}
 }
 
-// Websocket passes incoming stream request to the active PublisherSet's websocket handler,
-// ensuring that in the event of a PublisherSet failure, stream requests can still routed
-// during recovery.
+// Websocket is the Echo endpoint handler for streaming updates.  It wraps the business logic in
+// doWebsocket with some IO-specific code.
 func (ssup *Supervisor) Websocket(socket *websocket.Conn, c echo.Context) error {
-	var publisherSetCtx context.Context
-	var ps *PublisherSet
+
 	defer func() {
 		if err := socket.Close(); err != nil {
 			log.Debugf("error while cleaning up socket: %s", err)
 		}
 	}()
+
+	reqCtx := c.Request().Context()
+	detCtx, ok := c.(*detContext.DetContext)
+	if !ok {
+		log.Errorf("unable to run PublisherSet: expected DetContext but received %T", c)
+	}
+	user := detCtx.MustGetUser()
+
+	return ssup.doWebsocket(
+		reqCtx,
+		user,
+		&WrappedWebsocket{Conn: socket},
+		prepareWebsocketMessage,
+	)
+}
+
+// doWebsocket is a mockable entrypoint for the streaming updates system.  Websocket requests are
+// attached to the Supervisor instead of the PublisherSet because the Supervior is meant to be
+// always alive, while the PublisherSet may crash and get restarted from time to time.
+//
+// doWebsocket will grab the current PublisherSet and point this connection at it.
+func (ssup *Supervisor) doWebsocket (
+	reqCtx context.Context,
+	user model.User,
+	socket WebsocketLike,
+	prepareFunc func(message stream.MarshallableMsg) interface{},
+) error {
+	// Grab the current publisher set and its context.
+	var publisherSetCtx context.Context
+	var ps *PublisherSet
 	func() {
-		ssup.lock.Lock()
-		defer ssup.lock.Unlock()
+		ssup.cond.L.Lock()
+		defer ssup.cond.L.Unlock()
+		for ssup.ps == nil {
+			// Wait for the first publisher set to start.
+			ssup.cond.Wait()
+		}
 		publisherSetCtx = ssup.publisherSetCtx
 		ps = ssup.ps
 	}()
-	return ps.StreamHandler(publisherSetCtx, socket, c)
+
+	return ps.streamHandler(
+		publisherSetCtx,
+		reqCtx,
+		user,
+		socket,
+		prepareFunc,
+	)
 }

--- a/master/internal/stream/supervisor_intg_test.go
+++ b/master/internal/stream/supervisor_intg_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+// +build integration
+
+package stream
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/syncx/errgroupx"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func TestClientBeforeRunOne(t *testing.T) {
+	pgDB, dbCleanup := db.MustResolveNewPostgresDatabase(t)
+	t.Cleanup(dbCleanup)
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	// Startup a supervisor, but don't call ssup.Run() at all.
+	dbURL := os.Getenv("DET_INTEGRATION_POSTGRES_URL")
+	ssup := NewSupervisor(dbURL)
+
+	// Pretend a websocket connection arrives...
+	ctx := context.Background()
+	testUser := model.User{Username: uuid.New().String()}
+	socket := newMockSocket()
+
+	errgrp := errgroupx.WithContext(ctx)
+	defer errgrp.Cancel()
+
+	// Connect the websocket to the server.
+	errgrp.Go(func(ctx context.Context) error {
+		defer socket.Close()
+		return ssup.doWebsocket(ctx, testUser, socket, testPrepareFunc)
+	})
+
+	// Make sure our offline messages work and we get disconnect right afterwards.
+	errgrp.Go(func(ctx context.Context) error {
+		socket.WriteToServer(
+			t,
+			&StartupMsg{
+				SyncID: "x",
+				Known:  KnownKeySet{},
+				Subscribe: SubscriptionSpecSet{
+					Projects: &ProjectSubscriptionSpec{ProjectIDs: []int{1}},
+				},
+			},
+		)
+		socket.ReadUntilFound(
+			t,
+			"type: sync_msg, sync_id: x, complete: false",
+			"type: project, project_id: 1, state: UNSPECIFIED, workspace_id: 1",
+			"type: sync_msg, sync_id: x, complete: true",
+		)
+		// Since we start runOne with an already-canceled context, we expect the socket to break
+		// as soon as the offline messages are sent.
+		socket.AssertEOF(t)
+		return nil
+	})
+
+	// Start a runOne that comes already canceled; we don't want the publisher to actually do
+	// anything, we just need to test the synchronization logic.
+	//
+	// This also exercises the same codepaths as a websocket call which arrives after runOne crashes
+	// and before the next runOne starts, because this PublisherSet is basically instantly crashed.
+	// The result should be that all the offline messages are sent and the websocket breaks without
+	// ony online messages.
+	errgrp.Go(func(ctx context.Context) error {
+		deadCtx, cancelFn := context.WithCancel(ctx)
+		cancelFn()
+		return ssup.runOne(deadCtx)
+	})
+
+	require.NoError(t, errgrp.Wait())
+}


### PR DESCRIPTION
- Rename PublisherSet.Start() -> .Run(), since it doesn't return until
  the PublisherSet is done.
- Defer the PublisherSet.ready = true, so that no websocket clients can
  hang if PublisherSet crashes before it becomes ready.
- Refactor the IO wrapper to be at the Supervisor level rather than the
  PublisherSet level, to make testing the Supervisor easier.
- Stop creating Supervisor with an already-dead context, which people
  found surprising; instead use a normal conditional variable to make
  websockets block if they arrive before the first call to
  ssup.runOne().
- Add a test that simulates a websocket arriving before
  supervisor.runOne starts (technically it's a racy test but if it isn't
  flaky that means it is working).
- Rework MockSocket:
    - .Close() is pipeline-like, rather than preemption like.
    - No more output parameters; return things instead.
    - Rename WriteOutbound -> WriteToServer.
    - Rename ReadIncoming -> ReadFromServer.
    - Add AssertEOF for stricter testing.
    - Improve log readability from ReadUntilFound().
    - Use t.Fatalf instead of t.Errorf everywhere.

## Test Plan

- [x] it's literally a test already