### PR TITLE
chore: amend contributing doc to point to correct make rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Run `make test`.
 
 ```bash
 # Run a Determined cluster
-make -C tools run
+make devcluster
 
 # Run integration tests locally.
 pytest -m "e2e_cpu" e2e_tests/tests


### PR DESCRIPTION
## Description
From #2892 , `make -C tools run` is no longer a supported command. Users should run `devcluster [-c CONFIG_PATH]` or `make devcluster` instead.

## Test Plan
N/A

## Checklist

- [x] Changes have been manually QA'd
- [ ] ~~User-facing API changes need the "User-facing API Change" label.~~
- [ ] ~~Release notes should be added as a separate file under `docs/release-notes/`.~~
- [ ] ~~Licenses should be included for new code which was copied and/or modified from any external code.~~

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
