### PR TITLE
fix: Check auth validity before setting isAuthenticated

### DIFF
--- a/webui/react/src/hooks/useAuthCheck.ts
+++ b/webui/react/src/hooks/useAuthCheck.ts
@@ -1,4 +1,4 @@
-import { Observable, useObservable } from 'micro-observables';
+import { useObservable } from 'micro-observables';
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
@@ -53,11 +53,9 @@ const useAuthCheck = (): (() => Promise<boolean>) => {
       try {
         await getCurrentUser({});
         updateBearerToken(authToken);
-        Observable.batch(() => {
-          authStore.setAuth({ isAuthenticated: true, token: authToken });
-        });
+        authStore.setAuth({ isAuthenticated: true, token: authToken });
       } catch (e) {
-        // If an invalid auth token is detected we need to properl handle the auth error
+        // If an invalid auth token is detected we need to properly handle the auth error
         handleError(e);
       }
       authStore.setAuthChecked();


### PR DESCRIPTION
## Description

There is bug in GenAI currently where a user gets stuck in an infinite redirect loop, this fixes the issue. 

You can see the bug in action below:
https://github.com/determined-ai/determined/assets/103522725/7375fff4-bdc6-4c78-a6f0-5717080cf21f

The ultimate cause of the bug is that if you look at the logic in the sign in page we:

1. Check if the user `isAuthenticated"
2. Check if there is a redirect, if there is we redirect the user. 

However the issue is that in (1) the `isAuthenticated` can be set to true without the user actually being a valid and authenticated user. This causes an infinite login bug in GenAI since we use the `MLDE` login page for authentication also. The reason that this is not an issue in MLDE is because after sign-in:

1. The user is redirected to the `dashboard` page
2. As soon as an API call fails, we catch the auth error, and remove the bad token
3. We instantly send the user back to the sign-in page. 

However (2) cannot happen in GenAI since the invalid token lives and is controlled on the `MLDE` app.

In order to preserve all current log in and auth related behavior, this PR introduces an extra check to ensure the user is authenticated if an `auth-token` is present. If not, then we handle the error using out `handleError` function. This set up ensures that unauthenticated users will not be improperly redirected. 

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan
1. Ensure that you are logged out of MLDE.
2. Navigate to the login page.
3. Using devtools set a value for the `global/auth-token` 
4. Add a `?redirect` query to the login url such as `login?redirect=/lore/`
5. Visit the URL in (4).
6. Ensure that you are **not** redirected, and you instead immediately shown a "loading" message and then the login page again.

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
