### PR TITLE
fix: remove duplicate permissions in rbac CLI output

### DIFF
--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -20,6 +20,31 @@ viewerPerms = [
     "PERMISSION_TYPE_VIEW_TEMPLATES",
 ]
 
+editorPerms = [
+    "PERMISSION_TYPE_VIEW_PROJECT",
+    "PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS",
+    "PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA",
+    "PERMISSION_TYPE_VIEW_WORKSPACE",
+    "PERMISSION_TYPE_VIEW_MODEL_REGISTRY",
+    "PERMISSION_TYPE_VIEW_NSC",
+    "PERMISSION_TYPE_VIEW_TEMPLATES",
+    "PERMISSION_TYPE_CREATE_EXPERIMENT",
+    "PERMISSION_TYPE_UPDATE_EXPERIMENT",
+    "PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA",
+    "PERMISSION_TYPE_UPDATE_PROJECT",
+    "PERMISSION_TYPE_DELETE_EXPERIMENT",
+    "PERMISSION_TYPE_CREATE_PROJECT",
+    "PERMISSION_TYPE_EDIT_MODEL_REGISTRY",
+    "PERMISSION_TYPE_CREATE_MODEL_REGISTRY",
+    "PERMISSION_TYPE_CREATE_NSC",
+    "PERMISSION_TYPE_UPDATE_NSC",
+    "PERMISSION_TYPE_DELETE_MODEL_REGISTRY",
+    "PERMISSION_TYPE_UPDATE_TEMPLATES",
+    "PERMISSION_TYPE_CREATE_TEMPLATES",
+    "PERMISSION_TYPE_DELETE_TEMPLATES",
+    "PERMISSION_TYPE_DELETE_MODEL_VERSION"
+]
+
 
 @contextlib.contextmanager
 def create_workspaces_with_users(
@@ -412,9 +437,28 @@ def test_rbac_permission_assignment_no_dups() -> None:
     # Check that listed permissions do not contain any duplicates of overlapping permissions
     # between Viewer and Editor roles.
     res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
-    for p in viewerPerms:
+    for p in editorPerms:
         assert res.count(p) == 1
-
+        
+@pytest.mark.e2e_cpu_rbac
+@api_utils.skipif_rbac_not_enabled()  
+def test_rbac_list_all_perms_single_role() -> None:
+    # Assign Viewer role in one workspace and Editor role in another and verify that correct number
+    # of permissions are listed within each respective workspace.
+    perm_assigments = [
+        [
+            (1, ["Editor"]),
+        ],
+        [
+            (1, ["Viewer"]),
+        ],
+    ]
+    with create_workspaces_with_users(perm_assigments) as (workspaces, rid_to_sess):
+        res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
+        for p in viewerPerms:
+            assert res.count(p) == 1
+        for p in editorPerms:
+            assert res.count(p) == 1
 
 @pytest.mark.e2e_cpu_rbac
 @api_utils.skipif_rbac_not_enabled()

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -20,31 +20,6 @@ viewerPerms = [
     "PERMISSION_TYPE_VIEW_TEMPLATES",
 ]
 
-editorPerms = [
-    "PERMISSION_TYPE_VIEW_PROJECT",
-    "PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS",
-    "PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA",
-    "PERMISSION_TYPE_VIEW_WORKSPACE",
-    "PERMISSION_TYPE_VIEW_MODEL_REGISTRY",
-    "PERMISSION_TYPE_VIEW_NSC",
-    "PERMISSION_TYPE_VIEW_TEMPLATES",
-    "PERMISSION_TYPE_CREATE_EXPERIMENT",
-    "PERMISSION_TYPE_UPDATE_EXPERIMENT",
-    "PERMISSION_TYPE_UPDATE_EXPERIMENT_METADATA",
-    "PERMISSION_TYPE_UPDATE_PROJECT",
-    "PERMISSION_TYPE_DELETE_EXPERIMENT",
-    "PERMISSION_TYPE_CREATE_PROJECT",
-    "PERMISSION_TYPE_EDIT_MODEL_REGISTRY",
-    "PERMISSION_TYPE_CREATE_MODEL_REGISTRY",
-    "PERMISSION_TYPE_CREATE_NSC",
-    "PERMISSION_TYPE_UPDATE_NSC",
-    "PERMISSION_TYPE_DELETE_MODEL_REGISTRY",
-    "PERMISSION_TYPE_UPDATE_TEMPLATES",
-    "PERMISSION_TYPE_CREATE_TEMPLATES",
-    "PERMISSION_TYPE_DELETE_TEMPLATES",
-    "PERMISSION_TYPE_DELETE_MODEL_VERSION",
-]
-
 
 @contextlib.contextmanager
 def create_workspaces_with_users(
@@ -427,24 +402,41 @@ def test_rbac_permission_assignment_no_dups() -> None:
     # Assign Viewer and Editor roles to the user.
     detproc.check_call(
         admin,
-        ["det", "rbac", "assign-role", "Viewer", "--username-to-assign", sess.username],
+        [
+            "det",
+            "rbac",
+            "assign-role",
+            "Viewer",
+            "--username-to-assign",
+            sess.username,
+            "--workspace-name",
+            "Uncategorized",
+        ],
     )
     detproc.check_call(
         admin,
-        ["det", "rbac", "assign-role", "Editor", "--username-to-assign", sess.username],
+        [
+            "det",
+            "rbac",
+            "assign-role",
+            "Editor",
+            "--username-to-assign",
+            sess.username,
+            "--workspace-name",
+            "Uncategorized",
+        ],
     )
 
     # Check that listed permissions do not contain any duplicates of overlapping permissions
     # between Viewer and Editor roles.
     res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
-    for p in editorPerms:
+    for p in viewerPerms:
         assert res.count(p) == 1
 
 
 @pytest.mark.e2e_cpu_rbac
 @api_utils.skipif_rbac_not_enabled()
 def test_rbac_list_all_perms_single_role() -> None:
-    sess, _ = api_utils.create_test_user()
     # Assign Viewer role in one workspace and Editor role in another and verify that correct number
     # of permissions are listed within each respective workspace.
     perm_assigments = [
@@ -455,12 +447,11 @@ def test_rbac_list_all_perms_single_role() -> None:
             (1, ["Viewer"]),
         ],
     ]
-    with create_workspaces_with_users(perm_assigments) as (workspaces, rid_to_sess):
-        res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
-        for p in viewerPerms:
-            assert res.count(p) == 1
-        for p in editorPerms:
-            assert res.count(p) == 1
+    with create_workspaces_with_users(perm_assigments) as (_, rid_to_sess):
+        for _, sess in rid_to_sess.items():
+            res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
+            for p in viewerPerms:
+                assert res.count(p) == 2
 
 
 @pytest.mark.e2e_cpu_rbac

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -42,7 +42,7 @@ editorPerms = [
     "PERMISSION_TYPE_UPDATE_TEMPLATES",
     "PERMISSION_TYPE_CREATE_TEMPLATES",
     "PERMISSION_TYPE_DELETE_TEMPLATES",
-    "PERMISSION_TYPE_DELETE_MODEL_VERSION"
+    "PERMISSION_TYPE_DELETE_MODEL_VERSION",
 ]
 
 
@@ -439,9 +439,10 @@ def test_rbac_permission_assignment_no_dups() -> None:
     res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
     for p in editorPerms:
         assert res.count(p) == 1
-        
+
+
 @pytest.mark.e2e_cpu_rbac
-@api_utils.skipif_rbac_not_enabled()  
+@api_utils.skipif_rbac_not_enabled()
 def test_rbac_list_all_perms_single_role() -> None:
     sess, _ = api_utils.create_test_user()
     # Assign Viewer role in one workspace and Editor role in another and verify that correct number
@@ -460,6 +461,7 @@ def test_rbac_list_all_perms_single_role() -> None:
             assert res.count(p) == 1
         for p in editorPerms:
             assert res.count(p) == 1
+
 
 @pytest.mark.e2e_cpu_rbac
 @api_utils.skipif_rbac_not_enabled()

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -443,6 +443,7 @@ def test_rbac_permission_assignment_no_dups() -> None:
 @pytest.mark.e2e_cpu_rbac
 @api_utils.skipif_rbac_not_enabled()  
 def test_rbac_list_all_perms_single_role() -> None:
+    sess, _ = api_utils.create_test_user()
     # Assign Viewer role in one workspace and Editor role in another and verify that correct number
     # of permissions are listed within each respective workspace.
     perm_assigments = [

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -10,6 +10,16 @@ from tests.cluster import test_workspace_org
 
 PermCase = NamedTuple("PermCase", [("sess", api.Session), ("raises", Optional[Any])])
 
+viewerPerms = [
+    "PERMISSION_TYPE_VIEW_PROJECT",
+    "PERMISSION_TYPE_VIEW_EXPERIMENT_ARTIFACTS",
+    "PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA",
+    "PERMISSION_TYPE_VIEW_WORKSPACE",
+    "PERMISSION_TYPE_VIEW_MODEL_REGISTRY",
+    "PERMISSION_TYPE_VIEW_NSC",
+    "PERMISSION_TYPE_VIEW_TEMPLATES",
+]
+
 
 @contextlib.contextmanager
 def create_workspaces_with_users(
@@ -378,6 +388,32 @@ def test_rbac_permission_assignment_errors() -> None:
         ],
         "Not Found",
     )
+
+
+@pytest.mark.e2e_cpu_rbac
+@api_utils.skipif_rbac_not_enabled()
+def test_rbac_permission_assignment_no_dups() -> None:
+    admin = api_utils.admin_session()
+    sess, _ = api_utils.create_test_user()
+
+    # Verify user has no permissions.
+    assert "no permissions" in detproc.check_output(sess, ["det", "rbac", "my-permissions"])
+
+    # Assign Viewer and Editor roles to the user.
+    detproc.check_call(
+        admin,
+        ["det", "rbac", "assign-role", "Viewer", "--username-to-assign", sess.username],
+    )
+    detproc.check_call(
+        admin,
+        ["det", "rbac", "assign-role", "Editor", "--username-to-assign", sess.username],
+    )
+
+    # Check that listed permissions do not contain any duplicates of overlapping permissions
+    # between Viewer and Editor roles.
+    res = detproc.check_output(sess, ["det", "rbac", "my-permissions"])
+    for p in viewerPerms:
+        assert res.count(p) == 1
 
 
 @pytest.mark.e2e_cpu_rbac

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -58,9 +58,15 @@ def my_permissions(args: Namespace) -> None:
         return
 
     role_id_to_permissions: Dict[int, Set[bindings.v1Permission]] = {}
+    all_perms = set()
     for r in resp.roles:
         if r.permissions is not None and r.roleId is not None:
-            role_id_to_permissions[r.roleId] = set(r.permissions)
+            perms_for_role = set()
+            for p in r.permissions:
+                if p.id not in all_perms:
+                    perms_for_role.add(p)
+                    all_perms.add(p.id)
+            role_id_to_permissions[r.roleId] = perms_for_role
 
     scope_id_to_permissions: Dict[int, Set[bindings.v1Permission]] = {}
     for a in resp.assignments:

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -90,7 +90,7 @@ def my_permissions(args: Namespace) -> None:
             print(f"permissions assigned over workspace '{workspace_name}' with ID '{wid}'")
 
         perms_to_render = []
-        perms_added = set()
+        perms_added: set[bindings.v1PermissionType] = set()
         for p in perms:
             if p.id not in perms_added:
                 perms_added.add(p.id)

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -58,15 +58,9 @@ def my_permissions(args: Namespace) -> None:
         return
 
     role_id_to_permissions: Dict[int, Set[bindings.v1Permission]] = {}
-    all_perms = set()
     for r in resp.roles:
         if r.permissions is not None and r.roleId is not None:
-            perms_for_role = set()
-            for p in r.permissions:
-                if p.id not in all_perms:
-                    perms_for_role.add(p)
-                    all_perms.add(p.id)
-            role_id_to_permissions[r.roleId] = perms_for_role
+            role_id_to_permissions[r.roleId] = set(r.permissions)
 
     scope_id_to_permissions: Dict[int, Set[bindings.v1Permission]] = {}
     for a in resp.assignments:
@@ -95,8 +89,14 @@ def my_permissions(args: Namespace) -> None:
             workspace_name = bindings.get_GetWorkspace(sess, id=wid).workspace.name
             print(f"permissions assigned over workspace '{workspace_name}' with ID '{wid}'")
 
+        perms_to_render = []
+        perms_added = set()
+        for p in perms:
+            if p.id not in perms_added:
+                perms_added.add(p.id)
+                perms_to_render.append(render.unmarshal(v1PermissionHeaders, p.to_json()))
         render.render_objects(
-            v1PermissionHeaders, [render.unmarshal(v1PermissionHeaders, p.to_json()) for p in perms]
+            v1PermissionHeaders, perms_to_render
         )
         print()
 

--- a/harness/determined/cli/rbac.py
+++ b/harness/determined/cli/rbac.py
@@ -95,9 +95,7 @@ def my_permissions(args: Namespace) -> None:
             if p.id not in perms_added:
                 perms_added.add(p.id)
                 perms_to_render.append(render.unmarshal(v1PermissionHeaders, p.to_json()))
-        render.render_objects(
-            v1PermissionHeaders, perms_to_render
-        )
+        render.render_objects(v1PermissionHeaders, perms_to_render)
         print()
 
 


### PR DESCRIPTION
## Description

When a user is assigned to roles that have overlapping permissions, `det rbac my-permissions` lists each permission within a given scope as many times as the number of roles assigned to the user within that scope containing that permission. 
This leads to a lot of duplicate permissions being listed within a given scope when a user runs `det rbac my-permissions`. We fix that here!

It's also worth noting that this change does not affect the result of running `det rbac my-permissions --json`.

## Test Plan

CI passes.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10172
