### PR TITLE
chore: multirm unique resource pool config changes [RM-74]

### DIFF
--- a/master/internal/config/resource_config.go
+++ b/master/internal/config/resource_config.go
@@ -88,6 +88,7 @@ func (r *ResourceConfig) ResolveResource() error {
 	}
 
 	// Add a default resource pool for nonslurm default resource managers.
+	// TODO(multirm-slurm) rethink pool discovery.
 	if r.RootPoolsInternal == nil &&
 		(r.RootManagerInternal.AgentRM != nil || r.RootManagerInternal.KubernetesRM != nil) {
 		defaultPool := defaultRPConfig()

--- a/master/internal/config/resource_config.go
+++ b/master/internal/config/resource_config.go
@@ -105,7 +105,7 @@ func (r ResourceConfig) Validate() []error {
 	poolNames := make(map[string]bool)
 	var errs []error
 	for _, r := range r.ResourceManagers() {
-		// All non slurm resource managers must have a resource pol.
+		// All non slurm resource managers must have a resource pool.
 		if len(r.ResourcePools) == 0 &&
 			(r.ResourceManager.AgentRM != nil || r.ResourceManager.KubernetesRM != nil) {
 			errs = append(errs, fmt.Errorf(


### PR DESCRIPTION
## Description

Require unique resource pool names in config.

## Test Plan

unit tests


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
