### PR TITLE
chore: Bumpenvs for NGC+ images

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -37,7 +37,7 @@ parameters:
   # be referenced by --ee testing.
   default-pt-gpu-image:
     type: string
-    default: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-2196775
+    default: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-03ae7d7
   # Some python, go, and react dependencies are cached by circleci via `save_cache`/`restore_cache`.
   # If the dependencies stay the same, but the circleci code that would produce them is changed,
   # it may be necessary to invalidate the cache by incrementing this value.
@@ -223,7 +223,7 @@ commands:
       - when:
           condition: <<parameters.tf2>>
           steps:
-            - run: docker pull determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775
+            - run: docker pull determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7
 
   login-docker:
     parameters:
@@ -1870,7 +1870,7 @@ jobs:
 
   test-unit-harness-pytorch2-gpu:
     docker:
-      - image: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-2196775
+      - image: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-03ae7d7
     resource_class: determined-ai/container-runner-gpu
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
@@ -1891,7 +1891,7 @@ jobs:
 
   test-unit-harness-pytorch2-cpu:
     docker:
-      - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-2196775
+      - image: determinedai/environments:py-3.10-pytorch-2.0-cpu-03ae7d7
     steps:
       - run: mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
       - checkout

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -2,9 +2,12 @@
 
 **New Features**
 
--  Add experimental NGC-based images in our environments offerings. These images can be pulled from
+-  Add pre-release NGC-based images to our environments offerings. These images can be pulled from
    `https://hub.docker.com/r/determinedai/pytorch-ngc` or
    `https://hub.docker.com/r/determinedai/tensorflow-ngc`
+   Users can build their own images from a given NGC container version by using the
+   `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`.
+   Our environments repo is located at `https://github.com/determined-ai/environments`.
 
 **Improvements**
 

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -2,12 +2,15 @@
 
 **New Features**
 
--  Add pre-release NGC-based images to our environments offerings. These images can be pulled from
-   `https://hub.docker.com/r/determinedai/pytorch-ngc` or
-   `https://hub.docker.com/r/determinedai/tensorflow-ngc`
+-  Add Add early access NVIDIA NGC-based images to our environments offerings. These images can be
+   pulled from `https://hub.docker.com/r/determinedai/pytorch-ngc` or
+   `https://hub.docker.com/r/determinedai/tensorflow-ngc`. By downloading and using these images,
+   you accept the terms and conditions of all third-party software licenses contained within,
+   including the `NVIDIA Deep Learning Container
+   License.`<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_
    Users can build their own images from a given NGC container version by using the
-   `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`.
-   Our environments repo is located at `https://github.com/determined-ai/environments`.
+   `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`. Our
+   environments repo is located at `https://github.com/determined-ai/environments`.
 
 **Improvements**
 

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -2,17 +2,17 @@
 
 **New Features**
 
--  Add Add early access NVIDIA NGC-based images to our environments offerings. These images can be
-   pulled from `https://hub.docker.com/r/determinedai/pytorch-ngc` or
-   `https://hub.docker.com/r/determinedai/tensorflow-ngc`. By downloading and using these images,
-   you accept the terms and conditions of all third-party software licenses contained within,
-   including the (`NVIDIA Deep Learning Container
-   License.<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_)
-   Users can build their own images from a given NGC container version by using the
-   `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`. Our
-   environments repo is located at `https://github.com/determined-ai/environments`.
+-  Include early-access NVIDIA NGC-based images in our environment offerings. These images are
+   accessible from `pytorch-ngc <https://hub.docker.com/r/determinedai/pytorch-ngc>`_ or
+   `tensorflow-ngc <https://hub.docker.com/r/determinedai/tensorflow-ngc>`_. By downloading and
+   using these images, users acknowledge and agree to the terms and conditions of all third-party
+   software licenses contained within, including the `NVIDIA Deep Learning Container License
+   <https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`__.
+   Users can build their own images from a specified NGC container version by using the
+   ``build-pytorch-ngc`` or ``build-tensorflow-ngc`` workflows located in our environments
+   ``MakeFile`` in the `environments repository <https://github.com/determined-ai/environments>`_.
 
 **Improvements**
 
--  Remove TF 2.8 images from our offerings. Default TF 2.11 images are still available for
-   TensorFlow users.
+-  Eliminate TensorFlow 2.8 images from our offerings. Default TensorFlow 2.11 images remain 
+   available for TensorFlow users.

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+**New Features**
+
+-  Add experimental NGC-based images in our environments offerings. These images can be pulled from
+   `https://hub.docker.com/r/determinedai/pytorch-ngc` or
+   `https://hub.docker.com/r/determinedai/tensorflow-ngc`
+
+**Improvements**
+
+-  Remove TF 2.8 images from our offerings. Default TF 2.11 images are still available for
+   TensorFlow users.

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -6,8 +6,8 @@
    pulled from `https://hub.docker.com/r/determinedai/pytorch-ngc` or
    `https://hub.docker.com/r/determinedai/tensorflow-ngc`. By downloading and using these images,
    you accept the terms and conditions of all third-party software licenses contained within,
-   including the `NVIDIA Deep Learning Container
-   License.<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_
+   including the (`NVIDIA Deep Learning Container
+   License.<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_)
    Users can build their own images from a given NGC container version by using the
    `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`. Our
    environments repo is located at `https://github.com/determined-ai/environments`.

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -7,7 +7,7 @@
    `https://hub.docker.com/r/determinedai/tensorflow-ngc`. By downloading and using these images,
    you accept the terms and conditions of all third-party software licenses contained within,
    including the `NVIDIA Deep Learning Container
-   License.`<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_
+   License.<https://developer.download.nvidia.com/licenses/NVIDIA_Deep_Learning_Container_License.pdf>`_
    Users can build their own images from a given NGC container version by using the
    `build-pytorch-ngc` or `build-tensorflow-ngc` workflows found in our environments `MakeFile`. Our
    environments repo is located at `https://github.com/determined-ai/environments`.

--- a/docs/release-notes/ngc-images.rst
+++ b/docs/release-notes/ngc-images.rst
@@ -14,5 +14,5 @@
 
 **Improvements**
 
--  Eliminate TensorFlow 2.8 images from our offerings. Default TensorFlow 2.11 images remain 
+-  Eliminate TensorFlow 2.8 images from our offerings. Default TensorFlow 2.11 images remain
    available for TensorFlow users.

--- a/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
@@ -26,9 +26,9 @@ by default in this version of Determined are described below.
 +-------------+--------------------------------------------------------------------------+
 | Environment | File Name                                                                |
 +=============+==========================================================================+
-| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775``    |
+| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7``    |
 +-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775`` |
+| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7`` |
 +-------------+--------------------------------------------------------------------------+
 | AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
 +-------------+--------------------------------------------------------------------------+

--- a/docs/setup-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/slurm/singularity.rst
@@ -26,9 +26,9 @@ by default in this version of Determined are described below.
 +-------------+--------------------------------------------------------------------------+
 | Environment | File Name                                                                |
 +=============+==========================================================================+
-| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775``    |
+| CPUs        | ``determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7``    |
 +-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775`` |
+| NVIDIA GPUs | ``determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7`` |
 +-------------+--------------------------------------------------------------------------+
 | AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
 +-------------+--------------------------------------------------------------------------+

--- a/docs/setup-cluster/slurm/slurm-requirements.rst
+++ b/docs/setup-cluster/slurm/slurm-requirements.rst
@@ -510,7 +510,7 @@ platform. There may be additional per-user configuration that is required.
 
    .. code:: bash
 
-      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775
+      image=determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7
       cd /shared/enroot/images
       enroot import docker://$image
       enroot create /shared/enroot/images/${image//[\/:]/\+}.sqsh

--- a/e2e_tests/tests/config.py
+++ b/e2e_tests/tests/config.py
@@ -14,12 +14,12 @@ MAX_TASK_SCHEDULED_SECS = 30
 MAX_TRIAL_BUILD_SECS = 90
 
 
-DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775"
-DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
-DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-cpu-2196775"
-DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-2196775"
-DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-pytorch-2.0-cpu-2196775"
-DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-2196775"
+DEFAULT_TF2_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7"
+DEFAULT_TF2_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
+DEFAULT_PT_CPU_IMAGE = "determinedai/environments:py-3.9-pytorch-1.12-cpu-03ae7d7"
+DEFAULT_PT_GPU_IMAGE = "determinedai/environments:cuda-11.3-pytorch-1.12-gpu-03ae7d7"
+DEFAULT_PT2_CPU_IMAGE = "determinedai/environments:py-3.10-pytorch-2.0-cpu-03ae7d7"
+DEFAULT_PT2_GPU_IMAGE = "determinedai/environments:cuda-11.8-pytorch-2.0-gpu-03ae7d7"
 
 TF2_CPU_IMAGE = os.environ.get("TF2_CPU_IMAGE") or DEFAULT_TF2_CPU_IMAGE
 TF2_GPU_IMAGE = os.environ.get("TF2_GPU_IMAGE") or DEFAULT_TF2_GPU_IMAGE

--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -5,10 +5,10 @@ Mappings:
   RegionMap:
     us-gov-east-1:
       Master: ami-04ef693ebcf519dc3
-      Agent: ami-0b20a31b3607df583
+      Agent: ami-0f8b824c4dd2a429d
     us-gov-west-1:
       Master: ami-08bd15d820a3c087e
-      Agent: ami-09e52c95db3076b2a
+      Agent: ami-05ab84798a30661d3
 Parameters:
   Keypair:
     Type: AWS::EC2::KeyPair::KeyName

--- a/harness/determined/deploy/aws/templates/lore.yaml
+++ b/harness/determined/deploy/aws/templates/lore.yaml
@@ -3,35 +3,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
 
 Parameters:
   VpcCIDR:

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -4,44 +4,44 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
       Bastion: ami-00910ef9457f0df47
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     #   Bastion: ami-035e3e44dc41db6a2
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     #   Bastion: ami-0fd1ee6c8b656f020
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     #   Bastion: ami-0b62ecd3babd1c548
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
       Bastion: ami-0abbe417ed83c0b29
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
       Bastion: ami-0e3f7dd2dc743e48a
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     #   Bastion: ami-0d78429fb6af30994
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
       Bastion: ami-0172070f66a8ebe63
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
       Bastion: ami-0bafa3699418551cd
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
       Bastion: ami-0ceeab680f529cc36
 
 Parameters:

--- a/harness/determined/deploy/aws/templates/simple-rds.yaml
+++ b/harness/determined/deploy/aws/templates/simple-rds.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -5,35 +5,35 @@ Mappings:
   RegionMap:
     ap-northeast-1:
       Master: ami-00910ef9457f0df47
-      Agent: ami-0a06577b7707632f8
+      Agent: ami-0581f861a00dab473
     # TODO(DET-4258) Uncomment these when we fully support all P3 regions.
     # ap-northeast-2:
     #   Master: ami-035e3e44dc41db6a2
-    #   Agent: ami-00d8faa0b84ddbd88
+    #   Agent: ami-0ba8919c43d1d8cab
     # ap-southeast-1:
     #   Master: ami-0fd1ee6c8b656f020
-    #   Agent: ami-0435fcad25753a1a6
+    #   Agent: ami-08190d9f352e9157f
     # ap-southeast-2:
     #   Master: ami-0b62ecd3babd1c548
-    #   Agent: ami-0067e868a8d4f8a1e
+    #   Agent: ami-0af8a0dc1582a1f3b
     eu-central-1:
       Master: ami-0abbe417ed83c0b29
-      Agent: ami-0ec870b46499de494
+      Agent: ami-09d66f5a074e983ca
     eu-west-1:
       Master: ami-0e3f7dd2dc743e48a
-      Agent: ami-013c92fb90c7a7971
+      Agent: ami-027d2d1f92b4ba863
     # eu-west-2:
     #   Master: ami-0d78429fb6af30994
-    #   Agent: ami-0a5b2c87970d66d5b
+    #   Agent: ami-0c1f3c5203afb4a8f
     us-east-1:
       Master: ami-0172070f66a8ebe63
-      Agent: ami-061ff7cfe905dfbd5
+      Agent: ami-053c295dd390f2a40
     us-east-2:
       Master: ami-0bafa3699418551cd
-      Agent: ami-072947196f5aaa3a5
+      Agent: ami-07e0b9bf1ea2852d8
     us-west-2:
       Master: ami-0ceeab680f529cc36
-      Agent: ami-0d9494a6bae62f03e
+      Agent: ami-0f74a44ed4ce75025
 
 Parameters:
   Keypair:

--- a/harness/determined/deploy/gcp/constants.py
+++ b/harness/determined/deploy/gcp/constants.py
@@ -4,7 +4,7 @@ class defaults:
     DB_PASSWORD = "postgres"
     BOOT_DISK_SIZE = 200
     BOOT_DISK_TYPE = "pd-standard"
-    ENVIRONMENT_IMAGE = "det-environments-2196775"
+    ENVIRONMENT_IMAGE = "det-environments-03ae7d7"
     GPU_NUM = 4
     GPU_TYPE = "nvidia-tesla-t4"
     MASTER_INSTANCE_TYPE = "n1-standard-2"

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-keras/metadata.json
@@ -39,8 +39,8 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775",
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7",
         "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
       },
       "pod_spec": null,

--- a/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
+++ b/harness/tests/experiment/fixtures/ancient-checkpoints/0.17.6-pytorch/metadata.json
@@ -38,8 +38,8 @@
       },
       "force_pull_image": false,
       "image": {
-        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775",
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+        "cuda": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7",
         "rocm": "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
       },
       "pod_spec": null,

--- a/harness/tests/fixtures/checkpoint.json
+++ b/harness/tests/fixtures/checkpoint.json
@@ -69,8 +69,8 @@
           },
           "force_pull_image":false,
           "image":{
-            "cpu":"determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-            "cuda":"determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775",
+            "cpu":"determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+            "cuda":"determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7",
             "rocm":"determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
           },
           "pod_spec":null,

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -31,8 +31,8 @@ defaultImages:
   kubeSchedulerPreemption: "determinedai/kube-scheduler:0.17.0"
 
   # default images for CPU and GPU environments
-  cpuImage: "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775"
-  gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+  cpuImage: "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7"
+  gpuImage: "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
 
 # Install Determined enterprise edition.
 enterpriseEdition: false

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -50,16 +50,16 @@ type AWSClusterConfig struct {
 }
 
 var defaultAWSImageID = map[string]string{
-	"ap-northeast-1": "ami-0a06577b7707632f8",
-	"ap-northeast-2": "ami-00d8faa0b84ddbd88",
-	"ap-southeast-1": "ami-0435fcad25753a1a6",
-	"ap-southeast-2": "ami-0067e868a8d4f8a1e",
-	"us-east-2":      "ami-072947196f5aaa3a5",
-	"us-east-1":      "ami-061ff7cfe905dfbd5",
-	"us-west-2":      "ami-0d9494a6bae62f03e",
-	"eu-central-1":   "ami-0ec870b46499de494",
-	"eu-west-2":      "ami-0a5b2c87970d66d5b",
-	"eu-west-1":      "ami-013c92fb90c7a7971",
+	"ap-northeast-1": "ami-0581f861a00dab473",
+	"ap-northeast-2": "ami-0ba8919c43d1d8cab",
+	"ap-southeast-1": "ami-08190d9f352e9157f",
+	"ap-southeast-2": "ami-0af8a0dc1582a1f3b",
+	"us-east-2":      "ami-07e0b9bf1ea2852d8",
+	"us-east-1":      "ami-053c295dd390f2a40",
+	"us-west-2":      "ami-0f74a44ed4ce75025",
+	"eu-central-1":   "ami-09d66f5a074e983ca",
+	"eu-west-2":      "ami-0c1f3c5203afb4a8f",
+	"eu-west-1":      "ami-027d2d1f92b4ba863",
 }
 
 var defaultAWSClusterConfig = AWSClusterConfig{

--- a/master/internal/config/provconfig/gcp_config.go
+++ b/master/internal/config/provconfig/gcp_config.go
@@ -56,7 +56,7 @@ type GCPClusterConfig struct {
 func DefaultGCPClusterConfig() *GCPClusterConfig {
 	return &GCPClusterConfig{
 		BootDiskSize:        200,
-		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-2196775",
+		BootDiskSourceImage: "projects/determined-ai/global/images/det-environments-03ae7d7",
 		LabelKey:            "managed-by",
 		InstanceType: gceInstanceType{
 			MachineType: "n1-standard-32",

--- a/master/pkg/schemas/expconf/const.go
+++ b/master/pkg/schemas/expconf/const.go
@@ -8,7 +8,7 @@ const (
 
 // Default task environment docker image names.
 const (
-	CPUImage  = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775"
-	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+	CPUImage  = "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7"
+	CUDAImage = "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
 	ROCMImage = "determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512"
 )

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -5,7 +5,7 @@ SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 ARTIFACTS_DIR := /tmp/artifacts
 
 # Model-hub library environments will be built on top of the default GPU and CPU images in master/pkg/model/defaults.go
-DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775
+DEFAULT_GPU_IMAGE := determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7
 
 ############REMINDER############
 # When bumping third-party library versions, remember to bump versions in

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -32,8 +32,8 @@
       environment_variables: {}
       force_pull_image: false
       image:
-        cpu: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775
-        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775
+        cpu: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7
+        cuda: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7
         rocm: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512
       pod_spec: null
       ports:

--- a/tools/scripts/bumpenvs.yaml
+++ b/tools/scripts/bumpenvs.yaml
@@ -1,15 +1,17 @@
-ap_northeast_1_agent_ami: {new: ami-0a06577b7707632f8, old: ami-0bffb351742e4d778}
+ap_northeast_1_agent_ami: {new: ami-0581f861a00dab473, old: ami-0a06577b7707632f8}
 ap_northeast_1_bastion_ami: {new: ami-00910ef9457f0df47, old: ami-0c7cb70d3eb61492b}
 ap_northeast_1_master_ami: {new: ami-00910ef9457f0df47, old: ami-0c7cb70d3eb61492b}
-ap_northeast_2_agent_ami: {new: ami-00d8faa0b84ddbd88, old: ami-0429ee62fc06a8019}
+ap_northeast_2_agent_ami: {new: ami-0ba8919c43d1d8cab, old: ami-00d8faa0b84ddbd88}
 ap_northeast_2_bastion_ami: {new: ami-035e3e44dc41db6a2, old: ami-003bb1772f36a39a3}
 ap_northeast_2_master_ami: {new: ami-035e3e44dc41db6a2, old: ami-003bb1772f36a39a3}
-ap_southeast_1_agent_ami: {new: ami-0435fcad25753a1a6, old: ami-0aa9f5e7e1a9933f2}
+ap_southeast_1_agent_ami: {new: ami-08190d9f352e9157f, old: ami-0435fcad25753a1a6}
 ap_southeast_1_bastion_ami: {new: ami-0fd1ee6c8b656f020, old: ami-09f03fa5572692399}
 ap_southeast_1_master_ami: {new: ami-0fd1ee6c8b656f020, old: ami-09f03fa5572692399}
-ap_southeast_2_agent_ami: {new: ami-0067e868a8d4f8a1e, old: ami-01ae41ecfbb042eee}
+ap_southeast_2_agent_ami: {new: ami-0af8a0dc1582a1f3b, old: ami-0067e868a8d4f8a1e}
 ap_southeast_2_bastion_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
 ap_southeast_2_master_ami: {new: ami-0b62ecd3babd1c548, old: ami-06139e5e22cc2f7b1}
+deepspeed_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-03ae7d7}
+deepspeed_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-0.29.1}
 deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-2196775,
   old: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-f66cbce}
 deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-deepspeed-0.8.3-gpu-0.29.1,
@@ -18,16 +20,18 @@ deepspeed_gpu_1_hashed: {new:
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-9119094}
 deepspeed_gpu_1_versioned: {new: 
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-deepspeed-0.7.0-gpu-mpi-0.19.1}
-eu_central_1_agent_ami: {new: ami-0ec870b46499de494, old: ami-02a2a8e7cb59b8ca6}
+eu_central_1_agent_ami: {new: ami-09d66f5a074e983ca, old: ami-0ec870b46499de494}
 eu_central_1_bastion_ami: {new: ami-0abbe417ed83c0b29, old: ami-0b81e95bb0a06ea8c}
 eu_central_1_master_ami: {new: ami-0abbe417ed83c0b29, old: ami-0b81e95bb0a06ea8c}
-eu_west_1_agent_ami: {new: ami-013c92fb90c7a7971, old: ami-04d4dd517927955bb}
+eu_west_1_agent_ami: {new: ami-027d2d1f92b4ba863, old: ami-013c92fb90c7a7971}
 eu_west_1_bastion_ami: {new: ami-0e3f7dd2dc743e48a, old: ami-029cfca952b331b52}
 eu_west_1_master_ami: {new: ami-0e3f7dd2dc743e48a, old: ami-029cfca952b331b52}
-eu_west_2_agent_ami: {new: ami-0a5b2c87970d66d5b, old: ami-00f4c4dc577d844bd}
+eu_west_2_agent_ami: {new: ami-0c1f3c5203afb4a8f, old: ami-0a5b2c87970d66d5b}
 eu_west_2_bastion_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
 eu_west_2_master_ami: {new: ami-0d78429fb6af30994, old: ami-035469b606478d63d}
-gcp_env: {new: det-environments-2196775, old: det-environments-f66cbce}
+gcp_env: {new: det-environments-03ae7d7, old: det-environments-2196775}
+gpt_neox_deepspeed_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-03ae7d7}
+gpt_neox_deepspeed_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.29.1}
 gpt_neox_deepspeed_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-2196775,
   old: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-f66cbce}
 gpt_neox_deepspeed_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.10-gpt-neox-deepspeed-gpu-0.29.1,
@@ -36,44 +40,44 @@ gpt_neox_deepspeed_gpu_1_hashed: {new:
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-9119094}
 gpt_neox_deepspeed_gpu_1_versioned: {new: 
     determinedai/environments:cuda-11.3-pytorch-1.10-tf-2.8-gpt-neox-deepspeed-gpu-mpi-0.19.1}
-pt2_cpu_0_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-2196775,
-  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-f66cbce}
+pt2_cpu_0_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-03ae7d7,
+  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-2196775}
 pt2_cpu_0_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-0.29.1,
   old: determinedai/environments:py-3.10-pytorch-2.0-cpu-0.27.1}
-pt2_cpu_1_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-2196775,
-  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-f66cbce}
+pt2_cpu_1_hashed: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-03ae7d7,
+  old: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-2196775}
 pt2_cpu_1_versioned: {new: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-0.29.1,
   old: determinedai/environments:py-3.10-pytorch-2.0-cpu-mpi-0.27.1}
-pt2_gpu_0_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-2196775,
-  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-f66cbce}
+pt2_gpu_0_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-03ae7d7,
+  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-2196775}
 pt2_gpu_0_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-0.29.1,
   old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-0.27.1}
-pt2_gpu_1_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-2196775,
-  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-f66cbce}
+pt2_gpu_1_hashed: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-03ae7d7,
+  old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-2196775}
 pt2_gpu_1_versioned: {new: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-0.29.1,
   old: determinedai/environments:cuda-11.8-pytorch-2.0-gpu-mpi-0.27.1}
-pt_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-2196775,
-  old: determinedai/environments:py-3.9-pytorch-1.12-cpu-f66cbce}
+pt_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-03ae7d7,
+  old: determinedai/environments:py-3.9-pytorch-1.12-cpu-2196775}
 pt_cpu_0_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-0.29.1,
   old: determinedai/environments:py-3.9-pytorch-1.12-cpu-0.27.1}
-pt_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-2196775,
-  old: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-f66cbce}
+pt_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-03ae7d7,
+  old: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-2196775}
 pt_cpu_1_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-0.29.1,
   old: determinedai/environments:py-3.9-pytorch-1.12-cpu-mpi-0.27.1}
-pt_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-2196775,
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-f66cbce}
+pt_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-03ae7d7,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-2196775}
 pt_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.29.1,
   old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-0.27.1}
-pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-2196775,
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-f66cbce}
+pt_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-03ae7d7,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-2196775}
 pt_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.29.1,
   old: determinedai/environments:cuda-11.3-pytorch-1.12-gpu-mpi-0.27.1}
 pytorch10_tf27_rocm50_0_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512,
   old: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-bf9480b}
 pytorch10_tf27_rocm50_0_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4,
   old: determinedai/environments-dev:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4}
-pytorch13_tf210_rocm56_0_hashed: {new: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-2196775,
-  old: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-f66cbce}
+pytorch13_tf210_rocm56_0_hashed: {new: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-03ae7d7,
+  old: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-2196775}
 pytorch13_tf210_rocm56_0_versioned: {new: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-0.29.1,
   old: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-0.27.1}
 pytorch13_tf210_rocm56_1_hashed: {new: determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-ompi-2196775,
@@ -86,14 +90,18 @@ pytorch19_tf25_rocm_0_versioned: {new: determinedai/environments:rocm-5.0-pytorc
   old: determinedai/environments:rocm-4.2-pytorch-1.9-tf-2.5-rocm-0.18.5}
 pytorch19_tf25_rocm_1_hashed: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-096d730}
 pytorch19_tf25_rocm_1_versioned: {new: determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.19.4}
-pytorch20_tf210_rocm56_0_hashed: {new: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-2196775,
-  old: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-f66cbce}
+pytorch20_tf210_rocm56_0_hashed: {new: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-03ae7d7,
+  old: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-2196775}
 pytorch20_tf210_rocm56_0_versioned: {new: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-0.29.1,
   old: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-0.27.1}
 pytorch20_tf210_rocm56_1_hashed: {new: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-2196775,
   old: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-f66cbce}
 pytorch20_tf210_rocm56_1_versioned: {new: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-0.29.1,
   old: determinedai/environments:rocm-5.6-pytorch-2.0-tf-2.10-rocm-ompi-0.27.1}
+pytorch_ngc_hashed: {new: determinedai/pytorch-ngc:03ae7d7}
+pytorch_ngc_hpc_hashed: {new: determinedai/pytorch-ngc-hpc:03ae7d7}
+tensorflow_ngc_hashed: {new: determinedai/tensorflow-ngc:03ae7d7}
+tensorflow_ngc_hpc_hashed: {new: determinedai/tensorflow-ngc-hpc:03ae7d7}
 tf24_cpu_0_hashed: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-24586f0,
   old: determinedai/environments-dev:py-3.8-pytorch-1.9-tf-2.4-cpu-1c769fb}
 tf24_cpu_0_versioned: {new: determinedai/environments:py-3.8-pytorch-1.9-tf-2.4-cpu-0.19.10,
@@ -168,32 +176,32 @@ tf28_gpu_1_hashed: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-2196
   old: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-f66cbce}
 tf28_gpu_1_versioned: {new: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-0.29.1,
   old: determinedai/environments:cuda-11.2-tf-2.8-gpu-mpi-0.27.1}
-tf2_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775,
-  old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-f66cbce}
+tf2_cpu_0_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7,
+  old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775}
 tf2_cpu_0_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.29.1,
   old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-0.27.1}
-tf2_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-2196775,
-  old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-f66cbce}
+tf2_cpu_1_hashed: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-03ae7d7,
+  old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-2196775}
 tf2_cpu_1_versioned: {new: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-0.29.1,
   old: determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-mpi-0.27.1}
-tf2_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775,
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-f66cbce}
+tf2_gpu_0_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775}
 tf2_gpu_0_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.29.1,
   old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-0.27.1}
-tf2_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-2196775,
-  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-f66cbce}
+tf2_gpu_1_hashed: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-03ae7d7,
+  old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-2196775}
 tf2_gpu_1_versioned: {new: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-0.29.1,
   old: determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-mpi-0.27.1}
-us_east_1_agent_ami: {new: ami-061ff7cfe905dfbd5, old: ami-0cd3eb2e7394e6135}
+us_east_1_agent_ami: {new: ami-053c295dd390f2a40, old: ami-061ff7cfe905dfbd5}
 us_east_1_bastion_ami: {new: ami-0172070f66a8ebe63, old: ami-0b93ce03dcbcb10f6}
 us_east_1_master_ami: {new: ami-0172070f66a8ebe63, old: ami-0b93ce03dcbcb10f6}
-us_east_2_agent_ami: {new: ami-072947196f5aaa3a5, old: ami-092cd38207aded760}
+us_east_2_agent_ami: {new: ami-07e0b9bf1ea2852d8, old: ami-072947196f5aaa3a5}
 us_east_2_bastion_ami: {new: ami-0bafa3699418551cd, old: ami-0cbea92f2377277a4}
 us_east_2_master_ami: {new: ami-0bafa3699418551cd, old: ami-0cbea92f2377277a4}
-us_gov_east_1_agent_ami: {new: ami-0b20a31b3607df583, old: ami-065d670b7d0d648bf}
+us_gov_east_1_agent_ami: {new: ami-0f8b824c4dd2a429d, old: ami-0b20a31b3607df583}
 us_gov_east_1_master_ami: {new: ami-04ef693ebcf519dc3, old: ami-01d71f6009765d511}
-us_gov_west_1_agent_ami: {new: ami-09e52c95db3076b2a, old: ami-058ffd48428aaeaeb}
+us_gov_west_1_agent_ami: {new: ami-05ab84798a30661d3, old: ami-09e52c95db3076b2a}
 us_gov_west_1_master_ami: {new: ami-08bd15d820a3c087e, old: ami-0b64b04df085adbf1}
-us_west_2_agent_ami: {new: ami-0d9494a6bae62f03e, old: ami-0ab46b9ac642fc297}
+us_west_2_agent_ami: {new: ami-0f74a44ed4ce75025, old: ami-0d9494a6bae62f03e}
 us_west_2_bastion_ami: {new: ami-0ceeab680f529cc36, old: ami-0d31d7c9fc9503726}
 us_west_2_master_ami: {new: ami-0ceeab680f529cc36, old: ami-0d31d7c9fc9503726}

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -61,20 +61,28 @@ JOB_SUFFIXES_NO_MPI = [
 
 PACKER_JOBS = {"publish-cloud-images"}
 
-DOCKER_JOBS = {
-    f"build-and-publish-docker-{suffix}-{mpi}"
-    for (suffix, mpi) in itertools.product(JOB_SUFFIXES, [0, 1])
-} | {f"build-and-publish-docker-{suffix}-0" for suffix in JOB_SUFFIXES_WITHOUT_MPI} \
-| {f"build-and-publish-docker-{suffix}-0" for suffix in JOB_SUFFIXES_NO_MPI if "hpc" not in suffix}
+DOCKER_JOBS = (
+    {
+        f"build-and-publish-docker-{suffix}-{mpi}"
+        for (suffix, mpi) in itertools.product(JOB_SUFFIXES, [0, 1])
+    }
+    | {f"build-and-publish-docker-{suffix}-0" for suffix in JOB_SUFFIXES_WITHOUT_MPI}
+    | {
+        f"build-and-publish-docker-{suffix}-0"
+        for suffix in JOB_SUFFIXES_NO_MPI
+        if "hpc" not in suffix
+    }
+)
 
 PACKER_ARTIFACTS = {
     "packer-log",
 }
 
-DOCKER_ARTIFACTS = {
-    f"publish-{suffix}-{mpi}" for (suffix, mpi) in itertools.product(JOB_SUFFIXES, [0, 1])
-} | {f"publish-{suffix}-0" for suffix in JOB_SUFFIXES_WITHOUT_MPI} \
-| {f"publish-{suffix}" for suffix in JOB_SUFFIXES_NO_MPI}
+DOCKER_ARTIFACTS = (
+    {f"publish-{suffix}-{mpi}" for (suffix, mpi) in itertools.product(JOB_SUFFIXES, [0, 1])}
+    | {f"publish-{suffix}-0" for suffix in JOB_SUFFIXES_WITHOUT_MPI}
+    | {f"publish-{suffix}" for suffix in JOB_SUFFIXES_NO_MPI}
+)
 
 
 class Build:
@@ -154,8 +162,8 @@ def get_all_artifacts(builds: Dict[str, Build], cloud_images: bool) -> Dict[str,
         expected = DOCKER_ARTIFACTS
 
     found = set(artifacts.keys())
-    assert (
-        expected.issubset(found)
+    assert expected.issubset(
+        found
     ), "expected artifacts\n  {expected_list}\nbut found\n  {found_list}".format(
         expected_list="\n  ".join(sorted(expected)), found_list="\n  ".join(sorted(found))
     )

--- a/tools/scripts/update-bumpenvs-yaml.py
+++ b/tools/scripts/update-bumpenvs-yaml.py
@@ -162,8 +162,8 @@ def get_all_artifacts(builds: Dict[str, Build], cloud_images: bool) -> Dict[str,
         expected = DOCKER_ARTIFACTS
 
     found = set(artifacts.keys())
-    assert expected.issubset(
-        found
+    assert (
+        expected == found
     ), "expected artifacts\n  {expected_list}\nbut found\n  {found_list}".format(
         expected_list="\n  ".join(sorted(expected)), found_list="\n  ".join(sorted(found))
     )

--- a/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
+++ b/webui/react/src/fixtures/responses/experiment-details/non-scalar-metrics-4078.json
@@ -32,8 +32,8 @@
     "name": "Fork of Fork of mnist_tp_to_estimator_const",
     "environment": {
       "image": {
-        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+        "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+        "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
       },
       "ports": null,
       "pod_spec": null,

--- a/webui/react/src/fixtures/responses/experiment-details/set-a.json
+++ b/webui/react/src/fixtures/responses/experiment-details/set-a.json
@@ -694,8 +694,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
         },
         "pod_spec": null,
         "ports": null
@@ -838,8 +838,8 @@
         "environment_variables": {},
         "force_pull_image": false,
         "image": {
-          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+          "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+          "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
         },
         "pod_spec": {
           "metadata": {

--- a/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
+++ b/webui/react/src/fixtures/responses/trial-details/old-trial-config-noop-adaptive.json
@@ -30,8 +30,8 @@
   "name": "noop_adaptive",
   "environment": {
     "image": {
-      "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-2196775",
-      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-2196775"
+      "cpu": "determinedai/environments:py-3.9-pytorch-1.12-tf-2.11-cpu-03ae7d7",
+      "gpu": "determinedai/environments:cuda-11.3-pytorch-1.12-tf-2.11-gpu-03ae7d7"
     },
     "ports": null,
     "force_pull_image": false,


### PR DESCRIPTION
## Description

Bumpenvs for NGC+ Images (and tf2.8 removal)
https://github.com/determined-ai/environments/pull/235


## Test Plan

CI doesn't fail


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
MD-270
