### PR TITLE
ci: Djanicek/infraeng 487/circle test runner

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -567,36 +567,17 @@ commands:
                 port: <<parameters.master-port>>
 
       - run:
-          name: Split tests
-          working_directory: ~/project/e2e_tests
-          command: |
-            # Preselect the files that contain any matching tests to minimize how wrong CircleCI's
-            # splitting can get things. (The presence of files with no tests can cause the files
-            # with tests to be bunched up incorrectly, making the split suboptimal.)
-
-            # `--setup-plan` tells pytest to not run any tests but instead print out a description
-            # of the tests that would be run, along with some other stuff. Each file containing
-            # any selected tests is printed on a line by itself, except for (for some reason) a
-            # single trailing space.
-            pytest --setup-plan -m '<<parameters.mark>>' | egrep '\.py s*$' | sed 's/\.py.*$/.py/' > /tmp/all-relevant-files
-
-            echo 'All files with tests matching mark "<<parameters.mark>>":'
-            sed 's/^/- /' </tmp/all-relevant-files
-
-            circleci tests split --split-by=timings < /tmp/all-relevant-files > /tmp/tests-to-run
-            echo "Running tests from these files:"
-            sed 's/^/- /' </tmp/tests-to-run
-
-            if [ ! -s /tmp/tests-to-run ]; then
-              echo 'No test files found!'
-              exit 1
-            fi
-
-      - run:
           name: Run e2e tests
           working_directory: ~/project/e2e_tests
           no_output_timeout: 30m
           command: |
+            pytest --setup-plan -m '<<parameters.mark>>' | egrep '\.py s*$' | sed 's/\.py.*$/.py/' > /tmp/all-relevant-files
+            if [ ! -s /tmp/all-relevant-files ]; then
+              echo 'No test files found!'
+              exit 1
+            fi
+            
+            cat /tmp/all-relevant-files | circleci tests run --command="xargs \
             DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com' DD_ENV=ci DD_SERVICE='pytest-<<parameters.mark>>' \
             DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
             pytest -vv -s \
@@ -609,7 +590,8 @@ commands:
             -o junit_family=xunit1 \
             --junit-xml="<<parameters.junit-path>>" \
             <<parameters.extra-pytest-flags>> \
-            $(< /tmp/tests-to-run)
+            $(< /tmp/tests-to-run)" \
+            --verbose --split-by=timings
       - upload-test-job:
           only_on_branch: main
           test_results_path: <<parameters.junit-path>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -577,10 +577,12 @@ commands:
               exit 1
             fi
             
-            cat /tmp/all-relevant-files | circleci tests run --command="xargs \
-            DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_SITE='datadoghq.com' DD_ENV=ci DD_SERVICE='pytest-<<parameters.mark>>' \
-            DET_MASTER_CERT_FILE=<<parameters.master-cert>> DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
-            pytest -vv -s \
+            cat /tmp/all-relevant-files | circleci tests run --command="DD_CIVISIBILITY_AGENTLESS_ENABLED=true \
+            DD_SITE='datadoghq.com' \
+            DD_ENV=ci DD_SERVICE='pytest-<<parameters.mark>>' \
+            DET_MASTER_CERT_FILE=<<parameters.master-cert>> \
+            DET_MASTER_CERT_NAME=<<parameters.master-cert-name>> \
+            xargs pytest -vv -s \
             -m '<<parameters.mark>>' \
             --durations=0 \
             --ddtrace \
@@ -589,8 +591,7 @@ commands:
             --master-port="<<parameters.master-port>>" \
             -o junit_family=xunit1 \
             --junit-xml="<<parameters.junit-path>>" \
-            <<parameters.extra-pytest-flags>> \
-            $(< /tmp/tests-to-run)" \
+            <<parameters.extra-pytest-flags>>" \
             --verbose --split-by=timings
       - upload-test-job:
           only_on_branch: main


### PR DESCRIPTION
## Description

INFRAENG-487

Circle-ci lets us re-run failed tests individually if we use the circle ci runner instead of splitting and running separately. 
https://circleci.com/docs/rerun-failed-tests/

This makes it faster and cheaper to re-run failures on circle-ci since individual tests can be re-run instead of whole jobs.

## Test Plan

pipeline passed and all the E2E tests took the same amount of time. Spot checking most of them, they all ran the same number of tests as main.

https://app.circleci.com/pipelines/github/determined-ai/determined/52143/workflows/311b97d9-4e74-4c18-90c2-f03abd7f3cf6/jobs/2331410

We'll have to be careful of long-running nightly e2e. I'm running a sample to insure they work. https://app.circleci.com/pipelines/github/determined-ai/determined/52143/workflows/2e6ceb8a-4d72-4ae3-9f3c-73e85358f7ee

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

