### PR TITLE
chore: add type ResourcePoolName string

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/rbac/audit"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/templates"
 	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -97,7 +98,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	poolName, launchWarnings, err := a.m.ResolveResources(
-		resources.ResourcePool,
+		rm.ResourcePoolName(resources.ResourcePool),
 		resources.Slots,
 		int(cmdSpec.Metadata.WorkspaceID),
 		true,
@@ -133,7 +134,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 	// Copy discovered (default) resource pool name and slot count.
 	fillTaskConfig(resources.Slots, taskSpec, &config.Environment)
-	config.Resources.ResourcePool = poolName
+	config.Resources.ResourcePool = string(poolName)
 	config.Resources.Slots = resources.Slots
 
 	var contextDirectory []byte

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -24,7 +24,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/rbac/audit"
-	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/templates"
 	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -98,7 +97,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	poolName, launchWarnings, err := a.m.ResolveResources(
-		rm.ResourcePoolName(resources.ResourcePool),
+		resources.ResourcePool,
 		resources.Slots,
 		int(cmdSpec.Metadata.WorkspaceID),
 		true,

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -133,7 +133,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 	// Copy discovered (default) resource pool name and slot count.
 	fillTaskConfig(resources.Slots, taskSpec, &config.Environment)
-	config.Resources.ResourcePool = string(poolName)
+	config.Resources.ResourcePool = poolName.String()
 	config.Resources.Slots = resources.Slots
 
 	var contextDirectory []byte

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -36,6 +36,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
 	"github.com/determined-ai/determined/master/internal/prom"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/trials"
 	"github.com/determined-ai/determined/master/internal/user"
@@ -349,7 +350,7 @@ func (a *apiServer) GetExperiment(
 	}
 
 	jobID := model.JobID(exp.JobId)
-	jobSummary, err := jobservice.DefaultService.GetJobSummary(jobID, exp.ResourcePool)
+	jobSummary, err := jobservice.DefaultService.GetJobSummary(jobID, rm.ResourcePoolName(exp.ResourcePool))
 	if err != nil {
 		// An error here either is real or just that the experiment was not yet terminal in the DB
 		// when we first queried it but was by the time it got around to handling out ask. We can't

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -21,7 +21,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
 	"github.com/determined-ai/determined/master/internal/project"
-	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/task"
@@ -104,8 +103,7 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 		return nil, nil, nil, fmt.Errorf("resource slots must be >= 0")
 	}
 	isSingleNode := resources.IsSingleNode != nil && *resources.IsSingleNode
-	poolName, launchWarnings, err := a.m.ResolveResources(
-		rm.ResourcePoolName(resources.ResourcePool),
+	poolName, launchWarnings, err := a.m.ResolveResources(resources.ResourcePool,
 		resources.Slots,
 		int(proj.WorkspaceId),
 		isSingleNode)

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -126,7 +126,7 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 	// Copy discovered (default) resource pool name and slot count.
 
 	fillTaskConfig(resources.Slots, taskSpec, &taskConfig.Environment)
-	rawResourcePool := string(poolName)
+	rawResourcePool := poolName.String()
 	taskConfig.Resources.RawResourcePool = &rawResourcePool
 	taskConfig.Resources.RawSlots = &resources.Slots
 

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
 	"github.com/determined-ai/determined/master/internal/project"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/task"
@@ -103,7 +104,8 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 		return nil, nil, nil, fmt.Errorf("resource slots must be >= 0")
 	}
 	isSingleNode := resources.IsSingleNode != nil && *resources.IsSingleNode
-	poolName, launchWarnings, err := a.m.ResolveResources(resources.ResourcePool,
+	poolName, launchWarnings, err := a.m.ResolveResources(
+		rm.ResourcePoolName(resources.ResourcePool),
 		resources.Slots,
 		int(proj.WorkspaceId),
 		isSingleNode)
@@ -126,7 +128,8 @@ func (a *apiServer) getGenericTaskLaunchParameters(
 	// Copy discovered (default) resource pool name and slot count.
 
 	fillTaskConfig(resources.Slots, taskSpec, &taskConfig.Environment)
-	taskConfig.Resources.RawResourcePool = &poolName
+	rawResourcePool := string(poolName)
+	taskConfig.Resources.RawResourcePool = &rawResourcePool
 	taskConfig.Resources.RawSlots = &resources.Slots
 
 	var contextDirectoryBytes []byte

--- a/master/internal/api_job.go
+++ b/master/internal/api_job.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
+	"github.com/determined-ai/determined/master/internal/rm"
 
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
@@ -18,7 +19,7 @@ func (a *apiServer) GetJobs(
 	ctx context.Context, req *apiv1.GetJobsRequest,
 ) (resp *apiv1.GetJobsResponse, err error) {
 	jobs, err := jobservice.DefaultService.GetJobs(
-		req.ResourcePool,
+		rm.ResourcePoolName(req.ResourcePool),
 		req.OrderBy == apiv1.OrderBy_ORDER_BY_DESC,
 		req.States,
 	)
@@ -49,7 +50,7 @@ func (a *apiServer) GetJobsV2(
 	ctx context.Context, req *apiv1.GetJobsV2Request,
 ) (resp *apiv1.GetJobsV2Response, err error) {
 	jobs, err := jobservice.DefaultService.GetJobs(
-		req.ResourcePool,
+		rm.ResourcePoolName(req.ResourcePool),
 		req.OrderBy == apiv1.OrderBy_ORDER_BY_DESC,
 		req.States,
 	)

--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -89,7 +89,7 @@ func (a *apiServer) GetResourcePools(
 func (a *apiServer) BindRPToWorkspace(
 	ctx context.Context, req *apiv1.BindRPToWorkspaceRequest,
 ) (*apiv1.BindRPToWorkspaceResponse, error) {
-	err := a.checkIfPoolIsDefault(req.ResourcePoolName)
+	err := a.checkIfPoolIsDefault(rm.ResourcePoolName(req.ResourcePoolName))
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (a *apiServer) BindRPToWorkspace(
 func (a *apiServer) OverwriteRPWorkspaceBindings(
 	ctx context.Context, req *apiv1.OverwriteRPWorkspaceBindingsRequest,
 ) (*apiv1.OverwriteRPWorkspaceBindingsResponse, error) {
-	err := a.checkIfPoolIsDefault(req.ResourcePoolName)
+	err := a.checkIfPoolIsDefault(rm.ResourcePoolName(req.ResourcePoolName))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (a *apiServer) ListWorkspacesBoundToRP(
 	}, nil
 }
 
-func (a *apiServer) checkIfPoolIsDefault(poolName string) error {
+func (a *apiServer) checkIfPoolIsDefault(poolName rm.ResourcePoolName) error {
 	defaultComputePool, err := a.m.rm.GetDefaultComputeResourcePool()
 	if err != nil {
 		return err
@@ -222,8 +222,8 @@ func (a *apiServer) checkIfPoolIsDefault(poolName string) error {
 		return err
 	}
 
-	isDefaultCompute := poolName == string(defaultComputePool)
-	isDefaultAux := poolName == string(defaultAuxPool)
+	isDefaultCompute := poolName == defaultComputePool
+	isDefaultAux := poolName == defaultAuxPool
 	if isDefaultCompute || isDefaultAux {
 		return fmt.Errorf(
 			"default resource pool %s cannot be bound to any workspace",

--- a/master/internal/api_resourcepool.go
+++ b/master/internal/api_resourcepool.go
@@ -222,8 +222,8 @@ func (a *apiServer) checkIfPoolIsDefault(poolName string) error {
 		return err
 	}
 
-	isDefaultCompute := poolName == defaultComputePool
-	isDefaultAux := poolName == defaultAuxPool
+	isDefaultCompute := poolName == string(defaultComputePool)
+	isDefaultAux := poolName == string(defaultAuxPool)
 	if isDefaultCompute || isDefaultAux {
 		return fmt.Errorf(
 			"default resource pool %s cannot be bound to any workspace",

--- a/master/internal/api_resourcepool_intg_test.go
+++ b/master/internal/api_resourcepool_intg_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/mocks"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/pkg/set"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/resourcepoolv1"
@@ -58,9 +59,9 @@ func TestPostBindingFails(t *testing.T) {
 	// TODO (eliu): add some tests for workspaceIDs
 	// test resource pools on workspaces that do not exist
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	_, err := api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
 		ResourcePoolName: testPoolName,
 		WorkspaceNames:   []string{"nonexistent_workspace"},
@@ -69,9 +70,9 @@ func TestPostBindingFails(t *testing.T) {
 
 	// test resource pool doesn't exist
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Twice()
+		Return(rm.ResourcePoolName(""), nil).Twice()
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{},
@@ -85,7 +86,7 @@ func TestPostBindingFails(t *testing.T) {
 
 	// test resource pool is a default resource pool
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return(testPoolName, nil).Twice()
+		Return(rm.ResourcePoolName(testPoolName), nil).Twice()
 
 	_, err = api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
 		ResourcePoolName: testPoolName,
@@ -95,7 +96,7 @@ func TestPostBindingFails(t *testing.T) {
 	require.ErrorContains(t, err, "default resource pool testRP cannot be bound to any workspace")
 
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return(testPoolName, nil).Once()
+		Return(rm.ResourcePoolName(testPoolName), nil).Once()
 
 	_, err = api.BindRPToWorkspace(ctx, &apiv1.BindRPToWorkspaceRequest{
 		ResourcePoolName: testPoolName,
@@ -106,9 +107,9 @@ func TestPostBindingFails(t *testing.T) {
 
 	// test no resource pool specified
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return(testPoolName, nil).Once()
+		Return(rm.ResourcePoolName(testPoolName), nil).Once()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return(testPoolName, nil).Once()
+		Return(rm.ResourcePoolName(testPoolName), nil).Once()
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
@@ -134,9 +135,9 @@ func TestPostBindingSucceeds(t *testing.T) {
 
 	// bind first resource pool
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Twice()
+		Return(rm.ResourcePoolName(""), nil).Twice()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Twice()
+		Return(rm.ResourcePoolName(""), nil).Twice()
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
@@ -170,9 +171,9 @@ func TestListWorkspacesBoundToRPFails(t *testing.T) {
 
 	// bind first workspace
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
@@ -207,9 +208,9 @@ func TestListWorkspacesBoundToRPSucceeds(t *testing.T) {
 
 	// test bind resource pool to workspace
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Once()
+		Return(rm.ResourcePoolName(""), nil).Once()
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
@@ -256,9 +257,9 @@ func TestPatchBindingsSucceeds(t *testing.T) {
 
 	// setup first binding
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Times(4)
+		Return(rm.ResourcePoolName(""), nil).Times(4)
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Times(4)
+		Return(rm.ResourcePoolName(""), nil).Times(4)
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},
@@ -328,9 +329,9 @@ func TestDeleteBindingsSucceeds(t *testing.T) {
 	// TODO: fix all comments
 	// setup first binding
 	mockRM.On("GetDefaultComputeResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Times(1)
+		Return(rm.ResourcePoolName(""), nil).Times(1)
 	mockRM.On("GetDefaultAuxResourcePool", mock.Anything, mock.Anything).
-		Return("", nil).Times(1)
+		Return(rm.ResourcePoolName(""), nil).Times(1)
 	mockRM.On("GetResourcePools", mock.Anything, mock.Anything).
 		Return(&apiv1.GetResourcePoolsResponse{
 			ResourcePools: []*resourcepoolv1.ResourcePool{{Name: testPoolName}},

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/determined-ai/determined/master/internal/job/jobservice"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/rm/rmevents"
 	"github.com/determined-ai/determined/master/internal/sproto"
 
@@ -56,14 +57,14 @@ func MockRM() *mocks.ResourceManager {
 		return sproto.EmptyDeleteJobResponse()
 	}, nil)
 	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).Return(
-		func(name string, _, _ int) string {
+		func(name rm.ResourcePoolName, _, _ int) rm.ResourcePoolName {
 			return name
 		},
 		nil,
 	)
 	mockRM.On("ValidateResources", mock.Anything).Return(nil, nil)
 	mockRM.On("TaskContainerDefaults", mock.Anything, mock.Anything).Return(
-		func(name string, def model.TaskContainerDefaultsConfig) model.TaskContainerDefaultsConfig {
+		func(name rm.ResourcePoolName, def model.TaskContainerDefaultsConfig) model.TaskContainerDefaultsConfig {
 			return def
 		},
 		nil,

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -182,7 +182,7 @@ func runCheckpointGCTask(
 		FittingRequirements: sproto.FittingRequirements{
 			SingleAgent: true,
 		},
-		ResourcePool: rp,
+		ResourcePool: string(rp),
 	}, pgDB, rm, gcSpec, onExit)
 	if err != nil {
 		return err

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -182,7 +182,7 @@ func runCheckpointGCTask(
 		FittingRequirements: sproto.FittingRequirements{
 			SingleAgent: true,
 		},
-		ResourcePool: string(rp),
+		ResourcePool: rp.String(),
 	}, pgDB, rm, gcSpec, onExit)
 	if err != nil {
 		return err

--- a/master/internal/checkpoint_gc_test.go
+++ b/master/internal/checkpoint_gc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/mocks/allocationmocks"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -55,15 +56,15 @@ func TestRunCheckpointGCTask(t *testing.T) {
 			name: "simple success",
 			args: args{
 				rm: func() *mocks.ResourceManager {
-					var rm mocks.ResourceManager
+					var r mocks.ResourceManager
 
-					rm.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-						Return("default", nil)
+					r.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+						Return(rm.ResourcePoolName("default"), nil)
 
-					rm.On("TaskContainerDefaults", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					r.On("TaskContainerDefaults", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 						Return(model.TaskContainerDefaultsConfig{}, nil)
 
-					return &rm
+					return &r
 				}(),
 				as: func(t *testing.T) *allocationmocks.AllocationService {
 					var as allocationmocks.AllocationService
@@ -114,12 +115,12 @@ func TestRunCheckpointGCTask(t *testing.T) {
 			name: "simple failure",
 			args: args{
 				rm: func() *mocks.ResourceManager {
-					var rm mocks.ResourceManager
+					var r mocks.ResourceManager
 
-					rm.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-						Return("", errors.New("rm is down or something"))
+					r.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+						Return(rm.ResourcePoolName(""), errors.New("rm is down or something"))
 
-					return &rm
+					return &r
 				}(),
 				as: func(t *testing.T) *allocationmocks.AllocationService {
 					return &allocationmocks.AllocationService{}

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/project"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/templates"
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -298,7 +299,7 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
 	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
-		poolName,
+		rm.ResourcePoolName(poolName),
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -294,14 +294,13 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
 	isSingleNode := resources.IsSingleNode() != nil && *resources.IsSingleNode()
-	poolName, _, err := m.ResolveResources(resources.ResourcePool(), resources.SlotsPerTrial(), workspaceID, isSingleNode)
+	poolName, _, err := m.ResolveResources(
+		rm.ResourcePoolName(resources.ResourcePool()), resources.SlotsPerTrial(),
+		workspaceID, isSingleNode)
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
-	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
-		rm.ResourcePoolName(poolName),
-		m.config.TaskContainerDefaults,
-	)
+	taskContainerDefaults, err := m.rm.TaskContainerDefaults(poolName, m.config.TaskContainerDefaults)
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
 	}

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -20,7 +20,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/project"
-	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/templates"
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -294,13 +293,14 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
 	isSingleNode := resources.IsSingleNode() != nil && *resources.IsSingleNode()
-	poolName, _, err := m.ResolveResources(
-		rm.ResourcePoolName(resources.ResourcePool()), resources.SlotsPerTrial(),
-		workspaceID, isSingleNode)
+	poolName, _, err := m.ResolveResources(resources.ResourcePool(), resources.SlotsPerTrial(), workspaceID, isSingleNode)
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "invalid resource configuration")
 	}
-	taskContainerDefaults, err := m.rm.TaskContainerDefaults(poolName, m.config.TaskContainerDefaults)
+	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
+		poolName,
+		m.config.TaskContainerDefaults,
+	)
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrapf(err, "error getting TaskContainerDefaults")
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -117,7 +117,7 @@ func newExperiment(
 	var launchWarnings []command.LaunchWarning
 	if expModel.ID == 0 {
 		if launchWarnings, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-			ResourcePool: string(poolName),
+			ResourcePool: poolName.String(),
 			Slots:        resources.SlotsPerTrial(),
 			IsSingleNode: resources.IsSingleNode() != nil && *resources.IsSingleNode(),
 		}); err != nil {
@@ -127,7 +127,7 @@ func newExperiment(
 			return nil, nil, errors.New("slots requested exceeds cluster capacity")
 		}
 	}
-	resources.SetResourcePool(string(poolName))
+	resources.SetResourcePool(poolName.String())
 
 	activeConfig.SetResources(resources)
 
@@ -1115,11 +1115,11 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	switch {
 	case err != nil:
 		return fmt.Errorf("invalid resource pool name %s", resourcePool)
-	case oldRP == string(rp):
+	case oldRP == rp.String():
 		return fmt.Errorf("resource pool is unchanged (%s == %s)", oldRP, rp)
 	}
 
-	resources.SetResourcePool(string(rp))
+	resources.SetResourcePool(rp.String())
 	e.activeConfig.SetResources(resources)
 
 	if err := e.db.SaveExperimentConfig(e.ID, e.activeConfig); err != nil {
@@ -1133,7 +1133,7 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	for _, t := range e.trials {
 		t := t
 		g.Go(func() error {
-			t.PatchRP(string(rp))
+			t.PatchRP(rp.String())
 			return nil
 		})
 	}

--- a/master/internal/job/jobservice/jobservice.go
+++ b/master/internal/job/jobservice/jobservice.go
@@ -92,7 +92,7 @@ func (s *Service) jobQRefs(jobQ map[model.JobID]*sproto.RMJobInfo) (map[model.Jo
 
 // GetJobs returns a list of jobs for a resource pool.
 func (s *Service) GetJobs(
-	resourcePool string,
+	resourcePool rm.ResourcePoolName,
 	desc bool,
 	states []jobv1.State,
 ) ([]*jobv1.Job, error) {
@@ -160,7 +160,7 @@ func (s *Service) GetJobs(
 }
 
 // GetJobSummary returns a summary of the job given an id and resource pool.
-func (s *Service) GetJobSummary(id model.JobID, resourcePool string) (*jobv1.JobSummary, error) {
+func (s *Service) GetJobSummary(id model.JobID, resourcePool rm.ResourcePoolName) (*jobv1.JobSummary, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/determined-ai/determined/master/internal/experiment"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/workspace"
 
@@ -75,7 +76,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 	}
 	workspaceID := resolveWorkspaceID(workspaceModel)
 	poolName, err := m.rm.ResolveResourcePool(
-		activeConfig.Resources().ResourcePool(),
+		rm.ResourcePoolName(activeConfig.Resources().ResourcePool()),
 		workspaceID,
 		activeConfig.Resources().SlotsPerTrial(),
 	)
@@ -83,7 +84,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 		return fmt.Errorf("invalid resource configuration: %w", err)
 	}
 	if _, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-		ResourcePool: poolName,
+		ResourcePool: string(poolName),
 		Slots:        activeConfig.Resources().SlotsPerTrial(),
 		IsSingleNode: false,
 	}); err != nil {

--- a/master/internal/restore.go
+++ b/master/internal/restore.go
@@ -84,7 +84,7 @@ func (m *Master) restoreExperiment(expModel *model.Experiment) error {
 		return fmt.Errorf("invalid resource configuration: %w", err)
 	}
 	if _, err = m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-		ResourcePool: string(poolName),
+		ResourcePool: poolName.String(),
 		Slots:        activeConfig.Resources().SlotsPerTrial(),
 		IsSingleNode: false,
 	}); err != nil {

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -275,7 +275,7 @@ func (a *ResourceManager) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*
 		rpName = rm.ResourcePoolName(a.config.DefaultComputeResourcePool)
 	}
 
-	pool, err := a.poolByName(string(rpName))
+	pool, err := a.poolByName(rpName.String())
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (a *ResourceManager) ResolveResourcePool(name rm.ResourcePoolName, workspac
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if string(name) == poolName {
+		if name.String() == poolName {
 			found = true
 			break
 		}
@@ -506,7 +506,7 @@ func (a *ResourceManager) TaskContainerDefaults(
 	result := fallbackConfig
 	// Iterate through configured pools looking for a TaskContainerDefaults setting.
 	for _, pool := range a.poolsConfig {
-		if string(resourcePoolName) == pool.PoolName {
+		if resourcePoolName.String() == pool.PoolName {
 			if pool.TaskContainerDefaults == nil {
 				break
 			}
@@ -550,7 +550,7 @@ func (a *ResourceManager) ValidateResources(
 
 // ValidateResourcePool implements rm.ResourceManager.
 func (a *ResourceManager) ValidateResourcePool(name rm.ResourcePoolName) error {
-	_, err := a.poolByName(string(name))
+	_, err := a.poolByName(name.String())
 	if err != nil {
 		return err
 	}

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/rm/rmevents"
 	"github.com/determined-ai/determined/master/internal/rm/rmutils"
@@ -248,33 +249,33 @@ func (a *ResourceManager) GetAllocationSummaries() (map[model.AllocationID]sprot
 }
 
 // GetDefaultAuxResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) GetDefaultAuxResourcePool() (string, error) {
+func (a *ResourceManager) GetDefaultAuxResourcePool() (rm.ResourcePoolName, error) {
 	if a.config.DefaultAuxResourcePool == "" {
 		return "", rmerrors.ErrNoDefaultResourcePool
 	}
-	return a.config.DefaultAuxResourcePool, nil
+	return rm.ResourcePoolName(a.config.DefaultAuxResourcePool), nil
 }
 
 // GetDefaultComputeResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) GetDefaultComputeResourcePool() (string, error) {
+func (a *ResourceManager) GetDefaultComputeResourcePool() (rm.ResourcePoolName, error) {
 	if a.config.DefaultComputeResourcePool == "" {
 		return "", rmerrors.ErrNoDefaultResourcePool
 	}
-	return a.config.DefaultComputeResourcePool, nil
+	return rm.ResourcePoolName(a.config.DefaultComputeResourcePool), nil
 }
 
 // GetExternalJobs implements rm.ResourceManager.
-func (*ResourceManager) GetExternalJobs(string) ([]*jobv1.Job, error) {
+func (*ResourceManager) GetExternalJobs(rm.ResourcePoolName) ([]*jobv1.Job, error) {
 	return nil, rmerrors.ErrNotSupported
 }
 
 // GetJobQ implements rm.ResourceManager.
-func (a *ResourceManager) GetJobQ(rpName string) (map[model.JobID]*sproto.RMJobInfo, error) {
+func (a *ResourceManager) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sproto.RMJobInfo, error) {
 	if rpName == "" {
-		rpName = a.config.DefaultComputeResourcePool
+		rpName = rm.ResourcePoolName(a.config.DefaultComputeResourcePool)
 	}
 
-	pool, err := a.poolByName(rpName)
+	pool, err := a.poolByName(string(rpName))
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +404,9 @@ func (a *ResourceManager) Release(msg sproto.ResourcesReleased) {
 }
 
 // ResolveResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slots int) (string, error) {
+func (a *ResourceManager) ResolveResourcePool(name rm.ResourcePoolName, workspaceID int, slots int) (
+	rm.ResourcePoolName, error,
+) {
 	ctx := context.TODO()
 	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, workspaceID)
 	if err != nil {
@@ -418,7 +421,7 @@ func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slot
 			}
 			return resp, nil
 		}
-		name = defaultAuxPool
+		name = rm.ResourcePoolName(defaultAuxPool)
 	}
 
 	if name == "" && slots >= 0 {
@@ -429,7 +432,7 @@ func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slot
 			}
 			return resp, nil
 		}
-		name = defaultComputePool
+		name = rm.ResourcePoolName(defaultComputePool)
 	}
 
 	resp, err := a.GetResourcePools()
@@ -444,7 +447,7 @@ func (a *ResourceManager) ResolveResourcePool(name string, workspaceID int, slot
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if name == poolName {
+		if string(name) == poolName {
 			found = true
 			break
 		}
@@ -497,13 +500,13 @@ func (a *ResourceManager) SetGroupWeight(msg sproto.SetGroupWeight) error {
 
 // TaskContainerDefaults implements rm.ResourceManager.
 func (a *ResourceManager) TaskContainerDefaults(
-	resourcePoolName string,
+	resourcePoolName rm.ResourcePoolName,
 	fallbackConfig model.TaskContainerDefaultsConfig,
 ) (model.TaskContainerDefaultsConfig, error) {
 	result := fallbackConfig
 	// Iterate through configured pools looking for a TaskContainerDefaults setting.
 	for _, pool := range a.poolsConfig {
-		if resourcePoolName == pool.PoolName {
+		if string(resourcePoolName) == pool.PoolName {
 			if pool.TaskContainerDefaults == nil {
 				break
 			}
@@ -546,8 +549,8 @@ func (a *ResourceManager) ValidateResources(
 }
 
 // ValidateResourcePool implements rm.ResourceManager.
-func (a *ResourceManager) ValidateResourcePool(name string) error {
-	_, err := a.poolByName(name)
+func (a *ResourceManager) ValidateResourcePool(name rm.ResourcePoolName) error {
+	_, err := a.poolByName(string(name))
 	if err != nil {
 		return err
 	}

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/rm/rmerrors"
 	"github.com/determined-ai/determined/master/internal/rm/rmevents"
 	"github.com/determined-ai/determined/master/internal/rm/rmutils"
@@ -192,33 +193,33 @@ func (k *ResourceManager) GetAllocationSummaries() (map[model.AllocationID]sprot
 }
 
 // GetDefaultAuxResourcePool implements rm.ResourceManager.
-func (k *ResourceManager) GetDefaultAuxResourcePool() (string, error) {
+func (k *ResourceManager) GetDefaultAuxResourcePool() (rm.ResourcePoolName, error) {
 	if k.config.DefaultComputeResourcePool == "" {
 		return "", rmerrors.ErrNoDefaultResourcePool
 	}
-	return k.config.DefaultAuxResourcePool, nil
+	return rm.ResourcePoolName(k.config.DefaultAuxResourcePool), nil
 }
 
 // GetDefaultComputeResourcePool implements rm.ResourceManager.
-func (k *ResourceManager) GetDefaultComputeResourcePool() (string, error) {
+func (k *ResourceManager) GetDefaultComputeResourcePool() (rm.ResourcePoolName, error) {
 	if k.config.DefaultComputeResourcePool == "" {
 		return "", rmerrors.ErrNoDefaultResourcePool
 	}
-	return k.config.DefaultComputeResourcePool, nil
+	return rm.ResourcePoolName(k.config.DefaultComputeResourcePool), nil
 }
 
 // GetExternalJobs implements rm.ResourceManager.
-func (ResourceManager) GetExternalJobs(string) ([]*jobv1.Job, error) {
+func (ResourceManager) GetExternalJobs(rm.ResourcePoolName) ([]*jobv1.Job, error) {
 	return nil, rmerrors.ErrNotSupported
 }
 
 // GetJobQ implements rm.ResourceManager.
-func (k *ResourceManager) GetJobQ(rpName string) (map[model.JobID]*sproto.RMJobInfo, error) {
+func (k *ResourceManager) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sproto.RMJobInfo, error) {
 	if rpName == "" {
-		rpName = k.config.DefaultComputeResourcePool
+		rpName = rm.ResourcePoolName(k.config.DefaultComputeResourcePool)
 	}
 
-	rp, err := k.poolByName(rpName)
+	rp, err := k.poolByName(string(rpName))
 	if err != nil {
 		return nil, err
 	}
@@ -371,9 +372,7 @@ func (k *ResourceManager) ValidateResources(
 }
 
 // getResourcePoolRef gets an actor ref to a resource pool by name.
-func (k ResourceManager) resourcePoolExists(
-	name string,
-) error {
+func (k ResourceManager) resourcePoolExists(name string) error {
 	resp, err := k.GetResourcePools()
 	if err != nil {
 		return err
@@ -389,10 +388,10 @@ func (k ResourceManager) resourcePoolExists(
 
 // ResolveResourcePool resolves the resource pool completely.
 func (k ResourceManager) ResolveResourcePool(
-	name string,
+	name rm.ResourcePoolName,
 	workspaceID int,
 	slots int,
-) (string, error) {
+) (rm.ResourcePoolName, error) {
 	ctx := context.TODO()
 	defaultComputePool, defaultAuxPool, err := db.GetDefaultPoolsForWorkspace(ctx, workspaceID)
 	if err != nil {
@@ -407,7 +406,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp, nil
 		}
-		name = defaultAuxPool
+		name = rm.ResourcePoolName(defaultAuxPool)
 	}
 
 	if name == "" && slots >= 0 {
@@ -418,7 +417,7 @@ func (k ResourceManager) ResolveResourcePool(
 			}
 			return resp, nil
 		}
-		name = defaultComputePool
+		name = rm.ResourcePoolName(defaultComputePool)
 	}
 
 	resp, err := k.GetResourcePools()
@@ -433,7 +432,7 @@ func (k ResourceManager) ResolveResourcePool(
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if name == poolName {
+		if string(name) == poolName {
 			found = true
 			break
 		}
@@ -451,8 +450,8 @@ func (k ResourceManager) ResolveResourcePool(
 }
 
 // ValidateResourcePool validates that the named resource pool exists.
-func (k ResourceManager) ValidateResourcePool(name string) error {
-	return k.resourcePoolExists(name)
+func (k ResourceManager) ValidateResourcePool(name rm.ResourcePoolName) error {
+	return k.resourcePoolExists(string(name))
 }
 
 // NotifyContainerRunning receives a notification from the container to let
@@ -474,10 +473,13 @@ func (k ResourceManager) IsReattachableOnlyAfterStarted() bool {
 
 // TaskContainerDefaults returns TaskContainerDefaults for the specified pool.
 func (k ResourceManager) TaskContainerDefaults(
-	pool string,
+	pool rm.ResourcePoolName,
 	fallbackConfig model.TaskContainerDefaultsConfig,
 ) (result model.TaskContainerDefaultsConfig, err error) {
-	return k.getTaskContainerDefaults(taskContainerDefaults{fallbackDefault: fallbackConfig, resourcePool: pool}), nil
+	return k.getTaskContainerDefaults(taskContainerDefaults{
+		fallbackDefault: fallbackConfig,
+		resourcePool:    string(pool),
+	}), nil
 }
 
 func (k *ResourceManager) podStatusUpdateCallback(msg sproto.UpdatePodStatus) {

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -219,7 +219,7 @@ func (k *ResourceManager) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*
 		rpName = rm.ResourcePoolName(k.config.DefaultComputeResourcePool)
 	}
 
-	rp, err := k.poolByName(string(rpName))
+	rp, err := k.poolByName(rpName.String())
 	if err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (k ResourceManager) ResolveResourcePool(
 	}
 	found := false
 	for _, poolName := range poolNames {
-		if string(name) == poolName {
+		if name.String() == poolName {
 			found = true
 			break
 		}
@@ -451,7 +451,7 @@ func (k ResourceManager) ResolveResourcePool(
 
 // ValidateResourcePool validates that the named resource pool exists.
 func (k ResourceManager) ValidateResourcePool(name rm.ResourcePoolName) error {
-	return k.resourcePoolExists(string(name))
+	return k.resourcePoolExists(name.String())
 }
 
 // NotifyContainerRunning receives a notification from the container to let
@@ -478,7 +478,7 @@ func (k ResourceManager) TaskContainerDefaults(
 ) (result model.TaskContainerDefaultsConfig, err error) {
 	return k.getTaskContainerDefaults(taskContainerDefaults{
 		fallbackDefault: fallbackConfig,
-		resourcePool:    string(pool),
+		resourcePool:    pool.String(),
 	}), nil
 }
 

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ErrRPNotDefined returns a detailed error if a resource pool isn't found.
-func ErrRPNotDefined(rp string) error {
+func ErrRPNotDefined(rp rm.ResourcePoolName) error {
 	return fmt.Errorf("could not find resource pool %s", rp)
 }
 
@@ -58,7 +58,7 @@ func (m *MultiRMRouter) GetAllocationSummaries() (
 
 // Allocate routes an AllocateRequest to the specified RM.
 func (m *MultiRMRouter) Allocate(req sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (m *MultiRMRouter) Allocate(req sproto.AllocateRequest) (*sproto.ResourcesS
 
 // Release routes an allocation release request.
 func (m *MultiRMRouter) Release(req sproto.ResourcesReleased) {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -79,7 +79,7 @@ func (m *MultiRMRouter) Release(req sproto.ResourcesReleased) {
 
 // ValidateResources routes a validation request for a specified resource manager/pool.
 func (m *MultiRMRouter) ValidateResources(req sproto.ValidateResourcesRequest) ([]command.LaunchWarning, error) {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (m *MultiRMRouter) NotifyContainerRunning(req sproto.NotifyContainerRunning
 
 // SetGroupMaxSlots routes a SetGroupMaxSlots request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupMaxSlots(req sproto.SetGroupMaxSlots) {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -113,7 +113,7 @@ func (m *MultiRMRouter) SetGroupMaxSlots(req sproto.SetGroupMaxSlots) {
 
 // SetGroupWeight routes a SetGroupWeight request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupWeight(req sproto.SetGroupWeight) error {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (m *MultiRMRouter) SetGroupWeight(req sproto.SetGroupWeight) error {
 
 // SetGroupPriority routes a SetGroupPriority request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupPriority(req sproto.SetGroupPriority) error {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (m *MultiRMRouter) GetResourcePools() (*apiv1.GetResourcePoolsResponse, err
 }
 
 // GetDefaultComputeResourcePool routes a GetDefaultComputeResourcePool to the specified resource manager.
-func (m *MultiRMRouter) GetDefaultComputeResourcePool() (string, error) {
+func (m *MultiRMRouter) GetDefaultComputeResourcePool() (rm.ResourcePoolName, error) {
 	resolvedRMName, err := m.getRM("")
 	if err != nil {
 		return "", err
@@ -176,7 +176,7 @@ func (m *MultiRMRouter) GetDefaultComputeResourcePool() (string, error) {
 }
 
 // GetDefaultAuxResourcePool routes a GetDefaultAuxResourcePool to the specified resource manager.
-func (m *MultiRMRouter) GetDefaultAuxResourcePool() (string, error) {
+func (m *MultiRMRouter) GetDefaultAuxResourcePool() (rm.ResourcePoolName, error) {
 	resolvedRMName, err := m.getRM("")
 	if err != nil {
 		return "", err
@@ -186,7 +186,7 @@ func (m *MultiRMRouter) GetDefaultAuxResourcePool() (string, error) {
 }
 
 // ValidateResourcePool routes a ValidateResourcePool call to the specified resource manager.
-func (m *MultiRMRouter) ValidateResourcePool(rpName string) error {
+func (m *MultiRMRouter) ValidateResourcePool(rpName rm.ResourcePoolName) error {
 	resolvedRMName, err := m.getRM(rpName)
 	if err != nil {
 		return err
@@ -196,7 +196,8 @@ func (m *MultiRMRouter) ValidateResourcePool(rpName string) error {
 }
 
 // ResolveResourcePool routes a ResolveResourcePool request for a specific resource manager/pool.
-func (m *MultiRMRouter) ResolveResourcePool(rpName string, workspace, slots int) (resourcePool string, err error,
+func (m *MultiRMRouter) ResolveResourcePool(rpName rm.ResourcePoolName, workspace, slots int) (
+	rm.ResourcePoolName, error,
 ) {
 	resolvedRMName, err := m.getRM(rpName)
 	if err != nil {
@@ -208,7 +209,7 @@ func (m *MultiRMRouter) ResolveResourcePool(rpName string, workspace, slots int)
 
 // TaskContainerDefaults routes a TaskContainerDefaults call to a specific resource manager/pool.
 func (m *MultiRMRouter) TaskContainerDefaults(
-	rpName string,
+	rpName rm.ResourcePoolName,
 	fallbackConfig model.TaskContainerDefaultsConfig,
 ) (model.TaskContainerDefaultsConfig, error) {
 	resolvedRMName, err := m.getRM(rpName)
@@ -220,7 +221,7 @@ func (m *MultiRMRouter) TaskContainerDefaults(
 }
 
 // GetJobQ routes a GetJobQ call to a specified resource manager/pool.
-func (m *MultiRMRouter) GetJobQ(rpName string) (map[model.JobID]*sproto.RMJobInfo, error) {
+func (m *MultiRMRouter) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sproto.RMJobInfo, error) {
 	resolvedRMName, err := m.getRM(rpName)
 	if err != nil {
 		return nil, err
@@ -233,7 +234,7 @@ func (m *MultiRMRouter) GetJobQ(rpName string) (map[model.JobID]*sproto.RMJobInf
 func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsRequest) (
 	*apiv1.GetJobQueueStatsResponse, error,
 ) {
-	resolvedRMName, err := m.getRM(req.ResourcePools[0])
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePools[0]))
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +244,7 @@ func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsReque
 
 // MoveJob routes a MoveJob call to a specified resource manager/pool.
 func (m *MultiRMRouter) MoveJob(req sproto.MoveJob) error {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -253,7 +254,7 @@ func (m *MultiRMRouter) MoveJob(req sproto.MoveJob) error {
 
 // RecoverJobPosition routes a RecoverJobPosition call to a specified resource manager/pool.
 func (m *MultiRMRouter) RecoverJobPosition(req sproto.RecoverJobPosition) {
-	resolvedRMName, err := m.getRM(req.ResourcePool)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -263,7 +264,7 @@ func (m *MultiRMRouter) RecoverJobPosition(req sproto.RecoverJobPosition) {
 }
 
 // GetExternalJobs routes a GetExternalJobs request to a specified resource manager.
-func (m *MultiRMRouter) GetExternalJobs(rpName string) ([]*jobv1.Job, error) {
+func (m *MultiRMRouter) GetExternalJobs(rpName rm.ResourcePoolName) ([]*jobv1.Job, error) {
 	resolvedRMName, err := m.getRM(rpName)
 	if err != nil {
 		return nil, err
@@ -290,7 +291,7 @@ func (m *MultiRMRouter) GetAgents() (*apiv1.GetAgentsResponse, error) {
 
 // GetAgent routes a GetAgent request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetAgent(req *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +301,7 @@ func (m *MultiRMRouter) GetAgent(req *apiv1.GetAgentRequest) (*apiv1.GetAgentRes
 
 // EnableAgent routes an EnableAgent request to the specified resource manager & agent.
 func (m *MultiRMRouter) EnableAgent(req *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +313,7 @@ func (m *MultiRMRouter) EnableAgent(req *apiv1.EnableAgentRequest) (*apiv1.Enabl
 func (m *MultiRMRouter) DisableAgent(req *apiv1.DisableAgentRequest) (
 	*apiv1.DisableAgentResponse, error,
 ) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +323,7 @@ func (m *MultiRMRouter) DisableAgent(req *apiv1.DisableAgentRequest) (
 
 // GetSlots routes an GetSlots request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetSlots(req *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +333,7 @@ func (m *MultiRMRouter) GetSlots(req *apiv1.GetSlotsRequest) (*apiv1.GetSlotsRes
 
 // GetSlot routes an GetSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func (m *MultiRMRouter) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotRespon
 
 // EnableSlot routes an EnableSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +353,7 @@ func (m *MultiRMRouter) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.EnableS
 
 // DisableSlot routes an DisableSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error) {
-	resolvedRMName, err := m.getRM(req.AgentId)
+	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +361,7 @@ func (m *MultiRMRouter) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Disab
 	return m.rms[resolvedRMName].DisableSlot(req)
 }
 
-func (m *MultiRMRouter) getRM(rpName string) (string, error) {
+func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
 	// If not given RP name, route to default RM.
 	if rpName == "" {
 		m.syslog.Infof("RM undefined, routing to default resource manager")
@@ -373,7 +374,7 @@ func (m *MultiRMRouter) getRM(rpName string) (string, error) {
 			return name, fmt.Errorf("could not get resource pools for %s", r)
 		}
 		for _, p := range rps.ResourcePools {
-			if p.Name == rpName {
+			if p.Name == string(rpName) {
 				m.syslog.Infof("RM defined as %s, %s", name, p.Name)
 				return name, nil
 			}

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -374,7 +374,7 @@ func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
 			return name, fmt.Errorf("could not get resource pools for %s", r)
 		}
 		for _, p := range rps.ResourcePools {
-			if p.Name == string(rpName) {
+			if p.Name == rpName.String() {
 				m.syslog.Infof("RM defined as %s, %s", name, p.Name)
 				return name, nil
 			}

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -642,7 +642,7 @@ func TestGetRMName(t *testing.T) {
 func mockRM(poolName rm.ResourcePoolName) *mocks.ResourceManager {
 	mockRM := mocks.ResourceManager{}
 	mockRM.On("GetResourcePools").Return(&apiv1.GetResourcePoolsResponse{
-		ResourcePools: []*resourcepoolv1.ResourcePool{{Name: string(poolName)}},
+		ResourcePools: []*resourcepoolv1.ResourcePool{{Name: poolName.String()}},
 	}, nil)
 	mockRM.On("Allocate", mock.Anything).Return(&sproto.ResourcesSubscription{}, nil)
 	mockRM.On("ValidateResources", mock.Anything).Return(nil, nil)

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -31,8 +31,8 @@ func TestMain(m *testing.M) {
 	testMultiRM = &MultiRMRouter{
 		defaultRMName: defaultRMName,
 		rms: map[string]rm.ResourceManager{
-			defaultRMName:   mockRM(defaultRMName),
-			"additional-rm": mockRM(additionalRMName),
+			defaultRMName:   mockRM(rm.ResourcePoolName(defaultRMName)),
+			"additional-rm": mockRM(rm.ResourcePoolName(additionalRMName)),
 		},
 		syslog: logrus.WithField("component", "resource-router"),
 	}
@@ -639,10 +639,10 @@ func TestGetRMName(t *testing.T) {
 	}
 }
 
-func mockRM(poolName string) *mocks.ResourceManager {
+func mockRM(poolName rm.ResourcePoolName) *mocks.ResourceManager {
 	mockRM := mocks.ResourceManager{}
 	mockRM.On("GetResourcePools").Return(&apiv1.GetResourcePoolsResponse{
-		ResourcePools: []*resourcepoolv1.ResourcePool{{Name: poolName}},
+		ResourcePools: []*resourcepoolv1.ResourcePool{{Name: string(poolName)}},
 	}, nil)
 	mockRM.On("Allocate", mock.Anything).Return(&sproto.ResourcesSubscription{}, nil)
 	mockRM.On("ValidateResources", mock.Anything).Return(nil, nil)

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -285,7 +285,7 @@ func TestGetDefaultResourcePools(t *testing.T) {
 func TestValidateResourcePool(t *testing.T) {
 	cases := []struct {
 		name   string
-		rpName string
+		rpName rm.ResourcePoolName
 		err    error
 	}{
 		{"empty RP name will default", "", nil},
@@ -304,7 +304,7 @@ func TestValidateResourcePool(t *testing.T) {
 func TestResolveResourcePool(t *testing.T) {
 	cases := []struct {
 		name   string
-		rpName string
+		rpName rm.ResourcePoolName
 		err    error
 	}{
 		{"empty RP name will default", "", nil},
@@ -324,7 +324,7 @@ func TestResolveResourcePool(t *testing.T) {
 func TestTaskContainerDefaults(t *testing.T) {
 	cases := []struct {
 		name   string
-		rpName string
+		rpName rm.ResourcePoolName
 		err    error
 	}{
 		{"empty RP name will default", "", nil},
@@ -343,7 +343,7 @@ func TestTaskContainerDefaults(t *testing.T) {
 func TestGetJobQ(t *testing.T) {
 	cases := []struct {
 		name   string
-		rpName string
+		rpName rm.ResourcePoolName
 		err    error
 	}{
 		{"empty RP name will default", "", nil},
@@ -400,7 +400,7 @@ func TestMoveJob(t *testing.T) {
 func TestGetExternalJobs(t *testing.T) {
 	cases := []struct {
 		name   string
-		rpName string
+		rpName rm.ResourcePoolName
 		err    error
 	}{
 		{"empty RP name will default", "", nil},
@@ -620,7 +620,7 @@ func TestGetRMName(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		rpName         string
+		rpName         rm.ResourcePoolName
 		err            error
 		expectedRMName string
 	}{

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -8,6 +8,10 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
 )
 
+// ResourcePoolName holds the name of the resource pool, and describes the input/output
+// of several ResourceManager methods.
+type ResourcePoolName string
+
 // ResourceManager is an interface for a resource manager, which can allocate and manage resources.
 type ResourceManager interface {
 	// Basic functionality
@@ -27,21 +31,20 @@ type ResourceManager interface {
 
 	// Resource pool stuff.
 	GetResourcePools() (*apiv1.GetResourcePoolsResponse, error)
-	GetDefaultComputeResourcePool() (string, error)
-	GetDefaultAuxResourcePool() (string, error)
-	ValidateResourcePool(name string) error
-	ResolveResourcePool(name string, workspace, slots int) (string, error)
+	GetDefaultComputeResourcePool() (ResourcePoolName, error)
+	GetDefaultAuxResourcePool() (ResourcePoolName, error)
+	ValidateResourcePool(ResourcePoolName) error
+	ResolveResourcePool(name ResourcePoolName, workspace, slots int) (ResourcePoolName, error)
 	TaskContainerDefaults(
-		resourcePoolName string,
-		fallbackConfig model.TaskContainerDefaultsConfig,
+		ResourcePoolName, model.TaskContainerDefaultsConfig,
 	) (model.TaskContainerDefaultsConfig, error)
 
 	// Job queue
-	GetJobQ(string) (map[model.JobID]*sproto.RMJobInfo, error)
+	GetJobQ(ResourcePoolName) (map[model.JobID]*sproto.RMJobInfo, error)
 	GetJobQueueStatsRequest(*apiv1.GetJobQueueStatsRequest) (*apiv1.GetJobQueueStatsResponse, error)
 	MoveJob(sproto.MoveJob) error
 	RecoverJobPosition(sproto.RecoverJobPosition)
-	GetExternalJobs(string) ([]*jobv1.Job, error)
+	GetExternalJobs(ResourcePoolName) ([]*jobv1.Job, error)
 
 	// Cluster Management APIs
 	GetAgents() (*apiv1.GetAgentsResponse, error)

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -8,10 +8,6 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
 )
 
-// ResourcePoolName holds the name of the resource pool, and describes the input/output
-// of several ResourceManager methods.
-type ResourcePoolName string
-
 // ResourceManager is an interface for a resource manager, which can allocate and manage resources.
 type ResourceManager interface {
 	// Basic functionality
@@ -55,4 +51,13 @@ type ResourceManager interface {
 	GetSlot(*apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error)
 	EnableSlot(*apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error)
 	DisableSlot(*apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error)
+}
+
+// ResourcePoolName holds the name of the resource pool, and describes the input/output
+// of several ResourceManager methods.
+type ResourcePoolName string
+
+// String converts a ResourcePoolName to String.
+func (r ResourcePoolName) String() string {
+	return string(r)
 }

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -41,7 +41,7 @@ func (m *Master) ResolveResources(
 		return "", nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 	launchWarnings, err := m.rm.ValidateResources(sproto.ValidateResourcesRequest{
-		ResourcePool: string(poolName),
+		ResourcePool: poolName.String(),
 		Slots:        slots,
 		IsSingleNode: isSingleNode,
 	})

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -31,12 +31,12 @@ import (
 
 // ResolveResources - Validate ResoucePool and check for availability.
 func (m *Master) ResolveResources(
-	resourcePool rm.ResourcePoolName,
+	resourcePool string,
 	slots int,
 	workspaceID int,
 	isSingleNode bool,
 ) (rm.ResourcePoolName, []pkgCommand.LaunchWarning, error) {
-	poolName, err := m.rm.ResolveResourcePool(resourcePool, workspaceID, slots)
+	poolName, err := m.rm.ResolveResourcePool(rm.ResourcePoolName(resourcePool), workspaceID, slots)
 	if err != nil {
 		return "", nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
@@ -61,7 +61,8 @@ func (m *Master) fillTaskSpec(
 	agentUserGroup *model.AgentUserGroup,
 	userModel *model.User,
 ) (tasks.TaskSpec, error) {
-	taskContainerDefaults, err := m.rm.TaskContainerDefaults(poolName,
+	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
+		poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/spec_util.go
+++ b/master/internal/spec_util.go
@@ -31,13 +31,12 @@ import (
 
 // ResolveResources - Validate ResoucePool and check for availability.
 func (m *Master) ResolveResources(
-	resourcePool string,
+	resourcePool rm.ResourcePoolName,
 	slots int,
 	workspaceID int,
 	isSingleNode bool,
-) (string, []pkgCommand.LaunchWarning, error) {
-	poolName, err := m.rm.ResolveResourcePool(
-		rm.ResourcePoolName(resourcePool), workspaceID, slots)
+) (rm.ResourcePoolName, []pkgCommand.LaunchWarning, error) {
+	poolName, err := m.rm.ResolveResourcePool(resourcePool, workspaceID, slots)
 	if err != nil {
 		return "", nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
@@ -53,17 +52,16 @@ func (m *Master) ResolveResources(
 		return "", nil, errors.New("slots requested exceeds cluster capacity")
 	}
 
-	return string(poolName), launchWarnings, nil
+	return poolName, launchWarnings, nil
 }
 
 // Fill and return TaskSpec.
 func (m *Master) fillTaskSpec(
-	poolName string,
+	poolName rm.ResourcePoolName,
 	agentUserGroup *model.AgentUserGroup,
 	userModel *model.User,
 ) (tasks.TaskSpec, error) {
-	taskContainerDefaults, err := m.rm.TaskContainerDefaults(
-		rm.ResourcePoolName(poolName),
+	taskContainerDefaults, err := m.rm.TaskContainerDefaults(poolName,
 		m.config.TaskContainerDefaults,
 	)
 	if err != nil {

--- a/master/internal/spec_util_intg_test.go
+++ b/master/internal/spec_util_intg_test.go
@@ -21,20 +21,20 @@ import (
 )
 
 func getMockResourceManager(poolName rm.ResourcePoolName) *mocks.ResourceManager {
-	rm := &mocks.ResourceManager{}
-	rm.On("ResolveResourcePool", "/", 0, 1).Return(poolName, nil)
-	rm.On("ValidateResources", sproto.ValidateResourcesRequest{
+	r := &mocks.ResourceManager{}
+	r.On("ResolveResourcePool", rm.ResourcePoolName("/"), 0, 1).Return(poolName, nil)
+	r.On("ValidateResources", sproto.ValidateResourcesRequest{
 		ResourcePool: string(poolName),
 		Slots:        1,
 		IsSingleNode: true,
 	}).Return(nil, nil)
-	return rm
+	return r
 }
 
 func TestResolveResources(t *testing.T) {
 	tests := map[string]struct {
 		expectedPoolName rm.ResourcePoolName
-		resourcePool     rm.ResourcePoolName
+		resourcePool     string
 		slots            int
 		workspaceID      int
 	}{

--- a/master/internal/spec_util_intg_test.go
+++ b/master/internal/spec_util_intg_test.go
@@ -24,7 +24,7 @@ func getMockResourceManager(poolName rm.ResourcePoolName) *mocks.ResourceManager
 	r := &mocks.ResourceManager{}
 	r.On("ResolveResourcePool", rm.ResourcePoolName("/"), 0, 1).Return(poolName, nil)
 	r.On("ValidateResources", sproto.ValidateResourcesRequest{
-		ResourcePool: string(poolName),
+		ResourcePool: poolName.String(),
 		Slots:        1,
 		IsSingleNode: true,
 	}).Return(nil, nil)

--- a/master/internal/spec_util_intg_test.go
+++ b/master/internal/spec_util_intg_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/mocks"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -19,11 +20,11 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/utilv1"
 )
 
-func getMockResourceManager(poolName string) *mocks.ResourceManager {
+func getMockResourceManager(poolName rm.ResourcePoolName) *mocks.ResourceManager {
 	rm := &mocks.ResourceManager{}
 	rm.On("ResolveResourcePool", "/", 0, 1).Return(poolName, nil)
 	rm.On("ValidateResources", sproto.ValidateResourcesRequest{
-		ResourcePool: poolName,
+		ResourcePool: string(poolName),
 		Slots:        1,
 		IsSingleNode: true,
 	}).Return(nil, nil)
@@ -32,8 +33,8 @@ func getMockResourceManager(poolName string) *mocks.ResourceManager {
 
 func TestResolveResources(t *testing.T) {
 	tests := map[string]struct {
-		expectedPoolName string
-		resourcePool     string
+		expectedPoolName rm.ResourcePoolName
+		resourcePool     rm.ResourcePoolName
 		slots            int
 		workspaceID      int
 	}{
@@ -61,7 +62,7 @@ func TestResolveResources(t *testing.T) {
 
 func TestFillTaskSpec(t *testing.T) {
 	tests := map[string]struct {
-		poolName       string
+		poolName       rm.ResourcePoolName
 		agentUserGroup *model.AgentUserGroup
 		userModel      *model.User
 		workDir        string

--- a/master/internal/sproto/jobs.go
+++ b/master/internal/sproto/jobs.go
@@ -57,12 +57,6 @@ func DeleteJobResponseOf(input error) DeleteJobResponse {
 	return DeleteJobResponse{Err: respC}
 }
 
-// GetJobQStats requests stats for a queue.
-// Expected response: jobv1.QueueStats.
-type GetJobQStats struct {
-	ResourcePool string
-}
-
 type (
 	// SetGroupWeight sets the weight of a group in the fair share scheduler.
 	SetGroupWeight struct {


### PR DESCRIPTION
## Description
Introduce a new type `ResourcePoolName` string, that replaces resource pool name string input/output in RM methods & provides more description where used.


## Test Plan
Pass existing tests


## Commentary (optional)
I couldn't substitute ResourcePoolName type into sproto messages because of an import cycle  -- ideally, as we move away from using sproto messages and simply passing in the variables, we can use ResourcePoolName wherever we pass in a string resource pool name.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
DET-76


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
