### PR TITLE
fix: nil deref in ReadPreemptionStatus

### DIFF
--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -481,7 +481,7 @@ func ReadRMPreemptionStatus(rpName string) bool {
 	for _, r := range config.ResourceManagers() {
 		for _, rpConfig := range r.ResourcePools {
 			if rpConfig.PoolName == rpName {
-				if rpConfig.Scheduler == nil {
+				if rpConfig.Scheduler != nil {
 					return rpConfig.Scheduler.GetPreemption()
 				}
 				// if not found, fall back to resource manager config

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -839,6 +839,13 @@ func TestMultiRMPreemptionAndPriority(t *testing.T) {
 					DefaultPriority: &prio1,
 				}},
 			}}},
+			// nil preemption case
+			{
+				ResourceManager: &ResourceManagerConfig{KubernetesRM: &KubernetesResourceManagerConfig{
+					Name: "nil-rm", DefaultScheduler: "not-preemption-scheduler",
+				}},
+				ResourcePools: []ResourcePoolConfig{{PoolName: "nil-rp"}},
+			},
 		},
 	}
 
@@ -867,4 +874,12 @@ func TestMultiRMPreemptionAndPriority(t *testing.T) {
 
 	priority = ReadPriority("default234", model.CommandConfig{})
 	require.Equal(t, prio1, priority)
+
+	// 'nil-rp' RP exists under 'nil-rm' RM, so the preemption
+	// & priority default to the RMs.
+	status = ReadRMPreemptionStatus("nil-rp")
+	require.False(t, status)
+
+	priority = ReadPriority("nil-rp", model.CommandConfig{})
+	require.Equal(t, KubernetesDefaultPriority, priority)
 }

--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -36,11 +36,10 @@ func (e *internalExperiment) ToV1Job() (*jobv1.Job, error) {
 		WorkspaceId:    int32(workspace.ID),
 	}
 
+	j.ResourcePool = e.activeConfig.Resources().ResourcePool()
 	j.IsPreemptible = config.ReadRMPreemptionStatus(j.ResourcePool)
 	j.Priority = int32(config.ReadPriority(j.ResourcePool, &e.activeConfig))
 	j.Weight = config.ReadWeight(j.ResourcePool, &e.activeConfig)
-
-	j.ResourcePool = e.activeConfig.Resources().ResourcePool()
 
 	return &j, nil
 }


### PR DESCRIPTION
## Description
Fix `ReadPreemptionStatus` bug where if resource pool name was passed in; if nil, it causes a nil pointer dereference.


## Test Plan
Pass `TestMultiRMPreemptionAndPriority` (see. new test case) and included e2e tests.


## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-77


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
