### PR TITLE
chore: remove panics from rm initialization

### DIFF
--- a/master/internal/rm/agentrm/resource_managers_test.go
+++ b/master/internal/rm/agentrm/resource_managers_test.go
@@ -35,7 +35,8 @@ func TestResourceManagerForwardMessage(t *testing.T) {
 		},
 	}
 
-	rm := New(nil, echo.New(), conf.ResourceManagers()[0], nil, nil)
+	rm, err := New(nil, echo.New(), conf.ResourceManagers()[0], nil, nil)
+	assert.NilError(t, err, "error initializing resource manager")
 
 	taskSummary, err := rm.GetAllocationSummaries()
 	assert.NilError(t, err)

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -56,16 +56,16 @@ func New(
 	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 	opts *aproto.MasterSetAgentOptions,
 	cert *tls.Certificate,
-) *ResourceManager {
+) (*ResourceManager, error) {
 	tlsConfig, err := model.MakeTLSConfig(cert)
 	if err != nil {
-		panic(errors.Wrap(err, "failed to set up TLS config"))
+		return nil, fmt.Errorf("failed to set up TLS config: %w", err)
 	}
 
 	// TODO(DET-9833) clusterID should just be a `internal/config` package singleton.
 	clusterID, err := db.GetOrCreateClusterID("")
 	if err != nil {
-		panic(fmt.Errorf("getting clusterID: %w", err))
+		return nil, fmt.Errorf("getting clusterID: %w", err)
 	}
 	setClusterID(clusterID)
 
@@ -132,7 +132,7 @@ func New(
 		}()
 		k.pools[poolConfig.PoolName] = rp
 	}
-	return k
+	return k, nil
 }
 
 // Allocate implements rm.ResourceManager.


### PR DESCRIPTION
## Description

Remove panics from resource manager initialization and replace them with error messages so that it is easier to trace back and handle errors.

## Test Plan

CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-9975