### PR TITLE
perf: improved textcell performance for novels

### DIFF
--- a/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/utils.ts
+++ b/webui/react/src/pages/F_ExpList/glide-table/custom-renderers/utils.ts
@@ -83,9 +83,18 @@ function truncate(
   if (textWidth <= maxWidth || textWidth <= ellipsisWidth) {
     return text;
   } else {
-    while (newText.length > 0 && textWidth + ellipsisWidth > maxWidth) {
-      newText = newText.substring(0, newText.length - 1);
+    // Binary search for the longest string below max width
+    let leftBound = 0;
+    let rightBound = text.length;
+    while (leftBound < rightBound) {
+      const subLength = Math.floor((leftBound + rightBound) / 2);
+      newText = text.substring(0, subLength);
       textWidth = ctx.measureText(newText).width;
+      if (textWidth + ellipsisWidth < maxWidth) {
+        leftBound = subLength + 1;
+      } else {
+        rightBound = subLength;
+      }
     }
     return newText + suffix;
   }


### PR DESCRIPTION
## Description
This fixes an issue where the glide table performance would chug when given a text cell with lots of text to truncate. while `measureText` is more performant than getBoundingClientRectangle, it can still be problematic to call excessively. To remedy, we implement a binary search for the longest string that's still below max width, reducing the number of times we need to measure the text for longer texts at the cost of calling it a few more times for shorter texts.
[ET-71]



## Test Plan

* create several experiments with long descriptions (<1000 characters) in the same project
* visit the project where you created the experiments in webui
* ensure the description column is selected in the table settings
* when the table is showing the created experiments, the ui should remain responsive


## Checklist

- [X] Changes have been manually QA'd
- [X] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [X] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
[ET-71]


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
