### PR TITLE
chore: ban http.Transport & http.Client; add cleanhttp

### DIFF
--- a/examples/tutorials/core_api/0_start.yaml
+++ b/examples/tutorials/core_api/0_start.yaml
@@ -10,6 +10,3 @@ searcher:
    max_length: 1
 
 max_restarts: 0
-
-resources:
-   resource_pool: test

--- a/examples/tutorials/core_api/0_start.yaml
+++ b/examples/tutorials/core_api/0_start.yaml
@@ -10,3 +10,6 @@ searcher:
    max_length: 1
 
 max_restarts: 0
+
+resources:
+   resource_pool: test

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -79,6 +79,8 @@ linters-settings:
       - 'fmt\.Print.*'
       - 'metaV1.NamespaceAll' # Will error if someone has namespace restricted permissions.
       - 'bundebug.WithVerbose'
+      - 'http.Client{' # Instead, we encourage use of cleanhttp.
+      - 'http.Transport{' # Instead, we encourage use of cleanhttp.
   staticcheck:
     go: "1.20"
 

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -79,8 +79,8 @@ linters-settings:
       - 'fmt\.Print.*'
       - 'metaV1.NamespaceAll' # Will error if someone has namespace restricted permissions.
       - 'bundebug.WithVerbose'
-      - 'http.Client' # Instead, we encourage use of cleanhttp.
-      - 'http.Transport' # Instead, we encourage use of cleanhttp.
+      - 'http.Client' # Use cleanhttp instead.
+      - 'http.Transport' # Use cleanhttp instead.
   staticcheck:
     go: "1.20"
 

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -79,8 +79,8 @@ linters-settings:
       - 'fmt\.Print.*'
       - 'metaV1.NamespaceAll' # Will error if someone has namespace restricted permissions.
       - 'bundebug.WithVerbose'
-      - 'http.Client{' # Instead, we encourage use of cleanhttp.
-      - 'http.Transport{' # Instead, we encourage use of cleanhttp.
+      - 'http.Client' # Instead, we encourage use of cleanhttp.
+      - 'http.Transport' # Instead, we encourage use of cleanhttp.
   staticcheck:
     go: "1.20"
 

--- a/master/internal/elastic/elastic.go
+++ b/master/internal/elastic/elastic.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/elastic/go-elasticsearch/v7"
@@ -37,11 +37,12 @@ func Setup(conf model.ElasticLoggingConfig) (*Elastic, error) {
 	addr := fmt.Sprintf("%s%s:%d", scheme, conf.Host, conf.Port)
 	log.Infof("connecting to elasticsearch %s", addr)
 
+	transport := cleanhttp.DefaultTransport()
+	transport.TLSClientConfig = tlsCfg
+
 	cfg := elasticsearch.Config{
 		Addresses: []string{addr},
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-		},
+		Transport: transport,
 	}
 
 	if conf.Security.Username != nil && conf.Security.Password != nil {

--- a/master/internal/rm/kubernetesrm/mock_client_test.go
+++ b/master/internal/rm/kubernetesrm/mock_client_test.go
@@ -225,7 +225,7 @@ func (m *mockPodInterface) Evict(ctx context.Context, eviction *v1beta1.Eviction
 func (m *mockPodInterface) GetLogs(name string, opts *k8sV1.PodLogOptions) *rest.Request {
 	client := cleanhttp.DefaultClient()
 	client.Transport = &mockRoundTripInterface{message: m.logMessage}
-	return rest.NewRequestWithClient(&url.URL{}, "", rest.ClientContentConfig{}, cleanhttp.DefaultClient())
+	return rest.NewRequestWithClient(&url.URL{}, "", rest.ClientContentConfig{}, client)
 }
 
 func (m *mockPodInterface) ProxyGet(

--- a/master/internal/rm/kubernetesrm/mock_client_test.go
+++ b/master/internal/rm/kubernetesrm/mock_client_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/pkg/errors"
 
 	k8sV1 "k8s.io/api/core/v1"
@@ -222,10 +223,9 @@ func (m *mockPodInterface) Evict(ctx context.Context, eviction *v1beta1.Eviction
 }
 
 func (m *mockPodInterface) GetLogs(name string, opts *k8sV1.PodLogOptions) *rest.Request {
-	return rest.NewRequestWithClient(&url.URL{}, "", rest.ClientContentConfig{},
-		&http.Client{
-			Transport: &mockRoundTripInterface{message: m.logMessage},
-		})
+	client := cleanhttp.DefaultClient()
+	client.Transport = &mockRoundTripInterface{message: m.logMessage}
+	return rest.NewRequestWithClient(&url.URL{}, "", rest.ClientContentConfig{}, cleanhttp.DefaultClient())
 }
 
 func (m *mockPodInterface) ProxyGet(

--- a/master/internal/webhooks/api_webhook.go
+++ b/master/internal/webhooks/api_webhook.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/google/uuid"
@@ -189,7 +190,7 @@ func (a *WebhooksAPIServer) TestWebhook(
 	}
 
 	log.Infof("creating webhook request for event %v", eventID)
-	c := http.Client{}
+	c := cleanhttp.DefaultClient()
 	resp, err := c.Do(tReq)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument,

--- a/master/internal/webhooks/api_webhook.go
+++ b/master/internal/webhooks/api_webhook.go
@@ -8,16 +8,14 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
-
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/webhookv1"
 )

--- a/master/internal/webhooks/shipper.go
+++ b/master/internal/webhooks/shipper.go
@@ -101,7 +101,7 @@ func newWorker(id int) *worker {
 type worker struct {
 	// System dependencies.
 	log *log.Entry
-	cl  *http.Client
+	cl  *http.Client //nolint:forbidigo
 }
 
 func (w *worker) work(ctx context.Context, wake <-chan struct{}) {


### PR DESCRIPTION
## Description
Ban use of `http.Transport` and `http.Client` in the codebase. Instead, use `cleanhttp` library.

## Test Plan
Pass existing tests.



## Commentary (optional)




## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-85


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
