### PR TITLE
chore: limit code coverage report to files in src; omit generated files

### DIFF
--- a/webui/react/vite.config.mts
+++ b/webui/react/vite.config.mts
@@ -153,6 +153,11 @@ export default defineConfig(({ mode }) => ({
     strictPort: true,
   },
   test: {
+    coverage: {
+      ...configDefaults.coverage,
+      include: ['src'],
+      exclude: [...configDefaults.coverage.exclude, 'src/vendor/**/*', 'src/services/api-ts-sdk/*']
+    },
     css: {
       modules: {
         classNameStrategy: 'non-scoped',


### PR DESCRIPTION
## Description

This PR updates the code reports generated by the frontend unit tests to only report code in the src folder, and omits vendor code and generated code from the reports. This is so the codecoverage report will be more accurate to what we actually care about.


## Test Plan
no testing needed



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
