### PR TITLE
test: document ui e2e with backend test instructions for local

### DIFF
--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -26,7 +26,16 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' }
+    },
+    
+    {
+      name: 'chromium-no-cors',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome', 
+      bypassCSP: true,
+      launchOptions: {
+        args: ['--disable-web-security']
+      }},
     },
 
     {
@@ -78,7 +87,8 @@ export default defineConfig({
     baseURL: 'http://localhost:3001/',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure'
   },
 
   /* Run your local dev server before starting the tests */

--- a/webui/react/src/e2e/README.md
+++ b/webui/react/src/e2e/README.md
@@ -18,6 +18,17 @@ Deteremined AI uses [Playwright 🎭](https://playwright.dev/).
 
 \*\*Avoid using `make` command because it does not take env variables
 
+### Quick start testing using det deploy
+
+If you don't want to use dev cluster, you can use det deploy to initiate the backend. These commands should run and pass tests on chrome:
+1. `det deploy local cluster-up --det-version="0.29.0" --no-gpu --master-port=8080`
+    * use whatever det-version you want here.
+2. `SERVER_ADDRESS="http://localhost:8080" npm run build --prefix webui/react`
+3. Optional if you want an experiment created for the test: `det experiment create ./examples/tutorials/mnist_pytorch/const.yaml ./examples/tutorials/mnist_pytorch/`
+4. To run the tests: `CI=true PW_SERVER_ADDRESS="http://localhost:8080"  PW_USER_NAME="admin" PW_PASSWORD="" npm run e2e --prefix webui/react -- --project=chromium-no-cors`
+    * `CI=true` currently causes Playwright to start a frontend webserver for the test. If `CI=false` you'll need to do `npm run preview` manually and point the tests at the right port.
+
+
 ## CI
 
 CI is setup as `test-e2e-react` in `.circleci/config.yml`.


### PR DESCRIPTION
## Description

Mostly a readme change to kick of automating the release party UI tests and give new folks a way to easily check their tests locally. 

There's a couple minor changes to the playwright config that shouldn't change functionality, but are useful for running locally.


## Test Plan

Tested using the documented setup and it works.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
INFRAENG-447


