### PR TITLE
docs: add EditorRestricted role release note

### DIFF
--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -477,7 +477,7 @@ update NTSC tasks within its scope.
 
 -  ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and perform all
    experiment-related jobs, just like those with the ``Editor`` role. The only additional
-   permissions granted by the ``Editor`` role include the ability to create notebooks, Tensorboards,
+   permissions granted by the ``Editor`` role include the ability to create notebooks, TensorBoards,
    shells, and commands (NTSC tasks), as well as the permission to update these tasks, such as
    changing the task's priority or deleting it.
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -475,11 +475,11 @@ edit, or delete projects and experiments within its scope.
 The ``Editor`` role supersedes the ``EditorRestricted`` role and includes permissions to create or
 update NTSC tasks within its scope.
 
-**Note**: ``EditorRestricted`` users can still open and use scoped JupyterLab Notebooks and perform
-all experiment-related jobs as those with the ``Editor`` role. The only additional permissions
-granted by the ``Editor`` role are the permission to create Notebooks, Tensorboards, Shells, and
-Commands (NTSC tasks) and the permission to perform updates on those tasks (such as changing the
-task's priority or deleting it).
+-  ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and perform all
+   experiment-related jobs, just like those with the ``Editor`` role. The only additional
+   permissions granted by the ``Editor`` role include the ability to create notebooks, Tensorboards,
+   shells, and commands (NTSC tasks), as well as the permission to update these tasks, such as
+   changing the task's priority or deleting it.
 
 ``WorkspaceAdmin``
 ==================

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -475,6 +475,12 @@ edit, or delete projects and experiments within its scope.
 The ``Editor`` role supersedes the ``EditorRestricted`` role and includes permissions to create or
 update NTSC tasks within its scope.
 
+- ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and perform all
+experiment-related jobs as those with the ``Editor`` role. The only additional permissions granted
+by the ``Editor`` role are the permission to create notebooks, tensorboards, shells, and commands
+(NTSC tasks) and the permssion to perform updates on those tasks (such as changing the task's
+priority or deleting it).
+
 ``WorkspaceAdmin``
 ==================
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -475,11 +475,11 @@ edit, or delete projects and experiments within its scope.
 The ``Editor`` role supersedes the ``EditorRestricted`` role and includes permissions to create or
 update NTSC tasks within its scope.
 
-- ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and perform all
-experiment-related jobs as those with the ``Editor`` role. The only additional permissions granted
-by the ``Editor`` role are the permission to create notebooks, tensorboards, shells, and commands
-(NTSC tasks) and the permssion to perform updates on those tasks (such as changing the task's
-priority or deleting it).
+**Note**: ``EditorRestricted`` users can still open and use scoped JupyterLab Notebooks and perform
+all experiment-related jobs as those with the ``Editor`` role. The only additional permissions
+granted by the ``Editor`` role are the permission to create Notebooks, Tensorboards, Shells, and
+Commands (NTSC tasks) and the permission to perform updates on those tasks (such as changing the
+task's priority or deleting it).
 
 ``WorkspaceAdmin``
 ==================

--- a/docs/release-notes/editor-restricted-role.rst
+++ b/docs/release-notes/editor-restricted-role.rst
@@ -2,22 +2,22 @@
 
 **New Features**
 
-*   RBAC: Add a pre-canned role called ``EditorRestricted`` which supersedes the ``Viewer`` role
-    and precedes the ``Editor`` role.
+-  RBAC: Add a pre-canned role called ``EditorRestricted`` which supersedes the ``Viewer`` role
+   and precedes the ``Editor`` role.
 
-    *   Like the ``Editor`` role, the ``EditorRestricted`` role grants the permissions to create,
-    edit, or delete projects and experiments within its designated scope. However, the
-    ``EditorRestricted`` role lacks the permissions to create or update NTSC type workloads.
+    -  Like the ``Editor`` role, the ``EditorRestricted`` role grants the permissions to create,
+       edit, or delete projects and experiments within its designated scope. However, the
+       ``EditorRestricted`` role lacks the permissions to create or update NTSC-type workloads.
 
-    Therefore, a user with ``EditorRestricted`` privileges in a given scope are limited when using
-    the webUI within that scope since the option to launch JupyterLab notebooks and kill running
-    tasks will be unavailable. The user will also be unable to run CLI commands that create scoped
-    notebooks, tensorboards, shells, and commands and will be unable to perform updates on these
-    tasks (such as changing the task's priority or deleting it). ``EditorRestricted`` users can
-    still, however, open and use scoped JupyterLab notebooks and perform all experiment-related
-    jobs as those with the ``Editor`` role.
+       Therefore, a user with ``EditorRestricted`` privileges in a given scope is limited when
+       using the web UI within that scope since the option to launch JupyterLab notebooks and kill
+       running tasks will be unavailable. The user will also be unable to run CLI commands that
+       create scoped Notebooks, Tensorboards, Shells, and Commands and will be unable to perform
+       updates on these tasks (such as changing the task's priority or deleting it).
+       ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and
+       perform all experiment-related jobs as those with the ``Editor`` role.
 
-    *   The ``EditorRestricted`` role was created to allow workspace and cluster editors and admins
-    to have more fine-grained control over GPU resources. Thus, users with this role lack the
-    ability to launch or modify tasks that indefinitely consume slot-requesting resources within a
-    given scope.
+    -  The ``EditorRestricted`` role was created to allow workspace and cluster editors and admins
+       to have more fine-grained control over GPU resources. Thus, users with this role cannot
+       launch or modify tasks that indefinitely consume slot-requesting resources within a given
+       scope.

--- a/docs/release-notes/editor-restricted-role.rst
+++ b/docs/release-notes/editor-restricted-role.rst
@@ -10,14 +10,14 @@
        ``EditorRestricted`` role lacks the permissions to create or update NTSC-type workloads.
 
        Therefore, a user with ``EditorRestricted`` privileges in a given scope is limited when
-       using the web UI within that scope since the option to launch JupyterLab notebooks and kill
+       using the WebUI within that scope since the option to launch JupyterLab notebooks and kill
        running tasks will be unavailable. The user will also be unable to run CLI commands that
-       create scoped Notebooks, Tensorboards, Shells, and Commands and will be unable to perform
+       create scoped notebooks, Tensorboards, shells, and commands and will be unable to perform
        updates on these tasks (such as changing the task's priority or deleting it).
        ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and
        perform all experiment-related jobs as those with the ``Editor`` role.
 
-    -  The ``EditorRestricted`` role was created to allow workspace and cluster editors and admins
-       to have more fine-grained control over GPU resources. Thus, users with this role cannot
-       launch or modify tasks that indefinitely consume slot-requesting resources within a given
-       scope.
+    -  The ``EditorRestricted`` role allows workspace and cluster editors and admins
+       to have more fine-grained control over GPU resources. Thus, users with this role lack the
+       ability to launch or modify tasks that indefinitely consume slot-requesting resources within
+       a given scope.

--- a/docs/release-notes/editor-restricted-role.rst
+++ b/docs/release-notes/editor-restricted-role.rst
@@ -9,14 +9,15 @@
     edit, or delete projects and experiments within its designated scope. However, the
     ``EditorRestricted`` role lacks the permissions to create or update NTSC type workloads.
 
-    Therefore, a user with ``EditorRestricted`` privileges in a given scope are limited using the
-    webUI within that scope as the option to lauch JupyterLab notebooks and kill tasks will be
-    unavailable. The user will also be unable to use CLI commands that create or update scoped
-    nootebooks, tensorboards, shells, and commands (such as changing a task's priority or deleting
-    it). ``EditorRestricted`` users can still, however, open and edit the code in scoped JupyterLab
-    notebooks and perform all experiment-related jobs as those with the ``Editor`` role.
+    Therefore, a user with ``EditorRestricted`` privileges in a given scope are limited when using
+    the webUI within that scope since the option to launch JupyterLab notebooks and kill running
+    tasks will be unavailable. The user will also be unable to run CLI commands that create scoped
+    notebooks, tensorboards, shells, and commands and will be unable to perform updates on these
+    tasks (such as changing the task's priority or deleting it). ``EditorRestricted`` users can
+    still, however, open and use scoped JupyterLab notebooks and perform all experiment-related
+    jobs as those with the ``Editor`` role.
 
     *   The ``EditorRestricted`` role was created to allow workspace and cluster editors and admins
     to have more fine-grained control over GPU resources. Thus, users with this role lack the
-    ability to indefinitely consume slot-requesting resources by launching long-running tasks
-    within a given scope.
+    ability to launch or modify tasks that indefinitely consume slot-requesting resources within a
+    given scope.

--- a/docs/release-notes/editor-restricted-role.rst
+++ b/docs/release-notes/editor-restricted-role.rst
@@ -1,0 +1,22 @@
+:orphan:
+
+**New Features**
+
+*   RBAC: Add a pre-canned role called ``EditorRestricted`` which supersedes the ``Viewer`` role
+    and precedes the ``Editor`` role.
+
+    *   Like the ``Editor`` role, the ``EditorRestricted`` role grants the permissions to create,
+    edit, or delete projects and experiments within its designated scope. However, the
+    ``EditorRestricted`` role lacks the permissions to create or update NTSC type workloads.
+
+    Therefore, a user with ``EditorRestricted`` privileges in a given scope are limited using the
+    webUI within that scope as the option to lauch JupyterLab notebooks and kill tasks will be
+    unavailable. The user will also be unable to use CLI commands that create or update scoped
+    nootebooks, tensorboards, shells, and commands (such as changing a task's priority or deleting
+    it). ``EditorRestricted`` users can still, however, open and edit the code in scoped JupyterLab
+    notebooks and perform all experiment-related jobs as those with the ``Editor`` role.
+
+    *   The ``EditorRestricted`` role was created to allow workspace and cluster editors and admins
+    to have more fine-grained control over GPU resources. Thus, users with this role lack the
+    ability to indefinitely consume slot-requesting resources by launching long-running tasks
+    within a given scope.

--- a/docs/release-notes/editor-restricted-role.rst
+++ b/docs/release-notes/editor-restricted-role.rst
@@ -2,22 +2,21 @@
 
 **New Features**
 
--  RBAC: Add a pre-canned role called ``EditorRestricted`` which supersedes the ``Viewer`` role
-   and precedes the ``Editor`` role.
+-  RBAC: Add a pre-canned role called ``EditorRestricted`` which supersedes the ``Viewer`` role and
+   precedes the ``Editor`` role.
 
-    -  Like the ``Editor`` role, the ``EditorRestricted`` role grants the permissions to create,
-       edit, or delete projects and experiments within its designated scope. However, the
-       ``EditorRestricted`` role lacks the permissions to create or update NTSC-type workloads.
+   -  Like the ``Editor`` role, the ``EditorRestricted`` role grants the permissions to create,
+      edit, or delete projects and experiments within its designated scope. However, the
+      ``EditorRestricted`` role lacks the permissions to create or update NTSC-type workloads.
 
-       Therefore, a user with ``EditorRestricted`` privileges in a given scope is limited when
-       using the WebUI within that scope since the option to launch JupyterLab notebooks and kill
-       running tasks will be unavailable. The user will also be unable to run CLI commands that
-       create scoped notebooks, Tensorboards, shells, and commands and will be unable to perform
-       updates on these tasks (such as changing the task's priority or deleting it).
-       ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and
-       perform all experiment-related jobs as those with the ``Editor`` role.
+      Therefore, a user with ``EditorRestricted`` privileges in a given scope is limited when using
+      the WebUI within that scope since the option to launch JupyterLab notebooks and kill running
+      tasks will be unavailable. The user will also be unable to run CLI commands that create scoped
+      notebooks, TensorBoards, shells, and commands and will be unable to perform updates on these
+      tasks (such as changing the task's priority or deleting it). ``EditorRestricted`` users can
+      still open and use scoped JupyterLab notebooks and perform all experiment-related jobs, just
+      like those with the ``Editor`` role.
 
-    -  The ``EditorRestricted`` role allows workspace and cluster editors and admins
-       to have more fine-grained control over GPU resources. Thus, users with this role lack the
-       ability to launch or modify tasks that indefinitely consume slot-requesting resources within
-       a given scope.
+   -  The ``EditorRestricted`` role allows workspace and cluster editors and admins to have more
+      fine-grained control over GPU resources. Thus, users with this role lack the ability to launch
+      or modify tasks that indefinitely consume slot-requesting resources within a given scope.


### PR DESCRIPTION
## Description

Add release note for the EditorRestricted role and add more info to RBAC docs to clearly distinguish `Editor` from `EditorRestricted`.


## Test Plan

 CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10173