### PR TITLE
fix: prevent selection from appearing out of place in infinite scroll

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -350,12 +350,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
           return loadedExperiments.map((experiment) => Loaded(experiment));
         }
 
-        let newExperiments = prev;
-
-        // Fill out the loadable experiments array with total count.
-        if (prev.length !== total) {
-          newExperiments = new Array(total).fill(NotLoaded);
-        }
+        // Ensure experiments array has enough space for full result set
+        const newExperiments = prev.length !== total ? new Array(total).fill(NotLoaded) : [...prev];
 
         // Update the list with the fetched results.
         Array.prototype.splice.apply(newExperiments, [


### PR DESCRIPTION
## Description

This fixes an issue where the user selection was placed in the wrong place without the glasbey colors applied

## Test Plan

* on the experiment list with infinite scroll enabled, scroll until you reach the second page (you can verify this by looking at the url -- it should contain the text `page=1`
* select one or two items from the list
* refresh the page
* the items should appear selected with different colors



## Commentary (optional)



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
no ticket


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
