### PR TITLE
test: playwright config and browser usability

### DIFF
--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -50,10 +50,10 @@ export default defineConfig({
     // },
 
     /* Test against branded browsers. */
-    {
-      name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
+    // {
+    //   name: 'edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
     // {
     //   name: 'Google Chrome',
     //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },

--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
 
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: !!process.env.CI,
 
   /* https://playwright.dev/docs/test-timeouts#global-timeout */
   globalTimeout: 3 * 60 * 1000, // 3 min
@@ -27,15 +27,6 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'], channel: 'chrome' }
-    },
-    
-    {
-      name: 'chromium-no-cors',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome', 
-      bypassCSP: true,
-      launchOptions: {
-        args: ['--disable-web-security']
-      }},
     },
 
     {
@@ -59,10 +50,10 @@ export default defineConfig({
     // },
 
     /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
+    {
+      name: 'edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    },
     // {
     //   name: 'Google Chrome',
     //   use: { ..devices['Desktop Chrome'], channel: 'chrome' },
@@ -77,7 +68,7 @@ export default defineConfig({
   ],
 
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
 
   testDir: './src/e2e',
 
@@ -98,6 +89,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
   },
 
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 4 : 1,
 });

--- a/webui/react/src/e2e/README.md
+++ b/webui/react/src/e2e/README.md
@@ -27,8 +27,7 @@ If you don't want to use dev cluster, you can use det deploy to initiate the bac
 2. `SERVER_ADDRESS="http://localhost:3001" npm run build --prefix webui/react`
 3. Optional if you want an experiment created for the test: `det experiment create ./examples/tutorials/mnist_pytorch/const.yaml ./examples/tutorials/mnist_pytorch/`
 4. `npm run preview --prefix webui/react` to run the preview app. Not necessary if CI=true
-4. To run the tests: `PW_SERVER_ADDRESS="http://localhost:3001"  PW_USER_NAME="admin" PW_PASSWORD="" npm run e2e --prefix webui/react`
-
+5. To run the tests: `PW_SERVER_ADDRESS="http://localhost:3001"  PW_USER_NAME="admin" PW_PASSWORD="" npm run e2e --prefix webui/react`
 
 ## CI
 

--- a/webui/react/src/e2e/README.md
+++ b/webui/react/src/e2e/README.md
@@ -14,7 +14,7 @@ Deteremined AI uses [Playwright 🎭](https://playwright.dev/).
 - Run `npx playwright install`
 - Run `SERVER_ADDRESS={set server address} npm run build` in `webui/react`
   - It is `SERVER_ADDRESS` here. not `PW_SERVER_ADDRESS`, but the both values should be the same
-- Run `npm run e2e` in `webui/react`
+- Run `npm run e2e` in `webui/react`. Use `-- --project=<browsername>` to run a specific browser.
 
 \*\*Avoid using `make` command because it does not take env variables
 
@@ -24,10 +24,11 @@ If you don't want to use dev cluster, you can use det deploy to initiate the bac
 
 1. `det deploy local cluster-up --det-version="0.29.0" --no-gpu --master-port=8080`
    - use whatever det-version you want here.
-2. `SERVER_ADDRESS="http://localhost:8080" npm run build --prefix webui/react`
+2. `SERVER_ADDRESS="http://localhost:3001" npm run build --prefix webui/react`
 3. Optional if you want an experiment created for the test: `det experiment create ./examples/tutorials/mnist_pytorch/const.yaml ./examples/tutorials/mnist_pytorch/`
-4. To run the tests: `CI=true PW_SERVER_ADDRESS="http://localhost:8080"  PW_USER_NAME="admin" PW_PASSWORD="" npm run e2e --prefix webui/react -- --project=chromium-no-cors`
-   - `CI=true` currently causes Playwright to start a frontend webserver for the test. If `CI=false` you'll need to do `npm run preview` manually and point the tests at the right port.
+4. `npm run preview --prefix webui/react` to run the preview app. Not necessary if CI=true
+4. To run the tests: `PW_SERVER_ADDRESS="http://localhost:3001"  PW_USER_NAME="admin" PW_PASSWORD="" npm run e2e --prefix webui/react`
+
 
 ## CI
 

--- a/webui/react/vite.config.mts
+++ b/webui/react/vite.config.mts
@@ -131,6 +131,14 @@ export default defineConfig(({ mode }) => ({
   ],
   preview: {
     port: 3001,
+    proxy: {
+      '/api': { target: webpackProxyUrl},
+      '/proxy': { target: webpackProxyUrl},
+      '/stream': {
+        target: websocketProxyUrl,
+        ws: true,
+      },
+    },
     strictPort: true,
   },
   resolve: {


### PR DESCRIPTION
## Description

Quick config changes primarily to make running locally easier.
some of the specific changes that may need justification:

- Using a proxy for `npm run preview` eliminates the need for the CORS workaround and uses the right http server.
- retries is down to one in CI. If it doesn't pass after one retry, in my experience, the second retry is normally a waste of time.
- edge now works locally but needs an install on CI. Since edge is just chromium under the hood I turned that off for now.

## Test Plan

ran locally with readme instructions and in pipeline



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
infeng-448


