### PR TITLE
docs: Describe multi rm k8s

### DIFF
--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -256,4 +256,26 @@
    namespaces. Maps to the ``resource_pools`` section from the :ref:`master configuration
    <master-config-reference>`.
 
+-  ``additional_resource_managers``: This section includes additional resource managers for
+   launching jobs across multiple Kubernetes clusters. Maps to :ref:`additional_resource_managers
+   <master-config-additional-resource-managers>` in the master configuration. An example
+   configuration is provided in the ``values.yaml`` file.
+
+   -  ``resource_manager``: Describes the configuration settings for the resource manager. Maps to
+      :ref:`resource_manager <master-config-resource-manager>` in the master configuration.
+
+      -  ``kubeconfig_secret_name``: Specifies the name of the secret containing the kubeconfig for
+         the resource manager. This kubeconfig is used to connect to the Kubernetes cluster and
+         launch tasks. Note that some kubeconfigs may require additional adjustments or
+         modifications. For example some kubeconfigs reference file paths, which may need to be
+         bind-mounted into the container or have their data paths encoded into the kubeconfig. Other
+         kubeconfigs, like those for GKE, may require installing plugins into the Determined master
+         container and binding certain credential files. (*Required*)
+
+      -  ``kubeconfig_secret_value``: The name of the secret that contains the resource manager's
+         kubeconfig. (*Required*)
+
+   -  ``resource_pools``: The resource pool configuration. See :ref:`resource_pools
+      <cluster-resource-pools>` for available configuration options.
+
 .. include:: ../../_shared/note-dtrain-learn-more.txt

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -241,6 +241,30 @@ otherwise active (as defined by the ``notebook_idle_type`` option in the :ref:`t
 
 The resource manager used to acquire resources. Defaults to ``agent``.
 
+For Kubernetes installations, if you define additional resource managers, the resource manager
+specified under the primary resource_manager key here is considered the default.
+
+``name``
+========
+
+Optional. Specifies the resource manager's name. Defaults to ``default`` if not specified. For
+Kubernetes installations with additional resource managers, ensure unique names for all resource
+managers in the cluster.
+
+``metadata``
+============
+
+Optional. Stores additional information about the resource manager in a yaml map, such as the zone,
+region, or location.
+
+For example:
+
+.. code:: yaml
+
+   metadata:
+      region: us-west1
+      zone: us-west1-a
+
 ``type: agent``
 ===============
 
@@ -1171,6 +1195,50 @@ those partitions/queues.
    In this example, jobs submitted to the resource pool named ``defq_GPU_tesla`` will be executed in
    the HPC partition named ``defq_GPU`` with the ``gpu_type`` property set, and Slurm constraint
    associated with the feature ``XL675d`` used to identify the model type of the compute node.
+
+.. _master-config-additional-resource-managers:
+
+**********************************
+ ``additional_resource_managers``
+**********************************
+
+Cluster administrators for Kubernetes installations can define additional resource managers for
+connecting the Determined master service with remote clusters. Support for notebooks and other
+workloads that require proxying on remote clusters is under development.
+
+To define a single resource manager or designate the default resource manager, do not define it
+under ``additional_resource_manager``; instead, use the primary ``resource_manager`` key.
+
+Resource manager names must be unique among all defined resource managers.
+
+Any additional resource managers must have at least one resource pool assigned to them. These
+resource pool names must be defined and must be distinct among all resource pools across all
+resource managers. You define resource pools for any additional resource managers within their
+respective elements in the resource manager list (not at the root level).
+
+For example, to define three resource managers (one default, two additional):
+
+.. code:: yaml
+
+   resource_manager: # the default resource manager
+   resource_pool: # resource pools for the resource manager defined above.
+      pool_name: "foo"
+
+   additional_resource_managers:
+
+      -  resource_manager:
+
+      type: kubernetes # required, this feature is only for Kubernetes.
+      name: "bar" # required
+      resource_pools:
+         pool_name: "abc"
+
+      -  resource_manager:
+
+      type: kubernetes # required, this feature is only for Kubernetes.
+      name: "baz" # required
+      resource_pools:
+         pool_name: "def"
 
 ``resource_manager``
 ====================

--- a/docs/release-notes/multirm-for-k8s.rst
+++ b/docs/release-notes/multirm-for-k8s.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+**New Features**
+
+-  Kubernetes: Add ability to set up the Determined master service on one Kubernetes cluster and
+   manage workloads across different Kubernetes clusters. Additional non-default resource managers
+   and resource pools are configured under the master configuration options
+   ``additional_resource_managers`` and ``resource_pools`` (additional resource managers are
+   required to have at least one resource pool defined). Additional resource managers and their
+   resource pools must have unique names. For more information, visit :ref:master configuration
+   <master-config-reference>. Support for notebooks and other workloads that require proxying is
+   under development.
+
+-  WebUI: Add ability to view resource manager name for resource pools.
+
+-  API/CLI/WebUI: Route any requests to resource pools not defined in the master configuration to
+   the default resource manager, not any additional resource manager, if defined.
+
+-  Configuration: Add a ``name`` and ``metadata`` field to resource manager section in the master
+   configuration. Add an ``additional_resource_managers`` section that follows the
+   ``resource_manager`` and ``resource_pool`` configuration pattern.

--- a/docs/setup-cluster/k8s/_index.rst
+++ b/docs/setup-cluster/k8s/_index.rst
@@ -163,4 +163,5 @@ These ``kubectl`` commands list and delete pods which are running Determined tas
    k8s-dev-guide
    custom-pod-specs
    helm-commands
+   setup-multiple-resource-managers
    troubleshooting

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -21,17 +21,18 @@ service in one Kubernetes cluster and schedule workloads in the same or other Ku
 -  Resource pools have a many-to-one relationship with resource managers.
 -  No single resource pool will span multiple resource managers.
 
-Multiple resource managers are defined in the :ref:`master configuration <master-config-reference>`
-using the ``additional_resource_managers`` and ``resource_pools`` options. Any requests to resource
-pools not defined in the master configuration are routed to the default resource manager. Such
-requests are not routed to additional resource managers, if defined.
+Any requests to resource pools not defined in the master configuration are routed to the default
+resource manager. Such requests are not routed to additional resource managers, if defined.
 
 *********************************************
  How to Configure Multiple Resource Managers
 *********************************************
 
-To begin, you'll need a user with the Cluster Admin role (requires Determined Enterprise Edition).
-The Cluster Admin role is required for configuring multiple resource managers.
+Multiple resource managers are defined in the :ref:`master configuration <master-config-reference>`
+file. To define multiple resource managers, first define one default resource manager and then
+define one or more additional resource managers. Default resource managers are defined using the
+``resource_manager`` option, whereas any additional resource managers are defined using the
+``addtional_resource_manager`` option.
 
 .. attention::
 
@@ -39,104 +40,113 @@ The Cluster Admin role is required for configuring multiple resource managers.
 
    -  Each resource manager under ``additional_resource_managers`` must have a unique name; failure
       to do so will cause the cluster to crash.
-
    -  Ensure each additional resource manager has at least one resource pool defined.
-
    -  Resource pool names must be unique across the cluster to prevent crashes.
 
 .. note::
 
-   The default resource manager is available by default and does not require a specific name.
+   If desired, you can apply a `name` to the default resource manager.
 
-#. Locate the ``resource_manager`` section in the :ref:`master configuration <master-config-reference>`
-   yaml file. This represents the default resource manager.
+#. Locate the ``resource_manager`` section in the :ref:`master configuration
+   <master-config-reference>` yaml file. This represents the default resource manager.
 #. Add ``additional_resource_managers`` under the ``resource_manager`` to configure extra resource
    managers.
 #. Under ``additional_resource_managers``, define ``resource_pools`` for each additional resource
    manager.
-
 
 Example: Master Configuration (devcluster)
 ==========================================
 
 Follow this example to create as many resource managers (clusters) as needed.
 
--  For each cluster, note each ``kubeconfig`` location for the cluster (this is where the credentials
-   are found).
+-  For each cluster, note each ``kubeconfig`` location for the cluster (this is where the credentials are found).
 
 -  Copy or modify the default devcluster template at ``tools/devcluster.yaml``.
 
 -  In the copied ``devcluster.yaml`` file, under the ``master configuration``, set one of your
    resource managers as the default, and the rest under ``additional_resource_managers``:
 
-.. code:: yaml
+   .. code:: yaml
 
-   resource_manager:
-   type: kubernetes
-   name: default-rm # optional, should match the name of your default RM/cluster
-   ... add any other specs you might need ...
-   additional_resource_managers:
-   - resource_manager:
-      type: kubernetes
-      name: additional-rm # should match the name of your other RM(s)
-      kubeconfig_path: <whatever-path-your-rm-config-is-like ~/.kubeconfig>
-      ... add whatever other specs you might need ...
-      resource_pools:
-         - pool_name: <your-rm-pool-name>
+        resource_manager:
+       type: kubernetes
+      name: default-rm # optional, should match the name of your default RM/cluster
+       ... add any other specs you might need ...
+      additional_resource_managers:
+      - resource_manager:
+         type: kubernetes
+         name: additional-rm # should match the name of your other RM(s)
+         kubeconfig_path: <whatever-path-your-rm-config-is-like ~/.kubeconfig>
+         ... add whatever other specs you might need ...
+         resource_pools:
+            - pool_name: <your-rm-pool-name>
 
 -  Run the new devcluster: ``devcluster -c <path-to-modified-devcluster>``.
+
+For more information, visit the Determined Kubernetes Developer Guide located in the ``k8s/``
+subdirectory of the `Determined GitHub repo
+<https://github.com/determined-ai/determined/tree/main/tools/k8s>`__.
 
 Example: Master Configuration (Helm)
 ====================================
 
-To deploy Multi-RM on Kubernetes through a Helm chart, the cluster administrator must load
-the credentials for each additional cluster through a Kubernetes secret. Follow these steps for each
-additional resource manager you want to add, and then apply the Helm chart once at the end. Let
-``rm-name`` be the same as the “cluster name” for a given cluster.
+To deploy Multi-RM on Kubernetes through a Helm chart, the cluster administrator must load the
+credentials for each additional cluster through a Kubernetes secret. Follow these steps for each
+additional resource manager you want to add, and then apply the Helm chart once. Let ``rm-name`` be
+the same as the “cluster name” for a given cluster.
 
-- Set up your additional clusters. These can be from the same or different clouds (e.g., GKE, AKS, EKS).
-- Gather the credentials for each cluster.
+-  Set up your additional clusters. These can be from the same or different clouds (e.g., GKE, AKS,
+   EKS).
 
-For example:
+-  Gather the credentials for each cluster.
 
-.. code:: bash
+   For example:
 
-   # for AKS az aks get-credentials --resource-group <resource-gp-name> --name <rm-name> # for
-   GKE gcloud container clusters get-credentials <rm-name>
+      .. code:: bash
+
+         # for AKS
+         az aks get-credentials --resource-group <resource-gp-name> --name <rm-name>
+
+         # for GKE
+         gcloud container clusters get-credentials <rm-name>
 
 -  Using the cluster as the current context, save its ``kubeconfig`` to a ``tmp`` file.
+
 -  Repeat the above steps as many times as needed for the additional clusters you want to add.
 
-Next, switch to the cluster/context that you want to use as the default cluster. Then, repeat the
-following steps to create secrets for each additional cluster you want to add.
+-  Next, switch to the cluster/context that you want to use as the default cluster. Then, repeat the
+   following steps to create secrets for each additional cluster you want to add.
 
 -  Create a Kubernetes secret, from the ``tmp`` files for each additional cluster.
+
 -  Specify each additional resource manager, and its kubeconfig secret/location in
    ``helm/charts/determined/values.yaml``.
+
 -  For example:
 
-.. code:: yaml
+   .. code:: yaml
 
-   additional_resource_managers: 
-   - resource_manager:
-      type: kubernetes name: <rm-name> namespace: default 
-      # or whatever other namespace you want to use 
-      kubeconfig_secret_name: <The secret name, from ``kubectl describe secret <rm-name>``> 
-      kubeconfig_secret_value: <The data value, from ``kubectl describe secret <rm-name>``> 
-      ... and any other specs you may want to configure ... 
-      resource_pools: 
-         -  pool_name: <rm-pool>
+      additional_resource_managers:
+      - resource_manager:
+         type: kubernetes name: <rm-name> namespace: default
+         # or whatever other namespace you want to use
+         kubeconfig_secret_name: <The secret name, from ``kubectl describe secret <rm-name>``>
+         kubeconfig_secret_value: <The data value, from ``kubectl describe secret <rm-name>``>
+         ... and any other specs you may want to configure ...
+         resource_pools:
+            -  pool_name: <rm-pool>
 
 -  Once all of your resource managers are added to helm values file, install the Helm chart.
 
-Setting the master IP/Port for different resource managers
-==========================================================
+.. attention::
 
-For resource managers where the master IP/Port is not reachable by the additional resource managers,
-you will need to update your Helm chart values/configuration to match the external IP of the default
-determined deployment. Once the cluster administrator has the master IP of the default Determined
-deployment, all that's necessary is to upgrade the Helm deployment with that value as the master IP
-for the additional clusters.
+   Setting the master IP/Port for different resource managers:
+
+   For resource managers where the master IP/Port is not reachable by the additional resource
+   managers, you will need to update your Helm chart values/configuration to match the external IP
+   of the default determined deployment. Once the cluster administrator has the master IP of the
+   default Determined deployment, all that's necessary is to upgrade the Helm deployment with that
+   value as the master IP for the additional clusters.
 
 *******
  WebUI
@@ -152,16 +162,16 @@ To view resource managers:
 This field helps identify whether a resource pool is managed locally or by another manager, tagged
 as “Remote” if defined in the :ref:`master-config-reference` file.
 
-Visibility and Access
-=====================
+**Usage Scenario**
+
+Let's say your environment contains a resource manager and a resource pool that have both adopted
+the name "default" due to their unnamed status, and you configure an additional resource pool named
+"additional-rm” with a resource pool named "test". When you sign in to the WebUI, you'll see both
+the default and test resource pools. The resource manager name for the default pool will display
+“default”, while the test pool displays "additional-rm" (or the name you specified).
+
+**Visibility and Access**
 
 **Resource Manager Name** is only visible to administrators or users with permissions to define
 multiple resource managers. Users can view all resource pools along with each resource pool's
 manager name to help distinguish between local and remote resource pools.
-
-Usage Example
-=============
-
-After configuring an additional resource pool named "test”, sign in to the cluster to see both the
-default and test resource pools. The Resource Manager Name for the default pool will be “default”,
-while for the test pool, it will display as “additional-rm” or the name you specified.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -25,49 +25,57 @@ We might want to describe the feature here.
 
 How To Configure (For Admins)
 
-* 		Modify Master Configuration File:
-* 		To set up multiple resource managers for Kubernetes, start by editing the master configuration file. The default resource manager will be in place without requiring a specific name.
-* 		Configuration Structure:
+-  Modify Master Configuration File:
 
-    * Locate the resource_manager section in the yaml file; this represents the default resource manager.
-    * Add ``additional_resource_managers`` under the resource_manager to configure extra resource managers.
-    * Under ``additional_resource_managers``, define resource_pools for each additional resource manager.
+-  To set up multiple resource managers for Kubernetes, start by editing the master configuration
+   file. The default resource manager will be in place without requiring a specific name.
 
-* 		Naming and Rules:
+-  Configuration Structure:
 
-    * Each resource manager under ``additional_resource_managers`` must have a unique name; failure to do so will cause the cluster to crash.
-    * Ensure each additional resource manager has at least one resource pool defined.
-    * Resource pool names must be unique across the cluster to prevent crashes.
+   -  Locate the resource_manager section in the yaml file; this represents the default resource
+      manager.
+   -  Add ``additional_resource_managers`` under the resource_manager to configure extra resource
+      managers.
+   -  Under ``additional_resource_managers``, define resource_pools for each additional resource
+      manager.
 
+-  Naming and Rules:
 
+   -  Each resource manager under ``additional_resource_managers`` must have a unique name; failure
+      to do so will cause the cluster to crash.
+   -  Ensure each additional resource manager has at least one resource pool defined.
+   -  Resource pool names must be unique across the cluster to prevent crashes.
 
 *********
-Example
+ Example
 *********
 
-Add examples for the following:
-- Setting kubeconfig
-- Setting masterip/port for the different resource managers
-- Multicloud
-- Multi gke cluster
+Add examples for the following: - Setting kubeconfig - Setting masterip/port for the different
+resource managers - Multicloud - Multi gke cluster
 
-******
-WebUI
-******
+*******
+ WebUI
+*******
 
 How to Interact with It in the WebUI (For WebUI Users)
 
-* 		Viewing Resource Managers:
+-  Viewing Resource Managers:
 
-    * In the WebUI, navigate to the cluster view where each resource pool card will now display a “Resource Manager Name” field.
-    * This field helps identify whether a resource pool is managed locally or by another manager, tagged as “Remote” if defined in the Master Configuration file.
+   -  In the WebUI, navigate to the cluster view where each resource pool card will now display a
+      “Resource Manager Name” field.
+   -  This field helps identify whether a resource pool is managed locally or by another manager,
+      tagged as “Remote” if defined in the Master Configuration file.
 
-* 		Understanding Visibility and Access:
+-  Understanding Visibility and Access:
 
-    * The “Resource Manager Name” field is visible to administrators or users with permissions to define multiple resource managers.
-    * Users can view all resource pools along with their respective manager names, which helps in distinguishing between local and remote resource pools.
+   -  The “Resource Manager Name” field is visible to administrators or users with permissions to
+      define multiple resource managers.
+   -  Users can view all resource pools along with their respective manager names, which helps in
+      distinguishing between local and remote resource pools.
 
-* 		Usage Example:
+-  Usage Example:
 
-    * After configuring an additional resource pool named “test”, you can log in to the cluster and see both the default and test resource pools.
-    * The Resource Manager Name for the default pool will be “default”, while for the test pool, it will appear as “additional-rm” or the name you specified.
+   -  After configuring an additional resource pool named “test”, you can log in to the cluster and
+      see both the default and test resource pools.
+   -  The Resource Manager Name for the default pool will be “default”, while for the test pool, it
+      will appear as “additional-rm” or the name you specified.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -1,0 +1,73 @@
+.. _multiple-resource-managers:
+
+#################################################
+ DRAFT ONLY Configure Multiple Resource Managers
+#################################################
+
+.. meta::
+   :description: Discover how to configure and manage multiple resource managers.
+
+Short introduction...
+
+.. attention::
+
+   For anything we want to call out to avoid crashing the cluster, etc.
+
+**********
+ Overview
+**********
+
+We might want to describe the feature here.
+
+*********************************************
+ How to Configure Multiple Resource Managers
+*********************************************
+
+How To Configure (For Admins)
+
+* 		Modify Master Configuration File:
+* 		To set up multiple resource managers for Kubernetes, start by editing the master configuration file. The default resource manager will be in place without requiring a specific name.
+* 		Configuration Structure:
+
+    * Locate the resource_manager section in the yaml file; this represents the default resource manager.
+    * Add ``additional_resource_managers`` under the resource_manager to configure extra resource managers.
+    * Under ``additional_resource_managers``, define resource_pools for each additional resource manager.
+
+* 		Naming and Rules:
+
+    * Each resource manager under ``additional_resource_managers`` must have a unique name; failure to do so will cause the cluster to crash.
+    * Ensure each additional resource manager has at least one resource pool defined.
+    * Resource pool names must be unique across the cluster to prevent crashes.
+
+
+
+*********
+Example
+*********
+
+Add examples for the following:
+- Setting kubeconfig
+- Setting masterip/port for the different resource managers
+- Multicloud
+- Multi gke cluster
+
+******
+WebUI
+******
+
+How to Interact with It in the WebUI (For WebUI Users)
+
+* 		Viewing Resource Managers:
+
+    * In the WebUI, navigate to the cluster view where each resource pool card will now display a “Resource Manager Name” field.
+    * This field helps identify whether a resource pool is managed locally or by another manager, tagged as “Remote” if defined in the Master Configuration file.
+
+* 		Understanding Visibility and Access:
+
+    * The “Resource Manager Name” field is visible to administrators or users with permissions to define multiple resource managers.
+    * Users can view all resource pools along with their respective manager names, which helps in distinguishing between local and remote resource pools.
+
+* 		Usage Example:
+
+    * After configuring an additional resource pool named “test”, you can log in to the cluster and see both the default and test resource pools.
+    * The Resource Manager Name for the default pool will be “default”, while for the test pool, it will appear as “additional-rm” or the name you specified.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -25,57 +25,49 @@ We might want to describe the feature here.
 
 How To Configure (For Admins)
 
--  Modify Master Configuration File:
+* 		Modify Master Configuration File:
+* 		To set up multiple resource managers for Kubernetes, start by editing the master configuration file. The default resource manager will be in place without requiring a specific name.
+* 		Configuration Structure:
 
--  To set up multiple resource managers for Kubernetes, start by editing the master configuration
-   file. The default resource manager will be in place without requiring a specific name.
+    * Locate the resource_manager section in the yaml file; this represents the default resource manager.
+    * Add ``additional_resource_managers`` under the resource_manager to configure extra resource managers.
+    * Under ``additional_resource_managers``, define resource_pools for each additional resource manager.
 
--  Configuration Structure:
+* 		Naming and Rules:
 
-   -  Locate the resource_manager section in the yaml file; this represents the default resource
-      manager.
-   -  Add ``additional_resource_managers`` under the resource_manager to configure extra resource
-      managers.
-   -  Under ``additional_resource_managers``, define resource_pools for each additional resource
-      manager.
+    * Each resource manager under ``additional_resource_managers`` must have a unique name; failure to do so will cause the cluster to crash.
+    * Ensure each additional resource manager has at least one resource pool defined.
+    * Resource pool names must be unique across the cluster to prevent crashes.
 
--  Naming and Rules:
 
-   -  Each resource manager under ``additional_resource_managers`` must have a unique name; failure
-      to do so will cause the cluster to crash.
-   -  Ensure each additional resource manager has at least one resource pool defined.
-   -  Resource pool names must be unique across the cluster to prevent crashes.
 
 *********
- Example
+Example
 *********
 
-Add examples for the following: - Setting kubeconfig - Setting masterip/port for the different
-resource managers - Multicloud - Multi gke cluster
+Add examples for the following:
+- Setting kubeconfig
+- Setting masterip/port for the different resource managers
+- Multicloud
+- Multi gke cluster
 
-*******
- WebUI
-*******
+******
+WebUI
+******
 
 How to Interact with It in the WebUI (For WebUI Users)
 
--  Viewing Resource Managers:
+* 		Viewing Resource Managers:
 
-   -  In the WebUI, navigate to the cluster view where each resource pool card will now display a
-      “Resource Manager Name” field.
-   -  This field helps identify whether a resource pool is managed locally or by another manager,
-      tagged as “Remote” if defined in the Master Configuration file.
+    * In the WebUI, navigate to the cluster view where each resource pool card will now display a “Resource Manager Name” field.
+    * This field helps identify whether a resource pool is managed locally or by another manager, tagged as “Remote” if defined in the Master Configuration file.
 
--  Understanding Visibility and Access:
+* 		Understanding Visibility and Access:
 
-   -  The “Resource Manager Name” field is visible to administrators or users with permissions to
-      define multiple resource managers.
-   -  Users can view all resource pools along with their respective manager names, which helps in
-      distinguishing between local and remote resource pools.
+    * The “Resource Manager Name” field is visible to administrators or users with permissions to define multiple resource managers.
+    * Users can view all resource pools along with their respective manager names, which helps in distinguishing between local and remote resource pools.
 
--  Usage Example:
+* 		Usage Example:
 
-   -  After configuring an additional resource pool named “test”, you can log in to the cluster and
-      see both the default and test resource pools.
-   -  The Resource Manager Name for the default pool will be “default”, while for the test pool, it
-      will appear as “additional-rm” or the name you specified.
+    * After configuring an additional resource pool named “test”, you can log in to the cluster and see both the default and test resource pools.
+    * The Resource Manager Name for the default pool will be “default”, while for the test pool, it will appear as “additional-rm” or the name you specified.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -1,156 +1,167 @@
 .. _multiple-resource-managers:
 
-#################################################
- DRAFT ONLY Configure Multiple Resource Managers
-#################################################
+######################################
+ Configure Multiple Resource Managers
+######################################
 
 .. meta::
    :description: Discover how to configure and manage multiple resource managers.
 
-Multi-RM for Kubernetes allows users to set up a Determined master service in one Kubernetes cluster
-and schedule workloads in the same or other Kubernetes clusters. - Resource pools are in a
-many-to-one relationship with resource managers. - No one resource pool will span multiple resource
-managers.
-
-.. attention::
-
-   Resource pool and resource manager names must be unique, among all pools and managers. Otherwise,
-   the cluster will crash. Additional resource managers are required to have at least one resource
-   pool defined.
+.. include:: ../../_shared/attn-enterprise-edition.txt
 
 **********
  Overview
 **********
 
-MultiRM for Kubernetes adds the ability to set up the Determined master service on one Kubernetes
-cluster and manage workloads across different Kubernetes clusters. Additional non-default resource
-managers and resource pools are configured under the master configuration options
-``additional_resource_managers`` and ``resource_pools``. On the WebUI, view the resource manager
-name for resource pools. Any requests to resource pools not defined in the master configuration to
-the default resource manager, not any additional resource manager, if defined.
+Multiple Resource Managers (Multi-RM) for Kubernetes allows you to set up a Determined master
+service in one Kubernetes cluster and schedule workloads in the same or other Kubernetes clusters.
+
+**Resource Pool Relationships**
+
+-  Resource pools have a many-to-one relationship with resource managers.
+-  No single resource pool will span multiple resource managers.
+
+Multiple resource managers are defined in the :ref:`master configuration <master-config-reference>`
+using the ``additional_resource_managers`` and ``resource_pools`` options. Any requests to resource
+pools not defined in the master configuration are routed to the default resource manager. Such
+requests are not routed to additional resource managers, if defined.
 
 *********************************************
  How to Configure Multiple Resource Managers
 *********************************************
 
-How To Configure (For Admins)
+To begin, you'll need a user with the Cluster Admin role (requires Determined Enterprise Edition).
+The Cluster Admin role is required for configuring multiple resource managers.
 
--  Modify Master Configuration File:
+.. attention::
 
--  To set up multiple resource managers for Kubernetes, start by editing the master configuration
-   file. The default resource manager will be in place without requiring a specific name.
-
--  Configuration Structure:
-
-   -  Locate the resource_manager section in the yaml file; this represents the default resource
-      manager.
-   -  Add ``additional_resource_managers`` under the resource_manager to configure extra resource
-      managers.
-   -  Under ``additional_resource_managers``, define resource_pools for each additional resource
-      manager.
-
--  Naming and Rules:
+   **Naming and Rules**
 
    -  Each resource manager under ``additional_resource_managers`` must have a unique name; failure
       to do so will cause the cluster to crash.
+
    -  Ensure each additional resource manager has at least one resource pool defined.
+
    -  Resource pool names must be unique across the cluster to prevent crashes.
 
-**********
- Examples
-**********
+.. note::
 
--  Setting the master configuration (devcluster): - Create as many resource managers (clusters) as
-   you’d like. - For each cluster, note each kubeconfig location for the cluster (this is where the
-   credentials are found). - Copy or modify the default devcluster template at
-   tools/devcluster.yaml. - In the copied devcluster.yaml file, under the master configuration, set
-   one of your resource managers as the default, and the rest under additional_resource_managers:
+   The default resource manager is available by default and does not require a specific name.
 
-   .. code:: yaml
+#. Locate the ``resource_manager`` section in the :ref:`master configuration <master-config-reference>`
+   yaml file. This represents the default resource manager.
+#. Add ``additional_resource_managers`` under the ``resource_manager`` to configure extra resource
+   managers.
+#. Under ``additional_resource_managers``, define ``resource_pools`` for each additional resource
+   manager.
 
-      resource_manager:
+
+Example: Master Configuration (devcluster)
+==========================================
+
+Follow this example to create as many resource managers (clusters) as needed.
+
+-  For each cluster, note each ``kubeconfig`` location for the cluster (this is where the credentials
+   are found).
+
+-  Copy or modify the default devcluster template at ``tools/devcluster.yaml``.
+
+-  In the copied ``devcluster.yaml`` file, under the ``master configuration``, set one of your
+   resource managers as the default, and the rest under ``additional_resource_managers``:
+
+.. code:: yaml
+
+   resource_manager:
+   type: kubernetes
+   name: default-rm # optional, should match the name of your default RM/cluster
+   ... add any other specs you might need ...
+   additional_resource_managers:
+   - resource_manager:
       type: kubernetes
-      name: default-rm # optional, should match the name of your default RM/cluster
+      name: additional-rm # should match the name of your other RM(s)
+      kubeconfig_path: <whatever-path-your-rm-config-is-like ~/.kubeconfig>
       ... add whatever other specs you might need ...
-      additional_resource_managers:
-      - resource_manager:
-         type: kubernetes
-         name: additional-rm # should match the name of your other RM(s)
-         kubeconfig_path: <whatever-path-your-rm-config-is-like ~/.kubeconfig>
-         ... add whatever other specs you might need ...
-         resource_pools:
-            - pool_name: <your-rm-pool-name>
+      resource_pools:
+         - pool_name: <your-rm-pool-name>
 
-   -  Run the new devcluster: ``devcluster -c <path-to-modified-devcluster>``.
+-  Run the new devcluster: ``devcluster -c <path-to-modified-devcluster>``.
 
--  Setting the master configuration (Helm): To deploy MultiRM on Kubernetes through a Helm chart,
-   the cluster administrator will have to load the credentials for each additional cluster through a
-   Kubernetes secret. Follow these steps for each additional resource manager you want to add, and
-   then apply the Helm chart once at the end. Let rm-name be the same as the “cluster name” for a
-   given cluster.
+Example: Master Configuration (Helm)
+====================================
 
-   -  Set up your additional clusters. These can be from the same or different clouds (i.e., GKE,
-      AKS, EKS).
+To deploy Multi-RM on Kubernetes through a Helm chart, the cluster administrator must load
+the credentials for each additional cluster through a Kubernetes secret. Follow these steps for each
+additional resource manager you want to add, and then apply the Helm chart once at the end. Let
+``rm-name`` be the same as the “cluster name” for a given cluster.
 
-   -  Gather the credentials for each cluster: - For example: .. code:: bash
+- Set up your additional clusters. These can be from the same or different clouds (e.g., GKE, AKS, EKS).
+- Gather the credentials for each cluster.
 
-         # for AKS az aks get-credentials --resource-group <resource-gp-name> --name <rm-name> # for
-         GKE gcloud container clusters get-credentials <rm-name>
+For example:
 
-   -  Using the cluster as the current context, save its kubeconfig to some tmp file.
+.. code:: bash
 
-   -  Repeat the above steps as many times as needed for the additional clusters you want to add.
+   # for AKS az aks get-credentials --resource-group <resource-gp-name> --name <rm-name> # for
+   GKE gcloud container clusters get-credentials <rm-name>
 
-   Then, switch to the cluster/context that you want to use as the default cluster. Then, repeat the
-   following steps to create secrets for each additional cluster you want to add.
+-  Using the cluster as the current context, save its ``kubeconfig`` to a ``tmp`` file.
+-  Repeat the above steps as many times as needed for the additional clusters you want to add.
 
-   -  Create a Kubernetes secret, from the tmp files for each additional cluster.
+Next, switch to the cluster/context that you want to use as the default cluster. Then, repeat the
+following steps to create secrets for each additional cluster you want to add.
 
-   -  Specify each additional resource manager, and its kubeconfig secret/location in
-      ``helm/charts/determined/values.yaml``: - For example: .. code:: yaml
+-  Create a Kubernetes secret, from the ``tmp`` files for each additional cluster.
+-  Specify each additional resource manager, and its kubeconfig secret/location in
+   ``helm/charts/determined/values.yaml``.
+-  For example:
 
-         additional_resource_managers: - resource_manager:
+.. code:: yaml
 
-            type: kubernetes name: <rm-name> namespace: default # or whatever other namespace you
-            want to use kubeconfig_secret_name: <The secret name, from ``kubectl describe secret
-            <rm-name>``> kubeconfig_secret_value: <The data value, from ``kubectl describe secret
-            <rm-name>``> ... and any other specs you may want to configure ... resource_pools:
+   additional_resource_managers: 
+   - resource_manager:
+      type: kubernetes name: <rm-name> namespace: default 
+      # or whatever other namespace you want to use 
+      kubeconfig_secret_name: <The secret name, from ``kubectl describe secret <rm-name>``> 
+      kubeconfig_secret_value: <The data value, from ``kubectl describe secret <rm-name>``> 
+      ... and any other specs you may want to configure ... 
+      resource_pools: 
+         -  pool_name: <rm-pool>
 
-               -  pool_name: <rm-pool>
+-  Once all of your resource managers are added to helm values file, install the Helm chart.
 
-   -  Once all of your resource managers are added to helm values file, install the Helm chart.
+Setting the master IP/Port for different resource managers
+==========================================================
 
--  Setting the master IP/Port for different resource managers:
-
-   For resource managers where the master IP/Port is not reachable by the additional resource
-   managers, you will need to update your Helm chart values/configuration to match the external IP
-   of the default determined deployment. Once the cluster administrator has the master IP of the
-   default Determined deployment, all that's necessary is to upgrade the Helm deployment with that
-   value as the master IP for the additional clusters.
+For resource managers where the master IP/Port is not reachable by the additional resource managers,
+you will need to update your Helm chart values/configuration to match the external IP of the default
+determined deployment. Once the cluster administrator has the master IP of the default Determined
+deployment, all that's necessary is to upgrade the Helm deployment with that value as the master IP
+for the additional clusters.
 
 *******
  WebUI
 *******
 
-How to Interact with It in the WebUI (For WebUI Users)
+In the WebUI, the resource manager name is visible for each resource pool.
 
--  Viewing Resource Managers:
+To view resource managers:
 
-   -  In the WebUI, navigate to the cluster view where each resource pool card will now display a
-      “Resource Manager Name” field.
-   -  This field helps identify whether a resource pool is managed locally or by another manager,
-      tagged as “Remote” if defined in the Master Configuration file.
+-  In the WebUI, navigate to the cluster view.
+-  Each resource pool card displays **Resource Manager Name**.
 
--  Understanding Visibility and Access:
+This field helps identify whether a resource pool is managed locally or by another manager, tagged
+as “Remote” if defined in the :ref:`master-config-reference` file.
 
-   -  The “Resource Manager Name” field is visible to administrators or users with permissions to
-      define multiple resource managers.
-   -  Users can view all resource pools along with their respective manager names, which helps in
-      distinguishing between local and remote resource pools.
+Visibility and Access
+=====================
 
--  Usage Example:
+**Resource Manager Name** is only visible to administrators or users with permissions to define
+multiple resource managers. Users can view all resource pools along with each resource pool's
+manager name to help distinguish between local and remote resource pools.
 
-   -  After configuring an additional resource pool named “test”, you can log in to the cluster and
-      see both the default and test resource pools.
-   -  The Resource Manager Name for the default pool will be “default”, while for the test pool, it
-      will appear as “additional-rm” or the name you specified.
+Usage Example
+=============
+
+After configuring an additional resource pool named "test”, sign in to the cluster to see both the
+default and test resource pools. The Resource Manager Name for the default pool will be “default”,
+while for the test pool, it will display as “additional-rm” or the name you specified.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -59,7 +59,8 @@ Example: Master Configuration (devcluster)
 
 Follow this example to create as many resource managers (clusters) as needed.
 
--  For each cluster, note each ``kubeconfig`` location for the cluster (this is where the credentials are found).
+-  For each cluster, note each ``kubeconfig`` location for the cluster (this is where the
+   credentials are found).
 
 -  Copy or modify the default devcluster template at ``tools/devcluster.yaml``.
 

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -346,4 +346,17 @@ resourcePools:
 # defaultComputeResourcePool: default
 
 ## Configure the initial user password for the cluster
-# initialUserPassword:
+# initialUserPassword
+
+# additional_resource_managers:
+#   - resource_manager:
+#       type: kubernetes
+#       max_slots_per_pod: 1
+#       name: carolina-multirm-1
+#       namespace: default
+#       kubeconfig_secret_name: additionalrm
+#       kubeconfig_secret_value: config
+#       determined_master_ip: 10.11.12.13
+#       determined_master_port: 8080
+#     resource_pools:
+#       - pool_name: additional_pool


### PR DESCRIPTION
##Description

Feature: Multiple Resource Managers for Kubernetes.
Docs: Add/Update the following:

- /reference/deploy/helm-config-reference
- /reference/deploy/master-config-reference
- /release-notes/multirm-for-k8s
- setup-cluster/k8s/setup-multiple-resource-managers

## Related
https://github.com/determined-ai/determined/pull/9050
https://github.com/determined-ai/determined/pull/9122
https://github.com/determined-ai/determined/pull/9119

## Add a New Page to the K8S Setup Section
- Tentative title "Configure Multiple Resource Managers"
- Draft docs page for describing how to work with and manage multiple resource managers for kubernetes installations. 
- Target audience: admin. 
- Target release date: Not tied to a release.

For starters, we need to add examples mentioned here in #9016:
https://github.com/determined-ai/determined/pull/9016/files#r1532170203

- Walk through an example
- - e.g., Setting `kubeconfig` 
- - e.g., Setting `masterip/port` for the different resource managers 
- - Example of doing multicloud or multi gke cluster.
