### PR TITLE
chore: add nightly gke cluster cleanup job

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2750,11 +2750,11 @@ jobs:
         - run:
             name: Delete GKE CI Cluster Namespaces
             command: |
-              kubectl get namespace | grep -Eo "^test-[a-z0-9]+-[a-z0-9]+-[0-9]" | xargs -L1 kubectl delete namespace || true
+              kubectl get namespace | grep -Eo "^test-cpu-[a-z0-9]+-[a-z0-9]+-[0-9]" | xargs -L1 kubectl delete namespace || true
         - run:
             name: Delete GCS CI Buckets
             command: |
-              gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
+              gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-cpu-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
         - run:
             name: Delete Firewall Rules
             command: |
@@ -3663,7 +3663,7 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
-
+          
       - run-shared-cluster-cleanup:
           name: gke-cleanup
           context: gcp-shared-cluster

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2754,7 +2754,7 @@ jobs:
         - run:
             name: Delete GCS CI Buckets
             command: |
-              gsutil ls -p dai-dev-55 | grep -Eo "^gs://test-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
+              gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
 
 workflows:
   lint:
@@ -3638,7 +3638,7 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
-          
+
       - run-gke-cluster-cleanup:
           name: gke-cleanup
           context: gcp-shared-cluster

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3203,10 +3203,6 @@ workflows:
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
 
-      - run-gke-cluster-cleanup:
-          name: gke-cleanup
-          context: gcp-shared-cluster
-
   test-e2e-longrunning:
     jobs:
       # Build and publish artifacts used in tests
@@ -3643,6 +3639,9 @@ workflows:
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
           
+      - run-gke-cluster-cleanup:
+          name: gke-cleanup
+          context: gcp-shared-cluster
 
   release:
     jobs:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2705,9 +2705,9 @@ jobs:
         cluster-id:
           type: string
           default: ${GKE_CLUSTER_NAME}
-        zone:
+        region:
           type: string
-          default: ${GKE_ZONE}
+          default: ${GKE_REGION}
         gcloud-service-key:
           default: GCLOUD_SERVICE_KEY
           description: The gcloud service key
@@ -2746,7 +2746,7 @@ jobs:
             name: Install GKE auth plugin
         - run:
             name: Get Kubeconfig
-            command: gcloud container clusters get-credentials ${CLUSTER_ID} --project ${GOOGLE_PROJECT_ID} --zone <<parameters.zone>>
+            command: gcloud container clusters get-credentials ${CLUSTER_ID} --project ${GOOGLE_PROJECT_ID} --region <<parameters.region>>
         - run:
             name: Delete GKE CI Cluster Namespaces
             command: |
@@ -2754,30 +2754,30 @@ jobs:
         - run:
             name: Delete GCS CI Buckets
             command: |
-              gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-cpu-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
+              gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-cpu-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil -m rm -r || true
         - run:
             name: Delete Firewall Rules
             command: |
-              gcloud compute networks get-effective-firewalls $GCP_NETWORK_NAME --project "$GCP_PROJECT_ID" \
+              gcloud compute networks get-effective-firewalls $GCP_NETWORK_NAME --project "$GOOGLE_PROJECT_ID" \
                 --format="table(name)" | tail -n +2 | \
                 while read fw; do
                   if [[ $fw =~ "k8s" ]]; then
-                    gcloud compute firewall-rules delete "$fw" --quiet --project "$GCP_PROJECT_ID"
+                    gcloud compute firewall-rules delete "$fw" --quiet --project "$GOOGLE_PROJECT_ID"
                   fi
                 done
         - run:
             name: Delete Forwarding Rules
             command: |
-              gcloud compute forwarding-rules list --format="table(name)" --project "$GCP_PROJECT_ID" | tail -n +2 | \
+              gcloud compute forwarding-rules list --format="table(name)" --project "$GOOGLE_PROJECT_ID" | tail -n +2 | \
                 while read fr; do   
-                  gcloud compute forwarding-rules delete "$fr" --quiet --project "$GCP_PROJECT_ID"
+                  gcloud compute forwarding-rules delete "$fr" --quiet --project "$GOOGLE_PROJECT_ID"
                 done
         - run:
             name: Delete Target Pools
             command: |
-              gcloud compute target-pools list --format="table(name)" --project "$GCP_PROJECT_ID" | tail -n +2 | \
+              gcloud compute target-pools list --format="table(name)" --project "$GOOGLE_PROJECT_ID" | tail -n +2 | \
                 while read tp; do   
-                  gcloud compute target-pools delete "$tp" --quiet --project "$GCP_PROJECT_ID"
+                  gcloud compute target-pools delete "$tp" --quiet --project "$GOOGLE_PROJECT_ID"
                 done
 
 
@@ -3227,6 +3227,10 @@ workflows:
               parallelism: [2]
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
+      
+      - run-shared-cluster-cleanup:
+          name: gke-cleanup
+          context: gcp-shared-cluster
 
   test-e2e-longrunning:
     jobs:
@@ -3663,10 +3667,6 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
-          
-      - run-shared-cluster-cleanup:
-          name: gke-cleanup
-          context: gcp-shared-cluster
 
   release:
     jobs:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2755,31 +2755,6 @@ jobs:
             name: Delete GCS CI Buckets
             command: |
               gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-cpu-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil -m rm -r || true
-        - run:
-            name: Delete Firewall Rules
-            command: |
-              gcloud compute networks get-effective-firewalls $GCP_NETWORK_NAME --project "$GOOGLE_PROJECT_ID" \
-                --format="table(name)" | tail -n +2 | \
-                while read fw; do
-                  if [[ $fw =~ "k8s" ]]; then
-                    gcloud compute firewall-rules delete "$fw" --quiet --project "$GOOGLE_PROJECT_ID"
-                  fi
-                done
-        - run:
-            name: Delete Forwarding Rules
-            command: |
-              gcloud compute forwarding-rules list --format="table(name)" --project "$GOOGLE_PROJECT_ID" | tail -n +2 | \
-                while read fr; do   
-                  gcloud compute forwarding-rules delete "$fr" --quiet --project "$GOOGLE_PROJECT_ID"
-                done
-        - run:
-            name: Delete Target Pools
-            command: |
-              gcloud compute target-pools list --format="table(name)" --project "$GOOGLE_PROJECT_ID" | tail -n +2 | \
-                while read tp; do   
-                  gcloud compute target-pools delete "$tp" --quiet --project "$GOOGLE_PROJECT_ID"
-                done
-
 
 workflows:
   lint:
@@ -3227,10 +3202,6 @@ workflows:
               parallelism: [2]
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
-      
-      - run-shared-cluster-cleanup:
-          name: gke-cleanup
-          context: gcp-shared-cluster
 
   test-e2e-longrunning:
     jobs:
@@ -3667,6 +3638,10 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
+
+      - run-shared-cluster-cleanup:
+          name: gke-cleanup
+          context: gcp-shared-cluster
 
   release:
     jobs:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2700,7 +2700,7 @@ jobs:
           mentions: <<parameters.slack-mentions>>
           channel: <<parameters.slack-channel>>
 
-  run-gke-cluster-cleanup:
+  run-shared-cluster-cleanup:
       parameters:
         cluster-id:
           type: string
@@ -2755,6 +2755,31 @@ jobs:
             name: Delete GCS CI Buckets
             command: |
               gsutil ls -p ${GOOGLE_PROJECT_ID} | grep -Eo "^gs://test-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
+        - run:
+            name: Delete Firewall Rules
+            command: |
+              gcloud compute networks get-effective-firewalls $GCP_NETWORK_NAME --project "$GCP_PROJECT_ID" \
+                --format="table(name)" | tail -n +2 | \
+                while read fw; do
+                  if [[ $fw =~ "k8s" ]]; then
+                    gcloud compute firewall-rules delete "$fw" --quiet --project "$GCP_PROJECT_ID"
+                  fi
+                done
+        - run:
+            name: Delete Forwarding Rules
+            command: |
+              gcloud compute forwarding-rules list --format="table(name)" --project "$GCP_PROJECT_ID" | tail -n +2 | \
+                while read fr; do   
+                  gcloud compute forwarding-rules delete "$fr" --quiet --project "$GCP_PROJECT_ID"
+                done
+        - run:
+            name: Delete Target Pools
+            command: |
+              gcloud compute target-pools list --format="table(name)" --project "$GCP_PROJECT_ID" | tail -n +2 | \
+                while read tp; do   
+                  gcloud compute target-pools delete "$tp" --quiet --project "$GCP_PROJECT_ID"
+                done
+
 
 workflows:
   lint:
@@ -3639,7 +3664,7 @@ workflows:
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
 
-      - run-gke-cluster-cleanup:
+      - run-shared-cluster-cleanup:
           name: gke-cleanup
           context: gcp-shared-cluster
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2700,6 +2700,62 @@ jobs:
           mentions: <<parameters.slack-mentions>>
           channel: <<parameters.slack-channel>>
 
+  run-gke-cluster-cleanup:
+      parameters:
+        cluster-id:
+          type: string
+          default: ${GKE_CLUSTER_NAME}
+        zone:
+          type: string
+          default: ${GKE_ZONE}
+        gcloud-service-key:
+          default: GCLOUD_SERVICE_KEY
+          description: The gcloud service key
+          type: env_var_name
+        google-compute-zone:
+          default: GOOGLE_COMPUTE_ZONE
+          description: The Google compute zone to connect with via the gcloud CLI
+          type: env_var_name
+        google-project-id:
+          default: GOOGLE_PROJECT_ID
+          description: The Google project ID to connect with via the gcloud CLI
+          type: env_var_name
+      circleci_ip_ranges: true
+      docker:
+        - image: <<pipeline.parameters.docker-image>>
+      steps:
+        - set-cluster-id:
+              cluster-id: <<parameters.cluster-id>>
+        - gcloud/install:
+              version: "412.0.0"
+        - kubernetes/install-kubectl
+        - gcloud/initialize:
+            gcloud-service-key: <<parameters.gcloud-service-key>>
+            google-compute-zone: <<parameters.google-compute-zone>>
+            google-project-id: <<parameters.google-project-id>>
+        - run:
+            command: |
+              tries=5
+              until gcloud components install gke-gcloud-auth-plugin --quiet; do
+                if [[ $((--tries)) -eq 0 ]]; then
+                  exit 1
+                fi
+                sleep 15
+              done
+              echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> $BASH_ENV
+            name: Install GKE auth plugin
+        - run:
+            name: Get Kubeconfig
+            command: gcloud container clusters get-credentials ${CLUSTER_ID} --project ${GOOGLE_PROJECT_ID} --zone <<parameters.zone>>
+        - run:
+            name: Delete GKE CI Cluster Namespaces
+            command: |
+              kubectl get namespace | grep -Eo "^test-[a-z0-9]+-[a-z0-9]+-[0-9]" | xargs -L1 kubectl delete namespace || true
+        - run:
+            name: Delete GCS CI Buckets
+            command: |
+              gsutil ls -p dai-dev-55 | grep -Eo "^gs://test-[a-z0-9]+-[a-z0-9]+-[0-9]-bucket" | xargs -L1 gsutil rm -r || true
+
 workflows:
   lint:
     jobs:
@@ -3147,6 +3203,10 @@ workflows:
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
 
+      - run-gke-cluster-cleanup:
+          name: gke-cleanup
+          context: gcp-shared-cluster
+
   test-e2e-longrunning:
     jobs:
       # Build and publish artifacts used in tests
@@ -3582,6 +3642,7 @@ workflows:
           cluster-id-prefix: aws-fs-efs
           deployment-type: efs
           slack-mentions: "${SLACK_USER_ID}"
+          
 
   release:
     jobs:


### PR DESCRIPTION
## Description

Create nightly cleanup job that removes all namespaces (and therefore all k8s objects within them) from the CircleCI GKE cluster and deletes all buckets created by CI jobs used for testing with that cluster.

Successful run with resources to delete: https://app.circleci.com/pipelines/github/determined-ai/determined/52752/workflows/ef46cdef-ca8d-4345-a1e7-49e15d7473aa/jobs/2370042

Successful run with no resources to delete: https://app.circleci.com/pipelines/github/determined-ai/determined/52764/workflows/0a6c0b3f-8e4b-427e-ba92-d6f7b5e930a6/jobs/2370726

## Test Plan

CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket

DET-10117


