### PR TITLE
feat: add command det model delete

### DIFF
--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -109,7 +109,8 @@ def list_versions(args: Namespace) -> None:
 
 
 def delete(args: Namespace) -> None:
-    model = client.Determined(args.master, None).get_model(args.name)
+    sess = cli.setup_session(args)
+    model = model_by_name(sess, args.name)
     model.delete()
 
 

--- a/harness/determined/cli/model.py
+++ b/harness/determined/cli/model.py
@@ -108,6 +108,11 @@ def list_versions(args: Namespace) -> None:
         _render_model_versions(model.list_versions())
 
 
+def delete(args: Namespace) -> None:
+    model = client.Determined(args.master, None).get_model(args.name)
+    model.delete()
+
+
 def create(args: Namespace) -> None:
     sess = cli.setup_session(args)
     d = client.Determined._from_session(sess)
@@ -222,6 +227,14 @@ args_description = [
                 [
                     Arg("name", type=str, help="unique name of the model"),
                     Arg("--json", action="store_true", help="print as JSON"),
+                ],
+            ),
+            Cmd(
+                "delete",
+                delete,
+                "delete model",
+                [
+                    Arg("name", type=str, help="unique name of the model"),
                 ],
             ),
             Cmd(


### PR DESCRIPTION
## Description
[DET-9632]

Essentially identical to a convenience CLI command that was part of a PR #7175 last year as it was useful for testing at the time. It spun off into a separate ticket due to being out of scope, but it's probably still convenient to (re)include.

https://github.com/determined-ai/determined/commit/8b0ec750a4c2dec1156d33feb97c4b7765788e42#diff-27dd013a7937c3e0392be1d4090837fec1f0fb87ef0037cac6516e447360ee40R138

## Test Plan
modified e2e test which exercises the new command should pass

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.



[DET-9632]: https://hpe-aiatscale.atlassian.net/browse/DET-9632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ