### PR TITLE
refactor: remove agentID type from agentrm

### DIFF
--- a/master/internal/rm/agentrm/agent.go
+++ b/master/internal/rm/agentrm/agent.go
@@ -43,7 +43,7 @@ type (
 
 		mu sync.Mutex
 
-		id               agentID
+		id               aproto.ID
 		registeredTime   time.Time
 		address          string
 		agentUpdates     *queue.Queue[agentUpdatedEvent]
@@ -115,7 +115,7 @@ type (
 )
 
 func newAgent(
-	id agentID,
+	id aproto.ID,
 	agentUpdates *queue.Queue[agentUpdatedEvent],
 	resourcePoolName string,
 	rpConfig *config.ResourcePoolConfig,
@@ -150,7 +150,7 @@ func newAgent(
 		// agentReconnectWait if it never reconnects.
 		// Ensure RP is aware of the agent.
 		a.syslog.Infof("adding agent: %s", a.agentState.agentID())
-		err := a.updateAgentStartStats(a.resourcePoolName, string(a.id), a.agentState.numSlots())
+		err := a.updateAgentStartStats(a.resourcePoolName, a.id, a.agentState.numSlots())
 		if err != nil {
 			a.syslog.WithError(err).Error("failed to update agent start stats")
 		}
@@ -298,7 +298,7 @@ func (a *agent) stop(cause error) {
 	}
 
 	a.syslog.Infof("removing agent: %s", a.id)
-	err := a.updateAgentEndStats(string(a.id))
+	err := a.updateAgentEndStats(a.id)
 	if err != nil {
 		a.syslog.WithError(err).Error("failed to update agent end stats")
 	}
@@ -680,7 +680,7 @@ func (a *agent) agentStarted(agentStarted *aproto.AgentStarted) {
 	a.agentState.agentStarted(agentStarted)
 
 	a.syslog.Infof("adding agent: %s", a.agentState.agentID())
-	err := a.updateAgentStartStats(a.resourcePoolName, string(a.id), a.agentState.numSlots())
+	err := a.updateAgentStartStats(a.resourcePoolName, a.id, a.agentState.numSlots())
 	if err != nil {
 		a.syslog.WithError(err).Error("failed to update agent start stats")
 	}
@@ -915,17 +915,17 @@ func (a *agent) notifyListeners() {
 }
 
 func (a *agent) updateAgentStartStats(
-	poolName string, agentID string, slots int,
+	poolName string, agentID aproto.ID, slots int,
 ) error {
 	return db.SingleDB().RecordAgentStats(&model.AgentStats{
 		ResourcePool: poolName,
-		AgentID:      agentID,
+		AgentID:      string(agentID),
 		Slots:        slots,
 	})
 }
 
-func (a *agent) updateAgentEndStats(agentID string) error {
+func (a *agent) updateAgentEndStats(agentID aproto.ID) error {
 	return db.EndAgentStats(&model.AgentStats{
-		AgentID: agentID,
+		AgentID: string(agentID),
 	})
 }

--- a/master/internal/rm/agentrm/agent_model.go
+++ b/master/internal/rm/agentrm/agent_model.go
@@ -17,15 +17,12 @@ type slotData struct {
 	ContainerID *cproto.ID
 }
 
-// agentID is the agent id type.
-type agentID string
-
 // agentSnapshot is a database representation of `agentState`.
 type agentSnapshot struct {
 	bun.BaseModel `bun:"table:resourcemanagers_agent_agentstate,alias:rmas"`
 
 	ID                    int64       `bun:"id,pk,autoincrement"`
-	AgentID               agentID     `bun:"agent_id,notnull,unique"`
+	AgentID               aproto.ID   `bun:"agent_id,notnull,unique"`
 	UUID                  string      `bun:"uuid,notnull,unique"`
 	ResourcePoolName      string      `bun:"resource_pool_name,notnull"`
 	Label                 string      `bun:"label"`

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -139,7 +139,7 @@ func (*ResourceManager) DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, e
 
 // DisableAgent implements rm.ResourceManager.
 func (a *ResourceManager) DisableAgent(msg *apiv1.DisableAgentRequest) (*apiv1.DisableAgentResponse, error) {
-	agent, ok := a.agentService.get(agentID(msg.AgentId))
+	agent, ok := a.agentService.get(aproto.ID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
 	}
@@ -155,7 +155,7 @@ func (a *ResourceManager) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Dis
 	deviceID := device.ID(deviceIDStr)
 
 	enabled := false
-	result, err := a.handlePatchSlotState(agentID(req.AgentId), patchSlotState{
+	result, err := a.handlePatchSlotState(aproto.ID(req.AgentId), patchSlotState{
 		id:      deviceID,
 		enabled: &enabled,
 		drain:   &req.Drain,
@@ -168,7 +168,7 @@ func (a *ResourceManager) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Dis
 
 // EnableAgent implements rm.ResourceManager.
 func (a *ResourceManager) EnableAgent(msg *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error) {
-	agent, ok := a.agentService.get(agentID(msg.AgentId))
+	agent, ok := a.agentService.get(aproto.ID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
 	}
@@ -184,7 +184,7 @@ func (a *ResourceManager) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.Enabl
 	deviceID := device.ID(deviceIDStr)
 
 	enabled := true
-	result, err := a.handlePatchSlotState(agentID(req.AgentId), patchSlotState{id: deviceID, enabled: &enabled})
+	result, err := a.handlePatchSlotState(aproto.ID(req.AgentId), patchSlotState{id: deviceID, enabled: &enabled})
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (a *ResourceManager) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.Enabl
 }
 
 func (a *ResourceManager) handlePatchSlotState(
-	agentID agentID, msg patchSlotState,
+	agentID aproto.ID, msg patchSlotState,
 ) (*model.SlotSummary, error) {
 	agent, ok := a.agentService.get(agentID)
 	if !ok {
@@ -225,7 +225,7 @@ func (*ResourceManager) ExternalPreemptionPending(sproto.PendingPreemption) erro
 
 // GetAgent implements rm.ResourceManager.
 func (a *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
-	agent, ok := a.agentService.get(agentID(msg.AgentId))
+	agent, ok := a.agentService.get(aproto.ID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
 	}
@@ -343,7 +343,7 @@ func (a *ResourceManager) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResp
 	}
 	deviceID := device.ID(deviceIDStr)
 
-	result, err := a.handlePatchSlotState(agentID(req.AgentId), patchSlotState{id: deviceID})
+	result, err := a.handlePatchSlotState(aproto.ID(req.AgentId), patchSlotState{id: deviceID})
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (a *ResourceManager) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResp
 
 // GetSlots implements rm.ResourceManager.
 func (a *ResourceManager) GetSlots(msg *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
-	agent, ok := a.agentService.get(agentID(msg.AgentId))
+	agent, ok := a.agentService.get(aproto.ID(msg.AgentId))
 	if !ok {
 		return nil, api.NotFoundErrs("agent", msg.AgentId, true)
 	}

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -49,7 +49,7 @@ func TestAgentStatePersistence(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fake an agent, test adding it to the db.
-	state := newAgentState(agentID(uuid.NewString()), 64)
+	state := newAgentState(aproto.ID(uuid.NewString()), 64)
 	state.handler = &agent{}
 	state.resourcePoolName = "compute"
 	devices := []device.Device{
@@ -187,7 +187,7 @@ func TestAgentStatePersistence(t *testing.T) {
 
 func TestClearAgentStates(t *testing.T) {
 	ctx := context.Background()
-	agentIDs := []agentID{agentID(uuid.NewString()), agentID(uuid.NewString())}
+	agentIDs := []aproto.ID{aproto.ID(uuid.NewString()), aproto.ID(uuid.NewString())}
 	for _, agentID := range agentIDs {
 		_, err := db.Bun().NewInsert().Model(&agentSnapshot{
 			AgentID:               agentID,
@@ -326,7 +326,7 @@ func Test_agentState_checkAgentStartedDevicesMatch(t *testing.T) {
 
 func TestSlotStates(t *testing.T) {
 	rpName := "test"
-	state := newAgentState(agentID(uuid.NewString()), 64)
+	state := newAgentState(aproto.ID(uuid.NewString()), 64)
 	state.handler = &agent{}
 	state.resourcePoolName = rpName
 	devices := []device.Device{

--- a/master/internal/rm/agentrm/fair_share.go
+++ b/master/internal/rm/agentrm/fair_share.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/check"
 	"github.com/determined-ai/determined/master/pkg/mathx"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -81,7 +82,7 @@ func (f *fairShare) JobQInfo(rp *resourcePool) map[model.JobID]*sproto.RMJobInfo
 func fairshareSchedule(
 	taskList *tasklist.TaskList,
 	groups map[model.JobID]*tasklist.Group,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 	allowHeterogeneousAgentFits bool,
 ) ([]*sproto.AllocateRequest, []model.AllocationID) {
@@ -133,7 +134,7 @@ func fairshareSchedule(
 	return allToAllocate, allToRelease
 }
 
-func totalCapacity(agents map[agentID]*agentState) int {
+func totalCapacity(agents map[aproto.ID]*agentState) int {
 	result := 0
 
 	for _, agent := range agents {
@@ -147,7 +148,7 @@ func calculateGroupStates(
 	taskList *tasklist.TaskList,
 	groups map[model.JobID]*tasklist.Group,
 	capacity int,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 	allowHeterogeneousAgentFits bool,
 ) []*groupState {
@@ -358,7 +359,7 @@ func calculateSmallestAllocatableTask(state *groupState) (smallest *sproto.Alloc
 }
 
 func assignTasks(
-	agents map[agentID]*agentState, states []*groupState, fittingMethod SoftConstraint,
+	agents map[aproto.ID]*agentState, states []*groupState, fittingMethod SoftConstraint,
 	allowHetergenousAgentFits bool,
 ) ([]*sproto.AllocateRequest, []model.AllocationID) {
 	toAllocate := make([]*sproto.AllocateRequest, 0)

--- a/master/internal/rm/agentrm/fitting.go
+++ b/master/internal/rm/agentrm/fitting.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/mathx"
 )
 
@@ -69,7 +70,7 @@ func (c candidateList) Swap(i, j int) {
 }
 
 func findFits(
-	req *sproto.AllocateRequest, agents map[agentID]*agentState, fittingMethod SoftConstraint,
+	req *sproto.AllocateRequest, agents map[aproto.ID]*agentState, fittingMethod SoftConstraint,
 	allowHeterogeneousFits bool,
 ) []*fittingState {
 	// TODO(DET-4035): Some of this code is duplicated in calculateDesiredNewAgentNum()
@@ -104,7 +105,7 @@ func isViable(
 }
 
 func findDedicatedAgentFits(
-	req *sproto.AllocateRequest, agentStates map[agentID]*agentState,
+	req *sproto.AllocateRequest, agentStates map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint, allowHeterogeneousFits bool,
 ) []*fittingState {
 	if len(agentStates) == 0 {
@@ -219,7 +220,7 @@ func findDedicatedAgentFits(
 }
 
 func findSharedAgentFit(
-	req *sproto.AllocateRequest, agents map[agentID]*agentState, fittingMethod SoftConstraint,
+	req *sproto.AllocateRequest, agents map[aproto.ID]*agentState, fittingMethod SoftConstraint,
 ) *fittingState {
 	var candidates candidateList
 	for _, agent := range agents {

--- a/master/internal/rm/agentrm/fitting_test.go
+++ b/master/internal/rm/agentrm/fitting_test.go
@@ -8,6 +8,7 @@ import (
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 )
 
 func TestIsViable(t *testing.T) {
@@ -504,8 +505,8 @@ func TestFindFitDisallowedNodes(t *testing.T) {
 
 func byID(
 	handlers ...*agentState,
-) (map[agentID]*agentState, []*agentState) {
-	agents := make(map[agentID]*agentState, len(handlers))
+) (map[aproto.ID]*agentState, []*agentState) {
+	agents := make(map[aproto.ID]*agentState, len(handlers))
 	index := make([]*agentState, 0, len(handlers))
 	for _, agent := range handlers {
 		agents[agent.id] = agent

--- a/master/internal/rm/agentrm/priority.go
+++ b/master/internal/rm/agentrm/priority.go
@@ -10,6 +10,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
@@ -50,7 +51,7 @@ func (p priorityScheduler) prioritySchedule(
 	taskList *tasklist.TaskList,
 	groups map[model.JobID]*tasklist.Group,
 	jobPositions tasklist.JobSortState,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 ) ([]*sproto.AllocateRequest, []model.AllocationID) {
 	toAllocate := make([]*sproto.AllocateRequest, 0)
@@ -83,7 +84,7 @@ func (p priorityScheduler) prioritySchedulerWithFilter(
 	taskList *tasklist.TaskList,
 	groups map[model.JobID]*tasklist.Group,
 	jobPositions tasklist.JobSortState,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 	filter func(*sproto.AllocateRequest) bool,
 ) ([]*sproto.AllocateRequest, []model.AllocationID) {
@@ -202,11 +203,11 @@ func (p priorityScheduler) trySchedulingTaskViaPreemption(
 	allocationPriority int,
 	jobPositions tasklist.JobSortState,
 	fittingMethod SoftConstraint,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	priorityToScheduledTaskMap map[int][]*sproto.AllocateRequest,
 	tasksAlreadyPreempted map[model.AllocationID]bool,
 	filter func(*sproto.AllocateRequest) bool,
-) (bool, map[agentID]*agentState, map[model.AllocationID]bool) {
+) (bool, map[aproto.ID]*agentState, map[model.AllocationID]bool) {
 	localAgentsState := deepCopyAgents(agents)
 	preemptedTasks := make(map[model.AllocationID]bool)
 	log.Debugf("trying to schedule task %s by preempting other tasks", allocationRequest.Name)
@@ -252,7 +253,7 @@ func (p priorityScheduler) trySchedulingTaskViaPreemption(
 // are listed.
 func (p priorityScheduler) trySchedulingPendingTasksInPriority(
 	allocationRequests []*sproto.AllocateRequest,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 ) ([]*sproto.AllocateRequest, []*sproto.AllocateRequest) {
 	successfulAllocations := make([]*sproto.AllocateRequest, 0)
@@ -307,8 +308,8 @@ func sortTasksByPriorityAndPositionAndTimestamp(
 	return priorityToPendingTasksMap, priorityToScheduledTaskMap
 }
 
-func deepCopyAgents(agents map[agentID]*agentState) map[agentID]*agentState {
-	copiedAgents := make(map[agentID]*agentState)
+func deepCopyAgents(agents map[aproto.ID]*agentState) map[aproto.ID]*agentState {
+	copiedAgents := make(map[aproto.ID]*agentState)
 	for key, agent := range agents {
 		copiedAgents[key] = agent.deepCopy()
 	}
@@ -324,7 +325,7 @@ func addTaskToAgents(fits []*fittingState) {
 }
 
 func removeTaskFromAgents(
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	resourcesAllocated *sproto.ResourcesAllocated,
 ) {
 	for _, allocation := range resourcesAllocated.Resources {

--- a/master/internal/rm/agentrm/priority_test.go
+++ b/master/internal/rm/agentrm/priority_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
@@ -743,7 +744,7 @@ func TestPrioritySchedulingNoPreemptionByPosition(t *testing.T) {
 
 func AllocateTasks(
 	toAllocate []*sproto.AllocateRequest,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	taskList *tasklist.TaskList,
 ) {
 	for _, req := range toAllocate {

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -42,7 +42,7 @@ type resourcePool struct {
 	provisionerError error
 
 	agentService     *agents
-	agentStatesCache map[agentID]*agentState
+	agentStatesCache map[aproto.ID]*agentState
 	taskList         *tasklist.TaskList
 	groups           map[model.JobID]*tasklist.Group
 	queuePositions   tasklist.JobSortState // secondary sort key based on job submission time
@@ -195,7 +195,7 @@ func (rp *resourcePool) restoreResources(
 	agentStateMap := map[aproto.ID]*agentState{}
 
 	for agentRef, state := range rp.agentStatesCache {
-		agentStateMap[aproto.ID(state.agentID())] = rp.agentStatesCache[agentRef]
+		agentStateMap[state.agentID()] = rp.agentStatesCache[agentRef]
 	}
 
 	for _, cs := range containerSnapshots {

--- a/master/internal/rm/agentrm/resource_pool_test.go
+++ b/master/internal/rm/agentrm/resource_pool_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
@@ -160,7 +161,7 @@ func TestScalingInfoAgentSummary(t *testing.T) {
 	})
 
 	// Test removing agents.
-	delete(rp.agentStatesCache, agentID("agent1"))
+	delete(rp.agentStatesCache, aproto.ID("agent1"))
 	updated = rp.updateScalingInfo()
 	assert.Check(t, updated)
 	assert.DeepEqual(t, *rp.scalingInfo, sproto.ScalingInfo{

--- a/master/internal/rm/agentrm/resources.go
+++ b/master/internal/rm/agentrm/resources.go
@@ -30,7 +30,7 @@ func (c containerResources) Summary() sproto.ResourcesSummary {
 		ResourcesType: sproto.ResourcesTypeDockerContainer,
 		AllocationID:  c.req.AllocationID,
 		AgentDevices: map[aproto.ID][]device.Device{
-			aproto.ID(c.agent.id): c.devices,
+			c.agent.id: c.devices,
 		},
 
 		ContainerID: &c.containerID,

--- a/master/internal/rm/agentrm/round_robin.go
+++ b/master/internal/rm/agentrm/round_robin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/rm/tasklist"
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
 
@@ -37,7 +38,7 @@ func (p *roundRobinScheduler) JobQInfo(rp *resourcePool) map[model.JobID]*sproto
 func roundRobinSchedule(
 	taskList *tasklist.TaskList,
 	groups map[model.JobID]*tasklist.Group,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	fittingMethod SoftConstraint,
 	allowHeterogeneousFits bool,
 ) ([]*sproto.AllocateRequest, []model.AllocationID) {

--- a/master/internal/rm/agentrm/scheduler_test.go
+++ b/master/internal/rm/agentrm/scheduler_test.go
@@ -60,13 +60,13 @@ func setupResourcePool(
 
 func forceAddAgent(
 	t *testing.T,
-	agents map[agentID]*agentState,
+	agents map[aproto.ID]*agentState,
 	agentIDStr string,
 	numSlots int,
 	numUsedSlots int,
 	numZeroSlotContainers int,
 ) *agentState {
-	state := newAgentState(agentID(agentIDStr), 100)
+	state := newAgentState(aproto.ID(agentIDStr), 100)
 	state.handler = &agent{}
 	for i := 0; i < numSlots; i++ {
 		state.Devices[device.Device{ID: device.ID(i)}] = nil
@@ -94,7 +94,7 @@ func newFakeAgentState(
 	maxZeroSlotContainers int,
 	zeroSlotContainers int,
 ) *agentState {
-	state := newAgentState(agentID(id), maxZeroSlotContainers)
+	state := newAgentState(aproto.ID(id), maxZeroSlotContainers)
 	state.handler = &agent{}
 	for i := 0; i < slots; i++ {
 		state.Devices[device.Device{ID: device.ID(i)}] = nil
@@ -456,17 +456,17 @@ func setupSchedulerStates(
 ) (
 	*tasklist.TaskList,
 	map[model.JobID]*tasklist.Group,
-	map[agentID]*agentState,
+	map[aproto.ID]*agentState,
 ) {
-	agents := make(map[agentID]*agentState, len(mockAgents))
+	agents := make(map[aproto.ID]*agentState, len(mockAgents))
 	for _, mockAgent := range mockAgents {
-		state := newAgentState(agentID(mockAgent.ID), mockAgent.MaxZeroSlotContainers)
+		state := newAgentState(aproto.ID(mockAgent.ID), mockAgent.MaxZeroSlotContainers)
 		state.handler = &agent{}
 
 		for i := 0; i < mockAgent.Slots; i++ {
 			state.Devices[device.Device{ID: device.ID(i)}] = nil
 		}
-		agents[agentID(mockAgent.ID)] = state
+		agents[aproto.ID(mockAgent.ID)] = state
 	}
 
 	groups := make(map[model.JobID]*tasklist.Group, len(mockGroups))
@@ -500,7 +500,7 @@ func setupSchedulerStates(
 
 		if mockTask.AllocatedAgent != nil {
 			assert.Assert(t, mockTask.AllocatedAgent.Slots >= mockTask.SlotsNeeded)
-			agentState := agents[agentID(mockTask.AllocatedAgent.ID)]
+			agentState := agents[aproto.ID(mockTask.AllocatedAgent.ID)]
 			containerID := cproto.NewID()
 
 			devices := make([]device.Device, 0)

--- a/master/internal/rm/agentrm/summaries.go
+++ b/master/internal/rm/agentrm/summaries.go
@@ -2,6 +2,7 @@ package agentrm
 
 import (
 	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/device"
 )
 
@@ -24,7 +25,7 @@ type resourceSummary struct {
 }
 
 func resourceSummaryFromAgentStates(
-	agentInfo map[agentID]*agentState,
+	agentInfo map[aproto.ID]*agentState,
 ) resourceSummary {
 	summary := resourceSummary{
 		numTotalSlots:          0,


### PR DESCRIPTION
## Description
[DET-9976]

Removes the `agentID` type in favor of using `aproto.ID` throughout package agentrm.

## Test Plan
N/A

## Commentary (optional)
A little surprising that there's a net gain of SLOC, but it's because of all the new `import...aproto` lines.

Also, this refactor touches a ton of untested code, but I promise it's purely a static change >.<

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


[DET-9976]: https://hpe-aiatscale.atlassian.net/browse/DET-9976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ