### PR TITLE
chore: mark db-dependent tests as needing to run in integration

### DIFF
--- a/master/internal/api_master_intg_test.go
+++ b/master/internal/api_master_intg_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package internal
 
 import (

--- a/master/internal/rm/agentrm/agent_test.go
+++ b/master/internal/rm/agentrm/agent_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package agentrm
 
 import (

--- a/master/internal/storage/service_intg_test.go
+++ b/master/internal/storage/service_intg_test.go
@@ -1,3 +1,7 @@
+//go:build integration
+// +build integration
+
+//
 //nolint:exhaustruct
 package storage
 

--- a/master/internal/telemetry/telemetry_test.go
+++ b/master/internal/telemetry/telemetry_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package telemetry
 
 import (


### PR DESCRIPTION
## Description
The definition of `db.ResolveTestPostgres()` is in a file marked with `// +build integration` and therefore files that reference it fail to compile when that file is ignored (e.g. when running `make test`).

The agent test does not directly access the DB, but it ends up spinning up some goroutine somewhere that attempts to use an uninitialized `Bun()` and panics (presumably, because there's no DB available to satisfy the initialization of The One Bun in time). When it's run as part of `make test-intg` instead, it passes.

These tests would always run with integration tests anyway, all this changes is that they're ignored if you're only running "unit tests" or some select subset of tests that need to ignore these files in order to compile correctly.

## Test Plan
Automated tests still pass

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

