### PR TITLE
fix: docs lint

### DIFF
--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -469,7 +469,12 @@ experiment metadata and artifacts within its scope.
 The ``EditorRestricted`` role supersedes the ``Viewer`` role and includes permissions to create,
 edit, or delete projects and experiments within its scope.
 
--  ``EditorRestricted`` users lack the permissions to create or update NSC (notebook, shell, command) type workloads. ``EditorRestricted`` users can still open and use scoped JupyterLab notebooks and perform all experiment-related jobs, just like those with the ``Editor`` role. The only additional permissions granted by the ``Editor`` role include the ability to create notebooks, shells, and commands (NSC tasks),  as well as the permission to update these tasks, such as changing the task's priority or deleting it.
+-  ``EditorRestricted`` users lack the permissions to create or update NSC (notebook, shell,
+   command) type workloads. ``EditorRestricted`` users can still open and use scoped JupyterLab
+   notebooks and perform all experiment-related jobs, just like those with the ``Editor`` role. The
+   only additional permissions granted by the ``Editor`` role include the ability to create
+   notebooks, shells, and commands (NSC tasks), as well as the permission to update these tasks,
+   such as changing the task's priority or deleting it.
 
 ``Editor``
 ==========


### PR DESCRIPTION
## Description

fix docs lint

## Test Plan

CI passes.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
