### PR TITLE
feat: initialize genai shared_fs permissions to agent group in helm deployment

### DIFF
--- a/helm/charts/determined/templates/genai/genai-initialize-shared-fs-permissions.yaml
+++ b/helm/charts/determined/templates/genai/genai-initialize-shared-fs-permissions.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.genai }}
+{{- if .Values.genai.version }}
+{{- /* Helm Job to make sure that the shared filesystem sets up group permissions for */ -}}
+{{- /* the all members of the group defined in .Values.genai.generatedPVC.agentGroupID */ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: genai-initialize-shared-fs-permissions-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: genai-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: genai-initialize-shared-fs-permissions-{{ .Release.Name }}
+      labels:
+        app: genai-initialize-shared-fs-permissions-{{ .Release.Name }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccount: determined-master-{{ .Release.Name }}
+      restartPolicy: OnFailure
+      {{ $gid := (required "A valid .Values.genai.generatedPVC.agentGroupID entry required!" .Values.genai.generatedPVC.agentGroupID) }}
+      securityContext:
+        runAsUser: 0
+        runAsGroup: {{ $gid }}
+        fsGroup: {{ $gid }}
+        fsGroupChangePolicy: "OnRootMismatch"
+      containers:
+      - name: initialize-shared-fs
+        image: debian:bookworm-slim
+        imagePullPolicy: "Always"
+        volumeMounts:
+          - name: genai-pvc-storage
+            mountPath: /shared_fs
+            readOnly: false
+          - name: permissions-script
+            mountPath: /scripts
+            readOnly: true
+        command: [ "sh", "-ex", "/scripts/enable_shared_fs.sh" ]
+      volumes:
+        - name: genai-pvc-storage
+          persistentVolumeClaim:
+            claimName: {{ include "genai.PVCName" . }}
+        - name: permissions-script
+          configMap:
+            name: genai-shared-fs-permissions-script-{{ .Release.Name }}
+{{- end }}
+{{- end }}

--- a/helm/charts/determined/templates/genai/genai-shared-fs-permissions-script.yaml
+++ b/helm/charts/determined/templates/genai/genai-shared-fs-permissions-script.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.genai }}
+{{- if .Values.genai.version }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: genai-shared-fs-permissions-script-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: genai-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+data:
+  enable_shared_fs.sh: |
+    #!/bin/sh -ex
+    echo "whoami: $(whoami)"
+    chmod 2775 /shared_fs
+    GROUP_ID={{ (required "A valid .Values.genai.generatedPVC.agentGroupID entry required!" .Values.genai.generatedPVC.agentGroupID) }}
+    GROUP_NAME={{ (required "A valid .Values.genai.generatedPVC.agentGroupName entry required!" .Values.genai.generatedPVC.agentGroupName) }}
+    groupadd -g $GROUP_ID $GROUP_NAME
+    chgrp $GROUP_NAME /shared_fs
+    ls -l / | grep shared_fs
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
Our helm deployments for GenAI have been not working for environments that use specific agent group IDs.

This change makes sure that we give the user a way to define the agent group ID for the shared drive, and initialize it to both use the group and allow all permissions underneath it to propagate this user with the setgid flag.

## Test Plan

Add the following to your `values.yaml`

```
## Configure GenAI Deployment
genai:
  ## Version of GenAI to use. If unset, GenAI will not be deployed
  version: "0.1.3"
  
  ## Port for GenAI to backend use
  port: 9011
  
  ## Port for GenAI message queue
  messageQueuePort: 9013
  
  ## Secret to pull the GenAI image
  # imagePullSecretName:

  ## GenAI pod memory request
  memRequest: 1Gi

  ## GenAI pod cpu request
  cpuRequest: 100m

  ## GenAI pod memory limit
  # memLimit: 1Gi

  ## GenAI pod cpu limit
  # cpuLimit: 2

  ## PVC Name for the shared file system for GenAI.
  ## Note: Either `sharedPVCName` or `generatedPVC.storageSize` (to
  ## generate a new PVC) is required for GenAI deployment
  # sharedPVCName:

  ## Spec for the generated PVC for GenAI
  ## Note: In order to generate a shared PVC, you will need access to a
  ## StorageClass that can provide a ReadWriteMany volume
  generatedPVC:
    ## Storage class name for the generated PVC
    storageClassName: standard

    ## Size of the generated PVC
    storageSize: 10Gi

    ## Unix Agent Group ID for the Shared Filesystem.
    ## Note: All users that work with GenAI need to have this assigned as their
    ## Agent Group ID in the User Admin settings
    agentGroupID: 1104

    ## Unix Agent Group Name for the Shared Filesystem.
    agentGroupName: determined
```

- Deploy: helm install --generate-name . --set maxSlotsPerPod=1 --debug --dry-run
- It should contain a `apiVersion: batch/v1` job that starts with the name `genai-initialize-shared-fs-permissions-chart`

## Commentary (optional)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
