### PR TITLE
fix: remove parent_id from create_experiment

### DIFF
--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -125,7 +125,6 @@ class Determined:
         config: Union[str, pathlib.Path, Dict],
         model_dir: Optional[Union[str, pathlib.Path]] = None,
         includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
-        parent_id: Optional[int] = None,
         project_id: Optional[int] = None,
         template: Optional[str] = None,
     ) -> experiment.Experiment:
@@ -139,8 +138,6 @@ class Determined:
             model_dir(string, optional): directory containing model definition. (default: ``None``)
             includes(Iterable[Union[str, pathlib.Path]], optional): Additional files or
                 directories to include in the model definition. (default: ``None``)
-            parent_id(int, optional): If specified, the created experiment will use the model
-                definition from the parent experiment. (default: ``None``)
             project_id(int, optional): The id of the project this experiment should belong to.
             (default: ``None``)
             template(string, optional): The name of the template for the experiment.
@@ -176,7 +173,6 @@ class Determined:
             activate=True,
             config=config_text,
             modelDefinition=model_context,
-            parentId=parent_id,
             projectId=project_id,
             template=template,
         )

--- a/harness/determined/experimental/client.py
+++ b/harness/determined/experimental/client.py
@@ -168,7 +168,6 @@ def create_experiment(
     config: Union[str, pathlib.Path, Dict],
     model_dir: Optional[str] = None,
     includes: Optional[Iterable[Union[str, pathlib.Path]]] = None,
-    parent_id: Optional[int] = None,
     project_id: Optional[int] = None,
     template: Optional[str] = None,
 ) -> Experiment:
@@ -178,8 +177,6 @@ def create_experiment(
         config: Experiment config filename (.yaml) or a dict.
         model_dir: Directory containing model definition.
         includes: Additional files or directories to include in the model definition.
-        parent_id: If specified, the created experiment will use the model definition
-            from the parent experiment.
         project_id: The id of the project this experiment should belong to.
         template: The name of the template for the experiment.
             See :ref:`config-template` for more details.
@@ -188,9 +185,7 @@ def create_experiment(
         An :class:`~determined.experimental.client.Experiment` of the created experiment.
     """
     assert _determined is not None
-    return _determined.create_experiment(
-        config, model_dir, includes, parent_id, project_id, template
-    )
+    return _determined.create_experiment(config, model_dir, includes, project_id, template)
 
 
 @_require_singleton


### PR DESCRIPTION
## Description

<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->
Follow up for https://github.com/determined-ai/determined/pull/8927
Since parent id is mostly used internally, and can be confusing for end user when exposed, we decide to remove it from SDK function `create_experiment`


## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
