### PR TITLE
feat: [security] require non-empty passwords

### DIFF
--- a/e2e_tests/tests/api_utils.py
+++ b/e2e_tests/tests/api_utils.py
@@ -46,7 +46,8 @@ def create_test_user(
     """
     session = admin_session()
     user = user or bindings.v1User(username=get_random_string(), admin=False, active=True)
-    password = get_random_string()
+    # passwords require an upper-case and a lower-case character, uuids tend to be all one case
+    password = get_random_string() + "aA1"
     bindings.post_PostUser(session, body=bindings.v1PostUserRequest(user=user, password=password))
     sess = make_session(user.username, password)
     return sess, password

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -156,14 +156,14 @@ def test_change_password() -> None:
     sess, old_password = api_utils.create_test_user()
     d = client.Determined._from_session(api_utils.admin_session())
     userobj = d.get_user_by_name(sess.username)
-    userobj.change_password("newpass")
+    userobj.change_password("newPass123!")
 
     # Old password does not work anymore.
     with pytest.raises(errors.UnauthenticatedException):
         api_utils.make_session(sess.username, old_password)
 
     # New password does work.
-    api_utils.make_session(sess.username, "newpass")
+    api_utils.make_session(sess.username, "newPass123!")
 
 
 @pytest.mark.e2e_cpu
@@ -173,12 +173,12 @@ def test_change_own_password() -> None:
 
     d = client.Determined._from_session(sess)
     userobj = d.get_user_by_name(sess.username)
-    userobj.change_password("newpass")
+    userobj.change_password("newPass123!")
 
     with pytest.raises(errors.UnauthenticatedException):
         api_utils.make_session(sess.username, old_password)
 
-    api_utils.make_session(sess.username, "newpass")
+    api_utils.make_session(sess.username, "newPass123!")
 
 
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -55,11 +55,12 @@ def extract_id_and_owner_from_exp_list(output: str) -> List[Tuple[int, str]]:
 @pytest.mark.e2e_cpu
 def test_post_user_api() -> None:
     new_username = api_utils.get_random_string()
+    new_password = api_utils.get_random_string() + "aA1"
 
     sess = api_utils.admin_session()
 
     user = bindings.v1User(active=True, admin=False, username=new_username)
-    body = bindings.v1PostUserRequest(password="", user=user)
+    body = bindings.v1PostUserRequest(password=new_password, user=user)
     resp = bindings.post_PostUser(sess, body=body)
     assert resp and resp.user
     assert resp.to_json()["user"]["username"] == new_username
@@ -73,7 +74,9 @@ def test_post_user_api() -> None:
             agentUid=1000, agentGid=1001, agentUser="username", agentGroup="groupname"
         ),
     )
-    resp = bindings.post_PostUser(sess, body=bindings.v1PostUserRequest(user=user))
+    resp = bindings.post_PostUser(
+        sess, body=bindings.v1PostUserRequest(user=user, password=new_password)
+    )
     assert resp and resp.user and resp.user.agentUserGroup
     assert resp.user.agentUserGroup.agentUser == "username"
     assert resp.user.agentUserGroup.agentGroup == "groupname"
@@ -91,7 +94,9 @@ def test_post_user_api() -> None:
     )
 
     with pytest.raises(errors.APIException):
-        bindings.post_PostUser(sess, body=bindings.v1PostUserRequest(user=user))
+        bindings.post_PostUser(
+            sess, body=bindings.v1PostUserRequest(user=user, password=new_password)
+        )
 
 
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -102,7 +102,7 @@ def test_post_user_api() -> None:
 @pytest.mark.e2e_cpu
 def test_create_user_sdk() -> None:
     username = api_utils.get_random_string()
-    password = api_utils.get_random_string()
+    password = api_utils.get_random_string() + "aA1"
     det_obj = client.Determined._from_session(api_utils.admin_session())
     user = det_obj.create_user(username=username, admin=False, password=password)
     assert user.user_id is not None and user.username == username

--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -21,7 +21,10 @@ from determined.common.api._rbac import (
     workspace_by_name,
     not_found_errs,
 )
-from determined.common.api.authentication import salt_and_hash
+from determined.common.api.authentication import (
+    salt_and_hash,
+    check_password_complexity,
+)
 from determined.common.api.logs import (
     pprint_logs,
     trial_logs,

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -23,7 +23,7 @@ def salt_and_hash(password: str) -> str:
         return password
 
 
-def check_password_complexity(password: str):
+def check_password_complexity(password: str) -> None:
     """
     raises a ValueError if the password does not meet complexity requirements
     """

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
@@ -20,6 +21,23 @@ def salt_and_hash(password: str) -> str:
         return hashlib.sha512((PASSWORD_SALT + password).encode()).hexdigest()
     else:
         return password
+
+
+def check_password_complexity(password: str):
+    """
+    raises a ValueError if the password does not meet complexity requirements
+    """
+    if len(password) < 8:
+        raise ValueError("password must have at least 8 characters")
+
+    if re.search(r"[A-Z]", password) is None:
+        raise ValueError("password must include an uppercase letter")
+
+    if re.search(r"[a-z]", password) is None:
+        raise ValueError("password must include a lowercase letter")
+
+    if re.search(r"\d", password) is None:
+        raise ValueError("password must include a number")
 
 
 def get_det_username_from_env() -> Optional[str]:

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -74,7 +74,8 @@ class Determined:
     ) -> user.User:
         create_user = bindings.v1User(username=username, admin=admin, active=True, remote=remote)
         hashedPassword = None
-        if password is not None:
+        if not remote:
+            api.check_password_complexity(password)
             hashedPassword = api.salt_and_hash(password)
         req = bindings.v1PostUserRequest(password=hashedPassword, user=create_user, isHashed=True)
         resp = bindings.post_PostUser(self._session, body=req)

--- a/harness/determined/common/experimental/determined.py
+++ b/harness/determined/common/experimental/determined.py
@@ -75,6 +75,8 @@ class Determined:
         create_user = bindings.v1User(username=username, admin=admin, active=True, remote=remote)
         hashedPassword = None
         if not remote:
+            if password is None:
+                raise ValueError("password can't be blank")
             api.check_password_complexity(password)
             hashedPassword = api.salt_and_hash(password)
         req = bindings.v1PostUserRequest(password=hashedPassword, user=create_user, isHashed=True)

--- a/harness/determined/common/experimental/user.py
+++ b/harness/determined/common/experimental/user.py
@@ -82,6 +82,7 @@ class User:
         self.reload()
 
     def change_password(self, new_password: str) -> None:
+        api.check_password_complexity(new_password)
         new_password = api.salt_and_hash(new_password)
         patch_user = bindings.v1PatchUser(password=new_password, isHashed=True)
         bindings.patch_PatchUser(self._session, body=patch_user, userId=self.user_id)

--- a/harness/tests/cli/test_user.py
+++ b/harness/tests/cli/test_user.py
@@ -20,7 +20,9 @@ def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
             json={"user": userobj.to_json()},
         )
 
-        patchobj = bindings.v1PatchUser(isHashed=True, password=api.salt_and_hash("newpass"))
+        patchobj = bindings.v1PatchUser(
+            isHashed=True, password=api.salt_and_hash("ce93AA76-2f62-4f29-ab5d-c56a3375e702")
+        )
         rsps.patch(
             "http://localhost:8080/api/v1/users/101",
             status=200,
@@ -33,11 +35,21 @@ def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
         cli.main(["user", "change-password", "tgt-user"])
 
         # cannot set password to blank
+        rsps.get(
+            "http://localhost:8080/api/v1/users/tgt-user/by-username",
+            status=200,
+            json={"user": userobj.to_json()},
+        )
         mock_getpass.side_effect = lambda *_: ""
         with pytest.raises(ValueError, match="password must have at least 8 characters"):
             cli.main(["user", "change-password", "tgt-user"])
 
         # cannot set password to something weak
+        rsps.get(
+            "http://localhost:8080/api/v1/users/tgt-user/by-username",
+            status=200,
+            json={"user": userobj.to_json()},
+        )
         mock_getpass.side_effect = lambda *_: "password"
         with pytest.raises(ValueError, match=r"password must contain .+"):
             cli.main(["user", "change-password", "tgt-user"])

--- a/harness/tests/cli/test_user.py
+++ b/harness/tests/cli/test_user.py
@@ -42,7 +42,7 @@ def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
             status=200,
             json={"user": userobj.to_json()},
         )
-        with pytest.raises(ValueError, match="password must have at least 8 characters"):
+        with pytest.raises(SystemExit):
             cli.main(["user", "change-password", "tgt-user"])
 
     # cannot set password to something weak
@@ -53,7 +53,7 @@ def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
             status=200,
             json={"user": userobj.to_json()},
         )
-        with pytest.raises(ValueError, match=r"password must contain .+"):
+        with pytest.raises(SystemExit):
             cli.main(["user", "change-password", "tgt-user"])
 
 

--- a/harness/tests/cli/test_user.py
+++ b/harness/tests/cli/test_user.py
@@ -34,23 +34,25 @@ def test_user_change_password(mock_getpass: mock.MagicMock) -> None:
 
         cli.main(["user", "change-password", "tgt-user"])
 
-        # cannot set password to blank
+    # cannot set password to blank
+    mock_getpass.side_effect = lambda *_: ""
+    with util.standard_cli_rsps() as rsps:
         rsps.get(
             "http://localhost:8080/api/v1/users/tgt-user/by-username",
             status=200,
             json={"user": userobj.to_json()},
         )
-        mock_getpass.side_effect = lambda *_: ""
         with pytest.raises(ValueError, match="password must have at least 8 characters"):
             cli.main(["user", "change-password", "tgt-user"])
 
-        # cannot set password to something weak
+    # cannot set password to something weak
+    mock_getpass.side_effect = lambda *_: "password"
+    with util.standard_cli_rsps() as rsps:
         rsps.get(
             "http://localhost:8080/api/v1/users/tgt-user/by-username",
             status=200,
             json={"user": userobj.to_json()},
         )
-        mock_getpass.side_effect = lambda *_: "password"
         with pytest.raises(ValueError, match=r"password must contain .+"):
             cli.main(["user", "change-password", "tgt-user"])
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -2150,9 +2150,11 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 
 	api, curUser, ctx := setupAPITest(t, nil, &mockRM)
 
+	_, project := createProjectAndWorkspace(ctx, t, api)
+
 	var expIDs []int32
 	for i := 0; i < 3; i++ {
-		exp := createTestExpWithProjectID(t, api, curUser, 4228892)
+		exp := createTestExpWithProjectID(t, api, curUser, project)
 		_, err := db.Bun().NewUpdate().Table("experiments").
 			Set("state = ?", model.CompletedState).
 			Where("id = ?", exp.ID).Exec(ctx)
@@ -2165,7 +2167,7 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 	// where we have a filter with the experiment delete request.
 	_, err := api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{
 		ExperimentIds: expIDs,
-		Filters:       &apiv1.BulkExperimentFilters{ProjectId: 4228892},
+		Filters:       &apiv1.BulkExperimentFilters{ProjectId: int32(project)},
 	})
 	require.NoError(t, err)
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1259,6 +1259,7 @@ func benchmarkGetExperiments(b *testing.B, n int) {
 			DisplayName: uuid.New().String(),
 			Active:      true,
 		},
+		Password: "abcDEF123!",
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -40,7 +40,6 @@ import (
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	modelauth "github.com/determined-ai/determined/master/internal/model"
-	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -2148,12 +2147,6 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 		errC <- errors.New("something real bad")
 		return sproto.DeleteJobResponse{Err: errC}
 	}, nil)
-	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).Return(
-		func(name rm.ResourcePoolName, _, _ int) rm.ResourcePoolName {
-			return name
-		},
-		nil,
-	)
 
 	api, curUser, ctx := setupAPITest(t, nil, &mockRM)
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -40,6 +40,7 @@ import (
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
 	"github.com/determined-ai/determined/master/internal/mocks"
 	modelauth "github.com/determined-ai/determined/master/internal/model"
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -2147,6 +2148,12 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 		errC <- errors.New("something real bad")
 		return sproto.DeleteJobResponse{Err: errC}
 	}, nil)
+	mockRM.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything).Return(
+		func(name rm.ResourcePoolName, _, _ int) rm.ResourcePoolName {
+			return name
+		},
+		nil,
+	)
 
 	api, curUser, ctx := setupAPITest(t, nil, &mockRM)
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -806,6 +806,7 @@ func TestGetExperiments(t *testing.T) {
 			DisplayName: uuid.New().String(),
 			Active:      true,
 		},
+		Password: "abcDEF123!",
 	})
 	require.NoError(t, err)
 

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -2152,7 +2152,7 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 
 	var expIDs []int32
 	for i := 0; i < 3; i++ {
-		exp := createTestExp(t, api, curUser)
+		exp := createTestExpWithProjectID(t, api, curUser, 4228892)
 		_, err := db.Bun().NewUpdate().Table("experiments").
 			Set("state = ?", model.CompletedState).
 			Where("id = ?", exp.ID).Exec(ctx)
@@ -2165,7 +2165,7 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 	// where we have a filter with the experiment delete request.
 	_, err := api.DeleteExperiments(ctx, &apiv1.DeleteExperimentsRequest{
 		ExperimentIds: expIDs,
-		Filters:       &apiv1.BulkExperimentFilters{ProjectId: 1},
+		Filters:       &apiv1.BulkExperimentFilters{ProjectId: 4228892},
 	})
 	require.NoError(t, err)
 

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -390,7 +390,7 @@ func (a *apiServer) SetUserPassword(
 	}
 
 	if err := user.CheckPasswordComplexity(req.Password); err != nil {
-		if errors.Is(err, user.ErrPasswordLowComplexity) {
+		if errors.As(err, &user.PasswordComplexityErrors{}) {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 		return nil, errors.Wrap(err, "error validating password")
@@ -541,7 +541,7 @@ func (a *apiServer) PatchUser(
 		hashedPassword := *req.User.Password
 		if !req.User.IsHashed {
 			if err := user.CheckPasswordComplexity(hashedPassword); err != nil {
-				if errors.Is(err, user.ErrPasswordLowComplexity) {
+				if errors.As(err, &user.PasswordComplexityErrors{}) {
 					return nil, status.Error(codes.InvalidArgument, err.Error())
 				}
 				return nil, errors.Wrap(err, "error validating password")

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -343,6 +343,9 @@ func (a *apiServer) PostUser(
 		if req.IsHashed {
 			hashedPassword = req.Password
 		} else {
+			if err := user.CheckPasswordComplexity(req.Password); err != nil {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
 			hashedPassword = user.ReplicateClientSideSaltAndHash(req.Password)
 		}
 
@@ -384,6 +387,13 @@ func (a *apiServer) SetUserPassword(
 			return nil, authz.SubIfUnauthorized(canGetErr, api.NotFoundErrs("user", "", true))
 		}
 		return nil, status.Error(codes.PermissionDenied, err.Error())
+	}
+
+	if err := user.CheckPasswordComplexity(req.Password); err != nil {
+		if errors.Is(err, user.ErrPasswordLowComplexity) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		return nil, errors.Wrap(err, "error validating password")
 	}
 
 	if err = targetUser.UpdatePasswordHash(user.ReplicateClientSideSaltAndHash(req.Password)); err != nil {
@@ -451,9 +461,12 @@ func (a *apiServer) PatchUser(
 			if willBeRemote {
 				updatedUser.PasswordHash = model.NoPasswordLogin
 				insertColumns = append(insertColumns, "password_hash")
-			} else if !willBeRemote && req.User.Password == nil {
-				updatedUser.PasswordHash = model.EmptyPassword
-				insertColumns = append(insertColumns, "password_hash")
+			} else if err := user.CheckPasswordComplexity(*req.User.Password); err != nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"non-remote users must have passwords that meet complexity requirements: %s",
+					err.Error(),
+				)
 			}
 		}
 	}
@@ -527,6 +540,12 @@ func (a *apiServer) PatchUser(
 
 		hashedPassword := *req.User.Password
 		if !req.User.IsHashed {
+			if err := user.CheckPasswordComplexity(hashedPassword); err != nil {
+				if errors.Is(err, user.ErrPasswordLowComplexity) {
+					return nil, status.Error(codes.InvalidArgument, err.Error())
+				}
+				return nil, errors.Wrap(err, "error validating password")
+			}
 			hashedPassword = user.ReplicateClientSideSaltAndHash(hashedPassword)
 		}
 		if err := updatedUser.UpdatePasswordHash(hashedPassword); err != nil {

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -461,6 +461,11 @@ func (a *apiServer) PatchUser(
 			if willBeRemote {
 				updatedUser.PasswordHash = model.NoPasswordLogin
 				insertColumns = append(insertColumns, "password_hash")
+			} else if req.User.Password == nil {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"non-remote users must have passwords",
+				)
 			} else if err := user.CheckPasswordComplexity(*req.User.Password); err != nil {
 				return nil, status.Errorf(
 					codes.InvalidArgument,

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -325,7 +325,7 @@ func TestLoginRemote(t *testing.T) {
 				Remote: ptrs.Ptr(false),
 			},
 		})
-		require.ErrorAs(t, err, &user.PasswordComplexityErrors{})
+		require.Error(t, err)
 
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,
@@ -416,7 +416,7 @@ func TestLoginRemote(t *testing.T) {
 				Remote: ptrs.Ptr(false),
 			},
 		})
-		require.ErrorAs(t, err, &user.PasswordComplexityErrors{})
+		require.Error(t, err)
 
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,
@@ -661,11 +661,13 @@ func TestPatchUsers(t *testing.T) {
 
 func TestRenameUserThenReuseName(t *testing.T) {
 	username := uuid.New().String()
+	password := uuid.New().String() + "aA1"
 	api, _, ctx := setupAPITest(t, nil)
 	resp, err := api.PostUser(ctx, &apiv1.PostUserRequest{
 		User: &userv1.User{
 			Username: username,
 		},
+		Password: password,
 	})
 	require.NoError(t, err)
 
@@ -690,6 +692,7 @@ func TestRenameUserThenReuseName(t *testing.T) {
 		User: &userv1.User{
 			Username: username,
 		},
+		Password: password,
 	})
 	require.NoError(t, err)
 }
@@ -800,16 +803,17 @@ func TestAuthzPostUserDuplicate(t *testing.T) {
 		Admin:          true,
 		AgentUserGroup: nil,
 	}
+	password := "testPassword1234!"
 
 	authzUsers.On("CanCreateUser", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Successfully post user once.
-	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{User: user})
+	_, err := api.PostUser(ctx, &apiv1.PostUserRequest{User: user, Password: password})
 	require.NoError(t, err)
 
 	// Post duplicate user & receive expected error.
 	expectedErr := apiPkg.ErrUserExists
-	_, err = api.PostUser(ctx, &apiv1.PostUserRequest{User: user})
+	_, err = api.PostUser(ctx, &apiv1.PostUserRequest{User: user, Password: password})
 	require.Contains(t, expectedErr.Error(), err.Error())
 }
 

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -205,7 +205,7 @@ func TestAuthMiddleware(t *testing.T) {
 			Username: username,
 			Active:   true,
 		},
-		Password: "testpassword",
+		Password: "testPassword1",
 	})
 	require.NoError(t, err)
 
@@ -313,22 +313,32 @@ func TestLoginRemote(t *testing.T) {
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,
 			User: &userv1.PatchUser{
-				Password: ptrs.Ptr("pass"),
+				Password: ptrs.Ptr("testPassword1"),
 			},
 		})
 		require.ErrorContains(t, err, "Cannot set password")
 
-		// Changing back to unremote means we can login with blank password.
+		// Changing back to unremote means we must set a password.
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,
 			User: &userv1.PatchUser{
 				Remote: ptrs.Ptr(false),
 			},
 		})
+		require.ErrorAs(t, err, &user.PasswordComplexityErrors{})
+
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote:   ptrs.Ptr(false),
+				Password: ptrs.Ptr("testPassword1"),
+			},
+		})
 		require.NoError(t, err)
 
 		_, err = api.Login(ctx, &apiv1.LoginRequest{
 			Username: username,
+			Password: "testPassword1",
 		})
 		require.NoError(t, err)
 	})
@@ -348,14 +358,14 @@ func TestLoginRemote(t *testing.T) {
 			UserId: resp.User.Id,
 			User: &userv1.PatchUser{
 				Remote:   ptrs.Ptr(false),
-				Password: ptrs.Ptr("testpassword"),
+				Password: ptrs.Ptr("testPassword1"),
 			},
 		})
 		require.NoError(t, err)
 
 		_, err = api.Login(ctx, &apiv1.LoginRequest{
 			Username: username,
-			Password: "testpassword",
+			Password: "testPassword1",
 		})
 		require.NoError(t, err)
 	})
@@ -367,13 +377,13 @@ func TestLoginRemote(t *testing.T) {
 				Username: username,
 				Active:   true,
 			},
-			Password: "testpassword",
+			Password: "testPassword1",
 		})
 		require.NoError(t, err)
 
 		_, err = api.Login(ctx, &apiv1.LoginRequest{
 			Username: username,
-			Password: "testpassword",
+			Password: "testPassword1",
 		})
 		require.NoError(t, err)
 
@@ -399,18 +409,27 @@ func TestLoginRemote(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, model.NoPasswordLogin, expectedUser.PasswordHash)
 
-		// Changing back to unremote unsets password to blank.
+		// Changing back to unremote requires setting an non-blank password.
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 			UserId: resp.User.Id,
 			User: &userv1.PatchUser{
-				Remote: ptrs.Ptr(true),
+				Remote: ptrs.Ptr(false),
+			},
+		})
+		require.ErrorAs(t, err, &user.PasswordComplexityErrors{})
+
+		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
+			UserId: resp.User.Id,
+			User: &userv1.PatchUser{
+				Remote:   ptrs.Ptr(false),
+				Password: ptrs.Ptr("testPassword2"),
 			},
 		})
 		require.NoError(t, err)
 
 		_, err = api.Login(ctx, &apiv1.LoginRequest{
 			Username: username,
-			Password: "testpassword",
+			Password: "testPassword1",
 		})
 		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
 
@@ -418,6 +437,12 @@ func TestLoginRemote(t *testing.T) {
 			Username: username,
 		})
 		require.ErrorIs(t, err, grpcutil.ErrInvalidCredentials)
+
+		_, err = api.Login(ctx, &apiv1.LoginRequest{
+			Username: username,
+			Password: "testPassword2",
+		})
+		require.NoError(t, err)
 	})
 }
 
@@ -521,7 +546,8 @@ func TestPatchUser(t *testing.T) {
 
 	username := uuid.New().String()
 	displayName := uuid.New().String()
-	password := uuid.New().String()
+	// a v4 uuid is probably a fantastic password, but it doesn't have an upper-case letter in it...
+	password := uuid.New().String() + "aA1"
 	resp, err := api.PatchUser(ctx, &apiv1.PatchUserRequest{
 		UserId: int32(userID),
 		User: &userv1.PatchUser{
@@ -558,7 +584,7 @@ func TestPatchUser(t *testing.T) {
 	require.NoError(t, err)
 
 	// Null out display name and set a client side hashed password.
-	password = uuid.New().String()
+	password = uuid.New().String() + "aA1"
 	displayName = ""
 	resp, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
 		UserId: int32(userID),

--- a/master/internal/user/passwords.go
+++ b/master/internal/user/passwords.go
@@ -60,7 +60,7 @@ func SetUserPassword(ctx context.Context, username, password string) error {
 // because it fails to meet current complexity requirements.
 var ErrPasswordLowComplexity = errors.New(
 	"passwords must be at least 8 characters long, not be entirely upper-case " +
-		"or lower-case, and contain at least one number or symbol",
+		"or lower-case, and contain at least one number",
 )
 
 // CheckPasswordComplexity returns an error if the provided password does not satisfy
@@ -75,7 +75,7 @@ func CheckPasswordComplexity(password string) error {
 	if !strings.ContainsFunc(password, unicode.IsLower) {
 		return ErrPasswordLowComplexity
 	}
-	if !strings.ContainsFunc(password, func(r rune) bool { return unicode.IsNumber(r) || unicode.IsSymbol(r) }) {
+	if !strings.ContainsFunc(password, unicode.IsNumber) {
 		return ErrPasswordLowComplexity
 	}
 	return nil

--- a/master/internal/user/passwords_intg_test.go
+++ b/master/internal/user/passwords_intg_test.go
@@ -14,11 +14,23 @@ import (
 
 func TestUpdateDefaultUserPasswords(t *testing.T) {
 	u := db.RequireMockUser(t, db.SingleDB())
-	err := SetUserPassword(context.Background(), u.Username, "abc")
+	err := SetUserPassword(context.Background(), u.Username, "abcDEF123!")
 	require.NoError(t, err)
 
 	nu, err := ByUsername(context.Background(), u.Username)
 	require.NoError(t, err)
-	ok := nu.ValidatePassword(ReplicateClientSideSaltAndHash("abc"))
+	ok := nu.ValidatePassword(ReplicateClientSideSaltAndHash("abcDEF123!"))
 	require.True(t, ok, "couldn't login after default changes")
+}
+
+func TestUpdateUserPasswordComplexityCheck(t *testing.T) {
+	u := db.RequireMockUser(t, db.SingleDB())
+	err := SetUserPassword(context.Background(), u.Username, "abc")
+	require.ErrorIs(t, err, ErrPasswordLowComplexity)
+
+	// empty passwords are grandfathered in, for now
+	nu, err := ByUsername(context.Background(), u.Username)
+	require.NoError(t, err)
+	ok := nu.ValidatePassword("")
+	require.True(t, ok, "couldn't login after changes")
 }

--- a/master/internal/user/passwords_intg_test.go
+++ b/master/internal/user/passwords_intg_test.go
@@ -26,7 +26,7 @@ func TestUpdateDefaultUserPasswords(t *testing.T) {
 func TestUpdateUserPasswordComplexityCheck(t *testing.T) {
 	u := db.RequireMockUser(t, db.SingleDB())
 	err := SetUserPassword(context.Background(), u.Username, "abc")
-	require.ErrorIs(t, err, ErrPasswordLowComplexity)
+	require.ErrorAs(t, err, &PasswordComplexityErrors{})
 
 	// empty passwords are grandfathered in, for now
 	nu, err := ByUsername(context.Background(), u.Username)

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -369,7 +369,7 @@ func (s *Service) patchUser(c echo.Context) (interface{}, error) {
 		}
 
 		if err := CheckPasswordComplexity(*params.Password); err != nil {
-			if errors.Is(err, ErrPasswordLowComplexity) {
+			if errors.As(err, &PasswordComplexityErrors{}) {
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 			return nil, errors.Wrap(err, "error validating password")

--- a/master/internal/user/service.go
+++ b/master/internal/user/service.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
@@ -364,6 +366,13 @@ func (s *Service) patchUser(c echo.Context) (interface{}, error) {
 		if err = AuthZProvider.Get().CanSetUsersPassword(ctx, currUser, *user); err != nil {
 			return nil, canViewUserErrorHandle(currUser, *user,
 				errors.Wrap(forbiddenError, err.Error()), userNotFoundErr)
+		}
+
+		if err := CheckPasswordComplexity(*params.Password); err != nil {
+			if errors.Is(err, ErrPasswordLowComplexity) {
+				return nil, status.Error(codes.InvalidArgument, err.Error())
+			}
+			return nil, errors.Wrap(err, "error validating password")
 		}
 
 		if err = user.UpdatePasswordHash(*params.Password); err != nil {

--- a/master/pkg/model/user.go
+++ b/master/pkg/model/user.go
@@ -15,6 +15,9 @@ import (
 
 var (
 	// EmptyPassword is the empty password (i.e., the empty string).
+	// With [DFR-455] and related issues this is no longer allowed
+	// for new users or new passwords, but users who already have
+	// no-password logins might need time to change to a new password.
 	EmptyPassword = null.NewString("", false)
 
 	// NoPasswordLogin is a password that prevents the user from logging in
@@ -113,15 +116,14 @@ func (user User) ValidatePassword(password string) bool {
 // techniques.
 func (user *User) UpdatePasswordHash(password string) error {
 	if password == "" {
-		user.PasswordHash = EmptyPassword
-	} else {
-		passwordHash, err := HashPassword(password)
-		if err != nil {
-			return errors.Wrap(err, "error updating user password")
-		}
-
-		user.PasswordHash = null.StringFrom(passwordHash)
+		return errors.New("cannot hash empty password")
 	}
+	passwordHash, err := HashPassword(password)
+	if err != nil {
+		return errors.Wrap(err, "error updating user password")
+	}
+
+	user.PasswordHash = null.StringFrom(passwordHash)
 	return nil
 }
 


### PR DESCRIPTION
## Description
BREAKING CHANGE: [DET-10183] passwords cannot be created or updated with empty or short values

This avoids breaking login for users who already had trivial passwords set (for now), it just prevents changing a user's password _to_ something trivial.

## Test Plan
Adding a few automated tests that should basically cover this, however there are lots of different ways to create and update users, and while working on this I noticed several code branches that imply there have been odd and unanticipated behaviors in the past, from things like creating a new user and then switching them to/from SSO. Please use good judgment on what cases are worth testing.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.


[DET-10183]: https://hpe-aiatscale.atlassian.net/browse/DET-10183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ