### PR TITLE
fix: job queue panic for multirm [RM-123]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -152,13 +152,13 @@ func (m *Master) getInfo(echo.Context) (interface{}, error) {
 	return m.Info(), nil
 }
 
-//	@Summary	Get health of Determined and the dependencies.
-//	@Tags		Cluster
-//	@ID			health
-//	@Produce	json
-//	@Success	200	{object}	model.HealthCheck
-//	@Failure	503	{object}	model.HealthCheck
-//	@Router		/health [get]
+//	@Summary Get health of Determined and the dependencies.
+//	@Tags	 Cluster
+//	@ID		 health
+//	@Produce json
+//	@Success 200     {object} model.HealthCheck
+//	@Failure 503     {object} model.HealthCheck
+//	@Router	 /health [get]
 //
 // nolint:lll
 func (m *Master) healthCheckEndpoint(c echo.Context) error {

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -152,13 +152,13 @@ func (m *Master) getInfo(echo.Context) (interface{}, error) {
 	return m.Info(), nil
 }
 
-//	@Summary Get health of Determined and the dependencies.
-//	@Tags	 Cluster
-//	@ID		 health
-//	@Produce json
-//	@Success 200     {object} model.HealthCheck
-//	@Failure 503     {object} model.HealthCheck
-//	@Router	 /health [get]
+//	@Summary	Get health of Determined and the dependencies.
+//	@Tags		Cluster
+//	@ID			health
+//	@Produce	json
+//	@Success	200	{object}	model.HealthCheck
+//	@Failure	503	{object}	model.HealthCheck
+//	@Router		/health [get]
 //
 // nolint:lll
 func (m *Master) healthCheckEndpoint(c echo.Context) error {

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -234,21 +234,8 @@ func (m *MultiRMRouter) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sp
 func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsRequest) (
 	*apiv1.GetJobQueueStatsResponse, error,
 ) {
-	filteredRMs := make(map[rm.ResourceManager]bool)
-	for _, rName := range req.ResourcePools {
-		resolvedRMName, err := m.getRM(rm.ResourcePoolName(rName))
-		if resolvedRMName != "" && err != nil {
-			return nil, err
-		} else if resolvedRMName != "" {
-			filteredRMs[m.rms[resolvedRMName]] = true
-		}
-	}
-
 	res, err := fanOutRMCall(m, func(rm rm.ResourceManager) (*apiv1.GetJobQueueStatsResponse, error) {
-		if filteredRMs[rm] || len(filteredRMs) == 0 {
-			return rm.GetJobQueueStatsRequest(req)
-		}
-		return &apiv1.GetJobQueueStatsResponse{}, nil
+		return rm.GetJobQueueStatsRequest(req)
 	})
 	if err != nil {
 		return nil, err

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -234,6 +234,34 @@ func (m *MultiRMRouter) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sp
 func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsRequest) (
 	*apiv1.GetJobQueueStatsResponse, error,
 ) {
+	/*
+		filteredRMs := map[string]rm.ResourceManager{}
+		for _, rName := range req.ResourcePools {
+			if r, ok := m.rms[rName]; ok {
+				filteredRMs[rName] = r
+			}
+		}
+
+		tmpM := &MultiRMRouter{
+			defaultRMName: m.defaultRMName,
+			syslog:        m.syslog,
+			rms:           filteredRMs,
+		}
+
+		res, err := fanOutRMCall(tmpM, func(rm rm.ResourceManager) (*apiv1.GetJobQueueStatsResponse, error) {
+			return rm.GetJobQueueStatsRequest(req)
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all := &apiv1.GetJobQueueStatsResponse{}
+		for _, r := range res {
+			all.Results = append(all.Results, r.Results...)
+		}
+		return all, nil
+	*/
+
 	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePools[0]))
 	if err != nil {
 		return nil, err

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -261,15 +261,6 @@ func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsReque
 		all.Results = append(all.Results, r.Results...)
 	}
 	return all, nil
-
-	/*
-		resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePools[0]))
-		if err != nil {
-			return nil, err
-		}
-
-		return m.rms[resolvedRMName].GetJobQueueStatsRequest(req)
-	*/
 }
 
 // MoveJob routes a MoveJob call to a specified resource manager/pool.
@@ -419,7 +410,7 @@ func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
 		}
 		for _, p := range rps.ResourcePools {
 			if p.Name == rpName.String() {
-				m.syslog.Debugf("RM defined as %s, %s", name, p.Name)
+				m.syslog.Infof("RM defined as %s, %s", name, p.Name)
 				return name, nil
 			}
 		}

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package multirm
 
 import (
@@ -365,6 +368,8 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		req  *apiv1.GetJobQueueStatsRequest
 		err  error
 	}{
+		// TODO CAROLINA -- this test should obvs fail, but it doesn't
+		{"empty request", &apiv1.GetJobQueueStatsRequest{}, ErrRPNotDefined("bogus")},
 		{"empty RP name will default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{""}}, nil},
 		{"defined RP in default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{defaultRMName}}, nil},
 		{"defined RP in additional RM", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{additionalRMName}}, nil},

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -370,14 +370,18 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		err         error
 		expectedLen int
 	}{
-		// Given an empty list of RM names, pull the JobQueueStats from ALL RMs.
+		// TODO RM-136: revist this.
+		// Per the mocks set-up, no matter the pools in the request, return the max # of responses.
 		{"empty request", &apiv1.GetJobQueueStatsRequest{}, nil, 2},
-		// Given a blank resource pool name, pull the JobQueueStats only from the default RM.
-		{"empty RP name will default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{""}}, nil, 1},
-		{"defined RP in default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{defaultRMName}}, nil, 1},
-		{"defined RP in additional RM", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{additionalRMName}}, nil, 1},
-		// Given an RP that's not defined in any RMs, operate the same as nil or empty case -- return ALL JobQueueStats.
+		{"empty RP name will default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{""}}, nil, 2},
+		{"defined RP in default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{defaultRMName}}, nil, 2},
+		{"defined RP in additional RM", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{additionalRMName}}, nil, 2},
 		{"undefined RP", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{"bogus"}}, nil, 2},
+		{
+			"undefined RP + defined RP",
+			&apiv1.GetJobQueueStatsRequest{ResourcePools: []string{"bogus", defaultRMName}},
+			nil, 2,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Fix index bug in GetJobQueueStatsRequest by executing the proper RM call on the correct RMs belonging to the list of resource pools given.

Also, add `os.Run()` to the multirm test file -- so now the tests run! Change the mock RM return values from mock.Anything to the relevant complex type.

## Test Plan
Without the changes to the GetJobQueueStatsRequest, its test should fail the `empty_request` case as follows:
```
--- FAIL: TestGetJobQueueStatsRequest (0.00s)
    --- FAIL: TestGetJobQueueStatsRequest/empty_request (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
```
With these changes, all should pass!

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-123


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
