### PR TITLE
chore: change log level for multirm messages [RM-125]

### DIFF
--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -378,7 +378,7 @@ func (m *MultiRMRouter) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Disab
 func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
 	// If not given RP name, route to default RM.
 	if rpName == "" {
-		m.syslog.Infof("RM undefined, routing to default resource manager")
+		m.syslog.Debugf("RM undefined, routing to default resource manager")
 		return m.defaultRMName, nil
 	}
 
@@ -389,7 +389,7 @@ func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
 		}
 		for _, p := range rps.ResourcePools {
 			if p.Name == rpName.String() {
-				m.syslog.Infof("RM defined as %s, %s", name, p.Name)
+				m.syslog.Debugf("RM defined as %s, %s", name, p.Name)
 				return name, nil
 			}
 		}


### PR DESCRIPTION
## Description

Change the multirm logs from info level to debug level



## Test Plan
Start a new experiment, on a multiRM cluster & define it to run on a resource pool 'XYZ' (or whatever other name). Then, after starting the experiment, check that your logs contain
`DEBU[2024-04-01T13:28:57-04:00] RM defined as <the-rm-name-where-the-pool-lives>, <the-pool-name>              component=resource-router`
If you test with a pool/pool name that doesn't exist, then you should see the default RM and pool name being used, with the message at the debug level.
If you test with a blank pool name (so _don't_ define a resource pool in your experiment yaml), you should see "RM undefined, routing to default resource manager" at the debug level.

## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-125


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
