### PR TITLE
fix: match GetJobQueueStats behavior in k8s RM to agent RM [RM-136]

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -239,13 +240,17 @@ func (k *ResourceManager) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*
 
 // GetJobQueueStatsRequest implements rm.ResourceManager.
 func (k *ResourceManager) GetJobQueueStatsRequest(
-	*apiv1.GetJobQueueStatsRequest,
+	msg *apiv1.GetJobQueueStatsRequest,
 ) (*apiv1.GetJobQueueStatsResponse, error) {
 	resp := &apiv1.GetJobQueueStatsResponse{
 		Results: make([]*apiv1.RPQueueStat, 0),
 	}
 
 	for poolName, rp := range k.pools {
+		if len(msg.ResourcePools) != 0 && !slices.Contains(msg.ResourcePools, poolName) {
+			continue
+		}
+
 		qStats := apiv1.RPQueueStat{
 			ResourcePool: poolName,
 			Stats:        rp.GetJobQStats(),

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -370,8 +370,8 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		err         error
 		expectedLen int
 	}{
-		// TODO RM-136: revist this.
-		// Per the mocks set-up, no matter the pools in the request, return the max # of responses.
+		// Per the mocks set-up, no matter the pools in the request, return the max # of responses because of
+		// the fan-out call to all RMs.
 		{"empty request", &apiv1.GetJobQueueStatsRequest{}, nil, 2},
 		{"empty RP name will default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{""}}, nil, 2},
 		{"defined RP in default", &apiv1.GetJobQueueStatsRequest{ResourcePools: []string{defaultRMName}}, nil, 2},


### PR DESCRIPTION
## Description
Match RM behavior for GetJobQueueStats in the kubernetes implementation of the interface to the agent implementation. Add a clause to filter _in_ resource pools in the included stats.



## Test Plan
See new tests for the agentRM & k8sRM -- without my changes to the code these tests would pass only for agent RM & fail in k8s.



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
RM-136

<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
