### PR TITLE
docs: Describe password requirements

### DIFF
--- a/docs/_shared/password-note.txt
+++ b/docs/_shared/password-note.txt
@@ -1,0 +1,7 @@
+.. important::
+
+   For your security, set strong passwords for any service accessible from the internet. 
+   Malicious actors are always scanning for vulnerabilities. Unauthorized access to your 
+   cluster could lead to data breaches, unauthorized processes like crypto mining, high costs, 
+   and disruptions to legitimate usage.
+

--- a/docs/_shared/password-steps-helm.txt
+++ b/docs/_shared/password-steps-helm.txt
@@ -1,0 +1,10 @@
+.. note::
+
+   A new cluster deployed with the :ref:`Helm Chart <helm-config-reference>` includes two default
+   users, ``admin`` and ``determined``. You must either configure an initial password for the these
+   default users or deactivate them.
+
+   Setting an ``initialUserPassword`` for the ``admin`` and ``determined`` user accounts is a required
+   step and is configured in the :ref:`Helm Chart <helm-config-reference>`. For additional information on 
+   managing users in determined, visit the :ref:`topic guide on users <users>`.
+

--- a/docs/_shared/password-steps-webui.txt
+++ b/docs/_shared/password-steps-webui.txt
@@ -1,0 +1,7 @@
+**Create a Strong Password**
+
+#. Select your profile in the upper left corner and then choose **Settings**.
+#. Edit the **Password** by typing a strong password.
+#. Select the checkmark to save your changes.
+
+If you are changing your password, the system asks you to confirm your change. The system lets you know your changes have been saved.

--- a/docs/get-started/webui-qs.rst
+++ b/docs/get-started/webui-qs.rst
@@ -89,6 +89,8 @@ You must have a running Determined cluster with the CLI installed.
       If you are changing your password, the system asks you to confirm your change. The system lets
       you know your changes have been saved.
 
+      .. include:: ../_shared/password-note.txt
+
    .. tab::
 
       remotely

--- a/docs/get-started/webui-qs.rst
+++ b/docs/get-started/webui-qs.rst
@@ -40,6 +40,8 @@ You must have a running Determined cluster with the CLI installed.
          a single CPU or GPU. A cluster is made up of a master and one or more agents. A single
          machine can serve as both a master and an agent.
 
+      **Create the Experiment**
+
       #. Download and extract the tar file: :download:`mnist_pytorch.tgz
          <../examples/mnist_pytorch.tgz>`.
 
@@ -59,12 +61,14 @@ You must have a running Determined cluster with the CLI installed.
          *context directory* for your model. Determined copies the model context directory contents
          to the trial container working directory.
 
+      **View the Experiment**
+
       #. To view the experiment in your browser:
 
          -  Enter the following URL: **http://localhost:8080/**. This is the cluster address for
             your local training environment.
-         -  Accept the default username of ``determined``, and click **Sign In**. A password is not
-            required.
+         -  Accept the default username of ``determined``, and click **Sign In**. You'll create a
+            strong password in the next section.
 
       #. Navigate to the home page and then visit your **Uncategorized** experiments.
 
@@ -75,6 +79,15 @@ You must have a running Determined cluster with the CLI installed.
 
          .. image:: /assets/images/qswebui-metrics-local.png
             :alt: Determined AI WebUI Dashboard showing details for a local experiment
+
+      **Create a Strong Password**
+
+      #. Select your profile in the upper left corner and then choose **Settings**.
+      #. Edit the **Password** by typing a strong password.
+      #. Select the checkmark to save your changes.
+
+      If you are changing your password, the system asks you to confirm your change. The system lets
+      you know your changes have been saved.
 
    .. tab::
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -32,8 +32,9 @@ Brand new Determined installations include two user accounts:
    role.
 -  The ``determined`` user has no permissions.
 
-Both accounts have empty passwords. You are encouraged to set strong passwords or deactivate these
-accounts for security reasons.
+For security purposes, either create a strong password for both accounts or deactivate them.
+
+.. _rbac-strong-password:
 
 Example Setup (CLI)
 ===================
@@ -41,8 +42,8 @@ Example Setup (CLI)
 In this section, we will configure a Determined instance to support a cluster administrator account,
 and a few engineers with varying level of access.
 
-First, create a new user ``alice``, set a password, make it an admin, and deactivate the default
-accounts:
+First, create a new user ``alice``, set a strong password, make it an admin, and deactivate the
+default accounts:
 
 .. code:: bash
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -26,13 +26,15 @@ set the following option in the master config:
      authz:
        type: rbac
 
-Brand new Determined installations include two user accounts:
+A new cluster deployed with the :ref:`Helm Chart <helm-config-reference>` includes two default
+users, ``admin`` and ``determined``. You must either configure an initial password for the these
+default users or deactivate them.
 
 -  The ``admin`` user has full cluster access by default through the pre-canned ``ClusterAdmin``
    role.
 -  The ``determined`` user has no permissions.
 
-For security purposes, either create a strong password for both accounts or deactivate them.
+.. include:: ../../_shared/password-note.txt
 
 .. _rbac-strong-password:
 

--- a/docs/manage/security/scim.rst
+++ b/docs/manage/security/scim.rst
@@ -60,7 +60,7 @@ and specify the following configurations for the integration:
    -  -  Username
       -  ``determined``
    -  -  Password
-      -  ``password``
+      -  ``strongpassword``
 
 .. note::
 
@@ -80,7 +80,7 @@ To configure Determined for this integration, update the :ref:`master configurat
      auth:
        type: basic
        username: "determined"
-       password: "password"
+       password: "strongpassword"
 
 ******************************************
  Automatically Update Users' Display Name

--- a/docs/manage/users.rst
+++ b/docs/manage/users.rst
@@ -19,7 +19,8 @@ Initially, there are two accounts:
 -  ``admin`` (full privileges)
 -  ``determined`` (for single-user installations)
 
-Both have blank passwords by default, therefore, you'll need to set a strong password.
+Setting an ``initialUserPassword`` for the ``admin`` and ``determined`` user accounts is a required
+step and is configured in the :ref:`Helm Chart <helm-config-reference>`.
 
 Setting the Admin Password
 ==========================
@@ -30,8 +31,10 @@ Use the following CLI command to set the admin password:
 
    det -u admin user change-password
 
-Creating Individual User Accounts
-=================================
+.. include:: ../_shared/password-note.txt
+
+Creating Individual User (Member) Accounts
+==========================================
 
 You can add, edit, and manage users manually via the CLI or the WebUI.
 
@@ -39,7 +42,7 @@ To create users via the CLI, use the following command:
 
 .. code::
 
-   det -u admin user create <username>
+   det -u admin user create <username> --password <password>
 
 To ensure that no one can access the Determined cluster as the ``determined`` user, deactivate it.
 Deactivating the ``determined`` user does not remove any objects created by the user.
@@ -57,6 +60,17 @@ Admins can configure Determined to auto-provision users who have been added to y
 are known as remote users.
 
 To find out more, visit :ref:`remote-users`.
+
+Password Requirements
+=====================
+
+Passwords:
+
+-  cannot be blank
+-  must be at least 8 characters
+-  must contain at least one upper-case letter
+-  must contain at least one lower-case letter
+-  must contain at least one number
 
 ****************
  Authentication
@@ -115,10 +129,7 @@ be discarded using the ``user logout`` subcommand:
  Change Passwords
 ******************
 
-Users have blank passwords by default. This might be sufficient for low-security or experimental
-clusters, and it still provides the organizational benefits of associating each Determined object
-with the user that created it. If desired, a user can change their own password using the ``user
-change-password`` subcommand:
+A user can change their own password via the ``user change-password`` subcommand:
 
 .. code::
 

--- a/docs/manage/users.rst
+++ b/docs/manage/users.rst
@@ -9,7 +9,7 @@
 *******
 
 Only the ``admin`` user can create users, change users' passwords, and activate or deactivate users.
-Upon initial installation, the admin should set an admin password.
+Upon initial installation, the admin must set a strong admin password.
 
 Default Accounts
 ================
@@ -19,7 +19,7 @@ Initially, there are two accounts:
 -  ``admin`` (full privileges)
 -  ``determined`` (for single-user installations)
 
-Both have blank passwords by default.
+Both have blank passwords by default, therefore, you'll need to set a strong password.
 
 Setting the Admin Password
 ==========================
@@ -108,6 +108,8 @@ be discarded using the ``user logout`` subcommand:
 .. code::
 
    det -u <username> user logout
+
+.. _strong-password:
 
 ******************
  Change Passwords

--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
@@ -85,8 +85,8 @@ CD into the directory and run this command:
    from the logs of the first trial as it progresses.
 
 Open the Determined WebUI by navigating to the master URL. One way to do this is to navigate to
-``http://localhost:8080/``, accept the default username of ``determined``, and click **Sign In**. A
-password is not required.
+``http://localhost:8080/``, accept the default username of ``determined``, and click **Sign In**.
+After signing in, you'll need to create a :ref:`strong-password`.
 
 .. include:: ../../../_shared/note-local-dtrain-job.txt
 

--- a/docs/setup-cluster/checklists/_index.rst
+++ b/docs/setup-cluster/checklists/_index.rst
@@ -509,9 +509,8 @@ Test your setup to ensure it is functioning correctly.
             det -m http://<ipAddress>:8080 experiment create distributed.yaml .
 
       #. To view the WebUI dashboard, enter the cluster address in your browser address bar, accept
-         ``determined`` as the default username, and click **Sign In**. A password is not initially
-         required. After signing in you can set a strong password using the **Settings** within your
-         profile.
+         ``determined`` as the default username, and click **Sign In**. After signing in, create a
+         strong password using the **Settings** within your profile.
 
       #. Click the **Experiment** name to view the experiment’s trial display.
 
@@ -522,9 +521,8 @@ Test your setup to ensure it is functioning correctly.
       Test that your users can access the cluster.
 
       To view the WebUI dashboard, enter the cluster address in the browser address bar, accept the
-      default username of ``determined``, and click **Sign In**. A password is not initially
-      required. After signing in you can set a strong password using the **Settings** within your
-      profile.
+      default username of ``determined``, and click **Sign In**. After signing in, create a strong
+      password using the **Settings** within your profile.
 
 ************
  Next Steps

--- a/docs/setup-cluster/checklists/_index.rst
+++ b/docs/setup-cluster/checklists/_index.rst
@@ -509,7 +509,9 @@ Test your setup to ensure it is functioning correctly.
             det -m http://<ipAddress>:8080 experiment create distributed.yaml .
 
       #. To view the WebUI dashboard, enter the cluster address in your browser address bar, accept
-         ``determined`` as the default username, and click **Sign In**. A password is not required.
+         ``determined`` as the default username, and click **Sign In**. A password is not initially
+         required. After signing in you can set a strong password using the **Settings** within your
+         profile.
 
       #. Click the **Experiment** name to view the experiment’s trial display.
 
@@ -520,7 +522,9 @@ Test your setup to ensure it is functioning correctly.
       Test that your users can access the cluster.
 
       To view the WebUI dashboard, enter the cluster address in the browser address bar, accept the
-      default username of ``determined``, and click **Sign In**. A password is not required.
+      default username of ``determined``, and click **Sign In**. A password is not initially
+      required. After signing in you can set a strong password using the **Settings** within your
+      profile.
 
 ************
  Next Steps

--- a/docs/setup-cluster/k8s/install-on-kubernetes.rst
+++ b/docs/setup-cluster/k8s/install-on-kubernetes.rst
@@ -175,13 +175,13 @@ CPU and GPU tasks. The defaults can be defined in ``values.yaml`` under
 to do this and a description of permissible fields, see the :ref:`specifying custom pod specs
 <custom-pod-specs>` guide.
 
-Default Password (Optional)
-===========================
+Default Password
+================
 
-Unless otherwise specified, the pre-existing users, ``admin`` and ``determined``, do not have
-passwords associated with their accounts. You can set a default password for the ``determined`` and
-``admin`` accounts if preferred or needed. This password will not affect any other user account. For
-additional information on managing users in determined, see the :ref:`topic guide on users <users>`.
+Setting an ``initialUserPassword`` for the ``admin`` and ``determined`` user accounts is a required
+step and is configured in the :ref:`Helm Chart <helm-config-reference>`. The password for these
+users will not affect any other user account. For additional information on managing users in
+determined, visit the :ref:`topic guide on users <users>`.
 
 Database (Optional)
 ===================

--- a/docs/setup-cluster/on-prem/options/wsl.rst
+++ b/docs/setup-cluster/on-prem/options/wsl.rst
@@ -144,7 +144,8 @@ To open the WebUI from WSL:
 
    explorer.exe http://localhost:8080
 
-The default username for the WebUI is ``determined`` and no password.
+The default username for the WebUI is ``determined`` and no password. After signing in, you'll need
+to create a :ref:`strong-password`.
 
 In the WebUI, go to the ``Cluster`` page. You should now see slots available (either CPU or GPU,
 depending on what hardware is available on the machine).

--- a/docs/tutorials/pachyderm-cat-dog.rst
+++ b/docs/tutorials/pachyderm-cat-dog.rst
@@ -270,7 +270,8 @@ Visit the Determined dashboard to view the progress of your experiment. One way 
 enter the following URL: ``http://localhost:8080/`` in your browser. This is the cluster address for
 your local training environment.
 
-Accept the default username of ``determined``, and click **Sign In**. A password is not required.
+Accept the default username of ``determined``, and click **Sign In**. After signing in, create a
+strong password using the **Settings** within your profile.
 
 Wait until Determined displays Best Checkpoint before continuing on to the next step. Then, obtain
 the ID of the completed trial, you'll need this to download the checkpoint.

--- a/docs/tutorials/quickstart-mdldev.rst
+++ b/docs/tutorials/quickstart-mdldev.rst
@@ -191,7 +191,7 @@ schedules to run.
 #. Enter the cluster address in the browser address bar to view experiment progress in the WebUI. If
    you installed locally using the ``det deploy local`` command, the URL is
    ``http://localhost:8080/``. Accept the default username of ``determined`` and click **Sign In**.
-   A password is not initially required. After signing in you can create a :ref:`strong-password`.
+   After signing in, create a :ref:`strong-password`.
 
    .. image:: /assets/images/qs01c.png
       :width: 704px
@@ -328,7 +328,8 @@ This example uses a fixed batch size and searches on dropout size, filters, and 
       det experiment create adaptive.yaml .
 
 #. To view the WebUI dashboard, enter your cluster address in the browser address bar, accept the
-   default username of ``determined``, and click **Sign In**. A password is not required.
+   default username of ``determined``, and click **Sign In**. After signing in, you'll need to
+   create a :ref:`strong-password`.
 
 #. The experiment can take some time to complete. You can monitor progress in the WebUI Dashboard by
    clicking the **Experiment** name. Notice that more trials have started:

--- a/docs/tutorials/quickstart-mdldev.rst
+++ b/docs/tutorials/quickstart-mdldev.rst
@@ -191,7 +191,7 @@ schedules to run.
 #. Enter the cluster address in the browser address bar to view experiment progress in the WebUI. If
    you installed locally using the ``det deploy local`` command, the URL is
    ``http://localhost:8080/``. Accept the default username of ``determined`` and click **Sign In**.
-   A password is not required.
+   A password is not initially required. After signing in you can create a :ref:`strong-password`.
 
    .. image:: /assets/images/qs01c.png
       :width: 704px


### PR DESCRIPTION
Replaced by https://github.com/determined-ai/determined/pull/9137

## Description

Draft for Phase II

### Phase I (Completed)

Deploying a cluster using the helm chart creates `admin` and `determined` users by default and setting an initial password for these users is no longer a separate step. Therefore, there will be a password set by admin for these users. If a user creates another user, they should create a strong password. For the tutorials where users can create an experiment locally, instruct the users to set a strong password.

#9113 the PR for this is #9137
from @ioga : New Determined installations include two default accounts: admin and determined. Administrators setting up new clusters which are publicly accessible on the internet must make sure to either configure both of these accounts to use strong passwords, or deactivate these default accounts.

from the proposed release notes: When deploying a new cluster with Helm, configuring a password is required and is no longer a separate step. To specify an initial password for the "admin" and "determined" users, use either `initialUserPassword` (preferred) or `defaultPassword` (deprecated). These settings are found in `helm/charts/determined/values.yaml` and referenced in helm-chart-configuration-reference (https://docs.determined.ai/latest/reference/deploy/helm-config-reference.html#helm-chart-configuration-reference).

### Phase II (this will be a different PR)
#9112 
there are breaking changes to the cli command `det user create` and there is a list of password requirements

