### PR TITLE
chore: auto pick the only matching name on partial hits

### DIFF
--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -358,6 +358,7 @@ args_description = [
                         [
                             cli.Arg("name", help="name of the function to call"),
                             cli.Arg(
+                                "-y",
                                 "--auto-confirm",
                                 help="auto-confirm if only a single match is found",
                                 action="store_true",

--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -243,7 +243,7 @@ def list_bindings(args: argparse.Namespace) -> None:
         print(bindings_sig_str(name, params))
 
 
-def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_picking: bool) -> str:
+def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_confirm: bool) -> str:
     """
     utility to allow partial matching of binding names.
     """
@@ -257,8 +257,7 @@ def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_pi
     ]
     if not matches:
         raise errors.CliError(f"no such binding found: {fn_name}")
-    if not skip_auto_picking and len(matches) == 1:
-        # print in stderr
+    if not skip_auto_confirm and len(matches) == 1:
         print(
             termcolor.colored(
                 f"Auto picked '{matches[0]}' for '{fn_name}'",
@@ -292,7 +291,7 @@ def call_bindings(args: argparse.Namespace) -> None:
     sess = cli.setup_session(args)
     fn_name: str = args.name
     fns = get_available_bindings(show_unusable=False)
-    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.skip_auto_picking)
+    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.skip_auto_confirm)
     fn = getattr(api.bindings, fn_name)
     params = fns[fn_name]
     try:
@@ -359,8 +358,8 @@ args_description = [
                         [
                             cli.Arg("name", help="name of the function to call"),
                             cli.Arg(
-                                "--skip-auto-picking",
-                                help="skip auto-picking of only matching name on partial hits",
+                                "--skip-auto-confirm",
+                                help="skip auto-confirm of only matching name on partial hits",
                                 action="store_true",
                             ),
                             cli.Arg(

--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -243,9 +243,7 @@ def list_bindings(args: argparse.Namespace) -> None:
         print(bindings_sig_str(name, params))
 
 
-def auto_complete_binding(
-    available_calls: List[str], fn_name: str, skip_partial_match: bool
-) -> str:
+def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_picking: bool) -> str:
     """
     utility to allow partial matching of binding names.
     """
@@ -259,7 +257,7 @@ def auto_complete_binding(
     ]
     if not matches:
         raise errors.CliError(f"no such binding found: {fn_name}")
-    if not skip_partial_match and len(matches) == 1:
+    if not skip_auto_picking and len(matches) == 1:
         # print in stderr
         print(
             termcolor.colored(
@@ -294,7 +292,7 @@ def call_bindings(args: argparse.Namespace) -> None:
     sess = cli.setup_session(args)
     fn_name: str = args.name
     fns = get_available_bindings(show_unusable=False)
-    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.skip_autopick)
+    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.skip_auto_picking)
     fn = getattr(api.bindings, fn_name)
     params = fns[fn_name]
     try:
@@ -361,7 +359,7 @@ args_description = [
                         [
                             cli.Arg("name", help="name of the function to call"),
                             cli.Arg(
-                                "--skip-autopick",
+                                "--skip-auto-picking",
                                 help="skip auto-picking of only matching name on partial hits",
                                 action="store_true",
                             ),

--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -243,7 +243,7 @@ def list_bindings(args: argparse.Namespace) -> None:
         print(bindings_sig_str(name, params))
 
 
-def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_confirm: bool) -> str:
+def auto_complete_binding(available_calls: List[str], fn_name: str, auto_confirm: bool) -> str:
     """
     utility to allow partial matching of binding names.
     """
@@ -257,7 +257,7 @@ def auto_complete_binding(available_calls: List[str], fn_name: str, skip_auto_co
     ]
     if not matches:
         raise errors.CliError(f"no such binding found: {fn_name}")
-    if not skip_auto_confirm and len(matches) == 1:
+    if auto_confirm and len(matches) == 1:
         print(
             termcolor.colored(
                 f"Auto picked '{matches[0]}' for '{fn_name}'",
@@ -291,7 +291,7 @@ def call_bindings(args: argparse.Namespace) -> None:
     sess = cli.setup_session(args)
     fn_name: str = args.name
     fns = get_available_bindings(show_unusable=False)
-    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.skip_auto_confirm)
+    fn_name = auto_complete_binding(list(fns.keys()), fn_name, args.auto_confirm)
     fn = getattr(api.bindings, fn_name)
     params = fns[fn_name]
     try:
@@ -358,8 +358,8 @@ args_description = [
                         [
                             cli.Arg("name", help="name of the function to call"),
                             cli.Arg(
-                                "--skip-auto-confirm",
-                                help="skip auto-confirm of only matching name on partial hits",
+                                "--auto-confirm",
+                                help="auto-confirm if only a single match is found",
                                 action="store_true",
                             ),
                             cli.Arg(


### PR DESCRIPTION
add a flag to skip this behavior

## Description
(this is a purely internal feature as it's nested under dev and "hidden" from users)
I find myself wanting this as I try out and test out changes otherwise I can never get the name right on the first try
<!---
Lead with the intended commit body in this description field. For breaking
changes, please include "BREAKING CHANGE:" at the beginning of your commit
body.  At a minimum, this section should include a bracketed reference to the
Jira ticket, e.g. "[DET-1234]". When squash-and-merging, copy this directly
into the description field.
-->



## Test Plan

<!---
Describe the situations in which you've tested your change, and/or a screenshot
as appropriate.  Reviewers may ask questions about this test plan to ensure
adequate manual coverage of changes.
-->



## Commentary (optional)

<!---
Use this section of your description to add context to the PR. Could be for
particularly tricky bits of code that could use extra scrutiny, historical
context useful for reviewers, etc.
You may intentionally leave this section blank and remove the title.
--->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

## Ticket
<!---
Retain the relevant line and replace 000 with ticket number.

DET-000
MLG-000
WEB-000
DESIGN-000
No Ticket
--->


<!---
## Title

Example title: "docs: tweak recommended "pip install" usage".

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")

-->
