### PR TITLE
fix: helm value for gke tests

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2773,7 +2773,6 @@ jobs:
       - run:
           name: Create Namespace & Cert Name
           command: |
-            # Extract the commit hash from Git metadata
             TIMESTAMP=$(date +"%Y%m%d%H%M%S")
             uuid=$(cat /proc/sys/kernel/random/uuid)
             uuid=${uuid:0:8}
@@ -3460,6 +3459,7 @@ workflows:
               det-version: [$CIRCLE_SHA1]
     
   test-e2e-gke-shared-cluster:
+    unless: << pipeline.parameters.do_nightly_tests >>
     jobs:
       - package-and-push-system-dev-small
       

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -57,7 +57,9 @@ masterPort: 8080
 #
 # WARNING
 # The first installation must run with the createNonNamespacedObjects flag set to true to ensure
-# the non-namespaced objects are created.
+# the non-namespaced objects are created. 
+# When deploying multiple namespaces within the same shared cluster, this should be set to false
+# with helm overrides.
 createNonNamespacedObjects: true
 
 # External ca.crt injection certificate/s secret name
@@ -239,11 +241,6 @@ checkpointStorage:
 # you have a cluster of different size nodes (e.g., 4 and 8 GPUs per node), set `maxSlotsPerPod` to
 # the greatest common divisor of all the sizes (4, in that case).
 maxSlotsPerPod:
-
-
-# Flag for determining whether or not to create the cluster-scoped objects, when deploying multiple
-# namespaces within the same cluster, should be set to false.
-createNonNamespacedObjects:
 
 ## For CPU-only clusters, use `slotType: cpu`, and make sure to set `slotResourceRequest` below.
 # slotType: cpu


### PR DESCRIPTION
## Description

Fix for e2e gke tests and don't run shared cluster e2e test during nightly (or it'll interfere with the cleanup job)


## Test Plan

CI passes.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
