### PR TITLE
fix: unlock mutex for experiment ResourcePool() [RM-152]

### DIFF
--- a/docs/release-notes/experiment-deadlock.rst
+++ b/docs/release-notes/experiment-deadlock.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  API: Fix an issue where calling ``det job update`` could cause jobs to be prevented from
-   scheduling and ``det job ls`` to hang.
+-  API: Fix a bug where calling ``det job update`` could prevent jobs from being scheduled and ``det
+   job ls`` to hang.

--- a/docs/release-notes/experiment-deadlock.rst
+++ b/docs/release-notes/experiment-deadlock.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix a bug where reading an experiment's resource pool name would hang indefinitely
+      and cause experiment job scheduling to freeze.

--- a/docs/release-notes/experiment-deadlock.rst
+++ b/docs/release-notes/experiment-deadlock.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Fix a bug where reading an experiment's resource pool name would hang indefinitely
-      and cause experiment job scheduling to freeze.
+-  API: Fix an issue where calling ``det job update`` could cause jobs to be prevented from
+   scheduling and ``det job ls`` to hang.

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -81,6 +81,7 @@ linters-settings:
       - 'bundebug.WithVerbose'
       - 'http.Client' # Use cleanhttp instead.
       - 'http.Transport' # Use cleanhttp instead.
+      - 'defer *.Unlock()'
   staticcheck:
     go: "1.20"
 

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -81,7 +81,7 @@ linters-settings:
       - 'bundebug.WithVerbose'
       - 'http.Client' # Use cleanhttp instead.
       - 'http.Transport' # Use cleanhttp instead.
-      - 'defer *.Unlock()'
+      - 'defer .*\.Lock\(\)'
   staticcheck:
     go: "1.20"
 

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -32,8 +32,10 @@ import (
 
 var pAuthZ *mocks.ProjectAuthZ
 
+const mockName = "mock"
+
 func isMockAuthZ() bool {
-	return config.GetMasterConfig().Security.AuthZ.Type == "mock"
+	return config.GetMasterConfig().Security.AuthZ.Type == mockName
 }
 
 // pgdb can be nil to use the singleton database for testing.
@@ -45,7 +47,7 @@ func setupProjectAuthZTest(
 
 	if pAuthZ == nil {
 		pAuthZ = &mocks.ProjectAuthZ{}
-		project.AuthZProvider.Register("mock", pAuthZ)
+		project.AuthZProvider.Register(mockName, pAuthZ)
 	}
 	return api, pAuthZ, workspaceAuthZ, curUser, ctx
 }

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -32,10 +32,8 @@ import (
 
 var pAuthZ *mocks.ProjectAuthZ
 
-const mockName = "mock"
-
 func isMockAuthZ() bool {
-	return config.GetMasterConfig().Security.AuthZ.Type == mockName
+	return config.GetMasterConfig().Security.AuthZ.Type == "mock"
 }
 
 // pgdb can be nil to use the singleton database for testing.
@@ -47,7 +45,7 @@ func setupProjectAuthZTest(
 
 	if pAuthZ == nil {
 		pAuthZ = &mocks.ProjectAuthZ{}
-		project.AuthZProvider.Register(mockName, pAuthZ)
+		project.AuthZProvider.Register("mock", pAuthZ)
 	}
 	return api, pAuthZ, workspaceAuthZ, curUser, ctx
 }

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -30,10 +30,12 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/userv1"
 )
 
+const mockType = "mock"
+
 var pAuthZ *mocks.ProjectAuthZ
 
 func isMockAuthZ() bool {
-	return config.GetMasterConfig().Security.AuthZ.Type == "mock"
+	return config.GetMasterConfig().Security.AuthZ.Type == mockType
 }
 
 // pgdb can be nil to use the singleton database for testing.
@@ -45,7 +47,7 @@ func setupProjectAuthZTest(
 
 	if pAuthZ == nil {
 		pAuthZ = &mocks.ProjectAuthZ{}
-		project.AuthZProvider.Register("mock", pAuthZ)
+		project.AuthZProvider.Register(mockType, pAuthZ)
 	}
 	return api, pAuthZ, workspaceAuthZ, curUser, ctx
 }

--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -82,7 +82,7 @@ func (e *internalExperiment) SetResourcePool(resourcePool string) error {
 // ResourcePool gets the experiment's resource pool.
 func (e *internalExperiment) ResourcePool() string {
 	e.mu.Lock()
-	defer e.mu.Lock()
+	defer e.mu.Unlock()
 
 	return e.activeConfig.Resources().ResourcePool()
 }

--- a/master/internal/experiment_job_service_test.go
+++ b/master/internal/experiment_job_service_test.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+)
+
+var rp = "mock"
+
+func TestResourcePool(t *testing.T) {
+	e := mockInternalExp()
+	require.Equal(t, mutexLocked(&e.mu), false)
+
+	rpName := e.ResourcePool()
+	require.Equal(t, rp, rpName)
+	require.Equal(t, mutexLocked(&e.mu), false)
+}
+
+func mutexLocked(m *sync.Mutex) bool {
+	state := reflect.ValueOf(m).Elem().FieldByName("state")
+	return state.Int()&1 == 1
+}
+
+func mockInternalExp() *internalExperiment {
+	//nolint:exhaustruct
+	return &internalExperiment{
+		activeConfig: expconf.ExperimentConfigV0{
+			RawResources: &expconf.ResourcesConfigV0{
+				RawResourcePool: &rp,
+			},
+		},
+	}
+}

--- a/master/internal/experiment_job_service_test.go
+++ b/master/internal/experiment_job_service_test.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,29 +8,17 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
-var rp = "mock"
-
 func TestResourcePool(t *testing.T) {
-	e := mockInternalExp()
-	require.Equal(t, mutexLocked(&e.mu), false)
-
-	rpName := e.ResourcePool()
-	require.Equal(t, rp, rpName)
-	require.Equal(t, mutexLocked(&e.mu), false)
-}
-
-func mutexLocked(m *sync.Mutex) bool {
-	state := reflect.ValueOf(m).Elem().FieldByName("state")
-	return state.Int()&1 == 1
-}
-
-func mockInternalExp() *internalExperiment {
+	rp := "mock"
 	//nolint:exhaustruct
-	return &internalExperiment{
+	e := &internalExperiment{
 		activeConfig: expconf.ExperimentConfigV0{
 			RawResources: &expconf.ResourcesConfigV0{
 				RawResourcePool: &rp,
 			},
 		},
 	}
+
+	rpName := e.ResourcePool()
+	require.Equal(t, rp, rpName)
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
fix: unlock mutex for experiment ResourcePool() [RM-152]
-->
## Ticket
RM-152


## Description

Unlock the internal experiment mutex in ResourcePool()




## Test Plan
I added a unit test that checks that the function returns smoothly. Without my change, the test would timeout anyway/fail.




## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[RM-152]: https://hpe-aiatscale.atlassian.net/browse/RM-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ