### PR TITLE
ci: publish docs without installing awscli

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1340,8 +1340,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: apk add make curl python3 py3-pip
-      - run: pip3 install awscli
+      - run: apk add make curl
       - run: make -C docs publish
 
   # TODO(danh): eventually replace 'publish-docs' with this new workflow after


### PR DESCRIPTION
`publish-docs` ultimately runs `make -C docs publish`, which itself runs the `make publish` in `docs/deploy`. This recipe runs a `terraform init` and a `terraform apply`, neither of which use anything installed with `awscli`.

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
I've tested this by hand by SSH'ing into a CI host, but have not tested it as a part of an automatic pipeline.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
