### PR TITLE
test: ignore e2e test cases in vitest

### DIFF
--- a/webui/react/vite.config.mts
+++ b/webui/react/vite.config.mts
@@ -132,8 +132,8 @@ export default defineConfig(({ mode }) => ({
   preview: {
     port: 3001,
     proxy: {
-      '/api': { target: webpackProxyUrl},
-      '/proxy': { target: webpackProxyUrl},
+      '/api': { target: webpackProxyUrl },
+      '/proxy': { target: webpackProxyUrl },
       '/stream': {
         target: websocketProxyUrl,
         ws: true,
@@ -164,7 +164,11 @@ export default defineConfig(({ mode }) => ({
     coverage: {
       ...configDefaults.coverage,
       include: ['src'],
-      exclude: [...configDefaults.coverage.exclude, 'src/vendor/**/*', 'src/services/api-ts-sdk/*']
+      exclude: [
+        ...(configDefaults.coverage.exclude ?? []),
+        'src/vendor/**/*',
+        'src/services/api-ts-sdk/*',
+      ],
     },
     css: {
       modules: {
@@ -179,7 +183,7 @@ export default defineConfig(({ mode }) => ({
       registerNodeLoader: true,
     },
     environment: 'jsdom',
-    exclude: [...configDefaults.exclude, './src/e2e/*'],
+    exclude: [...configDefaults.exclude, './src/e2e/**/*'],
     globals: true,
     setupFiles: ['./src/setupTests.ts'],
     testNamePattern: process.env.INCLUDE_FLAKY === 'true' ? /@flaky/ : /^(?!.*@flaky)/,


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

`npm run test` in `webui/react` caused these error because e2e tests were not ignored in Vitest.

<img width="1099" alt="image" src="https://github.com/determined-ai/determined/assets/109113616/3f53aa4f-0870-429e-b774-a350e5f09b39">



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Test CI should pass without the above errors


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ