### PR TITLE
fix: ensure all columns have widths

### DIFF
--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.settings.ts
@@ -3,7 +3,6 @@ import * as t from 'io-ts';
 import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 import { ioRowHeight, ioTableViewMode, RowHeight, TableViewMode } from 'components/OptionsMenu';
 import { SettingsConfig } from 'hooks/useSettings';
-import { optional } from 'ioTypes';
 
 import { defaultColumnWidths, defaultExperimentColumns } from './expListColumns';
 
@@ -29,7 +28,7 @@ export const ProjectSettings = t.intersection([
   t.type({}),
   t.partial({
     columns: t.array(t.string),
-    columnWidths: t.record(t.string, optional(t.number)),
+    columnWidths: t.record(t.string, t.number),
     compare: t.boolean,
     filterset: t.string, // save FilterFormSet as string
     heatmapOn: t.boolean,

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -599,9 +599,21 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const handleColumnsOrderChange = useCallback(
     (newColumnsOrder: string[]) => {
-      updateSettings({ columns: newColumnsOrder });
+      const newColumnWidths = newColumnsOrder
+        .filter((c) => !(c in settings.columnWidths))
+        .reduce((acc: Record<string, number>, col) => {
+          acc[col] = DEFAULT_COLUMN_WIDTH;
+          return acc;
+        }, {});
+      updateSettings({
+        columns: newColumnsOrder,
+        columnWidths: {
+          ...settings.columnWidths,
+          ...newColumnWidths,
+        },
+      });
     },
-    [updateSettings],
+    [updateSettings, settings.columnWidths],
   );
 
   const handleRowHeightChange = useCallback(
@@ -674,7 +686,11 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
       // Negative widthDifference: Table pane shrinking/compare pane growing
       const newColumnWidths: Record<string, number> = { ...settings.columnWidths };
       pinnedColumns
-        .filter((col) => widthDifference > 0 || newColumnWidths[col] !== MIN_COLUMN_WIDTH)
+        .filter(
+          (col) =>
+            !STATIC_COLUMNS.includes(col) &&
+            (widthDifference > 0 || newColumnWidths[col] > MIN_COLUMN_WIDTH),
+        )
         .forEach((col, _, arr) => {
           newColumnWidths[col] = Math.max(
             MIN_COLUMN_WIDTH,

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -709,7 +709,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
       updateSettings({
         columnWidths: {
           ...settings.columnWidths,
-          [columnId]: width,
+          [columnId]: Math.max(MIN_COLUMN_WIDTH, width),
         },
       });
     },


### PR DESCRIPTION


## Ticket
ET-161



## Description
this is an alternate fix for a bug where updating the compare width would cause the experiment list settings to be in an invalid state. It seems like the issue was due to settings widths not containing pinned columns, so we try to update the column widths along with the columns when they update.



## Test Plan
* Reset user settings
* visit an experiment list page
* open compare mode
* click and drag the divider
* the pinned columns in the left panel should shrink and grow with the divider position



## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ