### PR TITLE
docs: Describe pwds default accounts

### DIFF
--- a/docs/_shared/basic-installation.txt
+++ b/docs/_shared/basic-installation.txt
@@ -1,3 +1,5 @@
 -  Go to ``http://localhost:8080/``.
--  Accept the default username of ``determined`` and leave the password empty.
+-  Accept the default username of ``determined``.
 -  Click **Sign In**.
+
+After signing in, you'll need to create a :ref:`strong password <strong-password>`.

--- a/docs/_shared/password-note.txt
+++ b/docs/_shared/password-note.txt
@@ -1,0 +1,6 @@
+.. important::
+
+   For your security, set strong passwords for any service accessible from the internet. 
+   Malicious actors are always scanning for vulnerabilities. Unauthorized access to your 
+   cluster could lead to data breaches, unauthorized processes like crypto mining, high costs, 
+   and disruptions to legitimate usage.

--- a/docs/_shared/password-steps-helm.txt
+++ b/docs/_shared/password-steps-helm.txt
@@ -1,0 +1,8 @@
+.. note::
+
+   A new cluster deployed with the :ref:`Helm Chart <helm-config-reference>` includes two default
+   users, ``admin`` and ``determined``. You must either configure an initial password for the these
+   default users or deactivate them.
+
+   The ``initialUserPassword`` for these user accounts is configured in the :ref:`Helm Chart <helm-config-reference>`.
+   For additional information on managing users in determined, visit the :ref:`topic guide on users <users>`.

--- a/docs/_shared/password-steps-webui.txt
+++ b/docs/_shared/password-steps-webui.txt
@@ -1,0 +1,8 @@
+**Create a Strong Password**
+
+#. Select your profile in the upper left corner and then choose **Settings**.
+#. Edit the **Password** by typing a strong password.
+#. Select the checkmark to save your changes.
+
+If you are changing your password, the system asks you to confirm your change.
+The system lets you know your changes have been saved.

--- a/docs/get-started/webui-qs.rst
+++ b/docs/get-started/webui-qs.rst
@@ -40,6 +40,8 @@ You must have a running Determined cluster with the CLI installed.
          a single CPU or GPU. A cluster is made up of a master and one or more agents. A single
          machine can serve as both a master and an agent.
 
+      **Create the Experiment**
+
       #. Download and extract the tar file: :download:`mnist_pytorch.tgz
          <../examples/mnist_pytorch.tgz>`.
 
@@ -59,12 +61,14 @@ You must have a running Determined cluster with the CLI installed.
          *context directory* for your model. Determined copies the model context directory contents
          to the trial container working directory.
 
+      **View the Experiment**
+
       #. To view the experiment in your browser:
 
          -  Enter the following URL: **http://localhost:8080/**. This is the cluster address for
             your local training environment.
-         -  Accept the default username of ``determined``, and click **Sign In**. A password is not
-            required.
+         -  Accept the default username of ``determined``, and click **Sign In**. You'll create a
+            strong password in the next section.
 
       #. Navigate to the home page and then visit your **Uncategorized** experiments.
 
@@ -75,6 +79,15 @@ You must have a running Determined cluster with the CLI installed.
 
          .. image:: /assets/images/qswebui-metrics-local.png
             :alt: Determined AI WebUI Dashboard showing details for a local experiment
+
+      **Create a Strong Password**
+
+      #. Select your profile in the upper left corner and then choose **Settings**.
+      #. Edit the **Password** by typing a strong password.
+      #. Select the checkmark to save your changes.
+
+      If you are changing your password, the system asks you to confirm your change. The system lets
+      you know your changes have been saved.
 
    .. tab::
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -26,14 +26,17 @@ set the following option in the master config:
      authz:
        type: rbac
 
-Brand new Determined installations include two user accounts:
+A new cluster deployed with the :ref:`Helm Chart <helm-config-reference>` includes two default
+users, ``admin`` and ``determined``. You must either configure an initial password for the these
+default users or deactivate them.
 
 -  The ``admin`` user has full cluster access by default through the pre-canned ``ClusterAdmin``
    role.
 -  The ``determined`` user has no permissions.
 
-Both accounts have empty passwords. You are encouraged to set strong passwords or deactivate these
-accounts for security reasons.
+.. include:: ../../_shared/password-note.txt
+
+.. _rbac-strong-password:
 
 Example Setup (CLI)
 ===================
@@ -41,8 +44,8 @@ Example Setup (CLI)
 In this section, we will configure a Determined instance to support a cluster administrator account,
 and a few engineers with varying level of access.
 
-First, create a new user ``alice``, set a password, make it an admin, and deactivate the default
-accounts:
+First, create a new user ``alice``, set a strong password, make it an admin, and deactivate the
+default accounts:
 
 .. code:: bash
 

--- a/docs/manage/security/scim.rst
+++ b/docs/manage/security/scim.rst
@@ -60,7 +60,7 @@ and specify the following configurations for the integration:
    -  -  Username
       -  ``determined``
    -  -  Password
-      -  ``password``
+      -  ``strongpassword``
 
 .. note::
 
@@ -80,7 +80,7 @@ To configure Determined for this integration, update the :ref:`master configurat
      auth:
        type: basic
        username: "determined"
-       password: "password"
+       password: "strongpassword"
 
 ******************************************
  Automatically Update Users' Display Name

--- a/docs/manage/users.rst
+++ b/docs/manage/users.rst
@@ -9,7 +9,8 @@
 *******
 
 Only the ``admin`` user can create users, change users' passwords, and activate or deactivate users.
-Upon initial installation, the admin should set an admin password.
+Upon initial installation, the admin should set an admin password. Upon initial installation, the
+admin must set a strong admin password.
 
 Default Accounts
 ================
@@ -19,7 +20,8 @@ Initially, there are two accounts:
 -  ``admin`` (full privileges)
 -  ``determined`` (for single-user installations)
 
-Both have blank passwords by default.
+Setting an ``initialUserPassword`` for the ``admin`` and ``determined`` user accounts is a required
+step and is configured in the :ref:`Helm Chart <helm-config-reference>`.
 
 Setting the Admin Password
 ==========================
@@ -30,8 +32,10 @@ Use the following CLI command to set the admin password:
 
    det -u admin user change-password
 
-Creating Individual User Accounts
-=================================
+.. include:: ../_shared/password-note.txt
+
+Creating Individual User (Member) Accounts
+==========================================
 
 You can add, edit, and manage users manually via the CLI or the WebUI.
 
@@ -109,14 +113,13 @@ be discarded using the ``user logout`` subcommand:
 
    det -u <username> user logout
 
+.. _strong-password:
+
 ******************
  Change Passwords
 ******************
 
-Users have blank passwords by default. This might be sufficient for low-security or experimental
-clusters, and it still provides the organizational benefits of associating each Determined object
-with the user that created it. If desired, a user can change their own password using the ``user
-change-password`` subcommand:
+A user can change their own password using the ``user change-password`` subcommand:
 
 .. code::
 

--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
@@ -85,8 +85,8 @@ CD into the directory and run this command:
    from the logs of the first trial as it progresses.
 
 Open the Determined WebUI by navigating to the master URL. One way to do this is to navigate to
-``http://localhost:8080/``, accept the default username of ``determined``, and click **Sign In**. A
-password is not required.
+``http://localhost:8080/``, accept the default username of ``determined``, and click **Sign In**.
+After signing in, you'll need to create a :ref:`strong password <strong-password>`.
 
 .. include:: ../../../_shared/note-local-dtrain-job.txt
 

--- a/docs/setup-cluster/checklists/_index.rst
+++ b/docs/setup-cluster/checklists/_index.rst
@@ -509,7 +509,8 @@ Test your setup to ensure it is functioning correctly.
             det -m http://<ipAddress>:8080 experiment create distributed.yaml .
 
       #. To view the WebUI dashboard, enter the cluster address in your browser address bar, accept
-         ``determined`` as the default username, and click **Sign In**. A password is not required.
+         ``determined`` as the default username, and click **Sign In**. After signing in, create a
+         strong password using the **Settings** within your profile.
 
       #. Click the **Experiment** name to view the experiment’s trial display.
 
@@ -520,7 +521,8 @@ Test your setup to ensure it is functioning correctly.
       Test that your users can access the cluster.
 
       To view the WebUI dashboard, enter the cluster address in the browser address bar, accept the
-      default username of ``determined``, and click **Sign In**. A password is not required.
+      default username of ``determined``, and click **Sign In**. After signing in, create a strong
+      password using the **Settings** within your profile.
 
 ************
  Next Steps

--- a/docs/setup-cluster/k8s/install-on-kubernetes.rst
+++ b/docs/setup-cluster/k8s/install-on-kubernetes.rst
@@ -175,13 +175,13 @@ CPU and GPU tasks. The defaults can be defined in ``values.yaml`` under
 to do this and a description of permissible fields, see the :ref:`specifying custom pod specs
 <custom-pod-specs>` guide.
 
-Default Password (Optional)
-===========================
+Default Password
+================
 
-Unless otherwise specified, the pre-existing users, ``admin`` and ``determined``, do not have
-passwords associated with their accounts. You can set a default password for the ``determined`` and
-``admin`` accounts if preferred or needed. This password will not affect any other user account. For
-additional information on managing users in determined, see the :ref:`topic guide on users <users>`.
+Setting an ``initialUserPassword`` for the ``admin`` and ``determined`` user accounts is a required
+step and is configured in the :ref:`Helm Chart <helm-config-reference>`. The password for these
+users will not affect any other user account. For additional information on managing users in
+determined, visit the :ref:`topic guide on users <users>`.
 
 Database (Optional)
 ===================

--- a/docs/setup-cluster/on-prem/options/wsl.rst
+++ b/docs/setup-cluster/on-prem/options/wsl.rst
@@ -144,7 +144,8 @@ To open the WebUI from WSL:
 
    explorer.exe http://localhost:8080
 
-The default username for the WebUI is ``determined`` and no password.
+The default username for the WebUI is ``determined`` and no password. After signing in, you'll need
+to create a :ref:`strong password <strong-password>`.
 
 In the WebUI, go to the ``Cluster`` page. You should now see slots available (either CPU or GPU,
 depending on what hardware is available on the machine).

--- a/docs/tutorials/pachyderm-cat-dog.rst
+++ b/docs/tutorials/pachyderm-cat-dog.rst
@@ -270,7 +270,8 @@ Visit the Determined dashboard to view the progress of your experiment. One way 
 enter the following URL: ``http://localhost:8080/`` in your browser. This is the cluster address for
 your local training environment.
 
-Accept the default username of ``determined``, and click **Sign In**. A password is not required.
+Accept the default username of ``determined``, and click **Sign In**. After signing in, you'll need
+to create a :ref:`strong password <strong-password>`.
 
 Wait until Determined displays Best Checkpoint before continuing on to the next step. Then, obtain
 the ID of the completed trial, you'll need this to download the checkpoint.

--- a/docs/tutorials/quickstart-mdldev.rst
+++ b/docs/tutorials/quickstart-mdldev.rst
@@ -191,7 +191,7 @@ schedules to run.
 #. Enter the cluster address in the browser address bar to view experiment progress in the WebUI. If
    you installed locally using the ``det deploy local`` command, the URL is
    ``http://localhost:8080/``. Accept the default username of ``determined`` and click **Sign In**.
-   A password is not required.
+   After signing in, you'll need to create a :ref:`strong password <strong-password>`.
 
    .. image:: /assets/images/qs01c.png
       :width: 704px
@@ -328,7 +328,8 @@ This example uses a fixed batch size and searches on dropout size, filters, and 
       det experiment create adaptive.yaml .
 
 #. To view the WebUI dashboard, enter your cluster address in the browser address bar, accept the
-   default username of ``determined``, and click **Sign In**. A password is not required.
+   default username of ``determined``, and click **Sign In**. After signing in, create a
+   :ref:`strong password <strong-password>`.
 
 #. The experiment can take some time to complete. You can monitor progress in the WebUI Dashboard by
    clicking the **Experiment** name. Notice that more trials have started:


### PR DESCRIPTION
Replaces #9101 because it is partly out of scope. Intended to be merged with #9113 