### PR TITLE
test: fix logging test typehint syntax error

### DIFF
--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -175,7 +175,7 @@ def test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: Any) 
 
 
 def check_logs(
-    log_regex: Any,
+    log_regex: re.Pattern,
     log_fn: Callable[..., Iterable[Log]],
     log_fields_fn: Callable[..., Iterable[LogFields]],
 ) -> None:

--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -18,7 +18,7 @@ Log = Union[bindings.v1TaskLogsResponse, bindings.v1TrialLogsResponse]
 LogFields = Union[bindings.v1TaskLogsFieldsResponse, bindings.v1TrialLogsFieldsResponse]
 
 
-def _test_trial_logs(log_regex: re.Pattern[str]) -> None:
+def _test_trial_logs(log_regex: re.Pattern) -> None:
     sess = api_utils.user_session()
 
     experiment_id = exp.run_basic_test(
@@ -69,9 +69,7 @@ def test_trial_logs() -> None:
     _test_trial_logs(log_regex)
 
 
-def _test_task_logs(
-    task_type: str, task_config: Dict[str, Any], log_regex: re.Pattern[str]
-) -> None:
+def _test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: re.Pattern) -> None:
     sess = api_utils.user_session()
 
     rps = bindings.get_GetResourcePools(sess)

--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -148,13 +148,13 @@ def _test_task_logs(
 @pytest.mark.e2e_cpu
 def test_tcd_startup_hook_task_combined() -> None:
     for ntsc in ["command", "notebook", "shell"]:
-        _test_task_logs(ntsc, {}, re.compile("^.*hello from rp tcd startup hook.*$"))
+        _test_task_logs(ntsc, {}, re.compile("^.*hello noooooop from rp tcd startup hook.*$"))
 
 
 @pytest.mark.e2e_cpu_elastic
 def test_tcd_startup_hook_task_master() -> None:
     for ntsc in ["command", "notebook", "shell"]:
-        _test_task_logs(ntsc, {}, re.compile("^.*hello from master tcd startup hook.*$"))
+        _test_task_logs(ntsc, {}, re.compile("^.*hello noooooop from master tcd startup hook.*$"))
 
 
 @pytest.mark.e2e_cpu

--- a/e2e_tests/tests/cluster/test_logging.py
+++ b/e2e_tests/tests/cluster/test_logging.py
@@ -146,13 +146,13 @@ def _test_task_logs(task_type: str, task_config: Dict[str, Any], log_regex: re.P
 @pytest.mark.e2e_cpu
 def test_tcd_startup_hook_task_combined() -> None:
     for ntsc in ["command", "notebook", "shell"]:
-        _test_task_logs(ntsc, {}, re.compile("^.*hello noooooop from rp tcd startup hook.*$"))
+        _test_task_logs(ntsc, {}, re.compile("^.*hello from rp tcd startup hook.*$"))
 
 
 @pytest.mark.e2e_cpu_elastic
 def test_tcd_startup_hook_task_master() -> None:
     for ntsc in ["command", "notebook", "shell"]:
-        _test_task_logs(ntsc, {}, re.compile("^.*hello noooooop from master tcd startup hook.*$"))
+        _test_task_logs(ntsc, {}, re.compile("^.*hello from master tcd startup hook.*$"))
 
 
 @pytest.mark.e2e_cpu


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

intentional failures https://app.circleci.com/pipelines/github/determined-ai/determined/53837/workflows/64c6bb5a-d27e-44ec-9846-58f58754474e

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ