### PR TITLE
fix: count determined-system pods as det pods [RM-148]

### DIFF
--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1441,7 +1441,6 @@ func (p *pods) computeSummary() (map[string]model.AgentSummary, error) {
 }
 
 func (p *pods) summarizeClusterByNodes() map[string]model.AgentSummary {
-	// TODO RM-148
 	var allPods []podNodeInfo
 
 	for _, p := range p.podNameToPodHandler {
@@ -1574,7 +1573,6 @@ func (p *pods) getNonDetPods() []k8sV1.Pod {
 		_, ok3 := p.Labels[determinedPreemptionLabel]
 
 		if !(ok1 || ok2 || ok3) {
-			logrus.Infof("getting NonDet Pods: %s,%s", p.Name, p.Labels)
 			if p.Spec.NodeName != "" {
 				nonDetPods = append(nonDetPods, p)
 			}

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1568,11 +1568,10 @@ func (p *pods) getNonDetPods() []k8sV1.Pod {
 		return nonDetPods
 	}
 	for _, p := range pList.Items {
-		_, ok1 := p.Labels[determinedLabel]
-		_, ok2 := p.Labels[determinedSystemLabel]
-		_, ok3 := p.Labels[determinedPreemptionLabel]
+		_, isDet := p.Labels[determinedLabel]
+		_, isDetSystem := p.Labels[determinedSystemLabel]
 
-		if !(ok1 || ok2 || ok3) {
+		if !(isDet || isDetSystem) {
 			if p.Spec.NodeName != "" {
 				nonDetPods = append(nonDetPods, p)
 			}

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1441,6 +1441,7 @@ func (p *pods) computeSummary() (map[string]model.AgentSummary, error) {
 }
 
 func (p *pods) summarizeClusterByNodes() map[string]model.AgentSummary {
+	// TODO RM-148
 	var allPods []podNodeInfo
 
 	for _, p := range p.podNameToPodHandler {
@@ -1568,7 +1569,12 @@ func (p *pods) getNonDetPods() []k8sV1.Pod {
 		return nonDetPods
 	}
 	for _, p := range pList.Items {
-		if _, ok := p.Labels["determined"]; !ok {
+		_, ok1 := p.Labels[determinedLabel]
+		_, ok2 := p.Labels[determinedSystemLabel]
+		_, ok3 := p.Labels[determinedPreemptionLabel]
+
+		if !(ok1 || ok2 || ok3) {
+			logrus.Infof("getting NonDet Pods: %s,%s", p.Name, p.Labels)
 			if p.Spec.NodeName != "" {
 				nonDetPods = append(nonDetPods, p)
 			}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
fix: count determined-system pods as det pods [RM-148]
-->
## Ticket
RM-148


## Description
If a pod has a "determined system", "determined preemption" OR "determined" label, don't count it as a "nonDet" pod. This fixes a bug where the db/master pods were counted twice as det pods & nonDet pods, and the master logs gave a `too many pods mapping to node` warning. 


## Test Plan
Spin up your own small CPU cluster (or use mine -- slack me for the IP), and check that there are `# of slots - 2 ` slots left in the "default RM". This means that the db & master pod are being counted just once (correct). If there are fewer slots available than expected, or no slots free, this means the pods are being double counted.
Additionally, try spinning up your own experiment and make sure you don't get the "too many pods" warning in your master logs.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[RM-148]: https://hpe-aiatscale.atlassian.net/browse/RM-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ