### PR TITLE
chore: add a devcluster.yaml for using multiple k8s clusters

### DIFF
--- a/tools/k8s/README.md
+++ b/tools/k8s/README.md
@@ -29,3 +29,7 @@ Read `tools/k8s/devcluster.yaml` so you know what it's doing, then run it:
 ```sh
 devcluster -c tools/k8s/devcluster.yaml
 ```
+
+## Extras
+
+Follow the instructions in the top of `multicluster.yaml` to get a Determined master connected to multiple Kubernetes clusters.

--- a/tools/k8s/multicluster.yaml
+++ b/tools/k8s/multicluster.yaml
@@ -1,0 +1,79 @@
+# To use this devcluster file, you need two kubeconfigs, ~/.kube/config and ~/.kube/extraconfig that point
+# at two separate clusters. You can do this many different ways; if you have no preference, try this:
+#  1. Run an extra cluster with `minikube start -p extra`. This overwrites your current kubeconfig context to point at
+#     it. Copy it with `cp ~/.kube/config ~/.kube/extraconfig` to get a config for your additional resource manager.
+#  2. Run minikube again with `minikube start`. This will start a default cluster "minikube" and set it as the current
+#     context in your ~/.kube/config.
+#  3. Run this devcluster file with `devcluster --oneshot --config tools/k8s/multi-devcluster.yaml` (or how you usually
+#     run devcluster) and Determined will connect to both clusters.
+
+commands:
+  p: make -C harness clean build  # rebuild Python
+  w: make -C webui build          # rebuild Webui
+  c: make -C docs build           # rebuild doCs
+
+stages:
+  - db:
+      port: 5432
+      db_name: determined
+      password: postgres
+      container_name: determined_db
+      image_name: "postgres:10.14"
+      data_dir: ~/.postgres
+
+  - master:
+      pre:
+        - sh: make -C proto build
+        - sh: make -C master build
+        - sh: make -C tools prep-root
+        - sh: mkdir -p /tmp/determined-cp
+      post:
+        - logcheck:
+            regex: accepting incoming connections on port
+      cmdline:
+        - master/build/determined-master
+        - --config-file
+        - :config
+
+      config_file:
+        db:
+          host: localhost
+          port: 5432
+          password: postgres
+          user: postgres
+          name: determined
+        checkpoint_storage:
+          type: shared_fs
+          host_path: /tmp/determined-cp
+        cache:
+          cache_dir: /tmp/determined-cache
+        log:
+          level: debug
+        enable_cors: true
+        root: tools/build
+
+        resource_manager:
+          type: kubernetes
+          namespace: default
+          max_slots_per_pod: 1
+          slot_type: "cpu"
+          slot_resource_requests:
+            cpu: 1
+          kubeconfig_path: ~/.kube/config
+          determined_master_ip: $DOCKER_LOCALHOST
+          determined_master_port: 8080
+        
+        additional_resource_managers:
+          - resource_manager:
+              name: extra
+              type: kubernetes
+              max_slots_per_pod: 1
+              slot_type: "cpu"
+              slot_resource_requests:
+                cpu: 1
+              kubeconfig_path: ~/.kube/extraconfig
+              determined_master_ip: $DOCKER_LOCALHOST
+              determined_master_port: 8080
+            resource_pools:
+              - pool_name: extra
+                kubernetes_namespace: default


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
RM-164


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add a devcluster file to run Determined across multiple Kubernetes clusters locally.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Needs no testing.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ