### PR TITLE
fix: single-searcher MNIST example runs for multiple epochs

### DIFF
--- a/examples/tutorials/mnist_pytorch/const.yaml
+++ b/examples/tutorials/mnist_pytorch/const.yaml
@@ -9,6 +9,6 @@ searcher:
   name: single
   metric: validation_loss
   max_length:
-      epochs: 1
+      epochs: 4
   smaller_is_better: true
 entrypoint: python3 train.py

--- a/examples/tutorials/mnist_pytorch/const.yaml
+++ b/examples/tutorials/mnist_pytorch/const.yaml
@@ -9,6 +9,6 @@ searcher:
   name: single
   metric: validation_loss
   max_length:
-      epochs: 4
+      batches: 1000  # approximately 1 epoch
   smaller_is_better: true
 entrypoint: python3 train.py


### PR DESCRIPTION
When this searcher is run for a single epoch it doesn't get a chance to report progress before the entire experiment is complete. This means that the progress bar in the web jumps from 0 to 100 in a step change.

The step-change makes it look like something is broken. This eliminates that (by switching the searcher to step on batches) and demonstrates that the progress bar is working.

[MLG-1522]

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[MLG-1522]: https://hpe-aiatscale.atlassian.net/browse/MLG-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ