### PR TITLE
ci: merge EE and OSS doc deploy together [INFENG-625]

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -76,9 +76,20 @@ check-links: attributions.rst
 	sphinx-build -b linkcheck . build -a || true
 	! grep -n broken build/output.txt
 
+# publish defaults to the deploy/Makefile default
 .PHONY: publish
 publish: pre-publish publish-check
 	$(MAKE) -C deploy publish
+
+.PHONY: publish-oss
+publish-oss: export DET_VARIANT ?= OSS
+publish-oss:
+	$(MAKE) publish
+
+.PHONY: publish-ee
+publish-ee: export DET_VARIANT ?= EE
+publish-ee:
+	$(MAKE) publish
 
 .PHONY: preview
 preview: build

--- a/docs/deploy/.gitignore
+++ b/docs/deploy/.gitignore
@@ -201,6 +201,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+tfplan
 
 # Ignore CLI configuration files
 .terraformrc

--- a/docs/deploy/Makefile
+++ b/docs/deploy/Makefile
@@ -1,4 +1,7 @@
 export TF_VAR_det_version := $(shell cat ../../VERSION)
+export DET_VARIANT ?= OSS
+export TF_VAR_det_variant := ${DET_VARIANT}
+export TF_CLI_ARGS_init :=  "-backend-config=backend_${DET_VARIANT}.conf"
 
 .PHONY: clean
 clean:
@@ -6,12 +9,12 @@ clean:
 	-rm state/terraform.tfstate.backup
 
 .PHONY: verify
-verify:
-	terraform --version
+verify: init
+	terraform validate
 
 .PHONY: init
 init:
-	terraform init -upgrade
+	terraform init -upgrade -reconfigure
 
 .PHONY: plan
 plan: init
@@ -24,4 +27,4 @@ publish: init
 .PHONY: check
 check: init
 	terraform fmt -check=true -diff=true
-	terraform validate
+	$(MAKE) terraform verify

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -1,0 +1,15 @@
+To deploy OSS:
+```shell
+export DET_VARIANT=OSS
+make publish
+```
+
+To deploy EE:
+```shell
+export DET_VARIANT=OSS
+make publish
+```
+
+Before running local terraform commands, set the DET_VARIANT variable to OSS or
+EE and run `make init`.  Terraform commands will then work as normal once the
+backend is changed to reflect the variant.

--- a/docs/deploy/backend_EE.conf
+++ b/docs/deploy/backend_EE.conf
@@ -1,0 +1,4 @@
+# EE S3 backend config parameters
+bucket = "hpe-mlde-docs-terraform"
+key    = "terraform.tfstate"
+region = "us-west-2"

--- a/docs/deploy/backend_OSS.conf
+++ b/docs/deploy/backend_OSS.conf
@@ -1,0 +1,4 @@
+# OSS S3 backend config parameters
+bucket = "determined-ai-docs-terraform"
+key    = "terraform.tfstate"
+region = "us-west-2"

--- a/docs/deploy/cdn.tf
+++ b/docs/deploy/cdn.tf
@@ -9,13 +9,13 @@ resource "aws_cloudfront_distribution" "distribution" {
 
     domain_name = aws_s3_bucket_website_configuration.docs.website_endpoint
 
-    origin_id = local.domain
+    origin_id = local.config.domain
   }
 
   enabled             = true
   default_root_object = "index.html"
   aliases = [
-    local.domain,
+    local.config.domain,
   ]
 
   default_cache_behavior {
@@ -24,7 +24,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     allowed_methods        = ["GET", "HEAD"]
     cached_methods         = ["GET", "HEAD"]
 
-    target_origin_id = local.domain
+    target_origin_id = local.config.domain
     min_ttl          = 0
     default_ttl      = 3600
     max_ttl          = 31536000
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = "arn:aws:acm:us-east-1:573932760021:certificate/3f5a03d6-d95b-4d08-ade3-994799c658cf"
+    acm_certificate_arn = local.config.cdn.acm_certificate_arn
     ssl_support_method  = "sni-only"
   }
 }

--- a/docs/deploy/input.tf
+++ b/docs/deploy/input.tf
@@ -2,7 +2,15 @@ variable "det_version" {
   type        = string
   description = "The Determined version the docs are currently built under"
 }
+variable "det_variant" {
+  type        = string
+  description = "The Determined variant the docs are currently built under"
+  validation {
+    condition = contains(["EE", "OSS"], var.det_variant)
+    error_message = "The variant must be one of OSS or EE"
+  }
+}
 
 locals {
-  domain = "docs.determined.ai"
+  config = yamldecode(file("${path.module}/vars_${var.det_variant}.yaml"))
 }

--- a/docs/deploy/main.tf
+++ b/docs/deploy/main.tf
@@ -2,9 +2,7 @@ terraform {
   required_version = "~> 1.0"
 
   backend "s3" {
-    bucket = "determined-ai-docs-terraform"
-    key    = "terraform.tfstate"
-    region = "us-west-2"
+    # defined in backend_*.conf
   }
 
   required_providers {

--- a/docs/deploy/s3.tf
+++ b/docs/deploy/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "docs" {
-  bucket = "determined-ai-docs"
+  bucket = local.config.s3.bucket
 }
 
 # Set bucket object ownership if possible
@@ -86,10 +86,12 @@ resource "aws_s3_object" "index" {
 resource "aws_s3_object" "robots" {
   bucket       = aws_s3_bucket.docs.id
   key          = "robots.txt"
-  content      = "User-agent: *\nSitemap: https://docs.determined.ai/latest/sitemap.xml"
+  content      = local.config.s3.robots.content
   content_type = "text"
 }
 
+# TODO: replace deprecated null_resource with terraform_data
+# https://developer.hashicorp.com/terraform/language/resources/terraform-data
 resource "null_resource" "upload" {
   triggers = {
     version = "${var.det_version}"

--- a/docs/deploy/vars_EE.yaml
+++ b/docs/deploy/vars_EE.yaml
@@ -1,0 +1,8 @@
+---
+domain: "hpe-mlde.determined.ai"
+cdn:
+  acm_certificate_arn: "arn:aws:acm:us-east-1:573932760021:certificate/f117a2ed-a377-4a71-b42e-d00c9339adff"
+s3:
+  bucket: "hpe-mlde-docs"
+  robots:
+    content: "User-agent: *\nSitemap: https://hpe-mlde.determined.ai/latest/sitemap.xml"

--- a/docs/deploy/vars_OSS.yaml
+++ b/docs/deploy/vars_OSS.yaml
@@ -1,0 +1,8 @@
+---
+domain: "docs.determined.ai"
+cdn:
+  acm_certificate_arn: "arn:aws:acm:us-east-1:573932760021:certificate/3f5a03d6-d95b-4d08-ade3-994799c658cf"
+s3:
+  bucket: "determined-ai-docs"
+  robots:
+    content: "User-agent: *\nSitemap: https://docs.determined.ai/latest/sitemap.xml"


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Make the code for both doc deploy mechanisms the same with some variables to configure instead of directly editing the terraform.  Add convenience method for publish-oss and publish-ee, but setting the DET_VARIANT env var before calling publish (or publish-ee or publish-oss) will override the default, which is currently OSS.

Note that, if EE continues to exist separately, one should probably change the docs/deploy/Makefile's `DET_VARIANT` variable default to EE in order to maintain complete backwards compatibility.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Tested locally with `make plan` to verify everything aligns on both versions.  Real test will be in the next release, but it should be fine. :D

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ