### PR TITLE
trying a clean PR

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -120,6 +120,9 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 			return nil, launchWarnings, err
 		}
 	}
+	if w, _ := a.GetWorkspaceByID(ctx, int32(cmdSpec.Metadata.WorkspaceID), *userModel, false); w != nil {
+		taskSpec.Workspace = w.Name
+	}
 	workDirInDefaults := config.WorkDir
 	if len(configBytes) != 0 {
 		dec := json.NewDecoder(bytes.NewBuffer(configBytes))

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1603,6 +1603,7 @@ func TestAuthZCreateExperiment(t *testing.T) {
 func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
 	authZNSC := setupNSCAuthZ()
+	workspaceAuthZ := setupWorkspaceAuthZ()
 	exp := createTestExp(t, api, curUser)
 
 	// put/patch
@@ -1739,6 +1740,8 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 		{"CanGetExperimentArtifacts", func(id int) error {
 			authZNSC.On("CanGetTensorboard", mock.Anything, mockUserArg, mock.Anything, mock.Anything,
 				mock.Anything).Return(nil).Once()
+			workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Once()
 			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
 				ExperimentIds: []int32{int32(id)},
 			})

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -306,6 +306,7 @@ func TestAuthZCanSetNSCsPriority(t *testing.T) {
 
 func TestAuthZCanCreateNSC(t *testing.T) {
 	api, authz, curUser, ctx := setupNTSCAuthzTest(t)
+	workspaceAuthZ := setupWorkspaceAuthZ()
 	var err error
 
 	mockUserArg := mock.MatchedBy(func(u model.User) bool {
@@ -316,6 +317,8 @@ func TestAuthZCanCreateNSC(t *testing.T) {
 	authz.On("CanCreateNSC", mock.Anything, mockUserArg, mock.Anything).Return(
 		authz2.PermissionDeniedError{},
 	).Times(3)
+	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Times(3)
 	_, err = api.LaunchNotebook(ctx, &apiv1.LaunchNotebookRequest{})
 	require.Equal(t, codes.PermissionDenied, status.Code(err))
 	_, err = api.LaunchCommand(ctx, &apiv1.LaunchCommandRequest{})
@@ -327,6 +330,8 @@ func TestAuthZCanCreateNSC(t *testing.T) {
 	authz.On("CanCreateNSC", mock.Anything, mockUserArg, mock.Anything).Return(
 		errors.New("other error"),
 	).Times(3)
+	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Times(3)
 	_, err = api.LaunchNotebook(ctx, &apiv1.LaunchNotebookRequest{})
 	require.NotNil(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -220,6 +220,7 @@ func (a *apiServer) LaunchTensorboard(
 		return nil, status.Errorf(codes.Internal, "failed to get the user: %s", err)
 	}
 
+	// FIXME we call canGetWorkspace or something here
 	launchReq, launchWarnings, err := a.getCommandLaunchParams(ctx, &protoCommandParams{
 		TemplateName: req.TemplateName,
 		WorkspaceID:  req.WorkspaceId,

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -664,6 +664,7 @@ func TestUnusualMetricNames(t *testing.T) {
 func TestTrialAuthZ(t *testing.T) {
 	api, authZExp, _, curUser, ctx := setupExpAuthTest(t, nil)
 	authZNSC := setupNSCAuthZ()
+	workspaceAuthZ := setupWorkspaceAuthZ()
 	trial, _ := createTestTrial(t, api, curUser)
 
 	mockUserArg := mock.MatchedBy(func(u model.User) bool {
@@ -788,6 +789,8 @@ func TestTrialAuthZ(t *testing.T) {
 		{"CanGetExperimentArtifacts", func(id int) error {
 			authZNSC.On("CanGetTensorboard", mock.Anything, mockUserArg, mock.Anything, mock.Anything,
 				mock.Anything).Return(nil).Once()
+			workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil).Times(1)
 			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
 				TrialIds: []int32{int32(id)},
 			})

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -333,6 +333,14 @@ func setupWorkspaceAuthZTest(
 	return api, wAuthZ, curUser, ctx
 }
 
+func setupWorkspaceAuthZ() *mocks.WorkspaceAuthZ {
+	if wAuthZ == nil {
+		wAuthZ = &mocks.WorkspaceAuthZ{}
+		workspace.AuthZProvider.Register("mock", wAuthZ)
+	}
+	return wAuthZ
+}
+
 func TestAuthzGetWorkspace(t *testing.T) {
 	api, workspaceAuthZ, _, ctx := setupWorkspaceAuthZTest(t, nil)
 	// Deny returns same as 404.

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -386,8 +386,8 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 		dbExp.Username = owner.Username
 	}
 
-	taskSpec.Project = config.Project()
-	taskSpec.Workspace = config.Workspace()
+	taskSpec.Project = p.Name
+	taskSpec.Workspace = workspaceModel.Name
 	for label := range config.Labels() {
 		taskSpec.Labels = append(taskSpec.Labels, label)
 	}

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -35,8 +35,15 @@ import (
 const (
 	coscheduler = "coscheduler"
 
-	gcTask  = "gc"
-	cmdTask = "cmd"
+	gcTask            = "gc"
+	cmdTask           = "cmd"
+	labelPrefix       = "determined.ai/"
+	userLabel         = labelPrefix + "user"
+	workspaceLabel    = labelPrefix + "workspace"
+	resourcePoolLabel = labelPrefix + "resource_pool"
+	taskTypeLabel     = labelPrefix + "task_type"
+	taskIDLabel       = labelPrefix + "task_id"
+	containerIDLabel  = labelPrefix + "container_id"
 )
 
 func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {
@@ -361,7 +368,23 @@ func (p *pod) configurePodSpec(
 	if podSpec.ObjectMeta.Labels == nil {
 		podSpec.ObjectMeta.Labels = make(map[string]string)
 	}
+	// add determined metadata as pod labels
+	if p.submissionInfo.taskSpec.Owner != nil {
+		// note: owner label will disappear if Owner is somehow nil
+		podSpec.ObjectMeta.Labels[userLabel] = p.submissionInfo.taskSpec.Owner.Username
+	}
+	podSpec.ObjectMeta.Labels[workspaceLabel] = p.submissionInfo.taskSpec.Workspace
+	podSpec.ObjectMeta.Labels[resourcePoolLabel] = p.req.ResourcePool
+	podSpec.ObjectMeta.Labels[taskTypeLabel] = string(p.submissionInfo.taskSpec.TaskType)
+	podSpec.ObjectMeta.Labels[taskIDLabel] = p.submissionInfo.taskSpec.TaskID
+	podSpec.ObjectMeta.Labels[containerIDLabel] = p.submissionInfo.taskSpec.ContainerID
 	podSpec.ObjectMeta.Labels[determinedLabel] = p.submissionInfo.taskSpec.AllocationID
+
+	// add any extra pod labels from task spec
+	// note: if map is not populated, labels will be missing and observability will be impacted
+	for k, v := range p.submissionInfo.taskSpec.ExtraPodLabels {
+		podSpec.ObjectMeta.Labels[labelPrefix+k] = v
+	}
 
 	p.modifyPodSpec(podSpec, scheduler)
 

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/pkg/tasks"
 
 	k8sV1 "k8s.io/api/core/v1"
 )
@@ -218,4 +219,43 @@ func TestAllPrintableCharactersInEnv(t *testing.T) {
 	require.Contains(t, actual, k8sV1.EnvVar{Name: "test", Value: expectedValue})
 	require.Contains(t, actual, k8sV1.EnvVar{Name: "test2", Value: ""})
 	require.Contains(t, actual, k8sV1.EnvVar{Name: "func", Value: "f(x)=x"})
+}
+
+func TestDeterminedLabels(t *testing.T) {
+	// fill out task spec
+	taskSpec := tasks.TaskSpec{
+		Owner:       createUser(),
+		Workspace:   "test-workspace",
+		TaskType:    model.TaskTypeCommand,
+		TaskID:      model.NewTaskID().String(),
+		ContainerID: "container-id",
+	}
+
+	p := pod{
+		req: &sproto.AllocateRequest{
+			ResourcePool: "test-rp",
+		},
+		submissionInfo: &podSubmissionInfo{
+			taskSpec: taskSpec,
+		},
+	}
+
+	// define expectations
+	expectedLabels := map[string]string{
+		userLabel:         taskSpec.Owner.Username,
+		workspaceLabel:    taskSpec.Workspace,
+		resourcePoolLabel: p.req.ResourcePool,
+		taskTypeLabel:     string(taskSpec.TaskType),
+		taskIDLabel:       taskSpec.TaskID,
+		containerIDLabel:  taskSpec.ContainerID,
+	}
+
+	spec := p.configurePodSpec(make([]k8sV1.Volume, 1), k8sV1.Container{},
+		k8sV1.Container{}, make([]k8sV1.Container, 1), &k8sV1.Pod{}, "scheduler")
+
+	// confirm pod spec has required labels
+	require.NotNil(t, spec)
+	for expectedKey, expectedValue := range expectedLabels {
+		require.Equal(t, spec.ObjectMeta.Labels[expectedKey], expectedValue)
+	}
 }

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -85,6 +85,7 @@ type TaskSpec struct {
 	AgentUserGroup        *model.AgentUserGroup
 	ExtraArchives         []cproto.RunArchive
 	ExtraEnvVars          map[string]string
+	ExtraPodLabels        map[string]string
 	Entrypoint            []string
 	Mounts                []mount.Mount
 	// UseHostMode is whether host mode networking would be desirable for this task.

--- a/master/pkg/tasks/task_trial.go
+++ b/master/pkg/tasks/task_trial.go
@@ -132,6 +132,13 @@ func (s TrialSpec) ToTaskSpec() TaskSpec {
 		res.ExtraEnvVars = envVars
 	}
 
+	// populate extra pod labels for observability
+	podLabels := map[string]string{
+		"experiment_id": strconv.Itoa(s.ExperimentID),
+		"trial_id":      strconv.Itoa(s.TrialID),
+	}
+	res.ExtraPodLabels = podLabels
+
 	if shm := s.ExperimentConfig.Resources().ShmSize(); shm != nil {
 		res.ShmSize = int64(*shm)
 	}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ