### PR TITLE
docs: remove max supported k8s version.

### DIFF
--- a/docs/setup-cluster/k8s/install-on-kubernetes.rst
+++ b/docs/setup-cluster/k8s/install-on-kubernetes.rst
@@ -39,8 +39,7 @@ should be configured by editing the ``values.yaml`` and ``Chart.yaml`` files in 
 Before installing Determined on a Kubernetes cluster, please ensure that the following prerequisites
 are satisfied:
 
--  The Kubernetes cluster should be running Kubernetes version >= 1.21 and <= 1.25, though later
-   versions may work.
+-  The Kubernetes cluster should be running Kubernetes version >= 1.21.
 
 -  You should have access to the cluster via `kubectl <https://kubernetes.io/docs/tasks/tools/>`_.
 


### PR DESCRIPTION
## Description

Take out the max k8s version because that restriction is meaningless and only causes user confusion https://determined-community.slack.com/archives/CV3MTNZ6U/p1713214201626689

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
