### PR TITLE
chore: add typing annotations for zmq

### DIFF
--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -65,7 +65,7 @@ class ZMQBroadcastServer:
 
         import zmq
 
-        context = zmq.Context()
+        context = zmq.Context() # type: zmq.Context[zmq.Socket[bytes]]
 
         self._pub_socket = context.socket(zmq.PUB)
         self._pull_socket = context.socket(zmq.PULL)
@@ -176,7 +176,7 @@ class ZMQBroadcastClient:
     def __init__(self, srv_pub_url: str, srv_pull_url: str) -> None:
         import zmq
 
-        context = zmq.Context()
+        context = zmq.Context() # type: zmq.Context[zmq.Socket[bytes]]
 
         self._sub_socket = context.socket(zmq.SUB)
         # Subscriber always listens to ALL messages.

--- a/harness/determined/ipc.py
+++ b/harness/determined/ipc.py
@@ -65,7 +65,7 @@ class ZMQBroadcastServer:
 
         import zmq
 
-        context = zmq.Context() # type: zmq.Context[zmq.Socket[bytes]]
+        context = zmq.Context()  # type: zmq.Context[zmq.Socket[bytes]]
 
         self._pub_socket = context.socket(zmq.PUB)
         self._pull_socket = context.socket(zmq.PULL)
@@ -176,7 +176,7 @@ class ZMQBroadcastClient:
     def __init__(self, srv_pub_url: str, srv_pull_url: str) -> None:
         import zmq
 
-        context = zmq.Context() # type: zmq.Context[zmq.Socket[bytes]]
+        context = zmq.Context()  # type: zmq.Context[zmq.Socket[bytes]]
 
         self._sub_socket = context.socket(zmq.SUB)
         # Subscriber always listens to ALL messages.


### PR DESCRIPTION
## Ticket
None



## Description
Fix linting issue with `mypy`. zmq.Context is generic and needs a type. Adding the default type as referenced in [zmq docs](https://pyzmq.readthedocs.io/en/latest/api/zmq.html)



## Test Plan
lint-python passes



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.
