### PR TITLE
fix: better exception handling in detached mode

### DIFF
--- a/e2e_tests/tests/fixtures/unmanaged/error_termination.py
+++ b/e2e_tests/tests/fixtures/unmanaged/error_termination.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Demonstrate an experiment which errors out.
-
+import os
 import random
 import tempfile
 
@@ -9,12 +9,19 @@ from determined.experimental import core_v2
 
 
 def main():
+    assert "DET_TEST_EXTERNAL_EXP_ID" in os.environ
+    name = os.environ["DET_TEST_EXTERNAL_EXP_ID"]
+
     checkpoint_storage = tempfile.mkdtemp()
     core_v2.init(
         defaults=core_v2.DefaultConfig(
-            name="unmanaged-1-error",
+            name=name,
         ),
         checkpoint_storage=checkpoint_storage,
+        unmanaged=core_v2.UnmanagedConfig(
+            external_experiment_id=name,
+            external_trial_id=name,
+        ),
     )
 
     for i in range(100):

--- a/harness/determined/core/_log_shipper.py
+++ b/harness/determined/core/_log_shipper.py
@@ -1,4 +1,3 @@
-import atexit
 import collections
 import datetime
 import logging
@@ -186,12 +185,7 @@ class _UnmanagedTrialLogShipper(_LogShipper):
 
         self._log_sender.start()
 
-        atexit.register(self._exit_handler)
-
         return self
-
-    def _exit_handler(self) -> None:
-        self.close()
 
     def close(
         self,
@@ -199,8 +193,6 @@ class _UnmanagedTrialLogShipper(_LogShipper):
         exc_val: Optional[BaseException] = None,
         exc_tb: Optional[types.TracebackType] = None,
     ) -> "_LogShipper":
-        atexit.unregister(self._exit_handler)
-
         sys.stdout, sys.stderr = self._original_stdout, self._original_stderr
         self._log_sender.close()
         self._log_sender.join()


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

 
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->


in `_LogShipper` and `_Heartbeat`, atexit handlers never get called, since `_core_v2` registers an `atexit` on start, and on interpreter exit the latter atexit gets triggered and calls `close()` on `_LogShipper` and `_Heartbeat` which deregisters the handlers.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

run a detached mode experiment that throws an error:


```
import random
import tempfile
from determined.experimental import core_v2


def main():
    checkpoint_storage = tempfile.mkdtemp()
    core_v2.init(
        defaults=core_v2.DefaultConfig(
            name="unmanaged-1-error",
        ),
        checkpoint_storage=checkpoint_storage,
    )

    for i in range(100):
        core_v2.train.report_training_metrics(steps_completed=i, metrics={"loss": random.random()})
        if i == 15:
            raise ValueError("oops")
        if (i + 1) % 10 == 0:
            core_v2.train.report_validation_metrics(
                steps_completed=i, metrics={"loss": random.random()}
            )
    core_v2.close()


if __name__ == "__main__":
    main()
```
ensure that the trial does not hang, logs show the value error, and trial/exp is terminated in an ERROR state.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ