### PR TITLE
fix: louden server errors coming from deleteCheckpoints

### DIFF
--- a/webui/react/src/components/CheckpointModal.tsx
+++ b/webui/react/src/components/CheckpointModal.tsx
@@ -15,7 +15,7 @@ import {
   ExperimentConfig,
 } from 'types';
 import { formatDatetime } from 'utils/datetime';
-import handleError from 'utils/error';
+import handleError, { DetError, ErrorType } from 'utils/error';
 import { humanReadableBytes } from 'utils/string';
 import { checkpointSize } from 'utils/workload';
 
@@ -88,6 +88,9 @@ const CheckpointModalComponent: React.FC<Props> = ({
     try {
       await deleteCheckpoints({ checkpointUuids: [checkpoint.uuid] });
     } catch (e) {
+      if (e instanceof DetError && e.type === ErrorType.Server) {
+        e.silent = false;
+      }
       // modal error handling overwrites error message
       handleError(e);
     }

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCheckpoints.tsx
@@ -37,7 +37,7 @@ import {
 } from 'types';
 import { canActionCheckpoint, getActionsForCheckpointsUnion } from 'utils/checkpoint';
 import { ensureArray } from 'utils/data';
-import handleError, { ErrorLevel, ErrorType } from 'utils/error';
+import handleError, { DetError, ErrorLevel, ErrorType } from 'utils/error';
 import { validateDetApiEnum, validateDetApiEnumList } from 'utils/service';
 import { pluralizer } from 'utils/string';
 
@@ -130,6 +130,9 @@ const ExperimentCheckpoints: React.FC<Props> = ({ experiment, pageRef }: Props) 
     try {
       await deleteCheckpoints({ checkpointUuids });
     } catch (e) {
+      if (e instanceof DetError && e.type === ErrorType.Server) {
+        e.silent = false;
+      }
       // confirm modal overwrites error message
       handleError(e);
     }


### PR DESCRIPTION

## Ticket
ET-169


## Description
Server errors are silenced by default in production -- this pr undoes that for the server errors coming from deletecheckpoints.



## Test Plan
same as #9178 


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ