### PR TITLE
ci: do dry runs of `publish-docs` for RCs

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1414,6 +1414,9 @@ jobs:
       ee:
         type: boolean
         default: false
+      dry-run:
+        type: boolean
+        default: false
     docker:
       - image: hashicorp/terraform:latest
     steps:
@@ -1423,10 +1426,21 @@ jobs:
       - run: apk add make curl
       - run: pip install --user awscli  # used in the terraform apply
       - run: |
-          if <<parameters.ee>>; then
-            make -C docs publish-ee
+          if <<parameters.dry-run>>; then
+            echo 'Doing a dry run!'
+            if <<parameters.ee>>; then
+              export DET_VARIANT=EE
+            else
+              export DET_VARIANT=OSS
+            fi
+            make -C docs pre-publish publish-check
+            make -C docs/deploy plan
           else
-            make -C docs publish-oss
+            if <<parameters.ee>>; then
+              make -C docs publish-ee
+            else
+              make -C docs publish-oss
+            fi
           fi
 
   # TODO(danh): eventually replace 'publish-docs' with this new workflow after
@@ -5351,6 +5365,16 @@ workflows:
           filters: *release-filters
           requires:
             - package-and-push-system-release
+
+      - publish-docs:
+          name: publish-docs-rc
+          matrix:
+            parameters:
+              dry-run: [true]
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *rc-filters
 
       - publish-docs:
           requires:


### PR DESCRIPTION
## Description

In several recent releases, the final `publish-docs` has failed to complete, since it has no way of being tested beforehand. This adds a version of the job that runs on RCs and does most of the same things but stops short of the actual publish.

Ideally, we would have an even more complete dry run that did an actual publish to some sort of staging environment, but that would be rather more involved to set up and I believe this much of a dry run would already have caught the recent failures.

## Test Plan

- [ ] check that CircleCI at least does not reject the change as syntactically incorrect
- [ ] watch the dry run job during the next release
