### PR TITLE
chore: make multi-RM an EE-only feature [RM-166]

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1109,6 +1109,7 @@ func buildRM(
 			return nil, fmt.Errorf("no expected resource manager config is defined")
 		}
 	}
+
 	return multirm.New(defaultRMName, rms), nil
 }
 

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1083,6 +1083,9 @@ func buildRM(
 		}
 	}
 
+	// If multiple resource managers are defined, require license.
+	license.RequireLicense("multiple resource managers")
+
 	// Set the default RM name for the multi-rm, from the default RM index.
 	defaultRMName := rmConfigs[config.DefaultRMIndex].ResourceManager.Name()
 	rms := map[string]rm.ResourceManager{}
@@ -1106,7 +1109,6 @@ func buildRM(
 			return nil, fmt.Errorf("no expected resource manager config is defined")
 		}
 	}
-
 	return multirm.New(defaultRMName, rms), nil
 }
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
chore: make multi-RM an EE-only feature
-->

## Ticket
RM-166


## Description
Check for EE license when trying to start up Determined with multiple resource managers defined.

## Test Plan
Follow instructions at tools/k8s/multicluster.yaml, without a valid license, and confirm that the cluster crashes upon start-up. Then, with a valid license, try starting up the cluster again & confirm that it starts up successfully.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ