### PR TITLE
Fix: Skip expected error from web socket

### DIFF
--- a/master/internal/stream/publisher.go
+++ b/master/internal/stream/publisher.go
@@ -178,7 +178,12 @@ func (ps *PublisherSet) streamHandler(
 	var startupMsg StartupMsg
 	err := socket.ReadJSON(&startupMsg)
 	if err != nil {
-		return fmt.Errorf("error while reading initial startup message: %s", err.Error())
+		if websocket.IsUnexpectedCloseError(
+			err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure,
+		) {
+			return fmt.Errorf("error while reading initial startup message: %s", err.Error())
+		}
+		return nil
 	}
 
 	// startups is where we collect StartupMsg


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[MD-363](https://hpe-aiatscale.atlassian.net/browse/MD-363)


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
When the web socket connection closes from client side, server side read would receive expected error, and it can be confusing if displayed. 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Monitor the master log, then refresh the webpage, there should not be any error regarding web socket


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
