### PR TITLE
test: can't launch NSC test assert 404 instead of 403

### DIFF
--- a/e2e_tests/tests/cluster/test_rbac_ntsc.py
+++ b/e2e_tests/tests/cluster/test_rbac_ntsc.py
@@ -186,14 +186,9 @@ def test_ntsc_iface_access() -> None:
             assert "access denied" in fe.value.message
             # user 1 should be able to launch tensorboards but not NSCs in workspace 0.
             only_tensorboard_can_launch(creds[1], workspaces[0].id, typ, experiment_id)
-            # tensorboard requires workspace access so returns workspace not found if
-            # the user does not have access to the workspace.
-            if typ == api.NTSC_Kind.tensorboard:
-                with pytest.raises(errors.NotFoundException):
-                    api_utils.launch_ntsc(creds[1], workspaces[1].id, typ, experiment_id)
-            else:
-                with pytest.raises(errors.ForbiddenException):
-                    api_utils.launch_ntsc(creds[1], workspaces[1].id, typ, experiment_id)
+            # Don't leak workspace information to a user without access.
+            with pytest.raises(errors.NotFoundException):
+                api_utils.launch_ntsc(creds[1], workspaces[1].id, typ, experiment_id)
 
             # user 2
             assert not can_access_logs(

--- a/e2e_tests/tests/cluster/test_rbac_ntsc.py
+++ b/e2e_tests/tests/cluster/test_rbac_ntsc.py
@@ -206,12 +206,8 @@ def test_ntsc_iface_access() -> None:
                 # user 2 should not be able to set priority or know it exists.
                 api_utils.set_prio_ntsc(creds[2], typ, created_id, 1)
             assert e.value.status_code == 404, f"user 2 should not be able to set priority {typ}"
-            if typ == api.NTSC_Kind.tensorboard:
-                with pytest.raises(errors.NotFoundException):
-                    api_utils.launch_ntsc(creds[2], workspaces[0].id, typ, experiment_id)
-            else:
-                with pytest.raises(errors.ForbiddenException):
-                    api_utils.launch_ntsc(creds[2], workspaces[0].id, typ, experiment_id)
+            with pytest.raises(errors.NotFoundException):
+                api_utils.launch_ntsc(creds[2], workspaces[0].id, typ, experiment_id)
             # user 2 has view access to workspace 1 so gets forbidden instead of not found.
             with pytest.raises(errors.ForbiddenException):
                 api_utils.launch_ntsc(creds[2], workspaces[1].id, typ, experiment_id)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Fix failing test after this
https://github.com/determined-ai/determined/pull/9140

Notebooks, tensorboards, shells and commands should return 404 trying to launch a workspace you don't have access to.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
test passes


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ