### PR TITLE
test: ee and oss have separate handling

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1983,6 +1983,10 @@ jobs:
             - webui/react/build
 
   test-e2e-react:
+  parameters:
+      ee:
+        type: boolean
+        default: false
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: large
@@ -2003,8 +2007,11 @@ jobs:
           determined: true
           install-python: true
           executor: <<pipeline.parameters.machine-image>>
-      - install-protoc
-      - license-gen
+      - install-protoc 
+      - when:
+          condition: << parameters.ee >>
+          steps:
+            - license-gen
       - run: PATH=$HOME/.local/bin:$PATH make -C proto get-deps
       - run: PATH=$HOME/.local/bin:$PATH make -C proto build
       - run: make -C master get-deps
@@ -2023,6 +2030,7 @@ jobs:
           PW_SERVER_ADDRESS=${PW_SERVER_ADDRESS} \
           DET_WEBPACK_PROXY_URL=${DET_WEBPACK_PROXY_URL} \
           DET_WEBPACK_PROXY_URL=${DET_WEBSOCKET_PROXY_URL} \
+          PW_EE=<< parameters.ee >> \
           npm run e2e --prefix webui/react
       - store_artifacts:
           path: webui/react/src/e2e/playwright-report

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2094,6 +2094,9 @@ jobs:
       - run: make -C agent check
 
   build-go:
+    ee:
+        type: boolean
+        default: true
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -4146,6 +4149,7 @@ workflows:
             - build-helm
             - build-proto
       - build-go:
+          ee: false
           context: github-read
 
       - package-and-push-system-local:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2024,14 +2024,10 @@ jobs:
       - wait-for-master:
           host: "localhost"
           port: "8082"
-      - run: |
-          PW_USER_NAME=${PW_USER_NAME} \
-          PW_PASSWORD=${PW_PASSWORD} \
-          PW_SERVER_ADDRESS=${PW_SERVER_ADDRESS} \
-          DET_WEBPACK_PROXY_URL=${DET_WEBPACK_PROXY_URL} \
-          DET_WEBPACK_PROXY_URL=${DET_WEBSOCKET_PROXY_URL} \
-          PW_EE=<< parameters.ee >> \
-          npm run e2e --prefix webui/react
+      - run: 
+          environment:
+            PW_EE: << parameters.ee >> 
+          command: npm run e2e --prefix webui/react
       - store_artifacts:
           path: webui/react/src/e2e/playwright-report
       - store_artifacts:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1983,7 +1983,7 @@ jobs:
             - webui/react/build
 
   test-e2e-react:
-  parameters:
+    parameters:
       ee:
         type: boolean
         default: false

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2094,7 +2094,8 @@ jobs:
       - run: make -C agent check
 
   build-go:
-    ee:
+    parameters:
+      ee:
         type: boolean
         default: true
     docker:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4223,6 +4223,7 @@ workflows:
       - build-react:
           dev-mode: true
       - test-e2e-react:
+          ee: true
           requires:
             - build-go
           context:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2012,9 +2012,6 @@ jobs:
           condition: << parameters.ee >>
           steps:
             - license-gen
-      - run: rm -f ./public.txt
-      - run: rm -f ./license.txt
-      - run: ls -lf # DNJ TODO - debug, remove
       - run: PATH=$HOME/.local/bin:$PATH make -C proto get-deps
       - run: PATH=$HOME/.local/bin:$PATH make -C proto build
       - run: make -C master get-deps

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2108,7 +2108,10 @@ jobs:
       - skip-if-only-docs
       - skip-if-only-github
       - reinstall-go
-      - license-gen
+      - when:
+          condition: << parameters.ee >>
+          steps:
+            - license-gen
       - restore_cache:
           keys:
             - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2012,6 +2012,9 @@ jobs:
           condition: << parameters.ee >>
           steps:
             - license-gen
+      - run: rm -f ./public.txt
+      - run: rm -f ./license.txt
+      - run: ls -lf # DNJ TODO - debug, remove
       - run: PATH=$HOME/.local/bin:$PATH make -C proto get-deps
       - run: PATH=$HOME/.local/bin:$PATH make -C proto build
       - run: make -C master get-deps

--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -84,8 +84,8 @@ export default defineConfig({
     baseURL: `http://localhost:${port}/`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
-    video: 'retain-on-failure'
+    trace: 'on', // dnj TODO -debug
+    video: 'on'
   },
 
   /* Run your local dev server before starting the tests */

--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -84,8 +84,8 @@ export default defineConfig({
     baseURL: `http://localhost:${port}/`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on', // dnj TODO -debug
-    video: 'on'
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure'
   },
 
   /* Run your local dev server before starting the tests */

--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 
   /* https://playwright.dev/docs/test-timeouts#global-timeout */
   globalTimeout: process.env.PWDEBUG ? 0 : 5 * 60 * 1000, // 3 min unless debugging
-  timeout: 60000, // TODO [INFENG-628] Users page loads slow so we extend 5 minutes and 1 minute per test until we get an isolated backend
+  timeout: 90000, // TODO [INFENG-628] Users page loads slow so we extend 5 minutes and 1 minute per test until we get an isolated backend
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: './src/e2e/test-results',
 

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -5,8 +5,14 @@ import { BasePage } from 'e2e/models/BasePage';
 
 export class DevFixture {
   readonly #page: Page;
+  static readonly constants = {
+    isEE: !!process.env.PW_EE,
+    appTitle: !!process.env.PW_EE ? 'HPE Machine Learning Development Environment' : 'Determined',
+  }
+
   constructor(readonly page: Page) {
     this.#page = page;
+    Object.freeze(DevFixture.constants)
   }
 
   async setServerAddress(): Promise<void> {

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -5,17 +5,9 @@ import { BasePage } from 'e2e/models/BasePage';
 
 export class DevFixture {
   readonly #page: Page;
-  private static eeEnvironmentValue = Boolean(JSON.parse(process.env.PW_EE ?? ''));
-  static readonly constants = {
-    isEE: DevFixture.eeEnvironmentValue,
-    appTitle: DevFixture.eeEnvironmentValue
-      ? 'HPE Machine Learning Development Environment'
-      : 'Determined',
-  };
 
   constructor(readonly page: Page) {
     this.#page = page;
-    Object.freeze(DevFixture.constants);
   }
 
   async setServerAddress(): Promise<void> {

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -5,7 +5,6 @@ import { BasePage } from 'e2e/models/BasePage';
 
 export class DevFixture {
   readonly #page: Page;
-
   constructor(readonly page: Page) {
     this.#page = page;
   }

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -8,8 +8,10 @@ export class DevFixture {
   private static eeEnvironmentValue = Boolean(JSON.parse(process.env.PW_EE ?? ''));
   static readonly constants = {
     isEE: DevFixture.eeEnvironmentValue,
-    appTitle: DevFixture.eeEnvironmentValue ? 'HPE Machine Learning Development Environment' : 'Determined',
-  }
+    appTitle: DevFixture.eeEnvironmentValue
+      ? 'HPE Machine Learning Development Environment'
+      : 'Determined',
+  };
 
   constructor(readonly page: Page) {
     this.#page = page;

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -5,14 +5,15 @@ import { BasePage } from 'e2e/models/BasePage';
 
 export class DevFixture {
   readonly #page: Page;
+  private static eeEnvironmentValue = Boolean(JSON.parse(process.env.PW_EE ?? ''));
   static readonly constants = {
-    isEE: !!process.env.PW_EE,
-    appTitle: !!process.env.PW_EE ? 'HPE Machine Learning Development Environment' : 'Determined',
+    isEE: DevFixture.eeEnvironmentValue,
+    appTitle: DevFixture.eeEnvironmentValue ? 'HPE Machine Learning Development Environment' : 'Determined',
   }
 
   constructor(readonly page: Page) {
     this.#page = page;
-    Object.freeze(DevFixture.constants)
+    Object.freeze(DevFixture.constants);
   }
 
   async setServerAddress(): Promise<void> {

--- a/webui/react/src/e2e/models/BasePage.ts
+++ b/webui/react/src/e2e/models/BasePage.ts
@@ -14,6 +14,12 @@ export interface ModelBasics {
 export abstract class BasePage implements ModelBasics {
   readonly _page: Page;
   readonly nav: Navigation = new Navigation({ parent: this });
+
+  private static isEE = Boolean(JSON.parse(process.env.PW_EE ?? ''));
+  private static appTitle = BasePage.isEE
+    ? 'HPE Machine Learning Development Environment'
+    : 'Determined';
+
   abstract readonly url: string | RegExp;
   abstract readonly title: string | RegExp;
 
@@ -26,6 +32,23 @@ export abstract class BasePage implements ModelBasics {
    */
   get pwLocator(): Locator {
     return this._page.locator(':root');
+  }
+  /**
+   * The title of the page. Format of [prefix - ]appTitle
+   * @param prefix
+   */
+  public static getTitle(prefix: string = ''): string {
+    if (prefix === '') {
+      return BasePage.appTitle;
+    }
+    return `${prefix} - ${BasePage.appTitle}`;
+  }
+
+  public getUrlRegExp() {
+    if (this.url instanceof RegExp) {
+      return this.url;
+    }
+    return new RegExp(this.url, 'g');
   }
 
   /**

--- a/webui/react/src/e2e/models/BasePage.ts
+++ b/webui/react/src/e2e/models/BasePage.ts
@@ -44,7 +44,7 @@ export abstract class BasePage implements ModelBasics {
     return `${prefix} - ${BasePage.appTitle}`;
   }
 
-  public getUrlRegExp() {
+  public getUrlRegExp(): RegExp {
     if (this.url instanceof RegExp) {
       return this.url;
     }

--- a/webui/react/src/e2e/models/pages/Admin/UserManagement.ts
+++ b/webui/react/src/e2e/models/pages/Admin/UserManagement.ts
@@ -1,5 +1,4 @@
 import { expect, Page } from '@playwright/test';
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { BaseComponent } from 'e2e/models/BaseComponent';
 import { AddUsersToGroupsModal } from 'e2e/models/components/AddUsersToGroupsModal';
@@ -18,7 +17,7 @@ import { AdminPage } from 'e2e/models/pages/Admin/index';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class UserManagement extends AdminPage {
-  readonly title: string = DevFixture.constants.appTitle;
+  readonly title: string = UserManagement.getTitle();
   readonly url: string = 'admin/user-management';
   readonly getRowByID: (value: string) => UserRow;
 

--- a/webui/react/src/e2e/models/pages/Admin/UserManagement.ts
+++ b/webui/react/src/e2e/models/pages/Admin/UserManagement.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from '@playwright/test';
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { BaseComponent } from 'e2e/models/BaseComponent';
 import { AddUsersToGroupsModal } from 'e2e/models/components/AddUsersToGroupsModal';
@@ -17,7 +18,7 @@ import { AdminPage } from 'e2e/models/pages/Admin/index';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class UserManagement extends AdminPage {
-  readonly title: RegExp = /(Determined|HPE Machine Learning Development Environment)/;
+  readonly title: string = DevFixture.constants.appTitle;
   readonly url: string = 'admin/user-management';
   readonly getRowByID: (value: string) => UserRow;
 

--- a/webui/react/src/e2e/models/pages/ProjectDetails.ts
+++ b/webui/react/src/e2e/models/pages/ProjectDetails.ts
@@ -1,3 +1,4 @@
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BaseComponent } from 'e2e/models/BaseComponent';
 import { BasePage } from 'e2e/models/BasePage';
 import { DynamicTabs } from 'e2e/models/components/DynamicTabs';
@@ -11,8 +12,8 @@ import { Pivot } from 'e2e/models/hew/Pivot';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class ProjectDetails extends BasePage {
-  readonly title: RegExp =
-    /(Uncategorized Experiments|Project Details) - (Determined|HPE Machine Learning Development Environment)/;
+  readonly title: RegExp = new RegExp(
+    `(Uncategorized Experiments|Project Details) - ${DevFixture.constants.appTitle}`, "g");
   readonly url: RegExp = /projects\/\d+/;
 
   /**

--- a/webui/react/src/e2e/models/pages/ProjectDetails.ts
+++ b/webui/react/src/e2e/models/pages/ProjectDetails.ts
@@ -13,7 +13,9 @@ import { Pivot } from 'e2e/models/hew/Pivot';
  */
 export class ProjectDetails extends BasePage {
   readonly title: RegExp = new RegExp(
-    `(Uncategorized Experiments|Project Details) - ${DevFixture.constants.appTitle}`, "g");
+    `(Uncategorized Experiments|Project Details) - ${DevFixture.constants.appTitle}`,
+    'g',
+  );
   readonly url: RegExp = /projects\/\d+/;
 
   /**

--- a/webui/react/src/e2e/models/pages/ProjectDetails.ts
+++ b/webui/react/src/e2e/models/pages/ProjectDetails.ts
@@ -1,4 +1,3 @@
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BaseComponent } from 'e2e/models/BaseComponent';
 import { BasePage } from 'e2e/models/BasePage';
 import { DynamicTabs } from 'e2e/models/components/DynamicTabs';
@@ -13,7 +12,7 @@ import { Pivot } from 'e2e/models/hew/Pivot';
  */
 export class ProjectDetails extends BasePage {
   readonly title: RegExp = new RegExp(
-    `(Uncategorized Experiments|Project Details) - ${DevFixture.constants.appTitle}`,
+    ProjectDetails.getTitle('(Uncategorized Experiments|Project Details)'),
     'g',
   );
   readonly url: RegExp = /projects\/\d+/;

--- a/webui/react/src/e2e/models/pages/SignIn.ts
+++ b/webui/react/src/e2e/models/pages/SignIn.ts
@@ -1,4 +1,3 @@
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BasePage } from 'e2e/models/BasePage';
 import { DeterminedAuth } from 'e2e/models/components/DeterminedAuth';
 import { PageComponent } from 'e2e/models/components/Page';
@@ -9,7 +8,7 @@ import { PageComponent } from 'e2e/models/components/Page';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class SignIn extends BasePage {
-  readonly title: string = `Sign In - ${DevFixture.constants.appTitle}`;
+  readonly title: string = SignIn.getTitle('Sign In');
   readonly url: string = 'login';
   readonly pageComponent: PageComponent = new PageComponent({ parent: this });
   readonly detAuth: DeterminedAuth = new DeterminedAuth({ parent: this.pageComponent });

--- a/webui/react/src/e2e/models/pages/SignIn.ts
+++ b/webui/react/src/e2e/models/pages/SignIn.ts
@@ -1,3 +1,4 @@
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BasePage } from 'e2e/models/BasePage';
 import { DeterminedAuth } from 'e2e/models/components/DeterminedAuth';
 import { PageComponent } from 'e2e/models/components/Page';
@@ -8,7 +9,7 @@ import { PageComponent } from 'e2e/models/components/Page';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class SignIn extends BasePage {
-  readonly title: string = 'Sign In - HPE Machine Learning Development Environment';
+  readonly title: string = `Sign In - ${DevFixture.constants.appTitle}`;
   readonly url: string = 'login';
   readonly pageComponent: PageComponent = new PageComponent({ parent: this });
   readonly detAuth: DeterminedAuth = new DeterminedAuth({ parent: this.pageComponent });

--- a/webui/react/src/e2e/models/pages/Workspaces.ts
+++ b/webui/react/src/e2e/models/pages/Workspaces.ts
@@ -1,3 +1,4 @@
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BasePage } from 'e2e/models/BasePage';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { WorkspaceDeleteModal } from 'e2e/models/components/WorkspaceDeleteModal';
@@ -9,7 +10,7 @@ import { WorkspacesList } from 'e2e/models/components/WorkspacesList';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class Workspaces extends BasePage {
-  readonly title: RegExp = /Workspaces - (Determined|HPE Machine Learning Development Environment)/;
+  readonly title: string = `Workspaces - ${DevFixture.constants.appTitle}`;
   readonly url: string = 'workspaces';
   readonly list: WorkspacesList = new WorkspacesList({
     parent: this,

--- a/webui/react/src/e2e/models/pages/Workspaces.ts
+++ b/webui/react/src/e2e/models/pages/Workspaces.ts
@@ -1,4 +1,3 @@
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { BasePage } from 'e2e/models/BasePage';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { WorkspaceDeleteModal } from 'e2e/models/components/WorkspaceDeleteModal';
@@ -10,7 +9,7 @@ import { WorkspacesList } from 'e2e/models/components/WorkspacesList';
  * @param {Page} page - The '@playwright/test' Page being used by a test
  */
 export class Workspaces extends BasePage {
-  readonly title: string = `Workspaces - ${DevFixture.constants.appTitle}`;
+  readonly title: string = Workspaces.getTitle('Workspaces');
   readonly url: string = 'workspaces';
   readonly list: WorkspacesList = new WorkspacesList({
     parent: this,

--- a/webui/react/src/e2e/tests/auth.spec.ts
+++ b/webui/react/src/e2e/tests/auth.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { test } from 'e2e/fixtures/global-fixtures';
 import { SignIn } from 'e2e/models/pages/SignIn';
@@ -18,7 +19,7 @@ test.describe('Authentication', () => {
     await test.step('Login', async () => {
       await auth.login();
       await expect(page).toHaveTitle(
-        /Home - (Determined|HPE Machine Learning Development Environment)/,
+        `Home - ${DevFixture.constants.appTitle}`,
       );
       await expect(page).toHaveURL(/dashboard/);
     });
@@ -40,7 +41,7 @@ test.describe('Authentication', () => {
     await test.step('Login and expect redirect to previous page', async () => {
       await auth.login(/models/);
       await expect(page).toHaveTitle(
-        /Model Registry - (Determined|HPE Machine Learning Development Environment)/,
+        `Model Registry - ${DevFixture.constants.appTitle}`,
       );
     });
   });

--- a/webui/react/src/e2e/tests/auth.spec.ts
+++ b/webui/react/src/e2e/tests/auth.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { test } from 'e2e/fixtures/global-fixtures';
+import { BasePage } from 'e2e/models/BasePage';
 import { SignIn } from 'e2e/models/pages/SignIn';
 
 test.describe('Authentication', () => {
@@ -18,7 +18,7 @@ test.describe('Authentication', () => {
   test('Login and Logout', async ({ page, auth }) => {
     await test.step('Login', async () => {
       await auth.login();
-      await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
+      await expect(page).toHaveTitle(BasePage.getTitle('Home'));
       await expect(page).toHaveURL(/dashboard/);
     });
 
@@ -38,7 +38,7 @@ test.describe('Authentication', () => {
 
     await test.step('Login and expect redirect to previous page', async () => {
       await auth.login(/models/);
-      await expect(page).toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
+      await expect(page).toHaveTitle(BasePage.getTitle('Model Registry'));
     });
   });
 

--- a/webui/react/src/e2e/tests/auth.spec.ts
+++ b/webui/react/src/e2e/tests/auth.spec.ts
@@ -52,14 +52,18 @@ test.describe('Authentication', () => {
     await expect(page).toHaveTitle(signInPage.title);
     await expect(page).toHaveURL(/login/);
     await expect(signInPage.detAuth.errors.pwLocator).toBeVisible();
+    await expect(signInPage.detAuth.errors.alert.pwLocator).toBeVisible();
     expect(await signInPage.detAuth.errors.message.pwLocator.textContent()).toContain(
       'Login failed',
     );
     expect(await signInPage.detAuth.errors.description.pwLocator.textContent()).toContain(
       'invalid credentials',
     );
+    await signInPage.detAuth.errors.close.pwLocator.click()
+    await expect(signInPage.detAuth.errors.alert.pwLocator).not.toBeVisible();
+
     await signInPage.detAuth.submit.pwLocator.click();
-    await expect(signInPage.detAuth.errors.alert.pwLocator.first()).toBeVisible(); // This can show 2 but one sometimes closes during polling which adds flake
-    await expect(signInPage.detAuth.errors.message.pwLocator.first()).toBeVisible();
+    await expect(signInPage.detAuth.errors.alert.pwLocator).toBeVisible(); 
+    await expect(signInPage.detAuth.errors.message.pwLocator).toBeVisible();
   });
 });

--- a/webui/react/src/e2e/tests/auth.spec.ts
+++ b/webui/react/src/e2e/tests/auth.spec.ts
@@ -18,9 +18,7 @@ test.describe('Authentication', () => {
   test('Login and Logout', async ({ page, auth }) => {
     await test.step('Login', async () => {
       await auth.login();
-      await expect(page).toHaveTitle(
-        `Home - ${DevFixture.constants.appTitle}`,
-      );
+      await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
       await expect(page).toHaveURL(/dashboard/);
     });
 
@@ -40,9 +38,7 @@ test.describe('Authentication', () => {
 
     await test.step('Login and expect redirect to previous page', async () => {
       await auth.login(/models/);
-      await expect(page).toHaveTitle(
-        `Model Registry - ${DevFixture.constants.appTitle}`,
-      );
+      await expect(page).toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
     });
   });
 
@@ -59,11 +55,11 @@ test.describe('Authentication', () => {
     expect(await signInPage.detAuth.errors.description.pwLocator.textContent()).toContain(
       'invalid credentials',
     );
-    await signInPage.detAuth.errors.close.pwLocator.click()
+    await signInPage.detAuth.errors.close.pwLocator.click();
     await expect(signInPage.detAuth.errors.alert.pwLocator).not.toBeVisible();
 
     await signInPage.detAuth.submit.pwLocator.click();
-    await expect(signInPage.detAuth.errors.alert.pwLocator).toBeVisible(); 
+    await expect(signInPage.detAuth.errors.alert.pwLocator).toBeVisible();
     await expect(signInPage.detAuth.errors.message.pwLocator).toBeVisible();
   });
 });

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -1,7 +1,9 @@
 import { expect } from '@playwright/test';
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { test } from 'e2e/fixtures/global-fixtures';
+import { BasePage } from 'e2e/models/BasePage';
+import { UserManagement } from 'e2e/models/pages/Admin/UserManagement';
+import { SignIn } from 'e2e/models/pages/SignIn';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
 
 test.describe('Navigation', () => {
@@ -16,7 +18,7 @@ test.describe('Navigation', () => {
 
     await test.step('Login steps', async () => {
       await auth.login(/dashboard/);
-      await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
+      await expect(page).toHaveTitle(BasePage.getTitle('Home'));
       await expect(page).toHaveURL(/dashboard/);
     });
 
@@ -24,64 +26,56 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { exact: true, name: 'Uncategorized' }).click();
       const expectedURL = /projects\/1\/experiments/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(`Uncategorized Experiments - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(expectedURL);
+      await expect.soft(page).toHaveTitle(BasePage.getTitle('Uncategorized Experiments'));
     });
 
     await test.step('Navigate to Model Registry', async () => {
       await page.getByRole('link', { name: 'Model Registry' }).click();
-      const expectedURL = /models/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(expectedURL);
+      await page.waitForURL(/models/);
+      await expect.soft(page).toHaveTitle(BasePage.getTitle('Model Registry'));
     });
 
     await test.step('Navigate to Tasks', async () => {
       await page.getByRole('link', { name: 'Tasks' }).click();
       const expectedURL = /tasks/;
       await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(`Tasks - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(expectedURL);
+      await expect.soft(page).toHaveTitle(BasePage.getTitle('Tasks'));
     });
 
     await test.step('Navigate to Webhooks', async () => {
       await page.getByRole('link', { name: 'Webhooks' }).click();
       const expectedURL = /webhooks/;
       await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(`Webhooks - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(expectedURL);
+      await expect.soft(page).toHaveTitle(BasePage.getTitle('Webhooks'));
     });
 
     await test.step('Navigate to Cluster', async () => {
       await page.getByRole('link', { name: 'Cluster' }).click();
       const expectedURL = /clusters/;
       await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(`Cluster - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(expectedURL);
+      await expect.soft(page).toHaveTitle(BasePage.getTitle('Cluster'));
     });
 
     await test.step('Navigate to Workspaces', async () => {
       const workspacesPage = new Workspaces(page);
       await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
-      await page.waitForURL(`**/${workspacesPage.url}?**`);
+      await page.waitForURL(workspacesPage.getUrlRegExp());
       await expect.soft(page).toHaveTitle(workspacesPage.title);
     });
 
     await test.step('Navigate to Admin', async () => {
       await page.getByRole('navigation').getByText(USERNAME).click();
       await page.getByRole('link', { name: 'Admin' }).click();
-      const expectedURL = /admin\/user-management/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(DevFixture.constants.appTitle);
-      await expect.soft(page).toHaveURL(expectedURL);
+      const userManagementPage = new UserManagement(page);
+      await page.waitForURL(userManagementPage.getUrlRegExp());
+      await expect.soft(page).toHaveTitle(userManagementPage.title);
     });
 
     await test.step('Navigate to Logout', async () => {
       await auth.logout();
-      await expect.soft(page).toHaveTitle(`Sign In - ${DevFixture.constants.appTitle}`);
-      await expect.soft(page).toHaveURL(/login/);
+      const signInPage = new SignIn(page);
+      await expect.soft(page).toHaveTitle(signInPage.title);
+      await expect.soft(page).toHaveURL(signInPage.getUrlRegExp());
     });
   });
 });

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -16,9 +16,7 @@ test.describe('Navigation', () => {
 
     await test.step('Login steps', async () => {
       await auth.login(/dashboard/);
-      await expect(page).toHaveTitle(
-        `Home - ${DevFixture.constants.appTitle}`,
-      );
+      await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
       await expect(page).toHaveURL(/dashboard/);
     });
 
@@ -28,9 +26,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(
-          `Uncategorized Experiments - ${DevFixture.constants.appTitle}`,
-        );
+        .toHaveTitle(`Uncategorized Experiments - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -38,9 +34,7 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { name: 'Model Registry' }).click();
       const expectedURL = /models/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
+      await expect.soft(page).toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -48,9 +42,7 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { name: 'Tasks' }).click();
       const expectedURL = /tasks/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(`Tasks - ${DevFixture.constants.appTitle}`);
+      await expect.soft(page).toHaveTitle(`Tasks - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -58,9 +50,7 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { name: 'Webhooks' }).click();
       const expectedURL = /webhooks/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(`Webhooks - ${DevFixture.constants.appTitle}`);
+      await expect.soft(page).toHaveTitle(`Webhooks - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -68,9 +58,7 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { name: 'Cluster' }).click();
       const expectedURL = /clusters/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(`Cluster - ${DevFixture.constants.appTitle}`);
+      await expect.soft(page).toHaveTitle(`Cluster - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -86,17 +74,13 @@ test.describe('Navigation', () => {
       await page.getByRole('link', { name: 'Admin' }).click();
       const expectedURL = /admin\/user-management/;
       await page.waitForURL(expectedURL);
-      await expect
-        .soft(page)
-        .toHaveTitle(DevFixture.constants.appTitle);
+      await expect.soft(page).toHaveTitle(DevFixture.constants.appTitle);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
     await test.step('Navigate to Logout', async () => {
       await auth.logout();
-      await expect
-        .soft(page)
-        .toHaveTitle(`Sign In - ${DevFixture.constants.appTitle}`);
+      await expect.soft(page).toHaveTitle(`Sign In - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(/login/);
     });
   });

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 
 import { test } from 'e2e/fixtures/global-fixtures';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
@@ -16,7 +17,7 @@ test.describe('Navigation', () => {
     await test.step('Login steps', async () => {
       await auth.login(/dashboard/);
       await expect(page).toHaveTitle(
-        /Home - (Determined|HPE Machine Learning Development Environment)/,
+        `Home - ${DevFixture.constants.appTitle}`,
       );
       await expect(page).toHaveURL(/dashboard/);
     });
@@ -28,7 +29,7 @@ test.describe('Navigation', () => {
       await expect
         .soft(page)
         .toHaveTitle(
-          /Uncategorized Experiments - (Determined|HPE Machine Learning Development Environment)/,
+          `Uncategorized Experiments - ${DevFixture.constants.appTitle}`,
         );
       await expect.soft(page).toHaveURL(expectedURL);
     });
@@ -39,7 +40,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(/Model Registry - (Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(`Model Registry - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -49,7 +50,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(/Tasks - (Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(`Tasks - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -59,7 +60,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(/Webhooks - (Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(`Webhooks - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -69,7 +70,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(/Cluster - (Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(`Cluster - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -87,7 +88,7 @@ test.describe('Navigation', () => {
       await page.waitForURL(expectedURL);
       await expect
         .soft(page)
-        .toHaveTitle(/(Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(DevFixture.constants.appTitle);
       await expect.soft(page).toHaveURL(expectedURL);
     });
 
@@ -95,7 +96,7 @@ test.describe('Navigation', () => {
       await auth.logout();
       await expect
         .soft(page)
-        .toHaveTitle(/Sign In - (Determined|HPE Machine Learning Development Environment)/);
+        .toHaveTitle(`Sign In - ${DevFixture.constants.appTitle}`);
       await expect.soft(page).toHaveURL(/login/);
     });
   });

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from '@playwright/test';
 
 import { test } from 'e2e/fixtures/global-fixtures';
+import { BasePage } from 'e2e/models/BasePage';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
 import { randId, safeName } from 'e2e/utils/naming';
-import { BasePage } from 'e2e/models/BasePage';
 
 test.describe('Projects', () => {
   test.setTimeout(120_000);

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import { test } from 'e2e/fixtures/global-fixtures';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
+import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { randId, safeName } from 'e2e/utils/naming';
 
 test.describe('Projects', () => {
@@ -38,7 +39,7 @@ test.describe('Projects', () => {
     await dev.setServerAddress();
     await auth.login(/dashboard/);
     await expect(page).toHaveTitle(
-      /Home - (Determined|HPE Machine Learning Development Environment)/,
+      `Home - ${DevFixture.constants.appTitle}`,
     );
     await expect(page).toHaveURL(/dashboard/);
   });

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -38,9 +38,7 @@ test.describe('Projects', () => {
   test.beforeEach(async ({ dev, auth, page }) => {
     await dev.setServerAddress();
     await auth.login(/dashboard/);
-    await expect(page).toHaveTitle(
-      `Home - ${DevFixture.constants.appTitle}`,
-    );
+    await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
     await expect(page).toHaveURL(/dashboard/);
   });
 

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -3,8 +3,8 @@ import { expect } from '@playwright/test';
 import { test } from 'e2e/fixtures/global-fixtures';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
-import { DevFixture } from 'e2e/fixtures/dev.fixture';
 import { randId, safeName } from 'e2e/utils/naming';
+import { BasePage } from 'e2e/models/BasePage';
 
 test.describe('Projects', () => {
   test.setTimeout(120_000);
@@ -38,7 +38,7 @@ test.describe('Projects', () => {
   test.beforeEach(async ({ dev, auth, page }) => {
     await dev.setServerAddress();
     await auth.login(/dashboard/);
-    await expect(page).toHaveTitle(`Home - ${DevFixture.constants.appTitle}`);
+    await expect(page).toHaveTitle(BasePage.getTitle('Home'));
     await expect(page).toHaveURL(/dashboard/);
   });
 


### PR DESCRIPTION
## test: ee and oss have separate handling

## Ticket
INFENG-636


## Description
There were a few follow-ups from the effort to run UI tests with a devcluster backend that we put off in order to get the pipeline passing again. This is that follow up to make the sign in page test more accurate around the error messages, as well as to make sure the test can detect EE vs. OSS version and validate that the branding is correct depending on which version we are using.


## Test Plan
Tests should pass CI.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ