### PR TITLE
CI test

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4599,9 +4599,6 @@ workflows:
             - aws
             - determined-ee
             - aws-ci-cluster-default-user-credentials
-          filters:
-            branches:
-              only: main
           requires:
             - package-and-push-system-dev-ee
           matrix:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -687,7 +687,7 @@ commands:
         default: false
       deployment-type:
         type: string
-        default: simple-rds
+        default: simple
       ee:
         type: boolean
         default: false
@@ -816,7 +816,7 @@ commands:
         type: string
       deployment-type:
         type: string
-        default: simple-rds
+        default: simple
       ee:
         type: boolean
         default: false

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -145,11 +145,18 @@ def test_labels() -> None:
 
 
 @pytest.mark.e2e_cpu
+@pytest.mark.parallel
 def test_end_to_end_adaptive() -> None:
     sess = api_utils.user_session()
     exp_id = exp.run_basic_test(
         sess,
-        conf.fixtures_path("mnist_pytorch/adaptive_short.yaml"),
+        conf.fixtures_path("mnist_pytorch/adaptive.yaml"),
+        conf.tutorials_path("mnist_pytorch"),
+        None,
+    )
+    exp.run_basic_test(
+        sess,
+        conf.fixtures_path("mnist_pytorch/adaptive.yaml"),
         conf.tutorials_path("mnist_pytorch"),
         None,
     )

--- a/e2e_tests/tests/fixtures/mnist_pytorch/adaptive.yaml
+++ b/e2e_tests/tests/fixtures/mnist_pytorch/adaptive.yaml
@@ -1,0 +1,39 @@
+name: mnist_pytorch_adaptive
+entrypoint: python3 train.py
+hyperparameters:
+  learning_rate:
+    type: double
+    minval: .0001
+    maxval: 1.0
+  n_filters1:
+    type: int
+    minval: 8
+    maxval: 64
+  n_filters2:
+    type: int
+    minval: 8
+    maxval: 72
+  dropout1:
+    type: double
+    minval: .2
+    maxval: .8
+  dropout2:
+    type: double
+    minval: .2
+    maxval: .8
+searcher:
+  name: adaptive_asha
+  metric: validation_loss
+  smaller_is_better: true
+  max_length:
+    batches: 937
+  max_trials: 512
+  max_rungs: 2
+  mode: aggressive
+  divisor: 2
+max_restarts: 0
+# bind-mounting the /tmp/work_dir directory for the mnist_pytorch experiment
+# enables the reuse of the downloaded dataset.
+bind_mounts:
+  - host_path: /tmp
+    container_path: /tmp/work_dir

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1520,13 +1519,11 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	webhooks.Init()
 	defer webhooks.Deinit()
 
-	if slices.Contains(m.config.FeatureSwitches, "streaming_updates") {
-		ssup := stream.NewSupervisor(m.db.URL)
-		go func() {
-			_ = ssup.Run(ctx)
-		}()
-		m.echo.GET("/stream", api.WebSocketRoute(ssup.Websocket, m.config.EnableCors))
-	}
+	ssup := stream.NewSupervisor(m.db.URL)
+	go func() {
+		_ = ssup.Run(ctx)
+	}()
+	m.echo.GET("/stream", api.WebSocketRoute(ssup.Websocket, m.config.EnableCors))
 
 	return m.startServers(ctx, cert, gRPCLogInitDone)
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ