### PR TITLE
fix: support for metric names over 63 characters long [MD-285]

### DIFF
--- a/docs/release-notes/long-metrics.rst
+++ b/docs/release-notes/long-metrics.rst
@@ -2,6 +2,5 @@
 
 **Bug Fixes**
 
--  Experiment metrics tracking: add support for metrics with long names. Previously, a metric with a
-   name over 63 characters long will be recorded, but will not be displayed in the UI or returned by
-   the APIs.
+-  Experiment metrics tracking: Add support for metrics with long names. Previously, metrics with
+   names exceeding 63 characters were recorded but not displayed in the UI or returned via APIs.

--- a/docs/release-notes/long-metrics.rst
+++ b/docs/release-notes/long-metrics.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Experiment metrics tracking: add support for metrics with long names. Previously, a metric with a
+   name over 63 characters long will be recorded, but will not be displayed in the UI or returned by
+   the APIs.

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -664,8 +664,7 @@ func TestUnusualMetricNames(t *testing.T) {
 	require.NoError(t, err)
 
 	valuesMap := resp.Trials[0].Metrics[0].Data[0].Values.AsMap()
-	// One extra for the `epoch``.
-	require.Len(t, valuesMap, len(expectedMetricsMap)+1)
+	require.Len(t, valuesMap, len(expectedMetricsMap))
 	require.Equal(t, valuesMap[longMetric], expectedMetricsMap[longMetric])
 }
 

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -622,9 +623,11 @@ func TestReportCheckpointNonTrialErrors(t *testing.T) {
 
 func TestUnusualMetricNames(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
+	longMetric := strings.Repeat("a", 100)
 	expectedMetricsMap := map[string]any{
-		"a.loss": 1.5,
-		"b/loss": 2.5,
+		"a.loss":   1.5,
+		"b/loss":   2.5,
+		longMetric: 4.5,
 	}
 	asciiSweep := ""
 	for i := 1; i <= 255; i++ {
@@ -652,13 +655,18 @@ func TestUnusualMetricNames(t *testing.T) {
 	req := &apiv1.CompareTrialsRequest{
 		TrialIds:      []int32{int32(trial.ID)},
 		MaxDatapoints: 3,
-		MetricNames:   []string{"a.loss", "b/loss", asciiSweep},
+		MetricNames:   []string{"a.loss", "b/loss", asciiSweep, longMetric},
 		StartBatches:  0,
 		EndBatches:    1000,
 		MetricType:    apiv1.MetricType_METRIC_TYPE_VALIDATION,
 	}
-	_, err = api.CompareTrials(ctx, req)
+	resp, err := api.CompareTrials(ctx, req)
 	require.NoError(t, err)
+
+	valuesMap := resp.Trials[0].Metrics[0].Data[0].Values.AsMap()
+	// One extra for the `epoch``.
+	require.Len(t, valuesMap, len(expectedMetricsMap)+1)
+	require.Equal(t, valuesMap[longMetric], expectedMetricsMap[longMetric])
 }
 
 func TestTrialAuthZ(t *testing.T) {

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -181,13 +181,13 @@ func (m *Master) promHealth(ctx context.Context) {
 	}()
 }
 
-//	@Summary	Get health of Determined and the dependencies.
-//	@Tags		Cluster
-//	@ID			health
-//	@Produce	json
-//	@Success	200	{object}	model.HealthCheck
-//	@Failure	503	{object}	model.HealthCheck
-//	@Router		/health [get]
+//	@Summary Get health of Determined and the dependencies.
+//	@Tags	 Cluster
+//	@ID		 health
+//	@Produce json
+//	@Success 200     {object} model.HealthCheck
+//	@Failure 503     {object} model.HealthCheck
+//	@Router	 /health [get]
 //
 // nolint:lll
 func (m *Master) healthCheckEndpoint(c echo.Context) error {

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -181,13 +181,13 @@ func (m *Master) promHealth(ctx context.Context) {
 	}()
 }
 
-//	@Summary Get health of Determined and the dependencies.
-//	@Tags	 Cluster
-//	@ID		 health
-//	@Produce json
-//	@Success 200     {object} model.HealthCheck
-//	@Failure 503     {object} model.HealthCheck
-//	@Router	 /health [get]
+//	@Summary	Get health of Determined and the dependencies.
+//	@Tags		Cluster
+//	@ID			health
+//	@Produce	json
+//	@Success	200	{object}	model.HealthCheck
+//	@Failure	503	{object}	model.HealthCheck
+//	@Router		/health [get]
 //
 // nolint:lll
 func (m *Master) healthCheckEndpoint(c echo.Context) error {

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -148,15 +148,17 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		return metricMeasurements, errors.Wrapf(err, "failed to get metrics to sample for experiment")
 	}
 
+	selectMetrics := map[string]string{}
+
 	for i := range metricNames {
-		metricToColumnMap.LookupOrAdd(metricNames[i])
+		selectMetrics[metricToColumnMap.LookupOrAdd(metricNames[i])] = metricNames[i]
 	}
 
 	for i := range results {
 		valuesMap := make(map[string]interface{})
 		for mName, mVal := range results[i] {
-			if metricToColumnMap.ReverseLookup(mName) != "" {
-				valuesMap[metricToColumnMap.ReverseLookup(mName)] = mVal
+			if selectMetrics[mName] != "" {
+				valuesMap[selectMetrics[mName]] = mVal
 			}
 		}
 		var epoch *float64

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
@@ -24,6 +25,48 @@ const (
 	batches = "batches"
 )
 
+type safeMetricToColumnMap struct {
+	m       map[string]string
+	reverse map[string]string
+}
+
+func newSafeMetricToColumnMap() safeMetricToColumnMap {
+	return safeMetricToColumnMap{
+		m:       make(map[string]string),
+		reverse: make(map[string]string),
+	}
+}
+
+func (s safeMetricToColumnMap) LookupOrAdd(key string) string {
+	if _, ok := s.m[key]; !ok {
+		for {
+			safeKey := generateMetricToColumn(key)
+			if _, ok := s.reverse[safeKey]; !ok {
+				s.m[key] = safeKey
+				s.reverse[safeKey] = key
+				break
+			}
+		}
+	}
+	return s.m[key]
+}
+
+func (s safeMetricToColumnMap) ReverseLookup(key string) string {
+	return s.reverse[key]
+}
+
+func generateMetricToColumn(metric string) string {
+	// Max length of a column name in postgres is 63 characters.
+	// Replace longer column names with a metric name prefix (for readability)
+	// and a uuid for randomness.
+	s := strings.ReplaceAll(metric, ".", "·")
+	if len(s) > 62 {
+		uuid := uuid.NewString()
+		return s[:(63-len(uuid))] + uuid
+	}
+	return s
+}
+
 // MetricsTimeSeries returns a time-series of the specified metric in the specified
 // trial.
 func MetricsTimeSeries(trialID int32, startTime time.Time,
@@ -34,6 +77,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	metricMeasurements []db.MetricMeasurements, err error,
 ) {
 	var queryColumn, orderColumn string
+	metricToColumnMap := newSafeMetricToColumnMap()
 	// The data for batches and column are stored under different column names
 	switch timeSeriesColumn {
 	case "batches":
@@ -41,7 +85,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 	case "time":
 		queryColumn = "end_time"
 	default:
-		queryColumn = strings.ReplaceAll(timeSeriesColumn, ".", "·")
+		queryColumn = metricToColumnMap.LookupOrAdd(timeSeriesColumn)
 	}
 	subq := db.BunSelectMetricsQuery(metricGroup, false).Table("metrics").
 		ColumnExpr("(select setseed(1)) as _seed").
@@ -77,7 +121,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		}
 		subq = subq.ColumnExpr("(metrics->?->>?)::? as ?",
 			model.TrialMetricsJSONPath(metricGroup == model.ValidationMetricGroup),
-			metricName, bun.Safe(cast), bun.Ident(strings.ReplaceAll(metricName, ".", "·")))
+			metricName, bun.Safe(cast), bun.Ident(metricToColumnMap.LookupOrAdd(metricName)))
 	}
 
 	subq = subq.Where("trial_id = ?", trialID).OrderExpr("random()").
@@ -89,7 +133,7 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 			Where("total_batches <= 0 OR total_batches <= ?", endBatches).
 			Where("end_time > ?", startTime)
 	default:
-		orderColumn = strings.ReplaceAll(timeSeriesColumn, ".", "·")
+		orderColumn = metricToColumnMap.LookupOrAdd(timeSeriesColumn)
 		subq, err = db.ApplyPolymorphicFilter(subq, queryColumn, timeSeriesFilter)
 		if err != nil {
 			return metricMeasurements, errors.Wrapf(err, "failed to get metrics to sample for experiment")
@@ -104,17 +148,15 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		return metricMeasurements, errors.Wrapf(err, "failed to get metrics to sample for experiment")
 	}
 
-	selectMetrics := map[string]string{}
-
 	for i := range metricNames {
-		selectMetrics[strings.ReplaceAll(metricNames[i], ".", "·")] = metricNames[i]
+		metricToColumnMap.LookupOrAdd(metricNames[i])
 	}
 
 	for i := range results {
 		valuesMap := make(map[string]interface{})
 		for mName, mVal := range results[i] {
-			if selectMetrics[mName] != "" {
-				valuesMap[selectMetrics[mName]] = mVal
+			if metricToColumnMap.ReverseLookup(mName) != "" {
+				valuesMap[metricToColumnMap.ReverseLookup(mName)] = mVal
 			}
 		}
 		var epoch *float64

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -59,6 +59,8 @@ func generateMetricToColumn(metric string) string {
 	// Max length of a column name in postgres is 63 characters.
 	// Replace longer column names with a metric name prefix (for readability)
 	// and a uuid for randomness.
+	// Replace periods with a unicode dot to avoid postgres interpreting
+	// `val.loss` as `"val"."loss"` identifier.
 	s := strings.ReplaceAll(metric, ".", "·")
 	if len(s) > 62 {
 		uuid := uuid.NewString()


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
[MD-285]
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
TIL postgres has a 63 character limit on the column names. We use metric names as columns in this code, and so long metrics were trimmed to 63 characters, and not returned by the API as a result.

We had a test which tested full ascii metric names, but it only checked if the API errors out, not whether it returns useful values.

- Add a map to do an internal conversion between raw metric name and a column name.
- Updated the auto tests to check for this.

## Test Plan

Run an experiment with a metric name longer that 63 characters, and make sure it's present in the experiment table compare views.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[MD-285]: https://hpe-aiatscale.atlassian.net/browse/MD-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ