### PR TITLE
fix: properly merge resource configs

### DIFF
--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -518,10 +518,10 @@ func (a *ResourceManager) TaskContainerDefaults(
 	var poolConfigOverrides *model.TaskContainerDefaultsConfig
 	for _, pool := range a.poolsConfig {
 		if resourcePoolName.String() == pool.PoolName {
-			if pool.TaskContainerDefaults == nil {
-				break
+			if pool.TaskContainerDefaults != nil {
+				poolConfigOverrides = pool.TaskContainerDefaults
 			}
-			poolConfigOverrides = pool.TaskContainerDefaults
+			break
 		}
 	}
 

--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -510,18 +510,29 @@ func (a *ResourceManager) SetGroupWeight(msg sproto.SetGroupWeight) error {
 // TaskContainerDefaults implements rm.ResourceManager.
 func (a *ResourceManager) TaskContainerDefaults(
 	resourcePoolName rm.ResourcePoolName,
-	fallbackConfig model.TaskContainerDefaultsConfig,
+	defaultConfig model.TaskContainerDefaultsConfig,
 ) (model.TaskContainerDefaultsConfig, error) {
-	result := fallbackConfig
+	result := defaultConfig
+
 	// Iterate through configured pools looking for a TaskContainerDefaults setting.
+	var poolConfigOverrides *model.TaskContainerDefaultsConfig
 	for _, pool := range a.poolsConfig {
 		if resourcePoolName.String() == pool.PoolName {
 			if pool.TaskContainerDefaults == nil {
 				break
 			}
-			result = *pool.TaskContainerDefaults
+			poolConfigOverrides = pool.TaskContainerDefaults
 		}
 	}
+
+	if poolConfigOverrides != nil {
+		tmp, err := result.Merge(*poolConfigOverrides)
+		if err != nil {
+			return model.TaskContainerDefaultsConfig{}, err
+		}
+		result = tmp
+	}
+
 	return result, nil
 }
 

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -497,10 +497,10 @@ func (k ResourceManager) TaskContainerDefaults(
 	var poolConfigOverrides *model.TaskContainerDefaultsConfig
 	for _, pool := range k.poolsConfig {
 		if resourcePoolName.String() == pool.PoolName {
-			if pool.TaskContainerDefaults == nil {
-				break
+			if pool.TaskContainerDefaults != nil {
+				poolConfigOverrides = pool.TaskContainerDefaults
 			}
-			poolConfigOverrides = pool.TaskContainerDefaults
+			break
 		}
 	}
 

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -189,7 +189,7 @@ func (c TaskContainerDefaultsConfig) Merge(
 	if other.GLOOPortRange != "" {
 		res.GLOOPortRange = other.GLOOPortRange
 	}
-	fmt.Println("checkpoint 1")
+
 	if other.ShmSizeBytes != 0 {
 		res.ShmSizeBytes = other.ShmSizeBytes
 	}
@@ -205,7 +205,6 @@ func (c TaskContainerDefaultsConfig) Merge(
 	if other.GPUPodSpec != nil {
 		res.GPUPodSpec = other.GPUPodSpec.DeepCopy()
 	}
-	fmt.Println("checkpoint 2")
 
 	if other.Image != nil {
 		err := copier.CopyWithOption(&res.Image, other.Image, mergeCopier)

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -301,6 +301,14 @@ func (c TaskContainerDefaultsConfig) Merge(
 		res.Pbs.SetSbatchArgs(tmp)
 	}
 
+	if other.LogPolicies != nil {
+		if res.LogPolicies == nil {
+			res.LogPolicies = other.LogPolicies
+		} else {
+			res.LogPolicies = res.LogPolicies.Merge(other.LogPolicies)
+		}
+	}
+
 	return res, nil
 }
 

--- a/master/pkg/model/task_container_defaults.go
+++ b/master/pkg/model/task_container_defaults.go
@@ -189,7 +189,7 @@ func (c TaskContainerDefaultsConfig) Merge(
 	if other.GLOOPortRange != "" {
 		res.GLOOPortRange = other.GLOOPortRange
 	}
-
+	fmt.Println("checkpoint 1")
 	if other.ShmSizeBytes != 0 {
 		res.ShmSizeBytes = other.ShmSizeBytes
 	}
@@ -205,6 +205,7 @@ func (c TaskContainerDefaultsConfig) Merge(
 	if other.GPUPodSpec != nil {
 		res.GPUPodSpec = other.GPUPodSpec.DeepCopy()
 	}
+	fmt.Println("checkpoint 2")
 
 	if other.Image != nil {
 		err := copier.CopyWithOption(&res.Image, other.Image, mergeCopier)
@@ -223,10 +224,13 @@ func (c TaskContainerDefaultsConfig) Merge(
 	}
 
 	if otherEnvVars := other.EnvironmentVariables; otherEnvVars != nil {
-		otherEnvs := other.EnvironmentVariables
-		res.EnvironmentVariables.CPU = mergeEnvVars(res.EnvironmentVariables.CPU, otherEnvs.CPU)
-		res.EnvironmentVariables.CUDA = mergeEnvVars(res.EnvironmentVariables.CUDA, otherEnvs.CUDA)
-		res.EnvironmentVariables.ROCM = mergeEnvVars(res.EnvironmentVariables.ROCM, otherEnvs.ROCM)
+		if res.EnvironmentVariables == nil {
+			res.EnvironmentVariables = other.EnvironmentVariables
+		} else {
+			res.EnvironmentVariables.CPU = mergeEnvVars(res.EnvironmentVariables.CPU, otherEnvVars.CPU)
+			res.EnvironmentVariables.CUDA = mergeEnvVars(res.EnvironmentVariables.CUDA, otherEnvVars.CUDA)
+			res.EnvironmentVariables.ROCM = mergeEnvVars(res.EnvironmentVariables.ROCM, otherEnvVars.ROCM)
+		}
 	}
 
 	if other.AddCapabilities != nil {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
[DET-10245]
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Task container defaults weren't being merged properly between cluster level and resource pool level. Instead, cluster level TCDs were being completely overwritten. This changes the logic so that it is actually merging. 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Test on both kubernetes and agents if possible.

In this example, we'll demonstrate setting environment variables and log policies.
Start by setting a task container default at the cluster level, such as:

```
        resource_manager:
        ...
        task_container_defaults:
          environment_variables:
            - testCluster=testCluster
          log_policies:
            - action:
                type: exclude_node
              pattern: ECC Error_Cluster_TCD
        ...
```
Additionally, set the TCD at the resource pool level:
```
        resource_manager:
        ...
        resource_pools:
          - pool_name: default
            task_container_defaults:
              environment_variables:
                - testRP=testRP
              log_policies:
                - action:
                    type: exclude_node
                  pattern: ECC Error_RP_TCD
        ...
```
Lastly, set the same values in your experiment config:
```
environment:
  environment_variables:
    - testExp=testExp
log_policies:
   - pattern: "ECC Error"
     action:
       type: exclude_node
```

With all three of those set, run devcluster/kubernetes and make sure that in the trial logs you see all of those in the printed config. 

Next, comment out each of the three in different combinations to make sure that both the environment variables and the log policies are getting merged correctly. e.g. if there is no log policies in the TCD, the experiment logs should show the cluster level log policies + experiment level log policies.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10245]: https://hpe-aiatscale.atlassian.net/browse/DET-10245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ