### PR TITLE
feat: don't attempt to deal with EE when cherry-picking PRs for release

### DIFF
--- a/tools/scripts/track-pr
+++ b/tools/scripts/track-pr
@@ -125,7 +125,9 @@ def find_project(owner: str, query: str, filt: Callable[[dict], bool]) -> dict:
 
 def next_project_id() -> str:
     return find_project(
-        ORG, "Next release", lambda p: p["title"] == "TEST Next release" if TEST else "Next release"
+        ORG,
+        "Next release",
+        lambda p: p["title"] == ("TEST Next release" if TEST else "Next release"),
     )["id"]
 
 
@@ -164,17 +166,13 @@ def cherry_pick_skipping_empty(commit):
 
 
 def cherry_pick_pr(pr_id: str) -> None:
-    is_ee_pr = "determined-ee" in run_capture("git", "remote", "get-url", CLONED_REMOTE).stdout
-
     pr = gql.get_pr_merge_commit_and_url(id=pr_id)["node"]
     pr_commit = pr["mergeCommit"]["oid"]
     print(f"Cherry-picking {pr_commit}")
 
     try:
         # Find and fetch the PR commit and both release branches.
-        branch_pat = re.compile(
-            r"/release-(\d+)\.(\d+)\.(\d+){}$".format("-ee" if is_ee_pr else "")
-        )
+        branch_pat = re.compile(r"/release-(\d+)\.(\d+)\.(\d+)$")
         release_branch = max(
             (
                 line.split()[1]
@@ -195,40 +193,12 @@ def cherry_pick_pr(pr_id: str) -> None:
             f"{release_branch}:{release_branch}",
         )
 
-        # Set up authentication to access EE.
-        auth = base64.b64encode(f"x-access-token:{GITHUB_TOKEN}".encode()).decode()
-        run(
-            "git",
-            "config",
-            "--local",
-            "http.https://github.com/.extraHeader",
-            f"Authorization: Basic {auth}",
-        )
-
-        # Perform both cherry-picks.
+        # Perform the cherry-pick and push.
         run("git", "config", "user.email", "automation@determined.ai")
         run("git", "config", "user.name", "Determined CI")
         run("git", "checkout", release_branch)
         cherry_pick_skipping_empty(pr_commit)
-        if not is_ee_pr:
-            ee_remote = "ee"
-            ee_release_branch = f"{release_branch}-ee"
-            run(
-                "git",
-                "remote",
-                "add",
-                ee_remote,
-                "https://github.com/determined-ai/determined-ee.git",
-            )
-            run("git", "fetch", "--depth=2", ee_remote, f"{ee_release_branch}:{ee_release_branch}")
-            run("git", "checkout", ee_release_branch)
-            cherry_pick_skipping_empty(pr_commit)
-
-        # Perform both pushes only if both cherry-picks succeeded, so we don't
-        # end up with the two branches in different states.
         run("git", "push", CLONED_REMOTE, f"{release_branch}:{release_branch}")
-        if not is_ee_pr:
-            run("git", "push", ee_remote, f"{ee_release_branch}:{ee_release_branch}")
 
         print("Cherry-pick succeeded, updating item status")
         set_project_pr_status(current_project_id(), pr_id, FIX_UNRELEASED_STATUS)


### PR DESCRIPTION
## Description

Also correct a bug caused by operator precedence.

## Test Plan

- [x] test the precedence change locally
- [ ] see what happens when the next cherry-pick runs with this merged
