### PR TITLE
fix: allow genai deployments with agent GIDs set to share data properly

### DIFF
--- a/helm/charts/determined/templates/genai/genai-deployment.yaml
+++ b/helm/charts/determined/templates/genai/genai-deployment.yaml
@@ -21,6 +21,14 @@ spec:
     spec:
       priorityClassName: determined-system-priority
       serviceAccount: genai-{{ .Release.Name }}
+      {{- if .Values.genai.agentGroupID }}
+      {{ $gid := .Values.genai.agentGroupID }}
+      securityContext:
+        runAsUser: {{ $gid }}
+        runAsGroup: {{ $gid }}
+        fsGroup: {{ $gid }}
+        fsGroupChangePolicy: "OnRootMismatch"
+      {{- end }}
       containers:
       - name: genai-{{ .Release.Name }}
         {{ $tag := (required "A valid .Values.genai.version entry required!" .Values.genai.version) }}

--- a/helm/charts/determined/templates/genai/genai-initialize-shared-fs-permissions.yaml
+++ b/helm/charts/determined/templates/genai/genai-initialize-shared-fs-permissions.yaml
@@ -48,12 +48,10 @@ spec:
           - bash
           - -exc
           - |
-            apt-get update -y && apt-get install acl -y;
             echo "whoami: $(whoami)";
             chmod 2775 /shared_fs;
             GROUP_ID={{ (required "A valid .Values.genai.agentGroupID entry required!" .Values.genai.agentGroupID) }};
             chgrp +${GROUP_ID} /shared_fs;
-            setfacl -d -m g::rwX /shared_fs;
             ls -l / | grep shared_fs;
       volumes:
         - name: genai-pvc-storage


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[GAS-690]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
When using agent GIDs on a cluster, both the genai backend and the controller experiments must run with that agent GID as it's primary group, or the setgid flag on the shared drive will be ignored. This is because root's default group is "root", so it uses this group instead of the intended top level directories group of "determined". This prevents the data from being shared properly.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Should not need to be validated in release party.

I did test this by building a full cluster on GKE, creating an unprivileged user, running the shared filesystem group script on the shared_fs, and running through the process of making a dataset and running generation on it


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[GAS-690]: https://hpe-aiatscale.atlassian.net/browse/GAS-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ