### PR TITLE
ci: try to fix podman tests by building proto once

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2645,7 +2645,6 @@ jobs:
 
       - reinstall-go
       - go-get-deps
-      - run: PATH=$HOME/.local/bin:$PATH make -C proto build
 
       - setup-python-venv:
           install-python: true

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4446,6 +4446,7 @@ workflows:
               extra-pytest-flags: ["-k 'not test_slurm_verify_home'"]
           requires:
             - build-go-ee
+            - build-proto
 
       - test-e2e:
           name: test-e2e-rbac


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Fix failing podman tests

https://app.circleci.com/pipelines/github/determined-ai/determined/54910/workflows/19816278-7088-4c7e-910e-5a6c50699a96/jobs/2515396

Don't build proto again. We probably shouldn't be building proto more than once per CI. We also likely don't even need to build ```proto``` at all.  My best guess of what is going on is somehow the ```store_artifacts``` is interacting weirdly with us building proto again so try making sure we always run after build proto is done. 

## Test Plan

Tests pass on main after landing


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ