### PR TITLE
fix: show non det pods in other namespaces than 'default' [RM-141]

### DIFF
--- a/docs/release-notes/non-det-tasks-k8s-fix.rst
+++ b/docs/release-notes/non-det-tasks-k8s-fix.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where Determined failed to report slots as occupied when non Determined
+   jobs were running on namespaces besides 'default'.

--- a/docs/release-notes/non-det-tasks-k8s-fix.rst
+++ b/docs/release-notes/non-det-tasks-k8s-fix.rst
@@ -3,4 +3,5 @@
 **Bug Fixes**
 
 -  Kubernetes: Fix an issue where Determined failed to report slots as occupied when non Determined
-   jobs were running on namespaces besides 'default'.
+   jobs were running on namespaces besides 'default'. For Determined to detect non Determined jobs
+   they must be running in a namespace that Determined can launch jobs into.

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -256,6 +256,7 @@ def _test_master_restart_stopping(managed_cluster_restarts: abstract_cluster.Clu
         exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.CANCELED)
 
     # All slots are empty, we don't leave a hanging container.
+    time.sleep(15) # Wait for k8s agent cache to end.
     agentsResp = bindings.get_GetAgents(sess)
     for a in agentsResp.agents:
         if a.slots is not None:

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -256,7 +256,7 @@ def _test_master_restart_stopping(managed_cluster_restarts: abstract_cluster.Clu
         exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.CANCELED)
 
     # All slots are empty, we don't leave a hanging container.
-    time.sleep(15) # Wait for k8s agent cache to end.
+    time.sleep(15)  # Wait for k8s agent cache to end.
     agentsResp = bindings.get_GetAgents(sess)
     for a in agentsResp.agents:
         if a.slots is not None:

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -1595,7 +1595,6 @@ func (p *pods) getNonDetPods() ([]k8sV1.Pod, error) {
 		return nil, err
 	}
 
-	// TODO cache not working.
 	var nonDetPods []k8sV1.Pod
 	for _, p := range allPods.Items {
 		_, isDet := p.Labels[determinedLabel]

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -48,7 +48,10 @@ import (
 // ResourceTypeNvidia describes the GPU resource type.
 const ResourceTypeNvidia = "nvidia.com/gpu"
 
-const summarizeCacheDuration = 5 * time.Second
+const (
+	getAgentsCacheDuration = 15 * time.Second
+	summarizeCacheDuration = 5 * time.Second
+)
 
 type podMetadata struct {
 	podName     string
@@ -1300,7 +1303,7 @@ func (p *pods) handleGetAgentsRequest() *apiv1.GetAgentsResponse {
 	p.getAgentsCacheLock.Lock()
 	defer p.getAgentsCacheLock.Unlock()
 
-	if time.Since(p.getAgentsCacheTime) > summarizeCacheDuration {
+	if time.Since(p.getAgentsCacheTime) > getAgentsCacheDuration {
 		p.getAgentsCacheTime = time.Now()
 
 		nodeSummaries := p.summarizeClusterByNodes()

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -48,6 +48,8 @@ import (
 // ResourceTypeNvidia describes the GPU resource type.
 const ResourceTypeNvidia = "nvidia.com/gpu"
 
+const summarizeCacheDuration = 5 * time.Second
+
 type podMetadata struct {
 	podName     string
 	containerID string
@@ -1298,7 +1300,7 @@ func (p *pods) handleGetAgentsRequest() *apiv1.GetAgentsResponse {
 	p.getAgentsCacheLock.Lock()
 	defer p.getAgentsCacheLock.Unlock()
 
-	if time.Since(p.getAgentsCacheTime) > 5*time.Second {
+	if time.Since(p.getAgentsCacheTime) > summarizeCacheDuration {
 		p.getAgentsCacheTime = time.Now()
 
 		nodeSummaries := p.summarizeClusterByNodes()
@@ -1336,7 +1338,7 @@ func (p *pods) summarize() (map[string]model.AgentSummary, error) {
 	p.summarizeCacheLock.Lock()
 	defer p.summarizeCacheLock.Unlock()
 
-	if time.Since(p.summarizeCacheTime) > 5*time.Second {
+	if time.Since(p.summarizeCacheTime) > summarizeCacheDuration {
 		summary, err := p.computeSummary()
 		p.summarizeCacheTime = time.Now()
 		p.summarizeCache = summarizeResult{


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Fix an issue where we only looked at the default namespace for getting pods.

Also cache get agents which probably should have been done anyway but getting all namespaces makes this even more important.


## Test Plan

unit test + manual

Make a non default named namespace that determined master has access to 
```
apiVersion: v1
kind: Pod
metadata:
  name: sleep-pod
spec:
  containers:
  - name: sleep
    image: busybox
    command: ["sleep", "100"]
    resources:
      requests:
        cpu: "2000m" # Or request gpus if this is on a gpu cluster
```

Then apply the file with ```kubectl -n namespace -f file.yaml```


```det slot ls``` should show
```
 Agent ID   | Resource Pool   |   Slot ID | Enabled   | Draining   | Allocation ID   | Task Name                      | Type   | Device
------------+-----------------+-----------+-----------+------------+-----------------+--------------------------------+--------+----------
 minikube   | a, default      |         0 | True      | False      | OCCUPIED        | Non-Determined Task: sleep-pod | cpu    |
 minikube   | a, default      |         1 | True      | False      | OCCUPIED        | Non-Determined Task: sleep-pod | cpu    |
```

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ