### PR TITLE
test: increase runner size for react e2e

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1987,7 +1987,7 @@ jobs:
         default: false
     machine:
       image: <<pipeline.parameters.machine-image>>
-    resource_class: large
+    resource_class: xlarge
     steps:
       - run: echo 'export PW_SERVER_ADDRESS="http://localhost:3001"' >> $BASH_ENV # DNJ TODO -remove when tested
       - run: echo 'export PW_USER_NAME=admin' >> $BASH_ENV

--- a/webui/react/src/e2e/fixtures/user.fixture.ts
+++ b/webui/react/src/e2e/fixtures/user.fixture.ts
@@ -170,7 +170,6 @@ export class UserFixture {
     // get all user ids so we can update the status later
     const ids = await this.userManagementPage.table.table.allRowKeys();
     // select all users
-    await this.userManagementPage.actions.pwLocator.waitFor({ state: 'hidden' });
     await this.userManagementPage.table.table.headRow.selectAll.pwLocator.click();
     await expect(this.userManagementPage.table.table.headRow.selectAll.pwLocator).toBeChecked();
     // open group actions

--- a/webui/react/src/e2e/tests/userManagement.spec.ts
+++ b/webui/react/src/e2e/tests/userManagement.spec.ts
@@ -216,12 +216,16 @@ test.describe('User Management', () => {
           expect(async () => {
             // BUG [ET-240]
             await userManagementPage.table.table.pagination.pageButtonLocator(2).click();
+            await expect(
+              userManagementPage.table.table.pagination.pageButtonLocator(2),
+            ).toHaveClass(/ant-pagination-item-active/);
             await expect(userManagementPage.table.table.rows.pwLocator).toHaveCount(1, {
               timeout: 2_000,
             });
           }).toPass({ timeout: 10_000 });
         });
         await test.step("Disable all users on the table's page", async () => {
+          await userManagementPage.actions.pwLocator.waitFor({ state: 'hidden' });
           await user.deactivateTestUsersOnTable();
         });
         // expect this test step to fail


### PR DESCRIPTION

## test: increase runner size for react e2e


## Ticket
INFENG-666



## Description
increase react runner size to large since we are maxing out CPU on the current runner.



## Test Plan
Ran and passed CI


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ