### PR TITLE
fix: Hide runs in archived experiments

### DIFF
--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -253,7 +253,7 @@ func filterRunQuery(getQ *bun.SelectQuery, filter *string) (*bun.SelectQuery, er
 		return q
 	}).WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
 		if !efr.ShowArchived {
-			return q.Where(`r.archived = false`)
+			return q.Where(`r.archived OR e.archived`)
 		}
 		return q
 	})

--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -253,7 +253,7 @@ func filterRunQuery(getQ *bun.SelectQuery, filter *string) (*bun.SelectQuery, er
 		return q
 	}).WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
 		if !efr.ShowArchived {
-			return q.Where(`r.archived OR e.archived`)
+			return q.Where(`NOT (r.archived OR e.archived)`)
 		}
 		return q
 	})


### PR DESCRIPTION
## Ticket
ET-245


## Description
Runs that are part of an archived experiment should be considered archived


## Test Plan
Integration tests should pass

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

