### PR TITLE
chore: stop publishing helm charts to NGC.

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -248,10 +248,6 @@ commands:
     steps:
       - run: echo "<<parameters.password>>" | docker login <<parameters.repository>> -u "<<parameters.username>>" --password-stdin
 
-  login-helm:
-    steps:
-      - run: helm repo add determined https://helm.ngc.nvidia.com/isv-ngc-partner/determined --username=$NGC_API_USERNAME --password=$NGC_API_KEY
-
   reinstall-go:
     steps:
       - run: sudo rm -rf /usr/local/go # Remove system go.
@@ -1806,18 +1802,6 @@ jobs:
       - store_artifacts:
           path: /tmp/pkgs
 
-  publish-helm:
-    docker:
-      - image: <<pipeline.parameters.docker-image>>
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - helm/install-helm-client
-      - run: helm plugin install https://github.com/chartmuseum/helm-push.git
-      - login-helm
-      - run: make -C helm release
-
   publish-helm-gh:
     parameters:
       ee:
@@ -2005,7 +1989,7 @@ jobs:
           determined: true
           install-python: true
           executor: <<pipeline.parameters.machine-image>>
-      - install-protoc 
+      - install-protoc
       - when:
           condition: << parameters.ee >>
           steps:
@@ -2022,9 +2006,9 @@ jobs:
       - wait-for-master:
           host: "localhost"
           port: "8082"
-      - run: 
+      - run:
           environment:
-            PW_EE: << parameters.ee >> 
+            PW_EE: << parameters.ee >>
           command: npm run e2e --prefix webui/react
       - store_artifacts:
           path: webui/react/src/e2e/playwright-report
@@ -5476,12 +5460,6 @@ workflows:
             - build-docs
           context: determined-production
           filters: *release-filters
-
-      - publish-helm:
-          requires:
-            - build-helm
-          context: determined-production
-          filters: *release-and-rc-filters
 
       - publish-helm-gh:
           requires:

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -17,14 +17,6 @@ fmt:
 clean:
 	rm -rf build/
 
-.PHONY: release
-release: export NGC_REPO := https://helm.ngc.nvidia.com/isv-ngc-partner/determined
-release: export NGC_API_USERNAME ?=
-release: export NGC_API_KEY ?=
-release:
-	helm repo add determined $$NGC_REPO --username $$NGC_API_USERNAME --password $$NGC_API_KEY
-	helm cm-push -f build/determined-latest.tgz determined
-
 .PHONY: release-gh
 release-gh: export GORELEASER_CURRENT_TAG := $(VERSION)
 release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')


### PR DESCRIPTION
## Description

Publishing helm charts to NGC is useless. Publishing to `https://helm.determined.ai` is done elsewhere.

https://hpe-aiatscale.slack.com/archives/C03JGLKTBEJ/p1714429971196879
https://hpe-aiatscale.slack.com/archives/C7E6HPZ5F/p1714432108065479

## Test Plan

This is changing CI jobs for release which we have no way to test or dry-run. Please review carefully.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ