### PR TITLE
feat: Update workspace for templates server side

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -21843,7 +21843,7 @@ def put_PutTemplate(
     body: "v1Template",
     template_name: str,
 ) -> "v1PutTemplateResponse":
-    """DEPRECATED: Update or create (upsert) the requested template.
+    """Update or create (upsert) the requested template.
 
     - body: The template to put.
     - template_name: The name of the template.

--- a/master/internal/templates/api.go
+++ b/master/internal/templates/api.go
@@ -109,29 +109,53 @@ func (a *TemplateAPIServer) PutTemplate(
 	if len(req.Template.Name) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
-	if req.Template.WorkspaceId != 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "setting workspace_id is not supported.")
-	}
 
-	switch _, err := TemplateByName(ctx, req.Template.Name); {
+	switch tpl, err := TemplateByName(ctx, req.Template.Name); {
 	case errors.Is(err, db.ErrNotFound):
 		_, err := a.PostTemplate(ctx, &apiv1.PostTemplateRequest{Template: req.Template})
 		if err != nil {
 			return nil, err
 		}
+		return &apiv1.PutTemplateResponse{Template: req.Template}, nil
 	case err != nil:
 		return nil, err
 	default:
-		req := &apiv1.PatchTemplateConfigRequest{
-			TemplateName: req.Template.Name,
-			Config:       req.Template.Config,
-		}
-		_, err = a.PatchTemplateConfig(ctx, req)
+		user, _, err := grpcutil.GetUser(ctx)
 		if err != nil {
 			return nil, err
 		}
+		permErr, err := AuthZProvider.Get().CanUpdateTemplate(
+			ctx, user, model.AccessScopeID(tpl.WorkspaceID),
+		)
+		switch {
+		case err != nil:
+			return nil, fmt.Errorf("failed to check for permissions: %w", err)
+		case permErr != nil:
+			return nil, permErr
+		}
+
+		var updated templatev1.Template
+		q := db.Bun().NewUpdate().Model(&model.Template{}).Where("name = ?", req.Template.Name)
+
+		if req.Template.Config != nil {
+			configBytes, err := json.Marshal(req.Template.Config.AsMap())
+			if err != nil {
+				return nil, err
+			}
+			q.Set("config = ?", string(configBytes))
+		}
+		if req.Template.WorkspaceId != 0 {
+			err = canCreateTemplateWorkspace(ctx, user, req.Template.WorkspaceId)
+			if err != nil {
+				return nil, err
+			}
+
+			q.Set("workspace_id = ?", req.Template.WorkspaceId)
+		}
+		q.Returning("*").Scan(ctx, &updated)
+
+		return &apiv1.PutTemplateResponse{Template: &updated}, nil
 	}
-	return &apiv1.PutTemplateResponse{Template: req.Template}, nil
 }
 
 // PostTemplate creates a template. If a template with the same name exists, an error is returned.
@@ -147,34 +171,14 @@ func (a *TemplateAPIServer) PostTemplate(
 		return nil, status.Error(codes.InvalidArgument, "name is required")
 	}
 
-	workspaceID := int(req.Template.WorkspaceId)
+	workspaceID := req.Template.WorkspaceId
 	if req.Template.WorkspaceId == 0 {
 		workspaceID = model.DefaultWorkspaceID
 	}
 
-	err = workspace.AuthZProvider.Get().CanGetWorkspaceID(ctx, *user, req.Template.WorkspaceId)
+	err = canCreateTemplateWorkspace(ctx, user, workspaceID)
 	if err != nil {
 		return nil, err
-	}
-
-	exists, err := workspace.Exists(ctx, workspaceID)
-	switch {
-	case err != nil:
-		return nil, fmt.Errorf("failed to check workspace %d: %w", workspaceID, err)
-	case !exists:
-		return nil, api.NotFoundErrs("workspace", fmt.Sprint(workspaceID), true)
-	}
-
-	permErr, err := AuthZProvider.Get().CanCreateTemplate(
-		ctx,
-		user,
-		model.AccessScopeID(workspaceID),
-	)
-	switch {
-	case err != nil:
-		return nil, fmt.Errorf("failed to check for permissions: %w", err)
-	case permErr != nil:
-		return nil, permErr
 	}
 
 	// json.Marshal + AsMap is 2x faster than protojson.Marshal or just json.Marshal because
@@ -186,7 +190,7 @@ func (a *TemplateAPIServer) PostTemplate(
 
 	var inserted templatev1.Template
 	err = db.Bun().NewInsert().
-		Model(&model.Template{Name: req.Template.Name, WorkspaceID: workspaceID}).
+		Model(&model.Template{Name: req.Template.Name, WorkspaceID: int(workspaceID)}).
 		Value("config", "?", string(configBytes)).
 		Returning("*").
 		Scan(ctx, &inserted)
@@ -284,4 +288,32 @@ func (a *TemplateAPIServer) DeleteTemplate(
 		return nil, fmt.Errorf("error deleting template '%v': %w", req.TemplateName, err)
 	}
 	return &apiv1.DeleteTemplateResponse{}, nil
+}
+
+func canCreateTemplateWorkspace(ctx context.Context, user *model.User, workspaceId int32) error {
+	err := workspace.AuthZProvider.Get().CanGetWorkspaceID(ctx, *user, workspaceId)
+	if err != nil {
+		return err
+	}
+
+	exists, err := workspace.Exists(ctx, int(workspaceId))
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed to check workspace %d: %w", workspaceId, err)
+	case !exists:
+		return api.NotFoundErrs("workspace", fmt.Sprint(workspaceId), true)
+	}
+
+	permErr, err := AuthZProvider.Get().CanCreateTemplate(
+		ctx,
+		user,
+		model.AccessScopeID(workspaceId),
+	)
+	switch {
+	case err != nil:
+		return fmt.Errorf("failed to check for permissions: %w", err)
+	case permErr != nil:
+		return permErr
+	}
+	return nil
 }

--- a/master/internal/templates/api_intg_test.go
+++ b/master/internal/templates/api_intg_test.go
@@ -296,6 +296,29 @@ func TestPutTemplate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp1.Template.WorkspaceId, int32(w.ID))
 	})
+
+	t.Run("TestPutTemplate with invalid workspace change", func(t *testing.T) {
+		input := &templatev1.Template{
+			Name:        uuid.NewString(),
+			Config:      fakeTemplate(t),
+			WorkspaceId: 1,
+		}
+		resp, err := api.PostTemplate(ctx, &apiv1.PostTemplateRequest{Template: input})
+		require.NoError(t, err)
+		requireToJSONEq(t, input, resp.Template)
+
+		w := &model.Workspace{
+			Name:   uuid.New().String(),
+			UserID: 1,
+		}
+		_, err = db.Bun().NewInsert().Model(w).Exec(ctx)
+		require.NoError(t, err)
+
+		input.WorkspaceId = int32(w.ID) + 1
+
+		_, err = api.PutTemplate(ctx, &apiv1.PutTemplateRequest{Template: input})
+		require.ErrorContains(t, err, "not found")
+	})
 }
 
 func TestDeleteTemplate(t *testing.T) {

--- a/master/internal/templates/api_intg_test.go
+++ b/master/internal/templates/api_intg_test.go
@@ -270,7 +270,31 @@ func TestPutTemplate(t *testing.T) {
 
 		resp, err = api.PutTemplate(ctx, &apiv1.PutTemplateRequest{Template: input})
 		require.NoError(t, err)
+		requireToJSONEq(t, input.Config, resp.Template.Config)
+	})
+
+	t.Run("TestPutTemplate with workspace change", func(t *testing.T) {
+		input := &templatev1.Template{
+			Name:        uuid.NewString(),
+			Config:      fakeTemplate(t),
+			WorkspaceId: 1,
+		}
+		resp, err := api.PostTemplate(ctx, &apiv1.PostTemplateRequest{Template: input})
+		require.NoError(t, err)
 		requireToJSONEq(t, input, resp.Template)
+
+		w := &model.Workspace{
+			Name:   uuid.New().String(),
+			UserID: 1,
+		}
+		_, err = db.Bun().NewInsert().Model(w).Exec(ctx)
+		require.NoError(t, err)
+
+		input.WorkspaceId = int32(w.ID)
+
+		resp1, err := api.PutTemplate(ctx, &apiv1.PutTemplateRequest{Template: input})
+		require.NoError(t, err)
+		require.Equal(t, resp1.Template.WorkspaceId, int32(w.ID))
 	})
 }
 

--- a/proto/pkg/apiv1/api.pb.go
+++ b/proto/pkg/apiv1/api.pb.go
@@ -3877,7 +3877,7 @@ type DeterminedClient interface {
 	// Get the requested template.
 	GetTemplate(ctx context.Context, in *GetTemplateRequest, opts ...grpc.CallOption) (*GetTemplateResponse, error)
 	// Deprecated: Do not use.
-	// DEPRECATED: Update or create (upsert) the requested template.
+	// Update or create (upsert) the requested template.
 	PutTemplate(ctx context.Context, in *PutTemplateRequest, opts ...grpc.CallOption) (*PutTemplateResponse, error)
 	// Post a new template.
 	PostTemplate(ctx context.Context, in *PostTemplateRequest, opts ...grpc.CallOption) (*PostTemplateResponse, error)
@@ -6835,7 +6835,7 @@ type DeterminedServer interface {
 	// Get the requested template.
 	GetTemplate(context.Context, *GetTemplateRequest) (*GetTemplateResponse, error)
 	// Deprecated: Do not use.
-	// DEPRECATED: Update or create (upsert) the requested template.
+	// Update or create (upsert) the requested template.
 	PutTemplate(context.Context, *PutTemplateRequest) (*PutTemplateResponse, error)
 	// Post a new template.
 	PostTemplate(context.Context, *PostTemplateRequest) (*PostTemplateResponse, error)

--- a/proto/src/determined/api/v1/api.proto
+++ b/proto/src/determined/api/v1/api.proto
@@ -1330,7 +1330,7 @@ service Determined {
       tags: "Templates"
     };
   }
-  // DEPRECATED: Update or create (upsert) the requested template.
+  // Update or create (upsert) the requested template.
   rpc PutTemplate(PutTemplateRequest) returns (PutTemplateResponse) {
     option (google.api.http) = {
       put: "/api/v1/templates/{template.name}"

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -30261,7 +30261,7 @@ export const TemplatesApiFetchParamCreator = function (configuration?: Configura
         },
         /**
          * 
-         * @summary DEPRECATED: Update or create (upsert) the requested template.
+         * @summary Update or create (upsert) the requested template.
          * @param {string} templateName The name of the template.
          * @param {V1Template} body The template to put.
          * @param {*} [options] Override http request option.
@@ -30416,7 +30416,7 @@ export const TemplatesApiFp = function (configuration?: Configuration) {
         },
         /**
          * 
-         * @summary DEPRECATED: Update or create (upsert) the requested template.
+         * @summary Update or create (upsert) the requested template.
          * @param {string} templateName The name of the template.
          * @param {V1Template} body The template to put.
          * @param {*} [options] Override http request option.
@@ -30502,7 +30502,7 @@ export const TemplatesApiFactory = function (configuration?: Configuration, fetc
         },
         /**
          * 
-         * @summary DEPRECATED: Update or create (upsert) the requested template.
+         * @summary Update or create (upsert) the requested template.
          * @param {string} templateName The name of the template.
          * @param {V1Template} body The template to put.
          * @param {*} [options] Override http request option.
@@ -30590,7 +30590,7 @@ export class TemplatesApi extends BaseAPI {
     
     /**
      * 
-     * @summary DEPRECATED: Update or create (upsert) the requested template.
+     * @summary Update or create (upsert) the requested template.
      * @param {string} templateName The name of the template.
      * @param {V1Template} body The template to put.
      * @param {*} [options] Override http request option.


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[MD-379]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
In order to support move templates between workspaces, update `PutTemplate` to take workspace id. 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Change workspace id for a template through `/api/v1/templates/{templateName}` endpoint. 
Using invalid workspace id should not go through. 


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[MD-379]: https://hpe-aiatscale.atlassian.net/browse/MD-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ