### PR TITLE
fix: slots being filled returned out of order on k8s [RM-42]

### DIFF
--- a/docs/release-notes/k8s-slots-jumping.rst
+++ b/docs/release-notes/k8s-slots-jumping.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Fix an issue where the cluster page could display different slots filled on every
+   page refresh. Now the indication of slots filled should always be filled from the left to the
+   right.

--- a/master/internal/authz/obfuscate.go
+++ b/master/internal/authz/obfuscate.go
@@ -49,7 +49,6 @@ func ObfuscateSlot(slot *agentv1.Slot) error {
 	if slot == nil {
 		return errors.New("slot must be defined")
 	}
-	// TODO(DET-10276) the slotID isn't obfuscated, but it is in the agent.Slots map.
 	if err := ObfuscateDevice(slot.Device); err != nil {
 		return errors.Errorf("unable to obfuscate slot: %s", err)
 	}

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -461,6 +461,18 @@ func TestGetSlot(t *testing.T) {
 			wantedSlotNum: strconv.Itoa(4),
 		},
 		{
+			Name: "GetSlot-GPU-PodLabels-Comp1-Id4",
+			podsService: createMockPodsService(map[string]*k8sV1.Node{
+				compNode1Name: compNode1,
+				compNode2Name: compNode2,
+			},
+				slotTypeGPU,
+				true,
+			),
+			agentID:       compNode1Name,
+			wantedSlotNum: "004",
+		},
+		{
 			Name: "GetSlot-GPU-PodLabels-Comp1-Id0",
 			podsService: createMockPodsService(map[string]*k8sV1.Node{
 				compNode1Name: compNode1,
@@ -500,14 +512,18 @@ func TestGetSlot(t *testing.T) {
 
 	for _, test := range slotTests {
 		t.Run(test.Name, func(t *testing.T) {
+			wantedSlotInt, err := strconv.Atoi(test.wantedSlotNum)
+			require.NoError(t, err)
+
 			slotResp := test.podsService.handleGetSlotRequest(test.agentID, test.wantedSlotNum)
 			if slotResp == nil {
-				wantedSlotInt, err := strconv.Atoi(test.wantedSlotNum)
-				require.NoError(t, err)
 				require.True(t, wantedSlotInt < 0 || wantedSlotInt >= int(nodeNumSlots))
 				return
 			}
-			require.Equal(t, test.wantedSlotNum, slotResp.Slot.Id)
+
+			actualSlotID, err := strconv.Atoi(slotResp.Slot.Id)
+			require.NoError(t, err)
+			require.Equal(t, wantedSlotInt, actualSlotID)
 		})
 	}
 }

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -282,9 +282,7 @@ func TestGetAgent(t *testing.T) {
 				compNode1Name: largeNode,
 			}, slotTypeGPU, false),
 			wantedAgentID: compNode1Name,
-			// agentID:        compNode1Name,
-			agentExists: false,
-			// wantedSlotsNum: 16,
+			agentExists:   false,
 		},
 	}
 
@@ -416,7 +414,7 @@ func TestGetSlots(t *testing.T) {
 			for _, slot := range slotsResp.Slots {
 				slotID, err := strconv.Atoi(slot.Id)
 				require.NoError(t, err)
-				require.True(t, slotID >= 0 && slotID < test.wantedSlotsNum,
+				require.True(t, slotID >= 0 && slotID < int(nodeNumSlots),
 					fmt.Sprintf("slot %s is out of range", slot.Id))
 				if slot.Container != nil {
 					activeSlots++

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1528,8 +1527,8 @@ func (p *pods) summarizeClusterByNodes() map[string]model.AgentSummary {
 					continue
 				}
 
-				slotsSummary[strconv.Itoa(curSlot)] = model.SlotSummary{
-					ID:        strconv.Itoa(curSlot),
+				slotsSummary[model.SortableSlotIndex(curSlot)] = model.SlotSummary{
+					ID:        model.SortableSlotIndex(curSlot),
 					Device:    device.Device{Type: deviceType},
 					Draining:  isDraining,
 					Enabled:   !isDisabled,
@@ -1546,8 +1545,8 @@ func (p *pods) summarizeClusterByNodes() map[string]model.AgentSummary {
 					continue
 				}
 
-				slotsSummary[strconv.Itoa(curSlot)] = model.SlotSummary{
-					ID:       strconv.Itoa(curSlot),
+				slotsSummary[model.SortableSlotIndex(curSlot)] = model.SlotSummary{
+					ID:       model.SortableSlotIndex(curSlot),
 					Device:   device.Device{Type: deviceType},
 					Draining: isDraining,
 					Enabled:  !isDisabled,
@@ -1563,8 +1562,8 @@ func (p *pods) summarizeClusterByNodes() map[string]model.AgentSummary {
 		}
 
 		for i := curSlot; i < int(numSlots); i++ {
-			slotsSummary[strconv.Itoa(i)] = model.SlotSummary{
-				ID:       strconv.Itoa(i),
+			slotsSummary[model.SortableSlotIndex(i)] = model.SlotSummary{
+				ID:       model.SortableSlotIndex(i),
 				Device:   device.Device{Type: deviceType},
 				Draining: isDraining,
 				Enabled:  !isDisabled,

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1292,8 +1293,14 @@ func (p *pods) handleGetSlotRequest(agentID string, slotID string) *apiv1.GetSlo
 	slots := agentResp.Agent.Slots
 	slot, ok := slots[slotID]
 	if !ok {
-		p.syslog.Warnf("no slot with id %s", slotID)
-		return nil
+		// Try converting an index input to a slot and see if that exists (1 to 001).
+		tryIndex, err := strconv.Atoi(slotID)
+		if s, ok := slots[model.SortableSlotIndex(tryIndex)]; err == nil && ok {
+			slot = s
+		} else {
+			p.syslog.Warnf("no slot with id %s", slotID)
+			return nil
+		}
 	}
 	return &apiv1.GetSlotResponse{Slot: slot}
 }

--- a/master/pkg/model/agent.go
+++ b/master/pkg/model/agent.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/determined-ai/determined/master/pkg/cproto"
@@ -128,4 +129,19 @@ type AgentStats struct {
 	ResourcePool string `db:"resource_pool"`
 	AgentID      string `db:"agent_id"`
 	Slots        int    `db:"slots"`
+}
+
+// SortableSlotIndex returns a slot index that will sort as you want to.
+//
+// This is a hack to fix a bug seen by the webui.
+// The webui displays a list of slots and if they are filled, so they expect that
+// the order of what slots are filled in is consistent. In Kubernetes this is an illusion,
+// we don't know what slot is running what job.
+// Our API returns a map of slot IDs to slots that get returned. This map gets parsed and display
+// in the frontend lexicographically. Just doing indexes breaks when there are more than 10 GPUs
+// per agent since it will go 1,10,11 instead of 1,2,3,4.
+//
+// To fix this on our just pad the numbers with 0s so they sort in the response.
+func SortableSlotIndex(i int) string {
+	return fmt.Sprintf("%03d", i)
 }

--- a/master/pkg/model/agent_test.go
+++ b/master/pkg/model/agent_test.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortableSlotIndex(t *testing.T) {
+	require.Equal(t, SortableSlotIndex(2), "002")
+	require.Equal(t, SortableSlotIndex(16), "016")
+
+	// Do we actually sort?
+	var gpuIndexes []string
+	for i := 0; i <= 999; i++ {
+		gpuIndexes = append(gpuIndexes, SortableSlotIndex(i))
+	}
+	require.True(t, slices.IsSorted(gpuIndexes))
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Fix issues where slots were being returned out of order. There are two fixes in this PR

1. Make k8s use slot IDs that will return sorted. For more than 10 gpus on an agent the response would be out of order
2. The issue in the ticket, rbac would jumble the order. 



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Unit tests cover this pretty well

Manual 

Run a devcluster with
```
        security:
          authz:
            type: rbac
```

and agent
```
        artificial_slots: 8
```

run a experiment, create a user with no access ```det -u admin user create test```

check agents ```det -u test dev curl /api/v1/agents``` and see that the contaner is on the same slot id every refresh

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ