### PR TITLE
chore: upgrade golangci linter to 1.57.2

### DIFF
--- a/agent/get-deps.sh
+++ b/agent/get-deps.sh
@@ -1,5 +1,5 @@
 go install mvdan.cc/gofumpt@v0.4.0
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 go install golang.org/x/tools/cmd/goimports@v0.1.5
 go install github.com/goreleaser/goreleaser@v1.14.1
 go install gotest.tools/gotestsum@v1.9.0

--- a/agent/internal/container/container.go
+++ b/agent/internal/container/container.go
@@ -438,8 +438,7 @@ func hackAllocationID(spec *cproto.Spec) model.AllocationID {
 		}
 
 		value := split[1]
-		switch split[0] {
-		case AllocationIDEnvVar:
+		if split[0] == AllocationIDEnvVar {
 			return model.AllocationID(value)
 		}
 	}

--- a/agent/pkg/docker/docker_api_test.go
+++ b/agent/pkg/docker/docker_api_test.go
@@ -41,10 +41,8 @@ func TestPullImage(t *testing.T) {
 	cl := docker.NewClient(rawCl)
 
 	t.Log("removing image")
-	switch _, err = rawCl.ImageRemove(ctx, testImage, types.ImageRemoveOptions{Force: true}); {
-	case err == nil, strings.Contains(err.Error(), "No such image"):
-		break
-	case err != nil:
+	_, err = rawCl.ImageRemove(ctx, testImage, types.ImageRemoveOptions{Force: true})
+	if err != nil && !strings.Contains(err.Error(), "No such image") {
 		t.Errorf("removing image: %s", err.Error())
 		return
 	}
@@ -57,7 +55,7 @@ func TestPullImage(t *testing.T) {
 		return
 	}
 	close(evs)
-	if !witnessedPull(t, evs) {
+	if !witnessedPull(evs) {
 		t.Errorf("did not witness expected pull events")
 		return
 	}
@@ -72,7 +70,7 @@ func TestPullImage(t *testing.T) {
 		return
 	}
 	close(evs)
-	if witnessedPull(t, evs) {
+	if witnessedPull(evs) {
 		t.Error("saw pull of pulled image")
 		return
 	}
@@ -90,7 +88,7 @@ func TestPullImage(t *testing.T) {
 		return
 	}
 	close(evs)
-	if !witnessedPull(t, evs) {
+	if !witnessedPull(evs) {
 		t.Errorf("did not witness expected pull events")
 		return
 	}
@@ -98,7 +96,7 @@ func TestPullImage(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func witnessedPull(t *testing.T, events <-chan docker.Event) bool {
+func witnessedPull(events <-chan docker.Event) bool {
 	pullWitnessed, statsBeginWitnessed, statsEndWitnessed := false, false, false
 	for event := range events {
 		switch {
@@ -281,7 +279,6 @@ func TestRunContainerWithService(t *testing.T) {
 		return
 	case exit := <-c.ContainerWaiter.Waiter:
 		require.Equal(t, int64(0), exit.StatusCode)
-		break
 	}
 
 	t.Log("reattached waiters should also exit after being killed")
@@ -291,6 +288,5 @@ func TestRunContainerWithService(t *testing.T) {
 		return
 	case exit := <-reattached.ContainerWaiter.Waiter:
 		require.Equal(t, int64(0), exit.StatusCode)
-		break
 	}
 }

--- a/agent/pkg/podman/podman.go
+++ b/agent/pkg/podman/podman.go
@@ -249,7 +249,7 @@ func (s *PodmanClient) RunContainer(
 
 	// from master task_container_defaults.shm_size_bytes
 	if shmsize := req.HostConfig.ShmSize; shmsize != 4294967296 { // 4294967296 is the default.
-		args = append(args, "--shm-size", fmt.Sprintf("%d", shmsize))
+		args = append(args, "--shm-size", strconv.Itoa(int(shmsize)))
 	}
 
 	args = capabilitiesToPodmanArgs(req, args)

--- a/agent/pkg/singularity/singularity.go
+++ b/agent/pkg/singularity/singularity.go
@@ -396,11 +396,11 @@ func (s *SingularityClient) computeImageReference(requestedImage string) string 
 	s.log.Tracef("requested image: %s", requestedImage)
 	if s.imageRoot != "" {
 		cachePathName := s.imageRoot + "/" + requestedImage
-		if _, err := os.Stat(cachePathName); err != nil {
-			s.log.Tracef("image is not in cache: %s", err.Error())
-		} else {
+		_, err := os.Stat(cachePathName)
+		if err == nil {
 			return cachePathName
 		}
+		s.log.Tracef("image is not in cache: %s", err.Error())
 	}
 	return cruntimes.CanonicalizeImage(requestedImage)
 }

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -1,8 +1,8 @@
 run:
-  go: 1.20
+  go: "1.20"
 
-  # Deadline for individual linters to complete by.
-  deadline: 1m
+  # Timeout for individual linters to complete by.
+  timeout: 1m
 
   # Include tests files in linting process.
   tests: true
@@ -10,12 +10,10 @@ run:
   # The exit code when at least one issue was found.
   issues-exit-code: 1
 
-  skip-files:
-    - pkg/schemas/expconf/latest.go
-
 output:
-  # Linter output format.
-  format: colored-line-number
+  formats:
+    # Linter output format.
+    - format: colored-line-number
 
   # Print lines of code with issue.
   print-issued-lines: true
@@ -31,22 +29,26 @@ issues:
     - Consider preallocating
     # Exclude "gosec: Errors unhandled" because it duplicates errcheck.
     - G104
+    - G601
     - and that stutters
     - declaration of "(err|ctx)" shadows declaration at
 
   # Independently from option `exclude` golangci-lint uses default exclude patterns.
   exclude-use-default: false
 
+  exclude-files:
+    - pkg/schemas/expconf/latest.go
+
   # Disable the maximum issue count per linter.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      - gopkg.in/yaml.v2
-      - github.com/dgrijalva/jwt-go
+    rules:
+      main:
+        deny:
+          - pkg: gopkg.in/yaml.v2
+          - pkg: github.com/dgrijalva/jwt-go
   dupl:
     threshold: 210
   goconst:
@@ -55,40 +57,95 @@ linters-settings:
   gocritic:
     disabled-checks:
       - singleCaseSwitch
-  golint:
-    min-confidence: 0
   goimports:
     local-prefixes: github.com/determined-ai/determined
-  govet:
-    check-shadowing: true
   errcheck:
     exclude-functions:
-      - '(*database/sql.Rows).Close'
-      - '(*github.com/jmoiron/sqlx.NamedStmt).Close'
+      - "(*database/sql.Rows).Close"
+      - "(*github.com/jmoiron/sqlx.NamedStmt).Close"
   lll:
     line-length: 120
   misspell:
     locale: US
   exhaustruct:
     include:
-      - 'github.com/determined-ai/determined/master/pkg/schemas/expconf.*Config*'
-      - 'github.com/determined-ai/determined/proto/pkg/userv1.UserWebSetting'
+      - "github.com/determined-ai/determined/master/pkg/schemas/expconf.*Config*"
+      - "github.com/determined-ai/determined/proto/pkg/userv1.UserWebSetting"
   forbidigo:
     forbid:
       - 'fmt\.Print.*'
-      - 'metaV1.NamespaceAll' # Will error if someone has namespace restricted permissions.
-      - 'bundebug.WithVerbose'
-      - 'http.Client' # Use cleanhttp instead.
-      - 'http.Transport' # Use cleanhttp instead.
+      - "metaV1.NamespaceAll" # Will error if someone has namespace restricted permissions.
+      - "bundebug.WithVerbose"
+      - "http.Client" # Use cleanhttp instead.
+      - "http.Transport" # Use cleanhttp instead.
       - 'defer .*\.Lock\(\)'
-  staticcheck:
-    go: "1.20"
+  perfsprint:
+    errorf: false
+    strconcat: false
+  testifylint:
+    disable:
+      - go-require # Requires that require must only be used in the goroutine running the test function.
+  revive:
+    ignore-generated-header: true
+    enable-all-rules: true
+    rules:
+      # Do not enable these linters.
+      - name: function-length # We've internally decided that the char length for lines is 120, not 75.
+        disabled: true
+      - name: line-length-limit # Already have another linter enabled that takes care of this.
+        disabled: true 
+      - name: confusing-naming # We want to keep this to have lower-cased versions of our exported methods.
+        disabled: true 
+      - name: import-alias-naming # We like to use camel-case in our pkg names.
+        disabled: true 
+      - name: nested-structs # We allow nested structs.
+        disabled: true 
+      - name: if-return # Do not enable, as this is a style preference.
+        disabled: true
+      - name: defer # We probably shouldn't enable, we have defers inside loops.
+        disabled: true
+      - name: import-shadowing # We probably shouldn't enable.
+        disabled: true 
+      # Toss-up linters.
+      - name: var-naming # We're pretty inconsisent in using "IDs" vs "Ids" for our variables & API requests.
+        disabled: true
+      - name: deep-exit # We have several instances of log.Fatal().
+        disabled: true 
+      - name: function-result-limit # Sometimes we want to return more than 5 values in a function.
+        disabled: true 
+      - name: max-public-structs # In our defined pkg's, we define so many public structs.
+        disabled: true 
+      - name: modifies-value-receiver # Not an easy solution.
+        disabled: true 
+      - name: add-constant # We probably shouldn't enable, this will make too many messy import cycles.
+        disabled: true 
+      - name: unused-receiver # We probably shouldn't enable, keeping receivers named is consistent across all funcs.
+        disabled: true 
+      - name: argument-limit # When creating new structs, we often pass in more than 8 arguments.
+        disabled: true 
+      - name: unhandled-error # Toss-up linter, I'm not sure what it's supposed to do.
+        disabled: true 
+      - name: unused-parameter # A toss-up linter, it's nice to have parameters named in some cases.
+        disabled: true 
+      # Enable these linters.
+      - name: bare-return # TODO (RM-333)
+        disabled: true 
+      - name: cognitive-complexity # TODO (RM-334)
+        disabled: true
+      - name: cyclomatic # TODO (RM-335)
+        disabled: true
+      - name: use-any # TODO (RM-336)
+        disabled: true
+      - name: flag-parameter # TODO (RM-337)
+        disabled: true 
+      - name: unchecked-type-assertion # TODO (RM-338)
+        disabled: true
 
 linters:
   enable-all: true
   disable:
     # Linters that need triaging. Put all linters here if you upgrade.
-    # Below here are new linters from upgrading to 1.43.0. Since we enable all and disable
+    # Below here are new linters from upgrading to 1.57.2. Since we enable all and disable
     # selectively, when we upgrade we get a ton of new linters. For convenience next upgrade,
     # golangci-lint can tell you which linters are enabled:
     #   golangci-lint linters | sed -n '/Enabled/,/Disabled/p'
@@ -96,15 +153,17 @@ linters:
     #   comm -13 <(cut -d : -f 1 <oldlinters.txt) <(cut -d : -f 1 <newlinters.txt)
 
     # Linters that we should probably enable. Please give each a ticket.
-    - cyclop          # TODO(DET-9951)
-    - errorlint       # TODO(DET-9952)
-    - forcetypeassert # TODO(DET-9953)
-    - wrapcheck       # TODO(DET-9954)
-    - maintidx        # TODO(DET-9956)
-    - gocyclo         # TODO(DET-9957)
-    - gocognit        # TODO(DET-9958)
-    - funlen          # TODO(DET-9959)
-    - nestif          # TODO(DET-9960)
+    - cyclop          # TODO (RM-325)
+    - errorlint       # TODO (RM-330)
+    - forcetypeassert # TODO (RM-326)
+    - wrapcheck       # TODO (RM-222)
+    - maintidx        # TODO (RM-327)
+    - gocyclo         # TODO (RM-331)
+    - gocognit        # TODO (RM-328)
+    - funlen          # TODO (RM-332)
+    - nestif          # TODO (RM-329)
+    - nakedret        # TODO (RM-333)
+
 
     # Toss up linters.
     - predeclared
@@ -121,6 +180,7 @@ linters:
     - gochecknoinits
     - goerr113
     - gomnd
+    - inamedparam # We don't enforce this now, but might be useful in the future.
 
     # Linters that we should probably keep disabled.
     - errchkjson       # Requiring us to ignore errors (even if they won't be non nil) feels strange.
@@ -136,6 +196,8 @@ linters:
     - unparam          # We have a lot of unused parameters.
     - gochecknoglobals # We have globals currently and don't have an issue with too many.
     - exhaustive       # We often use switch statements as if statements.
+    - protogetter      # Carolina thinks this is overkill.
+    - tagalign         # Carolina thinks this is unnecessary.
 
     # Linters that are deprecated / replaced / removed.
     - nosnakecase      # Replaced by revive(var-naming).

--- a/master/cmd/determined-master/migrate.go
+++ b/master/cmd/determined-master/migrate.go
@@ -18,7 +18,7 @@ func newMigrateCmd() *cobra.Command {
 		Use:   "migrate",
 		Short: "migrate the db",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := runMigrate(cmd, args); err != nil {
+			if err := runMigrate(args); err != nil {
 				log.Error(fmt.Sprintf("%+v", err))
 				os.Exit(1)
 			}
@@ -26,7 +26,7 @@ func newMigrateCmd() *cobra.Command {
 	}
 }
 
-func runMigrate(cmd *cobra.Command, args []string) error {
+func runMigrate(args []string) error {
 	for _, arg := range args {
 		if arg == "down" || arg == "reset" {
 			return fmt.Errorf("migrating down or reseting is not supported")

--- a/master/cmd/determined-master/populate_metrics.go
+++ b/master/cmd/determined-master/populate_metrics.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -23,7 +23,7 @@ func newPopulateCmd() *cobra.Command {
 		Short: `populate metrics with given number of batches. 
 		trivial is an optional arg for trivial metrics rather than more complex ones.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := runPopulate(cmd, args); err != nil {
+			if err := runPopulate(args); err != nil {
 				log.Error(fmt.Sprintf("%+v", err))
 				os.Exit(1)
 			}
@@ -31,7 +31,7 @@ func newPopulateCmd() *cobra.Command {
 	}
 }
 
-func runPopulate(cmd *cobra.Command, args []string) error {
+func runPopulate(args []string) error {
 	start := time.Now()
 	err := initializeConfig()
 	if err != nil {

--- a/master/cmd/stream-gen/main.go
+++ b/master/cmd/stream-gen/main.go
@@ -639,13 +639,12 @@ func main() {
 			// old output is already up-to-date
 			fmt.Fprintf(os.Stderr, "output is up-to-date\n")
 			os.Exit(0)
-		} else {
-			// write a new output
-			err := os.WriteFile(output, content, 0o666) //nolint: gosec // let umask do its thing
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed writing to %v: %v\n", output, err.Error())
-				os.Exit(1)
-			}
+		}
+		// write a new output
+		err = os.WriteFile(output, content, 0o666) //nolint: gosec // let umask do its thing
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed writing to %v: %v\n", output, err.Error())
+			os.Exit(1)
 		}
 	}
 }

--- a/master/get-deps.sh
+++ b/master/get-deps.sh
@@ -1,5 +1,5 @@
 go install mvdan.cc/gofumpt@v0.4.0
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 go install github.com/bufbuild/buf/cmd/buf@v0.42.1
 go install golang.org/x/tools/cmd/goimports@v0.1.5
 go install github.com/goreleaser/goreleaser@v1.14.1

--- a/master/internal/api/apiutils/mask.go
+++ b/master/internal/api/apiutils/mask.go
@@ -3,7 +3,7 @@ package apiutils
 import (
 	"strings"
 
-	field_mask "google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/genproto/protobuf/field_mask"
 )
 
 // FieldMask is a utility type for efficiently interacting with protobuf FieldMasks in a compliant

--- a/master/internal/api/apiutils/mask_test.go
+++ b/master/internal/api/apiutils/mask_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	field_mask "google.golang.org/genproto/protobuf/field_mask"
+	"google.golang.org/genproto/protobuf/field_mask"
 )
 
 func TestFieldInSet(t *testing.T) {

--- a/master/internal/api/query.go
+++ b/master/internal/api/query.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	pref "google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pkg/errors"
 

--- a/master/internal/api_agent_test.go
+++ b/master/internal/api_agent_test.go
@@ -15,8 +15,8 @@ func TestSummarizeSlots_EmptySlots(t *testing.T) {
 	slots := make(map[string]*agentv1.Slot)
 	stats := model.SummarizeSlots(slots)
 
-	assert.Equal(t, 0, len(stats.TypeStats))
-	assert.Equal(t, 0, len(stats.BrandStats))
+	assert.Empty(t, len(stats.TypeStats))
+	assert.Empty(t, len(stats.BrandStats))
 }
 
 func TestSummarizeSlots_VariousStates(t *testing.T) {

--- a/master/internal/api_auth.go
+++ b/master/internal/api_auth.go
@@ -67,7 +67,7 @@ func (a *apiServer) Login(
 	if err != nil {
 		return nil, err
 	}
-	fullUser, err := getUser(ctx, a.m.db, userModel.ID)
+	fullUser, err := getUser(ctx, userModel.ID)
 	return &apiv1.LoginResponse{Token: token, User: fullUser}, err
 }
 
@@ -78,7 +78,7 @@ func (a *apiServer) CurrentUser(
 	if err != nil {
 		return nil, err
 	}
-	fullUser, err := getUser(ctx, a.m.db, user.ID)
+	fullUser, err := getUser(ctx, user.ID)
 	return &apiv1.CurrentUserResponse{User: fullUser}, err
 }
 

--- a/master/internal/api_checkpoint_intg_test.go
+++ b/master/internal/api_checkpoint_intg_test.go
@@ -428,7 +428,7 @@ func TestGetCheckpointNaNInfinityValues(t *testing.T) {
 			if testVars.metric == "NaN" {
 				require.True(t, math.IsNaN(*resp.Checkpoint.Training.SearcherMetric))
 			} else {
-				require.Equal(t, testVars.metricValue, *resp.Checkpoint.Training.SearcherMetric)
+				require.InEpsilon(t, testVars.metricValue, *resp.Checkpoint.Training.SearcherMetric, 0.01)
 			}
 		})
 	}
@@ -532,8 +532,8 @@ func TestPatchCheckpoint(t *testing.T) {
 	require.Equal(t, 1, actualSize) // Size and resources don't get cleared.
 	require.Equal(t, resources, actualResources)
 	require.Equal(t, model.DeletedState, actualState)
-	require.Equal(t, 0, getTrialSizeFromUUID(ctx, t, uuid))
-	require.Equal(t, 0, getExperimentSizeFromUUID(ctx, t, uuid))
+	require.Zero(t, getTrialSizeFromUUID(ctx, t, uuid))
+	require.Zero(t, getExperimentSizeFromUUID(ctx, t, uuid))
 
 	// Test metadata.json special handling.
 	startingResources = map[string]int64{

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strconv"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	pstruct "github.com/golang/protobuf/ptypes/struct"
@@ -176,7 +177,7 @@ func (a *apiServer) GetCommands(
 		return nil, err
 	}
 
-	workspaceNotFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(req.WorkspaceId), true)
+	workspaceNotFoundErr := api.NotFoundErrs("workspace", strconv.Itoa(int(req.WorkspaceId)), true)
 
 	if req.WorkspaceId != 0 {
 		// check if the workspace exists.
@@ -370,11 +371,11 @@ func (a *apiServer) LaunchCommand(
 		"DET_TASK_TYPE": string(model.TaskTypeCommand),
 	}
 
-	OIDCPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
+	oidcPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
 	if err != nil {
 		return nil, err
 	}
-	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, OIDCPachydermEnvVars)
+	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, oidcPachydermEnvVars)
 
 	// Launch a command.
 	cmd, err := command.DefaultCmdService.LaunchGenericCommand(

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2230,7 +2230,7 @@ func (a *apiServer) TrialsSample(req *apiv1.TrialsSampleRequest,
 				return err
 			}
 
-			if timeSinceLastAuth.Equal((time.Time{})) { // Initialzation.
+			if timeSinceLastAuth.IsZero() { // Initialzation.
 				searcherConfig = exp.Config.Searcher
 			}
 			timeSinceLastAuth = time.Now()

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -9,12 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/proto/pkg/checkpointv1"
 
@@ -342,9 +341,9 @@ func TestMoveExperiments(t *testing.T) {
 			Filters:              nil,
 		})
 		for _, v := range result.Results {
-			require.Equal(t, v.Error, "")
+			require.Empty(t, v.Error)
 		}
-		require.Equal(t, len(result.Results), 1)
+		require.Len(t, result.Results, 1)
 		require.NoError(t, err)
 	})
 
@@ -358,9 +357,9 @@ func TestMoveExperiments(t *testing.T) {
 			Filters:              nil,
 		})
 		for _, v := range result.Results {
-			require.Equal(t, v.Error, "")
+			require.Empty(t, v.Error)
 		}
-		require.Equal(t, len(result.Results), 2)
+		require.Len(t, result.Results, 2)
 		require.NoError(t, err)
 	})
 	t.Run("Move no experiments with filters (no filter match)", func(t *testing.T) {
@@ -376,7 +375,7 @@ func TestMoveExperiments(t *testing.T) {
 				Archived: &wrappers.BoolValue{Value: true},
 			},
 		})
-		require.Equal(t, len(result.Results), 0)
+		require.Empty(t, result.Results)
 		require.NoError(t, err)
 	})
 
@@ -400,7 +399,7 @@ func TestMoveExperiments(t *testing.T) {
 			DestinationProjectId: int32(projectID),
 			Filters:              nil,
 		})
-		require.Equal(t, len(result.Results), 0)
+		require.Empty(t, result.Results)
 		require.NoError(t, err)
 	})
 
@@ -411,7 +410,7 @@ func TestMoveExperiments(t *testing.T) {
 			DestinationProjectId: int32(projectID),
 			Filters:              nil,
 		})
-		require.Equal(t, len(result.Results), 2)
+		require.Len(t, result.Results, 2)
 		require.NoError(t, err)
 	})
 
@@ -428,7 +427,7 @@ func TestMoveExperiments(t *testing.T) {
 		errorIDList := make([]int32, 0)
 		for _, v := range result.Results {
 			if v.Error == "" {
-				require.Equal(t, v.Error, "")
+				require.Empty(t, v.Error)
 				successIDList = append(successIDList, v.Id)
 			} else {
 				require.Equal(
@@ -439,10 +438,10 @@ func TestMoveExperiments(t *testing.T) {
 				errorIDList = append(errorIDList, v.Id)
 			}
 		}
-		require.Equal(t, len(successIDList), 1)
-		require.Equal(t, len(errorIDList), 2)
+		require.Len(t, successIDList, 1)
+		require.Len(t, errorIDList, 2)
 		require.Equal(t, successIDList[0], int32(exp.ID))
-		require.Equal(t, len(result.Results), len(expIds))
+		require.Len(t, result.Results, len(expIds))
 		require.NoError(t, err)
 	})
 }
@@ -462,7 +461,7 @@ func TestDeleteExperimentWithoutCheckpoints(t *testing.T) {
 	for i := 0; i < 60; i++ {
 		e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: int32(exp.ID)})
 		if err != nil {
-			require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(exp.ID), true), err)
+			require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(exp.ID), true), err)
 			return
 		}
 		require.NotEqual(t, experimentv1.State_STATE_DELETE_FAILED, e.Experiment.State)
@@ -785,7 +784,7 @@ func TestGetExperimentsShowTrialData(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Experiments, 2)
 	require.NotNil(t, resp.Experiments[0].BestTrialSearcherMetric)
-	require.Equal(t, 0.0, *resp.Experiments[0].BestTrialSearcherMetric) // 0.0 is the best metric.
+	require.Zero(t, *resp.Experiments[0].BestTrialSearcherMetric) // 0.0 is the best metric.
 	require.Nil(t, resp.Experiments[1].BestTrialSearcherMetric)
 }
 
@@ -926,84 +925,84 @@ func TestGetExperiments(t *testing.T) {
 	}
 
 	// Filtering tests.
-	getExperimentsTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{}, exp0Expected, exp1Expected)
+	testGetExperiments(ctx, t, api, pid, &apiv1.GetExperimentsRequest{}, exp0Expected, exp1Expected)
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Description: "12345"}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Description: "234"}, exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Description: "123456"})
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Name: "longername"}, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Name: "name"}, exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Name: "longlongername"})
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Labels: []string{"l0", "l1"}}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Labels: []string{"l0"}}, exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Labels: []string{"l0", "l1", "l3"}})
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Archived: wrapperspb.Bool(false)}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Archived: wrapperspb.Bool(true)}, exp1Expected)
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			States: []experimentv1.State{experimentv1.State_STATE_PAUSED},
 		}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			States: []experimentv1.State{experimentv1.State_STATE_ERROR},
 		}, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			States: []experimentv1.State{
 				experimentv1.State_STATE_PAUSED,
 				experimentv1.State_STATE_ERROR,
 			},
 		}, exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			States: []experimentv1.State{experimentv1.State_STATE_CANCELED},
 		})
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Users: []string{"admin"}}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Users: []string{userResp.User.Username}}, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Users: []string{"admin", userResp.User.Username}},
 		exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{Users: []string{"notarealuser"}})
 
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{UserIds: []int32{1}}, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{UserIds: []int32{userResp.User.Id}}, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{UserIds: []int32{1, userResp.User.Id}},
 		exp0Expected, exp1Expected)
-	getExperimentsTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{UserIds: []int32{-999}})
+	testGetExperiments(ctx, t, api, pid, &apiv1.GetExperimentsRequest{UserIds: []int32{-999}})
 
 	// Sort and order by tests.
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			SortBy: apiv1.GetExperimentsRequest_SORT_BY_NUM_TRIALS,
 		}, exp1Expected, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			SortBy:  apiv1.GetExperimentsRequest_SORT_BY_NUM_TRIALS,
 			OrderBy: apiv1.OrderBy_ORDER_BY_ASC,
 		}, exp1Expected, exp0Expected)
-	getExperimentsTest(ctx, t, api, pid,
+	testGetExperiments(ctx, t, api, pid,
 		&apiv1.GetExperimentsRequest{
 			SortBy:  apiv1.GetExperimentsRequest_SORT_BY_NUM_TRIALS,
 			OrderBy: apiv1.OrderBy_ORDER_BY_DESC,
@@ -1011,21 +1010,21 @@ func TestGetExperiments(t *testing.T) {
 
 	// Pagination tests.
 	// No experiments should be returned for Limit -2.
-	getExperimentsTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: -2})
-	getExperimentsPageTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Offset: 1},
+	testGetExperiments(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: -2})
+	testGetExperimentsPage(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Offset: 1},
 		&apiv1.Pagination{Offset: 1, Limit: 0, StartIndex: 1, EndIndex: 2, Total: 2})
-	getExperimentsPageTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: 1},
+	testGetExperimentsPage(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: 1},
 		&apiv1.Pagination{Offset: 0, Limit: 1, StartIndex: 0, EndIndex: 1, Total: 2})
-	getExperimentsPageTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: 1, Offset: 1},
+	testGetExperimentsPage(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: 1, Offset: 1},
 		&apiv1.Pagination{Offset: 1, Limit: 1, StartIndex: 1, EndIndex: 2, Total: 2})
-	getExperimentsPageTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Offset: 2},
+	testGetExperimentsPage(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Offset: 2},
 		&apiv1.Pagination{Offset: 2, Limit: 0, StartIndex: 2, EndIndex: 2, Total: 2})
 
-	getExperimentsPageTest(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: -1},
+	testGetExperimentsPage(ctx, t, api, pid, &apiv1.GetExperimentsRequest{Limit: -1},
 		&apiv1.Pagination{Offset: 0, Limit: -1, StartIndex: 0, EndIndex: 2, Total: 2})
 }
 
-func getExperimentsPageTest(ctx context.Context, t *testing.T, api *apiServer, pid int32,
+func testGetExperimentsPage(ctx context.Context, t *testing.T, api *apiServer, pid int32,
 	req *apiv1.GetExperimentsRequest, expected *apiv1.Pagination,
 ) {
 	req.ProjectId = pid
@@ -1035,13 +1034,13 @@ func getExperimentsPageTest(ctx context.Context, t *testing.T, api *apiServer, p
 	require.Equal(t, expected, res.Pagination)
 }
 
-func getExperimentsTest(ctx context.Context, t *testing.T, api *apiServer, pid int32,
+func testGetExperiments(ctx context.Context, t *testing.T, api *apiServer, pid int32,
 	req *apiv1.GetExperimentsRequest, expected ...*experimentv1.Experiment,
 ) {
 	req.ProjectId = pid
 	res, err := api.GetExperiments(ctx, req)
 	require.NoError(t, err)
-	require.Equal(t, len(expected), len(res.Experiments),
+	require.Len(t, res.Experiments, len(expected),
 		fmt.Sprintf("wrong length of result set with request %+v", req))
 
 	for i := range expected {
@@ -1085,7 +1084,7 @@ func TestSearchExperiments(t *testing.T) {
 	}
 	resp, err := api.SearchExperiments(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Experiments, 0)
+	require.Empty(t, resp.Experiments)
 
 	// No trial doesn't cause errors.
 	exp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
@@ -1159,14 +1158,14 @@ func TestSearchExperiments(t *testing.T) {
 	require.NoError(t, err)
 	bestExpected, err := json.Marshal(valMetrics[0])
 	require.NoError(t, err)
-	require.Equal(t, string(bestActual), string(bestExpected))
+	require.Equal(t, string(bestExpected), string(bestActual))
 
 	require.Equal(t, int32(9), resp.Experiments[2].BestTrial.LatestValidation.TotalBatches)
 	latestActual, err := json.Marshal(resp.Experiments[2].BestTrial.LatestValidation.Metrics)
 	require.NoError(t, err)
 	latestExpected, err := json.Marshal(valMetrics[len(valMetrics)-1])
 	require.NoError(t, err)
-	require.Equal(t, string(latestActual), string(latestExpected))
+	require.Equal(t, string(latestExpected), string(latestActual))
 
 	require.Equal(t, int32(5), resp.Experiments[2].BestTrial.Restarts)
 }
@@ -1388,7 +1387,7 @@ func TestAuthZGetExperiment(t *testing.T) {
 	authZExp.On("CanGetExperiment", mock.Anything, mockUserArg, mock.Anything).
 		Return(authz2.PermissionDeniedError{}).Once()
 	_, err = api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: int32(exp.ID)})
-	require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(exp.ID), true).Error(),
+	require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(exp.ID), true).Error(),
 		err.Error())
 
 	// Error returns error unmodified.
@@ -1418,7 +1417,7 @@ func TestAuthZGetExperiments(t *testing.T) {
 	authZProject.On("CanGetProject", mock.Anything, mockUserArg,
 		mock.Anything).Return(authz2.PermissionDeniedError{}).Once()
 	_, err := api.GetExperiments(ctx, &apiv1.GetExperimentsRequest{ProjectId: int32(projectID)})
-	require.Equal(t, apiPkg.NotFoundErrs("project", fmt.Sprint(projectID), true).Error(),
+	require.Equal(t, apiPkg.NotFoundErrs("project", strconv.Itoa(projectID), true).Error(),
 		err.Error())
 
 	// Error from FilterExperimentsQuery passes through.
@@ -1470,7 +1469,7 @@ func TestAuthZGetExperimentLabels(t *testing.T) {
 	_, err := api.GetExperimentLabels(ctx, &apiv1.GetExperimentLabelsRequest{
 		ProjectId: int32(projectID),
 	})
-	require.Equal(t, apiPkg.NotFoundErrs("project", fmt.Sprint(projectID), true).Error(),
+	require.Equal(t, apiPkg.NotFoundErrs("project", strconv.Itoa(projectID), true).Error(),
 		err.Error())
 
 	// Error from FilterExperimentsLabelsQuery passes through.
@@ -1513,7 +1512,7 @@ func TestAuthZCreateExperiment(t *testing.T) {
 			ParentId: int32(forkFrom.ID),
 		})
 		require.Equal(t, apiPkg.NotFoundErrs("experiment",
-			fmt.Sprint(forkFrom.ID), true), err)
+			strconv.Itoa(forkFrom.ID), true), err)
 	})
 
 	t.Run("can't fork from experiment", func(t *testing.T) {
@@ -1534,7 +1533,7 @@ func TestAuthZCreateExperiment(t *testing.T) {
 			ProjectId: int32(projectID),
 			Config:    minExpConfToYaml(t),
 		})
-		require.Equal(t, apiPkg.NotFoundErrs("project", fmt.Sprint(projectID), true), err)
+		require.Equal(t, apiPkg.NotFoundErrs("project", strconv.Itoa(projectID), true), err)
 	})
 
 	t.Run("can't view project passed in from config", func(t *testing.T) {
@@ -1754,7 +1753,7 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 
 		authZExp.On("CanGetExperiment", mock.Anything, mockUserArg, mock.Anything).
 			Return(authz2.PermissionDeniedError{}).Once()
-		require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(exp.ID), true),
+		require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(exp.ID), true),
 			curCase.IDToReqCall(exp.ID))
 
 		// CanGetExperiment error returns unmodified.
@@ -1817,7 +1816,7 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 			q := args.Get(3).(*bun.SelectQuery).Where("0 = 1")
 			*resQuery = *q
 		})
-		require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(exp.ID), true),
+		require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(exp.ID), true),
 			curCase.IDToReqCall(exp.ID))
 
 		// FilterExperimentsQuery error returned unmodified.
@@ -1907,7 +1906,7 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 		})
 		results, _ := curCase.IDToReqCall(exp.ID)
 		require.Equal(t, apiPkg.NotFoundErrs("experiment",
-			fmt.Sprint(exp.ID), true).Error(), results[0].Error)
+			strconv.Itoa(exp.ID), true).Error(), results[0].Error)
 
 		// FilterExperimentsQuery error returned unmodified.
 		expectedErr := fmt.Errorf("canGetExperimentError")
@@ -2102,7 +2101,7 @@ func TestDeleteExperiments(t *testing.T) {
 	// still after that.
 	mockRM.On("DeleteJob", mock.Anything).Return(func(sproto.DeleteJob) sproto.DeleteJobResponse {
 		errC := make(chan error, 1)
-		errC <- errors.New("something real bad")
+		errC <- fmt.Errorf("something real bad")
 		return sproto.DeleteJobResponse{Err: errC}
 	}, nil)
 
@@ -2156,7 +2155,7 @@ func TestDeleteExperiments(t *testing.T) {
 		for _, expID := range expIDs {
 			e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: expID})
 			if err != nil {
-				require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(expID), true), err)
+				require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(int(expID)), true), err)
 				deleted++
 				continue
 			}
@@ -2176,7 +2175,7 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 	// still after that.
 	mockRM.On("DeleteJob", mock.Anything).Return(func(sproto.DeleteJob) sproto.DeleteJobResponse {
 		errC := make(chan error, 1)
-		errC <- errors.New("something real bad")
+		errC <- fmt.Errorf("something real bad")
 		return sproto.DeleteJobResponse{Err: errC}
 	}, nil)
 
@@ -2233,7 +2232,7 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 		for _, expID := range expIDs {
 			e, err := api.GetExperiment(ctx, &apiv1.GetExperimentRequest{ExperimentId: expID})
 			if err != nil {
-				require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(expID), true), err)
+				require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(int(expID)), true), err)
 				deleted++
 				continue
 			}

--- a/master/internal/api_generic_intg_test.go
+++ b/master/internal/api_generic_intg_test.go
@@ -82,6 +82,6 @@ func TestGetTaskChildren(t *testing.T) {
 	require.NoError(t, err)
 	for _, e := range tasks {
 		_, ok := taskSet[e.TaskID]
-		require.Equal(t, true, ok)
+		require.True(t, ok)
 	}
 }

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -164,7 +165,7 @@ func (a *apiServer) canCreateGenericTask(ctx context.Context, projectID int) err
 		return err
 	}
 
-	errProjectNotFound := api.NotFoundErrs("project", fmt.Sprint(projectID), true)
+	errProjectNotFound := api.NotFoundErrs("project", strconv.Itoa(projectID), true)
 	p := &projectv1.Project{}
 	// Get project details
 	projectExperimentsQuery := db.Bun().NewSelect().
@@ -231,9 +232,6 @@ func (a *apiServer) CreateGenericTask(
 		}
 
 		forkedConfig = []byte(resp.Config)
-		if err != nil {
-			return nil, err
-		}
 
 		if len(req.ContextDirectory) == 0 {
 			contextDirectoryResp, err := a.GetTaskContextDirectory(ctx, &apiv1.GetTaskContextDirectoryRequest{

--- a/master/internal/api_logretention_intg_test.go
+++ b/master/internal/api_logretention_intg_test.go
@@ -166,7 +166,7 @@ func TestDeleteExpiredTaskLogs(t *testing.T) {
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, logCount, 2)
+		require.Equal(t, 2, logCount)
 	}
 
 	// Move time database time 30 days in the future.
@@ -207,7 +207,7 @@ func TestDeleteExpiredTaskLogs(t *testing.T) {
 	for _, taskID := range taskIDs1 {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, 0, logCount)
+		require.Zero(t, logCount)
 	}
 	// Ensure that experiment2 logs are not deleted.
 	for _, taskID := range taskIDs2 {
@@ -240,7 +240,7 @@ func TestDeleteExpiredTaskLogs(t *testing.T) {
 	for _, taskID := range taskIDs2 {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, 0, logCount)
+		require.Zero(t, logCount)
 	}
 	// Ensure that experiment3 logs are not deleted.
 	for _, taskID := range taskIDs3 {
@@ -336,7 +336,7 @@ func TestScheduleRetentionNoConfig(t *testing.T) {
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, logCount, 2)
+		require.Equal(t, 2, logCount)
 	}
 
 	// Advance time to midnight.
@@ -380,13 +380,13 @@ func TestScheduleRetentionNoConfig(t *testing.T) {
 	// Verify that logs are deleted.
 	count, err = countTaskLogs(api.m.db, taskIDs)
 	require.NoError(t, err)
-	require.Equal(t, 0, count)
+	require.Zero(t, count)
 
 	// Ensure that experiment1 logs are deleted.
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, 0, logCount)
+		require.Zero(t, logCount)
 	}
 }
 
@@ -433,7 +433,7 @@ func TestScheduleRetention100days(t *testing.T) {
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, logCount, 2)
+		require.Equal(t, 2, logCount)
 	}
 
 	// Advance time to midnight.
@@ -484,13 +484,13 @@ func TestScheduleRetention100days(t *testing.T) {
 	// Verify that logs are deleted.
 	count, err = countTaskLogs(api.m.db, taskIDs)
 	require.NoError(t, err)
-	require.Equal(t, 0, count)
+	require.Zero(t, count)
 
 	// Ensure that experiment logs are deleted.
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, 0, logCount)
+		require.Zero(t, logCount)
 	}
 }
 
@@ -537,7 +537,7 @@ func TestScheduleRetentionNeverExpire(t *testing.T) {
 	for _, taskID := range taskIDs {
 		logCount, err := api.m.db.TaskLogsCount(taskID, nil)
 		require.NoError(t, err)
-		require.Equal(t, logCount, 2)
+		require.Equal(t, 2, logCount)
 	}
 
 	// Advance time to midnight.

--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -229,7 +229,7 @@ func (a *apiServer) GetModelLabels(
 	return &resp, errors.Wrapf(err, "error getting model labels")
 }
 
-func (a *apiServer) clearModelName(ctx context.Context, modelName string) error {
+func (a *apiServer) clearModelName(modelName string) error {
 	if len(strings.ReplaceAll(modelName, " ", "")) == 0 {
 		return status.Errorf(codes.InvalidArgument, "model names cannot be blank")
 	}
@@ -249,7 +249,7 @@ func (a *apiServer) clearModelName(ctx context.Context, modelName string) error 
 func (a *apiServer) PostModel(
 	ctx context.Context, req *apiv1.PostModelRequest,
 ) (*apiv1.PostModelResponse, error) {
-	if err := a.clearModelName(ctx, req.Name); err != nil {
+	if err := a.clearModelName(req.Name); err != nil {
 		return nil, err
 	}
 
@@ -322,7 +322,7 @@ func (a *apiServer) PatchModel(
 	if req.Model.Name != nil && req.Model.Name.Value != currModel.Name {
 		log.Infof("model (%v) name changing from %q to %q",
 			currModel.Id, currModel.Name, req.Model.Name.Value)
-		if err = a.clearModelName(ctx, req.Model.Name.Value); err != nil {
+		if err = a.clearModelName(req.Model.Name.Value); err != nil {
 			return nil, err
 		}
 		madeChanges = true

--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -196,7 +196,7 @@ func (a *apiServer) isNTSCPermittedToLaunch(
 	}
 
 	w := &workspacev1.Workspace{}
-	notFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(workspaceID), true)
+	notFoundErr := api.NotFoundErrs("workspace", strconv.Itoa(int(workspaceID)), true)
 	if err := a.m.db.QueryProto(
 		"get_workspace", w, workspaceID, user.ID,
 	); errors.Is(err, db.ErrNotFound) {
@@ -296,11 +296,11 @@ func (a *apiServer) LaunchNotebook(
 		"DET_TASK_TYPE":      string(model.TaskTypeNotebook),
 	}
 
-	OIDCPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
+	oidcPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
 	if err != nil {
 		return nil, err
 	}
-	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, OIDCPachydermEnvVars)
+	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, oidcPachydermEnvVars)
 
 	launchReq.Spec.Base.ExtraProxyPorts = append(launchReq.Spec.Base.ExtraProxyPorts,
 		expconf.ProxyPort{

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -132,28 +131,28 @@ func TestCanGetNTSC(t *testing.T) {
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanGetNSC", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		errors.New("other error"),
+		fmt.Errorf("other error"),
 	).Times(3)
 	_, err = api.GetNotebook(ctx, &apiv1.GetNotebookRequest{NotebookId: nb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	require.NotEqual(t, codes.NotFound, status.Code(err))
 
 	_, err = api.GetCommand(ctx, &apiv1.GetCommandRequest{CommandId: cmd.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	require.NotEqual(t, codes.NotFound, status.Code(err))
 
 	_, err = api.GetShell(ctx, &apiv1.GetShellRequest{ShellId: shell.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	require.NotEqual(t, codes.NotFound, status.Code(err))
 
 	authz.On("CanGetTensorboard", mock.Anything, curUser, mock.Anything, mock.Anything,
-		mock.Anything).Return(errors.New("other error")).Once()
+		mock.Anything).Return(fmt.Errorf("other error")).Once()
 
 	_, err = api.GetTensorboard(ctx, &apiv1.GetTensorboardRequest{TensorboardId: tb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	require.NotEqual(t, codes.NotFound, status.Code(err))
 }
@@ -212,26 +211,26 @@ func TestAuthZCanTerminateNSC(t *testing.T) {
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanTerminateNSC", mock.Anything, curUser, mock.Anything).Return(
-		errors.New("other error"),
+		fmt.Errorf("other error"),
 	).Times(3)
 
 	_, err = api.KillNotebook(ctx, &apiv1.KillNotebookRequest{NotebookId: nb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	_, err = api.KillCommand(ctx, &apiv1.KillCommandRequest{CommandId: cmd.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	_, err = api.KillShell(ctx, &apiv1.KillShellRequest{ShellId: shell.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	authz.On("CanTerminateTensorboard", mock.Anything, curUser, mock.Anything).Return(
-		errors.New("other error"),
+		fmt.Errorf("other error"),
 	)
 	_, err = api.KillTensorboard(ctx, &apiv1.KillTensorboardRequest{TensorboardId: tb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 }
 
@@ -285,22 +284,22 @@ func TestAuthZCanSetNSCsPriority(t *testing.T) {
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanSetNSCsPriority", mock.Anything, curUser, mock.Anything, mock.Anything).Return(
-		errors.New("other error"),
+		fmt.Errorf("other error"),
 	).Times(4)
 	_, err = api.SetNotebookPriority(ctx, &apiv1.SetNotebookPriorityRequest{NotebookId: nb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	_, err = api.SetCommandPriority(ctx, &apiv1.SetCommandPriorityRequest{CommandId: cmd.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	_, err = api.SetShellPriority(ctx, &apiv1.SetShellPriorityRequest{ShellId: shell.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 
 	_, err = api.SetTensorboardPriority(ctx, &apiv1.SetTensorboardPriorityRequest{TensorboardId: tb.Id})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 }
 
@@ -328,18 +327,18 @@ func TestAuthZCanCreateNSC(t *testing.T) {
 
 	// check other errors are not returned with permission denied status.
 	authz.On("CanCreateNSC", mock.Anything, mockUserArg, mock.Anything).Return(
-		errors.New("other error"),
+		fmt.Errorf("other error"),
 	).Times(3)
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Times(3)
 	_, err = api.LaunchNotebook(ctx, &apiv1.LaunchNotebookRequest{})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	_, err = api.LaunchCommand(ctx, &apiv1.LaunchCommandRequest{})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 	_, err = api.LaunchShell(ctx, &apiv1.LaunchShellRequest{})
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.NotEqual(t, codes.PermissionDenied, status.Code(err))
 }
 

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"sort"
-
-	"github.com/uptrace/bun"
+	"strconv"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"github.com/uptrace/bun"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -225,7 +225,7 @@ func getRunSummaryMetrics(ctx context.Context, whereClause string, group []int) 
 func (a *apiServer) GetProjectByID(
 	ctx context.Context, id int32, curUser model.User,
 ) (*projectv1.Project, error) {
-	notFoundErr := api.NotFoundErrs("project", fmt.Sprint(id), true)
+	notFoundErr := api.NotFoundErrs("project", strconv.Itoa(int(id)), true)
 	p := &projectv1.Project{}
 	if err := a.m.db.QueryProto("get_project", p, id); errors.Is(err, db.ErrNotFound) {
 		return nil, notFoundErr
@@ -608,7 +608,7 @@ func (a *apiServer) GetProjectNumericMetricsRange(
 		return nil, err
 	}
 	metricsValues, searcherMetricsValue, err := a.getProjectNumericMetricsRange(
-		ctx, *curUser, p)
+		ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +634,7 @@ func (a *apiServer) GetProjectNumericMetricsRange(
 }
 
 func (a *apiServer) getProjectNumericMetricsRange(
-	ctx context.Context, curUser model.User, project *projectv1.Project,
+	ctx context.Context, project *projectv1.Project,
 ) (map[string]([]float64), []float64, error) {
 	query := db.Bun().NewSelect().Table("trials").Table("experiments").
 		ColumnExpr(`searcher_metric_value_signed = searcher_metric_value AS smaller_is_better`).

--- a/master/internal/api_resourcepool_intg_test.go
+++ b/master/internal/api_resourcepool_intg_test.go
@@ -227,7 +227,7 @@ func TestListWorkspacesBoundToRPSucceeds(t *testing.T) {
 		ResourcePoolName: testPoolName,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(resp.WorkspaceIds))
+	require.Len(t, resp.WorkspaceIds, 1)
 	require.Equal(t, workspaceIDs[0], resp.WorkspaceIds[0])
 
 	// test listing on resource pool that has no bindings
@@ -241,7 +241,7 @@ func TestListWorkspacesBoundToRPSucceeds(t *testing.T) {
 		ResourcePoolName: testPool2Name,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 0, len(resp.WorkspaceIds))
+	require.Zero(t, len(resp.WorkspaceIds))
 
 	require.True(t, mockRM.AssertExpectations(t))
 }
@@ -282,7 +282,7 @@ func TestPatchBindingsSucceeds(t *testing.T) {
 		ResourcePoolName: testPoolName,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 0, len(resp.WorkspaceIds))
+	require.Zero(t, len(resp.WorkspaceIds))
 
 	// test patch binding with different workspace
 	_, err = api.OverwriteRPWorkspaceBindings(ctx, &apiv1.OverwriteRPWorkspaceBindingsRequest{
@@ -294,7 +294,7 @@ func TestPatchBindingsSucceeds(t *testing.T) {
 		ResourcePoolName: testPoolName,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(resp.WorkspaceIds))
+	require.Len(t, resp.WorkspaceIds, 1)
 	require.Equal(t, workspaceIDs[1], resp.WorkspaceIds[0])
 
 	// test patch binding with different workspaceID
@@ -308,7 +308,7 @@ func TestPatchBindingsSucceeds(t *testing.T) {
 		ResourcePoolName: testPoolName,
 	})
 	require.NoError(t, err)
-	require.Equal(t, 2, len(resp.WorkspaceIds))
+	require.Len(t, resp.WorkspaceIds, 2)
 	expectedIds := set.FromSlice[int32](workspaceIDs)
 	for _, id := range resp.WorkspaceIds {
 		require.True(t, expectedIds.Contains(id))
@@ -352,7 +352,7 @@ func TestDeleteBindingsSucceeds(t *testing.T) {
 	listReq := &apiv1.ListWorkspacesBoundToRPRequest{ResourcePoolName: testPoolName}
 	resp, err := api.ListWorkspacesBoundToRP(ctx, listReq)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(resp.WorkspaceIds))
+	require.Len(t, resp.WorkspaceIds, 1)
 	require.Equal(t, workspaceIDs[1], resp.WorkspaceIds[0])
 
 	_, err = api.UnbindRPFromWorkspace(ctx, &apiv1.UnbindRPFromWorkspaceRequest{
@@ -363,7 +363,7 @@ func TestDeleteBindingsSucceeds(t *testing.T) {
 
 	resp, err = api.ListWorkspacesBoundToRP(ctx, listReq)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(resp.WorkspaceIds))
+	require.Zero(t, len(resp.WorkspaceIds))
 
 	require.True(t, mockRM.AssertExpectations(t))
 }

--- a/master/internal/api_runs_intg_test.go
+++ b/master/internal/api_runs_intg_test.go
@@ -79,7 +79,7 @@ func TestSearchRunsArchivedExperiment(t *testing.T) {
 	// Run should not be in result
 	resp, err = api.SearchRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Runs, 0)
+	require.Empty(t, resp.Runs)
 }
 
 func TestSearchRunsSort(t *testing.T) {
@@ -94,7 +94,7 @@ func TestSearchRunsSort(t *testing.T) {
 	}
 	resp, err := api.SearchRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Runs, 0)
+	require.Empty(t, resp.Runs)
 
 	hyperparameters := map[string]any{"global_batch_size": 1, "test1": map[string]any{"test2": 1}}
 
@@ -170,7 +170,7 @@ func TestSearchRunsFilter(t *testing.T) {
 	}
 	resp, err := api.SearchRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Runs, 0)
+	require.Empty(t, resp.Runs)
 
 	hyperparameters := map[string]any{"global_batch_size": 1, "test1": map[string]any{"test2": 1}}
 
@@ -362,15 +362,15 @@ func TestMoveRunsIds(t *testing.T) {
 	// Experiment in new project
 	exp, err := api.getExperiment(ctx, curUser, run1.ExperimentID)
 	require.NoError(t, err)
-	require.Equal(t, destprojectID, exp.ProjectId)
+	require.Equal(t, exp.ProjectId, destprojectID)
 }
 
 func setUpMultiTrialExperiments(ctx context.Context, t *testing.T, api *apiServer, curUser model.User,
-) (int32, int32, int32, int32, int32) {
+) (sourceprojectID int32, destprojectID int32, runID1 int32, runID2 int32, expID int32) {
 	_, projectIDInt := createProjectAndWorkspace(ctx, t, api)
 	_, projectID2Int := createProjectAndWorkspace(ctx, t, api)
-	sourceprojectID := int32(projectIDInt)
-	destprojectID := int32(projectID2Int)
+	sourceprojectID = int32(projectIDInt)
+	destprojectID = int32(projectID2Int)
 
 	exp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
 
@@ -438,7 +438,7 @@ func TestMoveRunsMultiTrialSkip(t *testing.T) {
 
 	resp, err = api.SearchRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Runs, 0)
+	require.Empty(t, resp.Runs)
 }
 
 func TestMoveRunsMultiTrialNoSkip(t *testing.T) {
@@ -466,7 +466,7 @@ func TestMoveRunsMultiTrialNoSkip(t *testing.T) {
 	}
 	resp, err := api.SearchRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Runs, 0)
+	require.Empty(t, resp.Runs)
 
 	// runs in new project
 	req = &apiv1.SearchRunsRequest{
@@ -650,7 +650,7 @@ func TestDeleteRunsIds(t *testing.T) {
 
 	searchResp, err := api.SearchRuns(ctx, searchReq)
 	require.NoError(t, err)
-	require.Len(t, searchResp.Runs, 0)
+	require.Empty(t, searchResp.Runs)
 }
 
 func TestDeleteRunsIdsNonExistant(t *testing.T) {
@@ -824,11 +824,11 @@ func TestDeleteRunsLogs(t *testing.T) {
 
 	searchResp, err = api.SearchRuns(ctx, searchReq)
 	require.NoError(t, err)
-	require.Len(t, searchResp.Runs, 0)
+	require.Empty(t, searchResp.Runs)
 	// ensure all logs are deleted
 	total, err := api.m.taskLogBackend.TaskLogsCount(task1.TaskID, []a.Filter{})
 	require.NoError(t, err)
-	require.Equal(t, 0, total)
+	require.Zero(t, total)
 }
 
 func TestDeleteRunsOverfillInput(t *testing.T) {
@@ -844,7 +844,7 @@ func TestDeleteRunsOverfillInput(t *testing.T) {
 	}
 	expectedError := fmt.Errorf("if filter is provided run id list must be empty")
 	_, err := api.DeleteRuns(ctx, req)
-	require.Equal(t, expectedError, err)
+	require.Equal(t, expectedError.Error(), err.Error())
 }
 
 func TestDeleteRunsNoInput(t *testing.T) {
@@ -856,7 +856,7 @@ func TestDeleteRunsNoInput(t *testing.T) {
 	}
 	resp, err := api.DeleteRuns(ctx, req)
 	require.NoError(t, err)
-	require.Len(t, resp.Results, 0)
+	require.Empty(t, resp.Results)
 }
 
 func TestArchiveUnarchiveIds(t *testing.T) {
@@ -883,7 +883,7 @@ func TestArchiveUnarchiveIds(t *testing.T) {
 
 	searchResp, err := api.SearchRuns(ctx, searchReq)
 	require.NoError(t, err)
-	require.Len(t, searchResp.Runs, 0)
+	require.Empty(t, searchResp.Runs)
 
 	// Unarchive runs
 	unarchReq := &apiv1.UnarchiveRunsRequest{
@@ -993,7 +993,7 @@ func TestArchiveAlreadyArchived(t *testing.T) {
 
 	searchResp, err := api.SearchRuns(ctx, searchReq)
 	require.NoError(t, err)
-	require.Len(t, searchResp.Runs, 0)
+	require.Empty(t, searchResp.Runs)
 
 	// Try to archive again
 	archRes, err = api.ArchiveRuns(ctx, archReq)
@@ -1067,7 +1067,7 @@ func TestArchiveUnarchiveOverfilledInput(t *testing.T) {
 		Filter:    ptrs.Ptr("nonempty"),
 	}
 	_, err := api.ArchiveRuns(ctx, archReq)
-	require.Equal(t, expectedError, err)
+	require.Equal(t, expectedError.Error(), err.Error())
 
 	// Unarchive runs
 	unarchReq := &apiv1.UnarchiveRunsRequest{
@@ -1076,7 +1076,7 @@ func TestArchiveUnarchiveOverfilledInput(t *testing.T) {
 		Filter:    ptrs.Ptr("nonempty"),
 	}
 	_, err = api.UnarchiveRuns(ctx, unarchReq)
-	require.Equal(t, expectedError, err)
+	require.Equal(t, expectedError.Error(), err.Error())
 }
 
 func TestArchiveUnarchiveNoInput(t *testing.T) {
@@ -1088,7 +1088,7 @@ func TestArchiveUnarchiveNoInput(t *testing.T) {
 	}
 	archRes, err := api.ArchiveRuns(ctx, archReq)
 	require.NoError(t, err)
-	require.Len(t, archRes.Results, 0)
+	require.Empty(t, archRes.Results)
 
 	// Unarchive runs
 	unarchReq := &apiv1.UnarchiveRunsRequest{
@@ -1097,5 +1097,5 @@ func TestArchiveUnarchiveNoInput(t *testing.T) {
 	}
 	unarchRes, err := api.UnarchiveRuns(ctx, unarchReq)
 	require.NoError(t, err)
-	require.Len(t, unarchRes.Results, 0)
+	require.Empty(t, unarchRes.Results)
 }

--- a/master/internal/api_shell.go
+++ b/master/internal/api_shell.go
@@ -55,7 +55,7 @@ func (a *apiServer) GetShells(
 		return nil, err
 	}
 
-	workspaceNotFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(req.WorkspaceId), true)
+	workspaceNotFoundErr := api.NotFoundErrs("workspace", strconv.Itoa(int(req.WorkspaceId)), true)
 
 	if req.WorkspaceId != 0 {
 		// check if the workspace exists.
@@ -247,11 +247,11 @@ func (a *apiServer) LaunchShell(
 
 	launchReq.Spec.Base.ExtraEnvVars = map[string]string{"DET_TASK_TYPE": string(model.TaskTypeShell)}
 
-	OIDCPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
+	oidcPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
 	if err != nil {
 		return nil, err
 	}
-	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, OIDCPachydermEnvVars)
+	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, oidcPachydermEnvVars)
 
 	var passphrase *string
 	if len(req.Data) > 0 {

--- a/master/internal/api_tasks_intg_test.go
+++ b/master/internal/api_tasks_intg_test.go
@@ -10,14 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiPkg "github.com/determined-ai/determined/master/internal/api"
@@ -107,7 +106,7 @@ func TestPostTaskLogs(t *testing.T) {
 }
 
 func mockNotebookWithWorkspaceID(
-	ctx context.Context, api *apiServer, t *testing.T, workspaceID int,
+	ctx context.Context, t *testing.T, workspaceID int,
 ) model.TaskID {
 	nb := &model.Task{
 		TaskID:   model.NewTaskID(),
@@ -167,11 +166,11 @@ func TestGetTasksAuthZ(t *testing.T) {
 			return e.ID == cantAccessTrial.ExperimentID
 		})).Return(authz2.PermissionDeniedError{}).Once()
 
-	canAccessNotebookID := mockNotebookWithWorkspaceID(ctx, api, t, -100)
+	canAccessNotebookID := mockNotebookWithWorkspaceID(ctx, t, -100)
 	authZNSC.On("CanGetNSC", mock.Anything, mock.Anything, model.AccessScopeID(-100)).
 		Return(nil).Once()
 
-	cantAccessNotebookID := mockNotebookWithWorkspaceID(ctx, api, t, -101)
+	cantAccessNotebookID := mockNotebookWithWorkspaceID(ctx, t, -101)
 	authZNSC.On("CanGetNSC", mock.Anything, mock.Anything, model.AccessScopeID(-101)).
 		Return(authz2.PermissionDeniedError{}).Once()
 
@@ -345,7 +344,7 @@ func TestAddAllocationAcceleratorData(t *testing.T) {
 	resp, err := api.GetTaskAcceleratorData(ctx,
 		&apiv1.GetTaskAcceleratorDataRequest{TaskId: tID.String()})
 	require.NoError(t, err, "failed to get task AccelerationData")
-	require.Equal(t, len(resp.AcceleratorData), 1, "incorrect number of allocation accelerator data returned")
+	require.Len(t, resp.AcceleratorData, 1, "incorrect number of allocation accelerator data returned")
 	require.Equal(t, resp.AcceleratorData[0].AllocationId,
 		aID.String(), "failed to get the correct allocation's accelerator data")
 }
@@ -374,7 +373,7 @@ func TestGetAllocationAcceleratorDataWithNoData(t *testing.T) {
 	resp, err := api.GetTaskAcceleratorData(ctx,
 		&apiv1.GetTaskAcceleratorDataRequest{TaskId: tID.String()})
 	require.NoError(t, err, "failed to get task AccelerationData")
-	require.Equal(t, len(resp.AcceleratorData), 0, "unexpected allocation accelerator data returned")
+	require.Empty(t, resp.AcceleratorData, "unexpected allocation accelerator data returned")
 }
 
 // Checks if GetAllocationAcceleratorData works when a task has more than one allocation
@@ -421,7 +420,7 @@ func TestGetAllocationAcceleratorData(t *testing.T) {
 	resp, err := api.GetTaskAcceleratorData(ctx,
 		&apiv1.GetTaskAcceleratorDataRequest{TaskId: tID.String()})
 	require.NoError(t, err, "failed to get task AccelerationData")
-	require.Equal(t, len(resp.AcceleratorData), 1, "incorrect number of allocation accelerator data returned")
+	require.Len(t, resp.AcceleratorData, 1, "incorrect number of allocation accelerator data returned")
 	require.Equal(t, resp.AcceleratorData[0].AllocationId,
 		aID1.String(), "failed to get the correct allocation's accelerator data")
 }

--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -211,7 +211,7 @@ func (a *apiServer) LaunchTensorboard(
 
 	// Validate the request.
 	if len(req.ExperimentIds) == 0 && len(req.TrialIds) == 0 && req.Filters == nil {
-		err = errors.New("must set experiment, trial ids, or filters")
+		err = fmt.Errorf("must set experiment, trial ids, or filters")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -282,11 +282,11 @@ func (a *apiServer) LaunchTensorboard(
 		"DET_TASK_TYPE":        string(model.TaskTypeTensorboard),
 	}
 
-	OIDCPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
+	oidcPachydermEnvVars, err := a.getOIDCPachydermEnvVars(session)
 	if err != nil {
 		return nil, err
 	}
-	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, OIDCPachydermEnvVars)
+	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, oidcPachydermEnvVars)
 
 	if launchReq.Spec.Config.Debug {
 		uniqEnvVars["DET_DEBUG"] = "true"

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -544,7 +545,7 @@ func (a *apiServer) KillTrial(
 
 	e, ok := experiment.ExperimentRegistry.Load(eID)
 	if !ok {
-		return nil, api.NotFoundErrs("experiment", fmt.Sprint(eID), true)
+		return nil, api.NotFoundErrs("experiment", strconv.Itoa(eID), true)
 	}
 	if err = e.PatchTrialState(s); err != nil {
 		log.WithError(err).Error("error killing trial")
@@ -1313,7 +1314,7 @@ func (a *apiServer) GetCurrentTrialSearcherOperation(
 
 	e, ok := experiment.ExperimentRegistry.Load(eID)
 	if !ok {
-		return nil, api.NotFoundErrs("experiment", fmt.Sprint(eID), true)
+		return nil, api.NotFoundErrs("experiment", strconv.Itoa(eID), true)
 	}
 	resp, err := e.TrialGetSearcherState(rID)
 	if err != nil {
@@ -1344,7 +1345,7 @@ func (a *apiServer) CompleteTrialSearcherValidation(
 
 	e, ok := experiment.ExperimentRegistry.Load(eID)
 	if !ok {
-		return nil, api.NotFoundErrs("experiment", fmt.Sprint(eID), true)
+		return nil, api.NotFoundErrs("experiment", strconv.Itoa(eID), true)
 	}
 
 	msg := experiment.TrialCompleteOperation{
@@ -1372,7 +1373,7 @@ func (a *apiServer) ReportTrialSearcherEarlyExit(
 
 	e, ok := experiment.ExperimentRegistry.Load(eID)
 	if !ok {
-		return nil, api.NotFoundErrs("experiment", fmt.Sprint(eID), true)
+		return nil, api.NotFoundErrs("experiment", strconv.Itoa(eID), true)
 	}
 
 	msg := experiment.UserInitiatedEarlyTrialExit{
@@ -1399,7 +1400,7 @@ func (a *apiServer) ReportTrialProgress(
 
 	e, ok := experiment.ExperimentRegistry.Load(eID)
 	if !ok {
-		return nil, api.NotFoundErrs("experiment", fmt.Sprint(eID), true)
+		return nil, api.NotFoundErrs("experiment", strconv.Itoa(eID), true)
 	}
 
 	msg := experiment.TrialReportProgress{

--- a/master/internal/api_user.go
+++ b/master/internal/api_user.go
@@ -10,13 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v3"
 
-	bun "github.com/uptrace/bun"
+	"github.com/uptrace/bun"
 
 	"github.com/determined-ai/determined/master/internal/config"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
@@ -119,11 +119,7 @@ func getFullModelUser(
 	return userModel, err
 }
 
-func getUser(
-	ctx context.Context,
-	d *db.PgDB,
-	userID model.UserID,
-) (*userv1.User, error) {
+func getUser(ctx context.Context, userID model.UserID) (*userv1.User, error) {
 	user, err := getFullModelUser(ctx, userID)
 	if err != nil {
 		return nil, err
@@ -358,7 +354,7 @@ func (a *apiServer) PostUser(
 	case err != nil:
 		return nil, err
 	}
-	fullUser, err := getUser(ctx, a.m.db, userID)
+	fullUser, err := getUser(ctx, userID)
 	return &apiv1.PostUserResponse{User: fullUser}, err
 }
 
@@ -395,7 +391,7 @@ func (a *apiServer) SetUserPassword(
 	case err != nil:
 		return nil, err
 	}
-	fullUser, err := getUser(ctx, a.m.db, model.UserID(req.UserId))
+	fullUser, err := getUser(ctx, model.UserID(req.UserId))
 	return &apiv1.SetUserPasswordResponse{User: fullUser}, err
 }
 
@@ -554,7 +550,7 @@ func (a *apiServer) PatchUser(
 		return nil, err
 	}
 
-	fullUser, err := getUser(ctx, a.m.db, model.UserID(req.UserId))
+	fullUser, err := getUser(ctx, model.UserID(req.UserId))
 	return &apiv1.PatchUserResponse{User: fullUser}, err
 }
 

--- a/master/internal/api_user_intg_test.go
+++ b/master/internal/api_user_intg_test.go
@@ -11,30 +11,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-
-	"github.com/determined-ai/determined/master/internal/job/jobservice"
-	"github.com/determined-ai/determined/master/internal/rm"
-	"github.com/determined-ai/determined/master/internal/rm/rmevents"
-	"github.com/determined-ai/determined/master/internal/sproto"
-
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
-
-	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"gopkg.in/guregu/null.v3"
 
 	apiPkg "github.com/determined-ai/determined/master/internal/api"
 	authz2 "github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/job/jobservice"
 	"github.com/determined-ai/determined/master/internal/logpattern"
 	"github.com/determined-ai/determined/master/internal/mocks"
+	"github.com/determined-ai/determined/master/internal/rm"
+	"github.com/determined-ai/determined/master/internal/rm/rmevents"
+	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/user"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -137,7 +134,6 @@ func setupAPITest(t *testing.T, pgdb *db.PgDB,
 	require.NoError(t, err, "Couldn't get admin user")
 	ctx := metadata.NewIncomingContext(context.TODO(),
 		metadata.Pairs("x-user-token", fmt.Sprintf("Bearer %s", resp.Token)))
-
 	return api, *userModel, ctx
 }
 
@@ -235,11 +231,11 @@ func TestAuthMiddleware(t *testing.T) {
 			allocationHeader: fmt.Sprintf("Bearer %s", allocationToken),
 		}},
 		{proxiedSubRoute, http.StatusSeeOther, redirectedSubRoute, map[string]string{
-			allocationHeader: fmt.Sprintf("Bearer %s", "invalid-token"),
+			allocationHeader: "Bearer invalid-token",
 		}},
 		{proxiedSubRoute, http.StatusUnauthorized, "", map[string]string{
 			"Accept":         "application/json",
-			allocationHeader: fmt.Sprintf("Bearer %s", "invalid-token"),
+			allocationHeader: "Bearer invalid-token",
 		}},
 		{"/non-proxied-path", http.StatusUnauthorized, "", map[string]string{}},
 		{"/non-proxied-path", http.StatusUnauthorized, "", map[string]string{
@@ -397,7 +393,7 @@ func TestLoginRemote(t *testing.T) {
 			Where("username = ?", username).
 			Scan(ctx, &expectedUser)
 		require.NoError(t, err)
-		require.Equal(t, model.NoPasswordLogin, expectedUser.PasswordHash)
+		require.Equal(t, expectedUser.PasswordHash, model.NoPasswordLogin)
 
 		// Changing back to unremote unsets password to blank.
 		_, err = api.PatchUser(ctx, &apiv1.PatchUserRequest{
@@ -630,7 +626,7 @@ func TestPatchUsers(t *testing.T) {
 		UserId: int32(userID),
 	})
 	require.NoError(t, err)
-	require.Equal(t, resp2.User.Active, true)
+	require.True(t, resp2.User.Active)
 }
 
 func TestRenameUserThenReuseName(t *testing.T) {
@@ -909,7 +905,7 @@ func TestPostUserActivity(t *testing.T) {
 
 	activityCount, err := getActivityEntry(ctx, curUser.ID, 1)
 	require.NoError(t, err)
-	require.Equal(t, activityCount, 1, ctx)
+	require.Equal(t, 1, activityCount, ctx)
 
 	_, err = api.PostUserActivity(ctx, &apiv1.PostUserActivityRequest{
 		ActivityType: userv1.ActivityType_ACTIVITY_TYPE_GET,
@@ -921,7 +917,7 @@ func TestPostUserActivity(t *testing.T) {
 
 	activityCount, err = getActivityEntry(ctx, curUser.ID, 1)
 	require.NoError(t, err)
-	require.Equal(t, activityCount, 1, ctx)
+	require.Equal(t, 1, activityCount, ctx)
 }
 
 func getActivityEntry(ctx context.Context, userID model.UserID, entityID int32) (int, error) {

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -24,7 +24,6 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/master/pkg/set"
-
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
@@ -72,7 +71,7 @@ func validateWorkspaceName(name string) error {
 func (a *apiServer) GetWorkspaceByID(
 	ctx context.Context, id int32, curUser model.User, rejectImmutable bool,
 ) (*workspacev1.Workspace, error) {
-	notFoundErr := api.NotFoundErrs("workspace", fmt.Sprint(id), true)
+	notFoundErr := api.NotFoundErrs("workspace", strconv.Itoa(int(id)), true)
 	w := &workspacev1.Workspace{}
 
 	if err := a.m.db.QueryProto("get_workspace", w, id, curUser.ID); errors.Is(err, db.ErrNotFound) {
@@ -359,7 +358,6 @@ func (a *apiServer) PostWorkspace(
 	}
 
 	_, err = tx.NewInsert().Model(w).Exec(ctx)
-
 	if err != nil {
 		if strings.Contains(err.Error(), db.CodeUniqueViolation) {
 			return nil,

--- a/master/internal/api_workspace_intg_test.go
+++ b/master/internal/api_workspace_intg_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"google.golang.org/grpc/codes"
@@ -233,7 +234,7 @@ func TestWorkspacesIDsByExperimentIDs(t *testing.T) {
 
 	resp, err := workspace.WorkspacesIDsByExperimentIDs(ctx, nil)
 	require.NoError(t, err)
-	require.Len(t, resp, 0)
+	require.Empty(t, resp)
 
 	w0, p0 := createProjectAndWorkspace(ctx, t, api)
 	w1, p1 := createProjectAndWorkspace(ctx, t, api)
@@ -248,7 +249,7 @@ func TestWorkspacesIDsByExperimentIDs(t *testing.T) {
 
 	resp, err = workspace.WorkspacesIDsByExperimentIDs(ctx, []int{e0.ID, e1.ID, -1})
 	require.Error(t, err)
-	require.Len(t, resp, 0)
+	require.Empty(t, resp)
 }
 
 func TestPatchWorkspace(t *testing.T) {
@@ -560,7 +561,7 @@ func TestAuthzWorkspaceGetThenActionRoutes(t *testing.T) {
 		// Without permission to view returns not found.
 		workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
 			Return(authz2.PermissionDeniedError{}).Once()
-		require.Equal(t, apiPkg.NotFoundErrs("workspace", fmt.Sprint(id), true).Error(),
+		require.Equal(t, apiPkg.NotFoundErrs("workspace", strconv.Itoa(id), true).Error(),
 			curCase.IDToReqCall(id).Error())
 
 		// A error returned by CanGetWorkspace is returned unmodified.

--- a/master/internal/audit_test.go
+++ b/master/internal/audit_test.go
@@ -90,7 +90,7 @@ func TestAuditLogMiddleware(t *testing.T) {
 		defer resp.Body.Close() //nolint:errcheck
 	}
 	// Then webui static files are ignored.
-	require.Len(t, logs.inner, 0)
+	require.Empty(t, logs.inner)
 
 	// When making a GET request to some resource.
 	resp, err = http.Get("http://" + url + "/ok")
@@ -122,5 +122,5 @@ func TestAuditLogMiddleware(t *testing.T) {
 	require.Len(t, logs.inner, 3)
 	require.Equal(t, logrus.InfoLevel, logs.inner[2].Level)
 	require.Contains(t, logs.inner[2].Message, "/notok")
-	require.Equal(t, logs.inner[2].Data["unauthorized"], true)
+	require.Equal(t, true, logs.inner[2].Data["unauthorized"])
 }

--- a/master/internal/cache/cache_intg_test.go
+++ b/master/internal/cache/cache_intg_test.go
@@ -17,8 +17,8 @@ import (
 
 func TestCache(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(db.RootFromDB))
-	dbIns, close := db.MustResolveTestPostgres(t)
-	defer close()
+	dbIns, closeDB := db.MustResolveTestPostgres(t)
+	defer closeDB()
 	db.MustMigrateTestPostgres(t, dbIns, db.MigrationsFromDB)
 
 	user := db.RequireMockUser(t, dbIns)
@@ -30,7 +30,7 @@ func TestCache(t *testing.T) {
 	// Test fetch
 	files, _, err := cache.getFileTree(expID)
 	require.NoError(t, err)
-	require.True(t, len(files) > 0)
+	require.NotEmpty(t, files)
 	path := files[0].Path
 	_, err = cache.FileContent(expID, path)
 	require.NoError(t, err)

--- a/master/internal/cache/cache_test.go
+++ b/master/internal/cache/cache_test.go
@@ -192,7 +192,7 @@ func TestGenPathWithValidation(t *testing.T) {
 		if test.hasErr {
 			require.Errorf(t, err, test.description)
 		} else {
-			require.Equalf(t, p, test.expected, test.description)
+			require.Equalf(t, test.expected, p, test.description)
 		}
 	}
 }

--- a/master/internal/checkpoint_gc_test.go
+++ b/master/internal/checkpoint_gc_test.go
@@ -3,10 +3,9 @@
 package internal
 
 import (
+	"fmt"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -73,7 +72,7 @@ func TestRunCheckpointGCTask(t *testing.T) {
 						"StartAllocation",
 						mock.Anything,
 						mock.MatchedBy(func(ar sproto.AllocateRequest) bool {
-							return ar.IsUserVisible == false &&
+							return !ar.IsUserVisible &&
 								ar.ResourcePool == "default" &&
 								ar.SlotsNeeded == 0
 						}),
@@ -118,7 +117,7 @@ func TestRunCheckpointGCTask(t *testing.T) {
 					var r mocks.ResourceManager
 
 					r.On("ResolveResourcePool", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-						Return(rm.ResourcePoolName(""), errors.New("rm is down or something"))
+						Return(rm.ResourcePoolName(""), fmt.Errorf("rm is down or something"))
 
 					return &r
 				}(),

--- a/master/internal/checkpoints/postgres_checkpoints_intg_test.go
+++ b/master/internal/checkpoints/postgres_checkpoints_intg_test.go
@@ -409,7 +409,7 @@ func TestUpdateCheckpointStateToDeleted(t *testing.T) {
 		Scan(ctx, &numDStateCheckpoints)
 	require.NoError(t, err)
 
-	require.Equal(t, 0, numDStateCheckpoints)
+	require.Zero(t, numDStateCheckpoints)
 }
 
 func TestDeleteCheckpoints(t *testing.T) {
@@ -446,7 +446,7 @@ func TestDeleteCheckpoints(t *testing.T) {
 	// Verify that checkpoint was deleted once its state was marked 'DELETED'.
 	ct, err = db.Bun().NewSelect().Model(&model.CheckpointV2{}).Where("uuid = ?", ckpt1).Count(ctx)
 	require.NoError(t, err)
-	require.Equal(t, 0, ct)
+	require.Zero(t, ct)
 }
 
 func BenchmarkUpdateCheckpointSize(b *testing.B) {

--- a/master/internal/command/command_intg_test.go
+++ b/master/internal/command/command_intg_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -28,10 +27,9 @@ import (
 
 func TestCommandManagerLifecycle(t *testing.T) {
 	db := setupTest(t)
-	ctx := context.TODO()
 
 	// Launch a Command.
-	cmd1 := launchCommand(ctx, t, db)
+	cmd1 := launchCommand(t, db)
 
 	// Get Command.
 	resp1, err := DefaultCmdService.GetCommand(&apiv1.GetCommandRequest{CommandId: cmd1.Id})
@@ -39,13 +37,13 @@ func TestCommandManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Launch another command.
-	cmd2 := launchCommand(ctx, t, db)
+	cmd2 := launchCommand(t, db)
 
 	// Get Commands.
 	resp2, err := DefaultCmdService.GetCommands(&apiv1.GetCommandsRequest{})
 	require.NotNil(t, resp2)
 	require.NoError(t, err)
-	require.Equal(t, len(resp2.Commands), 2)
+	require.Len(t, resp2.Commands, 2)
 
 	// Kill 1 command.
 	resp3, err := DefaultCmdService.KillNTSC(cmd2.Id, model.TaskTypeCommand)
@@ -53,7 +51,7 @@ func TestCommandManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd3 := resp3.ToV1Command()
-	require.Equal(t, cmd3.State, taskv1.State_STATE_TERMINATED)
+	require.Equal(t, taskv1.State_STATE_TERMINATED, cmd3.State)
 
 	// Set command priority.
 	resp4, err := DefaultCmdService.SetNTSCPriority(cmd1.Id, 0, model.TaskTypeCommand)
@@ -63,10 +61,9 @@ func TestCommandManagerLifecycle(t *testing.T) {
 
 func TestNotebookManagerLifecycle(t *testing.T) {
 	db := setupTest(t)
-	ctx := context.TODO()
 
 	// Launch a Notebook.
-	cmd1 := launchNotebook(ctx, t, db)
+	cmd1 := launchNotebook(t, db)
 
 	// Get Notebook.
 	resp1, err := DefaultCmdService.GetNotebook(&apiv1.GetNotebookRequest{NotebookId: cmd1.Id})
@@ -74,13 +71,13 @@ func TestNotebookManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Launch another Notebook.
-	cmd2 := launchNotebook(ctx, t, db)
+	cmd2 := launchNotebook(t, db)
 
 	// Get Notebooks.
 	resp2, err := DefaultCmdService.GetNotebooks(&apiv1.GetNotebooksRequest{})
 	require.NotNil(t, resp2)
 	require.NoError(t, err)
-	require.Equal(t, len(resp2.Notebooks), 2)
+	require.Len(t, resp2.Notebooks, 2)
 
 	// Kill 1 Notebook.
 	resp3, err := DefaultCmdService.KillNTSC(cmd2.Id, model.TaskTypeNotebook)
@@ -88,7 +85,7 @@ func TestNotebookManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	nb3 := resp3.ToV1Notebook()
-	require.Equal(t, nb3.State, taskv1.State_STATE_TERMINATED)
+	require.Equal(t, taskv1.State_STATE_TERMINATED, nb3.State)
 
 	// Set Notebook priority.
 	resp4, err := DefaultCmdService.SetNTSCPriority(cmd1.Id, 0, model.TaskTypeNotebook)
@@ -98,10 +95,9 @@ func TestNotebookManagerLifecycle(t *testing.T) {
 
 func TestShellManagerLifecycle(t *testing.T) {
 	db := setupTest(t)
-	ctx := context.TODO()
 
 	// Launch a Shell.
-	cmd1 := launchShell(ctx, t, db)
+	cmd1 := launchShell(t, db)
 
 	// Get Shell.
 	resp1, err := DefaultCmdService.GetShell(&apiv1.GetShellRequest{ShellId: cmd1.Id})
@@ -109,13 +105,13 @@ func TestShellManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Launch another Shell.
-	cmd2 := launchShell(ctx, t, db)
+	cmd2 := launchShell(t, db)
 
 	// Get Shells.
 	resp2, err := DefaultCmdService.GetShells(&apiv1.GetShellsRequest{})
 	require.NotNil(t, resp2)
 	require.NoError(t, err)
-	require.Equal(t, len(resp2.Shells), 2)
+	require.Len(t, resp2.Shells, 2)
 
 	// Kill 1 Shell.
 	resp3, err := DefaultCmdService.KillNTSC(cmd2.Id, model.TaskTypeShell)
@@ -123,7 +119,7 @@ func TestShellManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	shell3 := resp3.ToV1Shell()
-	require.Equal(t, shell3.State, taskv1.State_STATE_TERMINATED)
+	require.Equal(t, taskv1.State_STATE_TERMINATED, shell3.State)
 
 	// Set Shell priority.
 	resp4, err := DefaultCmdService.SetNTSCPriority(cmd1.Id, 0, model.TaskTypeShell)
@@ -133,10 +129,9 @@ func TestShellManagerLifecycle(t *testing.T) {
 
 func TestTensorboardManagerLifecycle(t *testing.T) {
 	db := setupTest(t)
-	ctx := context.TODO()
 
 	// Launch a Tensorboard.
-	cmd1 := launchTensorboard(ctx, t, db)
+	cmd1 := launchTensorboard(t, db)
 
 	// Get Tensorboard.
 	resp1, err := DefaultCmdService.GetTensorboard(&apiv1.GetTensorboardRequest{TensorboardId: cmd1.Id})
@@ -144,13 +139,13 @@ func TestTensorboardManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Launch another Tensorboard.
-	cmd2 := launchTensorboard(ctx, t, db)
+	cmd2 := launchTensorboard(t, db)
 
 	// Get Tensorboards.
 	resp2, err := DefaultCmdService.GetTensorboards(&apiv1.GetTensorboardsRequest{})
 	require.NotNil(t, resp2)
 	require.NoError(t, err)
-	require.Equal(t, len(resp2.Tensorboards), 2)
+	require.Len(t, resp2.Tensorboards, 2)
 
 	// Kill 1 Tensorboard.
 	resp3, err := DefaultCmdService.KillNTSC(cmd2.Id, model.TaskTypeTensorboard)
@@ -158,7 +153,7 @@ func TestTensorboardManagerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	tb3 := resp3.ToV1Tensorboard()
-	require.Equal(t, tb3.State, taskv1.State_STATE_TERMINATED)
+	require.Equal(t, taskv1.State_STATE_TERMINATED, tb3.State)
 
 	// Set Tensorboard priority.
 	resp4, err := DefaultCmdService.SetNTSCPriority(cmd1.Id, 0, model.TaskTypeTensorboard)
@@ -197,7 +192,7 @@ func CreateMockGenericReq(t *testing.T, pgDB *db.PgDB) *CreateGeneric {
 	return &CreateGeneric{Spec: &cmdSpec}
 }
 
-func launchCommand(ctx context.Context, t *testing.T, db *db.PgDB) *commandv1.Command {
+func launchCommand(t *testing.T, db *db.PgDB) *commandv1.Command {
 	cmd, err := DefaultCmdService.LaunchGenericCommand(
 		model.TaskTypeCommand,
 		model.JobTypeCommand,
@@ -209,7 +204,7 @@ func launchCommand(ctx context.Context, t *testing.T, db *db.PgDB) *commandv1.Co
 	return v1cmd
 }
 
-func launchNotebook(ctx context.Context, t *testing.T, db *db.PgDB) *notebookv1.Notebook {
+func launchNotebook(t *testing.T, db *db.PgDB) *notebookv1.Notebook {
 	cmd, err := DefaultCmdService.LaunchGenericCommand(
 		model.TaskTypeNotebook,
 		model.JobTypeNotebook,
@@ -221,7 +216,7 @@ func launchNotebook(ctx context.Context, t *testing.T, db *db.PgDB) *notebookv1.
 	return v1nb
 }
 
-func launchShell(ctx context.Context, t *testing.T, db *db.PgDB) *shellv1.Shell {
+func launchShell(t *testing.T, db *db.PgDB) *shellv1.Shell {
 	cmd, err := DefaultCmdService.LaunchGenericCommand(
 		model.TaskTypeShell,
 		model.JobTypeShell,
@@ -233,7 +228,7 @@ func launchShell(ctx context.Context, t *testing.T, db *db.PgDB) *shellv1.Shell 
 	return v1shell
 }
 
-func launchTensorboard(ctx context.Context, t *testing.T, db *db.PgDB) *tensorboardv1.Tensorboard {
+func launchTensorboard(t *testing.T, db *db.PgDB) *tensorboardv1.Tensorboard {
 	cmd, err := DefaultCmdService.LaunchGenericCommand(
 		model.TaskTypeTensorboard,
 		model.JobTypeTensorboard,

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -48,7 +48,7 @@ func TestDeprecations(t *testing.T) {
 			},
 		},
 	}
-	require.Len(t, c.Deprecations(), 0)
+	require.Empty(t, c.Deprecations())
 
 	c.ResourceConfig.RootPoolsInternal[0].AgentReattachEnabled = true
 	c.ResourceConfig.AdditionalResourceManagersInternal[0].ResourcePools[0].AgentReattachEnabled = true

--- a/master/internal/config/dispatcher_resource_manager_config.go
+++ b/master/internal/config/dispatcher_resource_manager_config.go
@@ -80,7 +80,6 @@ func (c DispatcherResourceManagerConfig) Validate() []error {
 	if c.SlotType != nil {
 		switch *c.SlotType {
 		case device.CPU, device.CUDA, device.ROCM:
-			break
 		default:
 			return []error{fmt.Errorf(
 				"invalid slot_type '%s'.  Specify one of cuda, rocm, or cpu", *c.SlotType)}

--- a/master/internal/config/provconfig/aws_config.go
+++ b/master/internal/config/provconfig/aws_config.go
@@ -108,11 +108,11 @@ func (c *AWSClusterConfig) InitDefaultValues() error {
 	}
 
 	if len(c.ImageID) == 0 {
-		if v, ok := defaultAWSImageID[c.Region]; ok {
-			c.ImageID = v
-		} else {
+		v, ok := defaultAWSImageID[c.Region]
+		if !ok {
 			return errors.Errorf("cannot find default image ID in the region %s", c.Region)
 		}
+		c.ImageID = v
 	}
 
 	// One common reason that metadata.GetInstanceIdentityDocument() fails is that the master is not

--- a/master/internal/config/provconfig/aws_config_test.go
+++ b/master/internal/config/provconfig/aws_config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -94,5 +95,5 @@ func TestAWSClusterConfigMissingFields(t *testing.T) {
 	err := yaml.Unmarshal([]byte(`{}`), &config, yaml.DisallowUnknownFields)
 	assert.NilError(t, err)
 	err = check.Validate(&config)
-	assert.ErrorContains(t, err, "non-empty")
+	require.ErrorContains(t, err, "non-empty")
 }

--- a/master/internal/config/provconfig/config_test.go
+++ b/master/internal/config/provconfig/config_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
 	"gotest.tools/assert"
 
@@ -21,7 +22,7 @@ func TestProvisionerConfigMissingFields(t *testing.T) {
 	err := json.Unmarshal([]byte(`{}`), &config)
 	assert.NilError(t, err)
 	err = check.Validate(&config)
-	assert.ErrorContains(t, err, "must configure aws or gcp or hpc cluster")
+	require.ErrorContains(t, err, "must configure aws or gcp or hpc cluster")
 	expected := Config{
 		MaxIdleAgentPeriod:     model.Duration(20 * time.Minute),
 		MaxAgentStartingPeriod: model.Duration(20 * time.Minute),

--- a/master/internal/config/provconfig/gcp_config_test.go
+++ b/master/internal/config/provconfig/gcp_config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/check"
@@ -137,7 +138,7 @@ func TestGCEServiceAccount(t *testing.T) {
 			if err = check.Validate(&unmarshaled); tc.errContains == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.ErrorContains(t, err, tc.errContains)
+				require.ErrorContains(t, err, tc.errContains)
 			}
 		})
 	}
@@ -217,7 +218,7 @@ func TestGCEInstanceType(t *testing.T) {
 			if err = check.Validate(&unmarshaled); tc.errContains == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.ErrorContains(t, err, tc.errContains)
+				require.ErrorContains(t, err, tc.errContains)
 			}
 		})
 	}

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -213,7 +213,6 @@ func (k KubernetesResourceManagerConfig) Validate() []error {
 	var checkSlotType error
 	switch k.SlotType {
 	case device.CPU, device.CUDA:
-		break
 	case device.ROCM:
 		checkSlotType = errors.Errorf("rocm slot_type is not supported yet on k8s")
 	default:

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -75,7 +75,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
-	opentelemetry "github.com/determined-ai/determined/master/pkg/opentelemetry"
+	opentelemetry "github.com/determined-ai/determined/master/pkg/opentelemetry" //nolint:revive
 	"github.com/determined-ai/determined/master/pkg/tasks"
 	"github.com/determined-ai/determined/master/version"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"

--- a/master/internal/core_checkpoint_intg_test.go
+++ b/master/internal/core_checkpoint_intg_test.go
@@ -36,10 +36,9 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
-	"github.com/determined-ai/determined/proto/pkg/modelv1"
-
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/proto/pkg/modelv1"
 )
 
 const (
@@ -94,7 +93,7 @@ func createMockCheckpointS3(bucket string, prefix string) error {
 	return nil
 }
 
-func checkTar(t *testing.T, rec *httptest.ResponseRecorder, id string) {
+func checkTar(t *testing.T, rec *httptest.ResponseRecorder) {
 	require.Equal(t, strconv.Itoa(rec.Body.Len()), rec.Header().Get("Content-Length"))
 	content := rec.Body
 	tr := tar.NewReader(content)
@@ -115,7 +114,7 @@ func checkTar(t *testing.T, rec *httptest.ResponseRecorder, id string) {
 	require.Equal(t, mockCheckpointContent, gotMap)
 }
 
-func checkTgz(t *testing.T, rec *httptest.ResponseRecorder, id string) {
+func checkTgz(t *testing.T, rec *httptest.ResponseRecorder) {
 	content := rec.Body
 	zr, err := gzip.NewReader(content)
 	require.NoError(t, err, "failed to create a gzip reader")
@@ -137,7 +136,7 @@ func checkTgz(t *testing.T, rec *httptest.ResponseRecorder, id string) {
 	require.Equal(t, mockCheckpointContent, gotMap)
 }
 
-func checkZip(t *testing.T, rec *httptest.ResponseRecorder, id string) {
+func checkZip(t *testing.T, rec *httptest.ResponseRecorder) {
 	content := rec.Body.String()
 	zr, err := zip.NewReader(strings.NewReader(content), int64(len(content)))
 	require.NoError(t, err, "failed to create a zip reader")
@@ -220,7 +219,7 @@ func testGetCheckpointEcho(t *testing.T, bucket string) {
 			ctx.Request().Header.Set("Accept", MIMEApplicationXTar)
 			err = api.m.getCheckpoint(ctx)
 			require.NoError(t, err, "API call returns error")
-			checkTar(t, rec, id)
+			checkTar(t, rec)
 			return err
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 		{"CanGetCheckpointTgz", func() error {
@@ -235,7 +234,7 @@ func testGetCheckpointEcho(t *testing.T, bucket string) {
 			ctx.Request().Header.Set("Accept", MIMEApplicationGZip)
 			err = api.m.getCheckpoint(ctx)
 			require.NoError(t, err, "API call returns error")
-			checkTgz(t, rec, id)
+			checkTgz(t, rec)
 			return err
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 		{"CanGetCheckpointZip", func() error {
@@ -250,7 +249,7 @@ func testGetCheckpointEcho(t *testing.T, bucket string) {
 			ctx.Request().Header.Set("Accept", MIMEApplicationZip)
 			err = api.m.getCheckpoint(ctx)
 			require.NoError(t, err, "API call returns error")
-			checkZip(t, rec, id)
+			checkZip(t, rec)
 			return err
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 	}

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -83,7 +84,7 @@ func echoGetExperimentAndCheckCanDoActions(ctx context.Context, c echo.Context,
 ) (*model.Experiment, model.User, error) {
 	user := c.(*detContext.DetContext).MustGetUser()
 	e, err := db.ExperimentByID(ctx, expID)
-	expNotFound := api.NotFoundErrs("experiment", fmt.Sprint(expID), false)
+	expNotFound := api.NotFoundErrs("experiment", strconv.Itoa(expID), false)
 	if errors.Is(err, db.ErrNotFound) {
 		return nil, model.User{}, expNotFound
 	} else if err != nil {
@@ -228,14 +229,14 @@ func getCreateExperimentsProject(
 	// Place experiment in Uncategorized, unless project set in request params or config.
 	var err error
 	projectID := model.DefaultProjectID
-	errProjectNotFound := api.NotFoundErrs("project", fmt.Sprint(projectID), true)
+	errProjectNotFound := api.NotFoundErrs("project", strconv.Itoa(projectID), true)
 	if req.ProjectId > 1 {
 		projectID = int(req.ProjectId)
-		errProjectNotFound = api.NotFoundErrs("project", fmt.Sprint(projectID), true)
+		errProjectNotFound = api.NotFoundErrs("project", strconv.Itoa(projectID), true)
 	} else {
 		if (config.Workspace() == "") != (config.Project() == "") {
 			return nil,
-				errors.New("workspace and project must both be included in config if one is provided")
+				fmt.Errorf("workspace and project must both be included in config if one is provided")
 		}
 		if config.Workspace() != "" && config.Project() != "" {
 			errProjectNotFound = api.NotFoundErrs("workspace/project",
@@ -304,7 +305,7 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 		}
 
 		if defaulted.RawEntrypoint == nil {
-			return nil, nil, config, nil, nil, errors.New("managed experiments require entrypoint")
+			return nil, nil, config, nil, nil, fmt.Errorf("managed experiments require entrypoint")
 		}
 	}
 

--- a/master/internal/core_experiment_intg_test.go
+++ b/master/internal/core_experiment_intg_test.go
@@ -72,21 +72,21 @@ func TestAuthZGetExperimentAndCanDoActionsEcho(t *testing.T) {
 		{"CanGetExperimentArtifacts", func(id int) error {
 			ctx := newTestEchoContext(curUser)
 			ctx.SetParamNames("experiment_id")
-			ctx.SetParamValues(fmt.Sprintf("%d", id))
+			ctx.SetParamValues(strconv.Itoa(id))
 			ctx.SetRequest(httptest.NewRequest(http.MethodPost, "/", nil))
 			return api.m.getExperimentModelDefinition(ctx)
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 		{"CanGetExperimentArtifacts", func(id int) error {
 			ctx := newTestEchoContext(curUser)
 			ctx.SetParamNames("experiment_id")
-			ctx.SetParamValues(fmt.Sprintf("%d", id))
+			ctx.SetParamValues(strconv.Itoa(id))
 			ctx.SetRequest(httptest.NewRequest(http.MethodPost, "/?path=rootPath", nil))
 			return api.m.getExperimentModelFile(ctx)
 		}, []any{mock.Anything, mock.Anything, mock.Anything}},
 		{"CanGetExperimentArtifacts", func(id int) error {
 			ctx := newTestEchoContext(curUser)
 			ctx.SetParamNames("experiment_id")
-			ctx.SetParamValues(fmt.Sprintf("%d", id))
+			ctx.SetParamValues(strconv.Itoa(id))
 			ctx.SetRequest(httptest.NewRequest(http.MethodPost,
 				"/?save_experiment_best=10&save_trial_best=2&save_trial_latest=3", nil))
 
@@ -101,7 +101,7 @@ func TestAuthZGetExperimentAndCanDoActionsEcho(t *testing.T) {
 
 		authZExp.On("CanGetExperiment", mock.Anything, mock.Anything, mock.Anything).
 			Return(authz2.PermissionDeniedError{}).Once()
-		require.Equal(t, apiPkg.NotFoundErrs("experiment", fmt.Sprint(exp.ID), false),
+		require.Equal(t, apiPkg.NotFoundErrs("experiment", strconv.Itoa(exp.ID), false),
 			curCase.IDToReqCall(exp.ID))
 
 		// CanGetExperiment error returns unmodified.

--- a/master/internal/db/postgres_agent_intg_test.go
+++ b/master/internal/db/postgres_agent_intg_test.go
@@ -37,8 +37,8 @@ func agentStatsForRP(t *testing.T, rp string) []*agentStatsRow {
 
 func TestRecordAgentStats(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	lowStartTimeBound := time.Now()

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -18,8 +18,8 @@ import (
 func TestClusterAPI(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
 
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	_, err := db.GetOrCreateClusterID("")

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
-	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -31,8 +31,8 @@ import (
 func TestCheckpointMetadata(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	tests := []struct {
@@ -125,7 +125,7 @@ func TestCheckpointMetadata(t *testing.T) {
 				require.NoError(t, conv.Error())
 				require.Equal(t, expected.State, conv.ToCheckpointState(actual.State))
 				if tt.hasValidation {
-					require.Equal(t, metricValue, *actual.Training.SearcherMetric)
+					require.InEpsilon(t, metricValue, *actual.Training.SearcherMetric, 0.01)
 					require.NotNil(t, actual.Training.ValidationMetrics.AvgMetrics)
 				} else {
 					require.Nil(t, actual.Training.SearcherMetric)
@@ -161,14 +161,14 @@ func TestMetricNames(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	actualNames, err := db.MetricNames(ctx, []int{-1})
 	require.NoError(t, err)
-	require.Len(t, actualNames[model.TrainingMetricGroup], 0)
-	require.Len(t, actualNames[model.ValidationMetricGroup], 0)
+	require.Empty(t, actualNames[model.TrainingMetricGroup])
+	require.Empty(t, actualNames[model.ValidationMetricGroup])
 
 	user := RequireMockUser(t, db)
 
@@ -212,8 +212,8 @@ func TestExperimentByIDs(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
@@ -274,8 +274,8 @@ func TestTerminateExperimentInRestart(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
@@ -287,14 +287,14 @@ func TestTerminateExperimentInRestart(t *testing.T) {
 
 	actualExp, err := ExperimentByID(ctx, exp.ID)
 	require.NoError(t, err)
-	require.Equal(t, actualExp.State, model.ErrorState)
+	require.Equal(t, model.ErrorState, actualExp.State)
 	require.NotNil(t, actualExp.EndTime)
 	require.Nil(t, actualExp.Progress)
 
 	for _, trialID := range []int{trial0.ID, trial1.ID} {
 		actualTrial, err := TrialByID(ctx, trialID)
 		require.NoError(t, err)
-		require.Equal(t, actualTrial.State, model.ErrorState)
+		require.Equal(t, model.ErrorState, actualTrial.State)
 		require.NotNil(t, actualTrial.EndTime)
 	}
 }
@@ -303,20 +303,20 @@ func TestExperimentsTrialAndTaskIDs(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
 	tIDs, taskIDs, err := ExperimentsTrialAndTaskIDs(ctx, Bun(), nil)
 	require.NoError(t, err)
-	require.Len(t, tIDs, 0)
-	require.Len(t, taskIDs, 0)
+	require.Empty(t, tIDs)
+	require.Empty(t, taskIDs)
 
 	tIDs, taskIDs, err = ExperimentsTrialAndTaskIDs(ctx, Bun(), []int{-1})
 	require.NoError(t, err)
-	require.Len(t, tIDs, 0)
-	require.Len(t, taskIDs, 0)
+	require.Empty(t, tIDs)
+	require.Empty(t, taskIDs)
 
 	e0 := RequireMockExperiment(t, db, user)
 	e0Trial0, e0Task0 := RequireMockTrial(t, db, e0)
@@ -356,8 +356,8 @@ func TestExperimentBestSearcherValidation(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
@@ -376,7 +376,7 @@ func TestExperimentBestSearcherValidation(t *testing.T) {
 
 	val, err := ExperimentBestSearcherValidation(ctx, exp.ID)
 	require.NoError(t, err)
-	require.Equal(t, float32(-5.0), val)
+	require.InEpsilon(t, float32(-5.0), val, 0.01)
 
 	_, err = Bun().NewUpdate().Table("experiments").
 		Set("config = jsonb_set(config, '{searcher,smaller_is_better}', 'false'::jsonb)").
@@ -386,15 +386,15 @@ func TestExperimentBestSearcherValidation(t *testing.T) {
 
 	val, err = ExperimentBestSearcherValidation(ctx, exp.ID)
 	require.NoError(t, err)
-	require.Equal(t, float32(5.0), val)
+	require.InEpsilon(t, float32(5.0), val, 0.01)
 }
 
 func TestProjectHyperparameters(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
@@ -414,11 +414,11 @@ func TestProjectHyperparameters(t *testing.T) {
 
 	require.NoError(t,
 		RemoveProjectHyperparameters(ctx, nil, []int32{int32(exp0.ID), int32(exp1.ID)}))
-	require.Len(t, RequireGetProjectHParams(t, db, projectID), 0)
+	require.Empty(t, RequireGetProjectHParams(t, db, projectID))
 
 	require.NoError(t,
 		RemoveProjectHyperparameters(ctx, nil, []int32{int32(exp0.ID), int32(exp1.ID)}))
-	require.Len(t, RequireGetProjectHParams(t, db, projectID), 0)
+	require.Empty(t, RequireGetProjectHParams(t, db, projectID))
 
 	require.NoError(t,
 		AddProjectHyperparameters(ctx, nil, int32(projectID), []int32{int32(exp0.ID)}))
@@ -445,8 +445,8 @@ func TestActiveLogPatternPolicies(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
 
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	_, err := ActiveLogPolicies(ctx, -1)
@@ -457,7 +457,7 @@ func TestActiveLogPatternPolicies(t *testing.T) {
 
 	policies, err := ActiveLogPolicies(ctx, exp.ID)
 	require.NoError(t, err)
-	require.Len(t, policies, 0)
+	require.Empty(t, policies)
 
 	activeConfig, err := db.ActiveExperimentConfig(exp.ID)
 	require.NoError(t, err)
@@ -488,17 +488,17 @@ func TestActiveLogPatternPolicies(t *testing.T) {
 func TestGetNonTerminalExperimentCount(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 
 	c, err := GetNonTerminalExperimentCount(ctx, nil)
 	require.NoError(t, err)
-	require.Equal(t, 0, c)
+	require.Zero(t, c)
 	c, err = GetNonTerminalExperimentCount(ctx, []int32{})
 	require.NoError(t, err)
-	require.Equal(t, 0, c)
+	require.Zero(t, c)
 
 	e0 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		State: ptrs.Ptr(model.ActiveState),
@@ -512,7 +512,7 @@ func TestGetNonTerminalExperimentCount(t *testing.T) {
 	}, DefaultProjectID)
 	c, err = GetNonTerminalExperimentCount(ctx, []int32{int32(e1.ID)})
 	require.NoError(t, err)
-	require.Equal(t, 0, c)
+	require.Zero(t, c)
 
 	e2 := RequireMockExperimentParams(t, db, user, MockExperimentParams{
 		State: ptrs.Ptr(model.PausedState),
@@ -533,8 +533,8 @@ func TestGetNonTerminalExperimentCount(t *testing.T) {
 func TestMetricBatchesMilestones(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 	exp := RequireMockExperiment(t, db, user)
@@ -551,28 +551,28 @@ func TestMetricBatchesMilestones(t *testing.T) {
 	batches, _, err := MetricBatches(exp.ID, "a", startTime, model.MetricGroup("inference"))
 	require.NoError(t, err)
 	require.Len(t, batches, 1)
-	require.Equal(t, batches[0], int32(1))
+	require.Equal(t, int32(1), batches[0])
 
 	batches, _, err = MetricBatches(exp.ID, "b", startTime, model.MetricGroup("inference"))
 	require.NoError(t, err)
 	require.Len(t, batches, 2, "should have 2 batches", batches, trial1, trial2)
-	require.Equal(t, batches[0], int32(1))
-	require.Equal(t, batches[1], int32(2))
+	require.Equal(t, int32(1), batches[0])
+	require.Equal(t, int32(2), batches[1])
 }
 
 func TestTopTrialsByMetric(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
 
 	res, err := TopTrialsByMetric(ctx, -1, 1, "metric", true)
 	require.NoError(t, err)
-	require.Len(t, res, 0)
+	require.Empty(t, res)
 
 	exp := RequireMockExperiment(t, db, user)
 	trial1 := RequireMockTrialID(t, db, exp)
@@ -585,10 +585,10 @@ func TestTopTrialsByMetric(t *testing.T) {
 		`[{"a":-1.5, "b":1.0, "c":"Infinity"}]`, false)
 
 	const (
-		more             = false
-		less             = true
-		noError          = true
-		error            = false
+		moreExpected     = false
+		lessExpected     = true
+		noErrorExpected  = true
+		errorExpected    = false
 		orderExpected    = true
 		orderNotRequired = false
 	)
@@ -602,55 +602,55 @@ func TestTopTrialsByMetric(t *testing.T) {
 		expected              []int
 		expectedOrderRequired bool
 	}{
-		{"'a' limit 1 less", "a", less, 1, noError, []int{trial2}, orderExpected},
-		{"'a' limit 1 more", "a", more, 1, noError, []int{trial1}, orderExpected},
+		{"'a' limit 1 less", "a", lessExpected, 1, noErrorExpected, []int{trial2}, orderExpected},
+		{"'a' limit 1 more", "a", moreExpected, 1, noErrorExpected, []int{trial1}, orderExpected},
 
-		{"'a' limit 2 less", "a", less, 2, noError, []int{trial2, trial1}, orderExpected},
-		{"'a' limit 2 more", "a", more, 2, noError, []int{trial1, trial2}, orderExpected},
+		{"'a' limit 2 less", "a", lessExpected, 2, noErrorExpected, []int{trial2, trial1}, orderExpected},
+		{"'a' limit 2 more", "a", moreExpected, 2, noErrorExpected, []int{trial1, trial2}, orderExpected},
 
 		{
-			"NaNs are bigger than everything less", "b", less, 2, noError,
+			"NaNs are bigger than everything less", "b", lessExpected, 2, noErrorExpected,
 			[]int{trial2, trial1},
 			orderExpected,
 		},
 		{
-			"NaNs are bigger than everything more", "b", more, 2, noError,
+			"NaNs are bigger than everything more", "b", moreExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 
 		{
-			"Infinity works as expected less", "c", less, 2, noError,
+			"Infinity works as expected less", "c", lessExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 		{
-			"Infinity works as expected more", "c", more, 2, noError,
+			"Infinity works as expected more", "c", moreExpected, 2, noErrorExpected,
 			[]int{trial2, trial1},
 			orderExpected,
 		},
 
-		{"Non numeric metrics error less", "d", less, 2, error, nil, orderExpected},
-		{"Non numeric metrics error more", "d", more, 2, error, nil, orderExpected},
+		{"Non numeric metrics error less", "d", lessExpected, 2, errorExpected, nil, orderExpected},
+		{"Non numeric metrics error more", "d", moreExpected, 2, errorExpected, nil, orderExpected},
 
 		{
-			"Metrics only reported in one trial appear first less", "e", less, 2, noError,
+			"Metrics only reported in one trial appear first less", "e", lessExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 		{
-			"Metrics only reported in one trial appear first more", "e", more, 2, noError,
+			"Metrics only reported in one trial appear first more", "e", moreExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 
 		{
-			"Metric doesn't exist order doesn't matter less", "z", less, 2, noError,
+			"Metric doesn't exist order doesn't matter less", "z", lessExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderNotRequired,
 		},
 		{
-			"Metric doesn't exist order doesn't matter more", "z", more, 2, noError,
+			"Metric doesn't exist order doesn't matter more", "z", moreExpected, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderNotRequired,
 		},
@@ -809,12 +809,12 @@ func TestDeleteExperiments(t *testing.T) {
 		var ids []int
 		err := Bun().NewSelect().Table(table).Column(column).Scan(context.Background(), &ids)
 		require.NoError(t, err)
-		require.Equalf(t, num, len(ids),
+		require.Len(t, ids, num,
 			"table=%s column=%s removed=%+v num=%d", table, column, removed, num)
 
 		for _, id := range ids {
 			_, inRm := removed[id]
-			require.Equal(t, false, inRm)
+			require.False(t, inRm)
 		}
 	}
 
@@ -915,8 +915,8 @@ func TestDeleteExperiments(t *testing.T) {
 
 func TestProjectExperiments(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	// add a workspace, and project
@@ -927,7 +927,7 @@ func TestProjectExperiments(t *testing.T) {
 	t.Run("valid project with zero experiments", func(t *testing.T) {
 		actualExps, err := ProjectExperiments(context.Background(), projectID)
 		require.NoError(t, err)
-		assert.Equal(t, len(actualExps), 0)
+		assert.Empty(t, actualExps)
 	})
 
 	t.Run("valid project with experiments", func(t *testing.T) {
@@ -947,7 +947,7 @@ func TestProjectExperiments(t *testing.T) {
 	t.Run("invalid project", func(t *testing.T) {
 		actualExps, err := ProjectExperiments(context.Background(), -11)
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(actualExps))
+		assert.Empty(t, len(actualExps))
 	})
 
 	t.Run("archived project", func(t *testing.T) {
@@ -986,7 +986,7 @@ func validateExperimentMatch(t *testing.T, expected []*model.Experiment, actual 
 	}
 
 	// map should be empty
-	require.Equal(t, len(m), 0)
+	require.Empty(t, m)
 }
 
 func TestExperimentTotalStepTime(t *testing.T) {
@@ -999,7 +999,7 @@ func TestExperimentTotalStepTime(t *testing.T) {
 
 	t.Run("invalid experiment, return 0.0, no error", func(t *testing.T) {
 		sec, err := ExperimentTotalStepTime(ctx, -1)
-		require.Equal(t, 0.0, sec)
+		require.Zero(t, sec)
 		require.NoError(t, err)
 	})
 
@@ -1008,7 +1008,7 @@ func TestExperimentTotalStepTime(t *testing.T) {
 		exp := RequireMockExperiment(t, db, user)
 		timeInSeconds, err := ExperimentTotalStepTime(ctx, exp.ID)
 		require.NoError(t, err)
-		require.Equal(t, 0.0, timeInSeconds)
+		require.Zero(t, timeInSeconds)
 	})
 
 	t.Run("experiment with single trial/task with set endtime", func(t *testing.T) {
@@ -1021,7 +1021,7 @@ func TestExperimentTotalStepTime(t *testing.T) {
 		require.NoError(t, CompleteAllocation(ctx, alloc))
 		timeInSeconds, err := ExperimentTotalStepTime(ctx, exp.ID)
 		require.NoError(t, err)
-		require.Equal(t, 3600.0, timeInSeconds)
+		require.InEpsilon(t, 3600.0, timeInSeconds, 0.01)
 	})
 
 	t.Run("experiment with multiple trials/tasks", func(t *testing.T) {
@@ -1049,7 +1049,7 @@ func TestExperimentTotalStepTime(t *testing.T) {
 
 		timeInSeconds, err := ExperimentTotalStepTime(ctx, exp.ID)
 		require.NoError(t, err)
-		require.Equal(t, 3661.0, timeInSeconds)
+		require.InEpsilon(t, 3661.0, timeInSeconds, 0.01)
 	})
 }
 

--- a/master/internal/db/postgres_experiments_intg_test.go
+++ b/master/internal/db/postgres_experiments_intg_test.go
@@ -585,8 +585,8 @@ func TestTopTrialsByMetric(t *testing.T) {
 		`[{"a":-1.5, "b":1.0, "c":"Infinity"}]`, false)
 
 	const (
-		moreExpected     = false
-		lessExpected     = true
+		moreIsBetter     = false
+		lessIsBetter     = true
 		noErrorExpected  = true
 		errorExpected    = false
 		orderExpected    = true
@@ -602,55 +602,55 @@ func TestTopTrialsByMetric(t *testing.T) {
 		expected              []int
 		expectedOrderRequired bool
 	}{
-		{"'a' limit 1 less", "a", lessExpected, 1, noErrorExpected, []int{trial2}, orderExpected},
-		{"'a' limit 1 more", "a", moreExpected, 1, noErrorExpected, []int{trial1}, orderExpected},
+		{"'a' limit 1 less", "a", lessIsBetter, 1, noErrorExpected, []int{trial2}, orderExpected},
+		{"'a' limit 1 more", "a", moreIsBetter, 1, noErrorExpected, []int{trial1}, orderExpected},
 
-		{"'a' limit 2 less", "a", lessExpected, 2, noErrorExpected, []int{trial2, trial1}, orderExpected},
-		{"'a' limit 2 more", "a", moreExpected, 2, noErrorExpected, []int{trial1, trial2}, orderExpected},
+		{"'a' limit 2 less", "a", lessIsBetter, 2, noErrorExpected, []int{trial2, trial1}, orderExpected},
+		{"'a' limit 2 more", "a", moreIsBetter, 2, noErrorExpected, []int{trial1, trial2}, orderExpected},
 
 		{
-			"NaNs are bigger than everything less", "b", lessExpected, 2, noErrorExpected,
+			"NaNs are bigger than everything less", "b", lessIsBetter, 2, noErrorExpected,
 			[]int{trial2, trial1},
 			orderExpected,
 		},
 		{
-			"NaNs are bigger than everything more", "b", moreExpected, 2, noErrorExpected,
+			"NaNs are bigger than everything more", "b", moreIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 
 		{
-			"Infinity works as expected less", "c", lessExpected, 2, noErrorExpected,
+			"Infinity works as expected less", "c", lessIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 		{
-			"Infinity works as expected more", "c", moreExpected, 2, noErrorExpected,
+			"Infinity works as expected more", "c", moreIsBetter, 2, noErrorExpected,
 			[]int{trial2, trial1},
 			orderExpected,
 		},
 
-		{"Non numeric metrics error less", "d", lessExpected, 2, errorExpected, nil, orderExpected},
-		{"Non numeric metrics error more", "d", moreExpected, 2, errorExpected, nil, orderExpected},
+		{"Non numeric metrics error less", "d", lessIsBetter, 2, errorExpected, nil, orderExpected},
+		{"Non numeric metrics error more", "d", moreIsBetter, 2, errorExpected, nil, orderExpected},
 
 		{
-			"Metrics only reported in one trial appear first less", "e", lessExpected, 2, noErrorExpected,
+			"Metrics only reported in one trial appear first less", "e", lessIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 		{
-			"Metrics only reported in one trial appear first more", "e", moreExpected, 2, noErrorExpected,
+			"Metrics only reported in one trial appear first more", "e", moreIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderExpected,
 		},
 
 		{
-			"Metric doesn't exist order doesn't matter less", "z", lessExpected, 2, noErrorExpected,
+			"Metric doesn't exist order doesn't matter less", "z", lessIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderNotRequired,
 		},
 		{
-			"Metric doesn't exist order doesn't matter more", "z", moreExpected, 2, noErrorExpected,
+			"Metric doesn't exist order doesn't matter more", "z", moreIsBetter, 2, noErrorExpected,
 			[]int{trial1, trial2},
 			orderNotRequired,
 		},

--- a/master/internal/db/postgres_jobs_intg_test.go
+++ b/master/internal/db/postgres_jobs_intg_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 func TestAddJob(t *testing.T) {
-	close := setupDBForTest(t)
-	defer close()
+	closeDB := setupDBForTest(t)
+	defer closeDB()
 
 	t.Run("add job", func(t *testing.T) {
 		_, err := createAndAddJob(0)
@@ -41,8 +41,8 @@ func TestAddJob(t *testing.T) {
 }
 
 func TestJobByID(t *testing.T) {
-	close := setupDBForTest(t)
-	defer close()
+	closeDB := setupDBForTest(t)
+	defer closeDB()
 
 	t.Run("add and retrieve job", func(t *testing.T) {
 		// create and send job
@@ -67,8 +67,8 @@ func TestJobByID(t *testing.T) {
 }
 
 func TestUpdateJobPosition(t *testing.T) {
-	close := setupDBForTest(t)
-	defer close()
+	closeDB := setupDBForTest(t)
+	defer closeDB()
 
 	t.Run("update position", func(t *testing.T) {
 		// create and send job
@@ -141,9 +141,9 @@ func TestUpdateJobPosition(t *testing.T) {
 func setupDBForTest(t *testing.T) func() {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
 
-	db, close := MustResolveTestPostgres(t)
+	db, closeDB := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
-	return close
+	return closeDB
 }
 
 func createAndAddJob(pos int64) (model.Job, error) {

--- a/master/internal/db/postgres_model_intg_test.go
+++ b/master/internal/db/postgres_model_intg_test.go
@@ -25,8 +25,8 @@ var emptyMetadata = []byte(`{}`)
 func TestModels(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	tests := []struct {
@@ -120,9 +120,8 @@ func TestModels(t *testing.T) {
 				require.Equal(t, expected.Model.Name, actual.Model.Name)
 				require.Equal(t, expected.Checkpoint.Uuid, actual.Checkpoint.Uuid)
 				if tt.hasValidation {
-					require.Equal(t,
-						*expected.Checkpoint.Training.SearcherMetric,
-						*actual.Checkpoint.Training.SearcherMetric)
+					require.InEpsilon(t, *expected.Checkpoint.Training.SearcherMetric,
+						*actual.Checkpoint.Training.SearcherMetric, 0.01)
 					require.NotNil(t, actual.Checkpoint.Training.ValidationMetrics.AvgMetrics)
 				} else {
 					require.Nil(t, actual.Checkpoint.Training.SearcherMetric)

--- a/master/internal/db/postgres_rbac_intg_test.go
+++ b/master/internal/db/postgres_rbac_intg_test.go
@@ -184,12 +184,12 @@ func cleanUp(t *testing.T) {
 
 func TestPermissionMatch(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
+	pgDB, closeDB := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	t.Cleanup(func() {
 		cleanUp(t)
-		close()
+		closeDB()
 	})
 	setup(t, pgDB)
 	userIDViewer := userModelViewer.ID
@@ -350,8 +350,8 @@ func TestEditorVSEditorRestricted(t *testing.T) {
 	// Verify that the EditorRestricted role only has two less permissions than Editor and that
 	// it does not have the create or update notebooks/shells/commands permissions.
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	numEditorRestrictedPermissions, err := Bun().NewSelect().Table("permission_assignments").
@@ -371,5 +371,5 @@ func TestEditorVSEditorRestricted(t *testing.T) {
 		Count(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, 0, num)
+	require.Zero(t, num)
 }

--- a/master/internal/db/postgres_resource_managers_dispatcher_intg_test.go
+++ b/master/internal/db/postgres_resource_managers_dispatcher_intg_test.go
@@ -18,8 +18,8 @@ func TestDispatchPersistence(t *testing.T) {
 	err := etc.SetRootPath(RootFromDB)
 	require.NoError(t, err)
 
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	u := RequireMockUser(t, db)
@@ -60,8 +60,8 @@ VALUES ($1, $2)
 	require.Equal(t, int64(1), count)
 
 	ds, _ = ListDispatchesByAllocationID(context.TODO(), d.AllocationID)
-	require.Len(t, ds, 0)
+	require.Empty(t, ds)
 
 	ds, _ = ListAllDispatches(context.TODO())
-	require.Len(t, ds, 0)
+	require.Empty(t, ds)
 }

--- a/master/internal/db/postgres_rp_workspace_bindings_intg_test.go
+++ b/master/internal/db/postgres_rp_workspace_bindings_intg_test.go
@@ -63,7 +63,7 @@ func TestAddAndRemoveBindings(t *testing.T) {
 
 	count, err = Bun().NewSelect().Model(&values).ScanAndCount(ctx)
 	require.NoError(t, err, "error when scanning DB: %t", err)
-	require.Equal(t, 0, count, "expected 0 items in DB, found %d", count)
+	require.Zero(t, count, "expected 0 items in DB, found %d", count)
 
 	err = AddRPWorkspaceBindings(ctx, workspaceIDs, testPool2Name, []config.ResourcePoolConfig{
 		{PoolName: testPoolName}, {PoolName: testPool2Name},
@@ -85,13 +85,13 @@ func TestAddAndRemoveBindings(t *testing.T) {
 
 	count, err = Bun().NewSelect().Model(&values).ScanAndCount(ctx)
 	require.NoError(t, err, "error when scanning DB: %t", err)
-	require.Equal(t, 0, count, "expected 0 items in DB, found %d", count)
+	require.Zero(t, count, "expected 0 items in DB, found %d", count)
 }
 
 func TestCheckIfRPUnbound(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	poolName := uuid.New().String()
@@ -114,8 +114,8 @@ func TestCheckIfRPUnbound(t *testing.T) {
 
 func TestGetDefaultPoolsForWorkspace(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	comp, aux, err := GetDefaultPoolsForWorkspace(ctx, -1)
@@ -163,8 +163,8 @@ func TestGetDefaultPoolsForWorkspace(t *testing.T) {
 func TestBindingFail(t *testing.T) {
 	// Test add the same binding multiple times - should fail
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	user := RequireMockUser(t, pgDB)
@@ -219,7 +219,7 @@ func TestListWorkspacesBindingRP(t *testing.T) {
 	// no bindings
 	bindings, _, err := ReadWorkspacesBoundToRP(ctx, testPoolName, 0, 0, existingPools)
 	require.NoError(t, err, "error when reading workspaces bound to RP %s", testPoolName)
-	require.Equal(t, 0, len(bindings),
+	require.Zero(t, len(bindings),
 		"expected length of bindings to be 0, but got %d", len(bindings))
 
 	// one binding
@@ -228,7 +228,7 @@ func TestListWorkspacesBindingRP(t *testing.T) {
 
 	bindings, _, err = ReadWorkspacesBoundToRP(ctx, testPoolName, 0, 0, existingPools)
 	require.NoError(t, err, "error when reading workspaces bound to RP %s", testPoolName)
-	require.Equal(t, 1, len(bindings),
+	require.Len(t, bindings, 1,
 		"expected length of bindings to be 0, but got %d", len(bindings))
 	require.Equal(t, int(workspaceIDs[0]), bindings[0].WorkspaceID,
 		"expected workspaceID %d, but got %d", workspaceIDs[0], bindings[0].WorkspaceID)
@@ -242,7 +242,7 @@ func TestListWorkspacesBindingRP(t *testing.T) {
 
 	bindings, _, err = ReadWorkspacesBoundToRP(ctx, testPoolName, 0, 0, existingPools)
 	require.NoError(t, err, "error when reading workspaces bound to RP %s", testPoolName)
-	require.Equal(t, 1, len(bindings),
+	require.Len(t, bindings, 1,
 		"expected length of bindings to be 0, but got %d", len(bindings))
 	require.Equal(t, int(workspaceIDs[0]), bindings[0].WorkspaceID,
 		"expected workspaceID %d, but got %d", workspaceIDs[0], bindings[0].WorkspaceID)
@@ -252,14 +252,14 @@ func TestListWorkspacesBindingRP(t *testing.T) {
 	require.NoError(t, err, "failed to add bindings: %t", err)
 	bindings, err = GetAllBindings(ctx)
 	require.NoError(t, err, "failed to get all bindings")
-	require.Equal(t, 2, len(bindings),
+	require.Len(t, bindings, 2,
 		"expected length of bindings to be 0 but got %d", len(bindings))
 }
 
 func TestListRPsAvailableToWorkspace(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	ctx := context.Background()
 	user := RequireMockUser(t, db)
@@ -391,8 +391,8 @@ func TestListRPsAvailableToWorkspace(t *testing.T) {
 
 func TestOverwriteBindings(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	ctx := context.Background()
 	user := RequireMockUser(t, db)
@@ -413,7 +413,7 @@ func TestOverwriteBindings(t *testing.T) {
 	require.NoError(t, err, "failed to add ")
 	bindings, _, err := ReadWorkspacesBoundToRP(ctx, testPoolName, 0, 0, existingPools)
 	require.NoError(t, err, "failed to read bindings: %t", err)
-	require.Equal(t, 3, len(bindings),
+	require.Len(t, bindings, 3,
 		"expected bindings length 3, but got length %d", len(bindings))
 	var bindingsIDs []int32
 	for _, binding := range bindings {
@@ -430,7 +430,7 @@ func TestOverwriteBindings(t *testing.T) {
 	require.NoError(t, err, "failed to overwrite bindings: %t", err)
 	bindings, _, err = ReadWorkspacesBoundToRP(ctx, testPoolName, 0, 0, existingPools)
 	require.NoError(t, err, "failed to read bindings: %t", err)
-	require.Equal(t, 1, len(bindings),
+	require.Len(t, bindings, 1,
 		"expected bindings length 1, but got length %d", len(bindings))
 	require.Equal(t, int(workspaceIDs[0]), bindings[0].WorkspaceID,
 		"workspaceID %d does not match bound workspace ID %d",
@@ -445,7 +445,7 @@ func TestOverwriteBindings(t *testing.T) {
 
 	bindings, _, err = ReadWorkspacesBoundToRP(ctx, testPool2Name, 0, 0, existingPools)
 	require.NoError(t, err, "failed to read bindings: %t", err)
-	require.Equal(t, 1, len(bindings),
+	require.Len(t, bindings, 1,
 		"expected bindings length 1, but got length %d", len(bindings))
 	require.Equal(t, int(workspaceIDs[0]), bindings[0].WorkspaceID,
 		"workspaceID %d does not match bound workspace ID %d",
@@ -457,8 +457,8 @@ func TestOverwriteBindings(t *testing.T) {
 
 func TestOverwriteFail(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	existingPools := []config.ResourcePoolConfig{{PoolName: testPoolName}}
@@ -475,8 +475,8 @@ func TestOverwriteFail(t *testing.T) {
 
 func TestRemoveInvalidBinding(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 	// remove binding that doesn't exist
 	workspaceIDs := []int32{1}

--- a/master/internal/db/postgres_snapshots_test.go
+++ b/master/internal/db/postgres_snapshots_test.go
@@ -20,8 +20,8 @@ import (
 func TestCustomSearcherSnapshot(t *testing.T) {
 	err := etc.SetRootPath(RootFromDB)
 	require.NoError(t, err)
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	user := RequireMockUser(t, db)
 	exp := RequireMockExperiment(t, db, user)

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -34,8 +34,8 @@ import (
 // database are total. We should look into an ORM in the near to medium term future.
 func TestJobTaskAndAllocationAPI(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -131,8 +131,8 @@ func TestJobTaskAndAllocationAPI(t *testing.T) {
 
 func TestRecordAndEndTaskStats(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	tID := model.NewTaskID()
@@ -181,8 +181,8 @@ func TestRecordAndEndTaskStats(t *testing.T) {
 
 func TestNonExperimentTasksContextDirectory(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	// Task doesn't exist.
@@ -201,7 +201,7 @@ func TestNonExperimentTasksContextDirectory(t *testing.T) {
 
 	dir, err := NonExperimentTasksContextDirectory(ctx, tID)
 	require.NoError(t, err)
-	require.Len(t, dir, 0)
+	require.Empty(t, dir)
 
 	// Non nil context directory.
 	tID = model.NewTaskID()
@@ -221,8 +221,8 @@ func TestNonExperimentTasksContextDirectory(t *testing.T) {
 
 func TestAllocationState(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -272,7 +272,7 @@ func TestAllocationState(t *testing.T) {
 			require.NoError(t, db.QueryProto("get_task", tOut, tID), "failed to get task")
 
 			// Ensure our state is the same as allocation.
-			require.Equal(t, len(tOut.Allocations), 1, "failed to get exactly 1 allocation")
+			require.Len(t, tOut.Allocations, 1, "failed to get exactly 1 allocation")
 			aOut := tOut.Allocations[0]
 
 			if slices.Contains([]model.AllocationState{
@@ -291,8 +291,8 @@ func TestAllocationState(t *testing.T) {
 }
 
 func TestExhaustiveEnums(t *testing.T) {
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	type check struct {
@@ -387,8 +387,8 @@ func TestExhaustiveEnums(t *testing.T) {
 
 func TestAddTask(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -416,8 +416,8 @@ func TestAddTask(t *testing.T) {
 
 func TestTaskCompleted(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -438,8 +438,8 @@ func TestTaskCompleted(t *testing.T) {
 
 func TestAddAllocation(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -465,8 +465,8 @@ func TestAddAllocation(t *testing.T) {
 
 func TestAddAllocationExitStatus(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -494,8 +494,8 @@ func TestAddAllocationExitStatus(t *testing.T) {
 
 func TestCompleteAllocation(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -514,8 +514,8 @@ func TestCompleteAllocation(t *testing.T) {
 }
 
 func TestCompleteAllocationTelemetry(t *testing.T) {
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -531,8 +531,8 @@ func TestCompleteAllocationTelemetry(t *testing.T) {
 }
 
 func TestAllocationByID(t *testing.T) {
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -547,8 +547,8 @@ func TestAllocationByID(t *testing.T) {
 
 func TestAllocationSessionFlow(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -561,7 +561,7 @@ func TestAllocationSessionFlow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tok)
 
-	as, err := allocationSessionByID(t, aIn.AllocationID)
+	as, err := allocationSessionByID(aIn.AllocationID)
 	require.NoError(t, err)
 	require.Equal(t, uIn.ID, *as.OwnerID)
 
@@ -577,15 +577,15 @@ func TestAllocationSessionFlow(t *testing.T) {
 	err = DeleteAllocationSession(ctx, aIn.AllocationID)
 	require.NoError(t, err)
 
-	as, err = allocationSessionByID(t, aIn.AllocationID)
+	as, err = allocationSessionByID(aIn.AllocationID)
 	require.ErrorContains(t, err, "no rows in result set")
 	require.Nil(t, as)
 }
 
 func TestUpdateAllocation(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -627,8 +627,8 @@ func TestUpdateAllocation(t *testing.T) {
 
 func TestCloseOpenAllocations(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -667,8 +667,8 @@ func TestCloseOpenAllocations(t *testing.T) {
 }
 
 func TestTaskLogsFlow(t *testing.T) {
-	pgDB, close := MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
 
 	db := SingleDB()
@@ -701,7 +701,7 @@ func TestTaskLogsFlow(t *testing.T) {
 		Values:    []string{"testing-agent-1"},
 	}})
 	require.NoError(t, err)
-	require.Equal(t, count, 0)
+	require.Zero(t, count)
 
 	// Try adding the rest of the Task logs, and count 2 for t1In.TaskID, and 1 for t2In.TaskID
 	err = db.AddTaskLogs([]*model.TaskLog{taskLog2, taskLog3})
@@ -709,11 +709,11 @@ func TestTaskLogsFlow(t *testing.T) {
 
 	count, err = db.TaskLogsCount(t1In.TaskID, []api.Filter{})
 	require.NoError(t, err)
-	require.Equal(t, count, 2)
+	require.Equal(t, 2, count)
 
 	count, err = db.TaskLogsCount(t2In.TaskID, []api.Filter{})
 	require.NoError(t, err)
-	require.Equal(t, count, 1)
+	require.Equal(t, 1, count)
 
 	// Test TaskLogsFields.
 	resp, err := db.TaskLogsFields(t1In.TaskID)
@@ -725,14 +725,14 @@ func TestTaskLogsFlow(t *testing.T) {
 	// Get 1 task log matching t1In task ID.
 	logs, _, err := db.TaskLogs(t1In.TaskID, 1, []api.Filter{}, apiv1.OrderBy_ORDER_BY_UNSPECIFIED, nil)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(logs))
+	require.Len(t, logs, 1)
 	require.Equal(t, logs[0].TaskID, string(t1In.TaskID))
 	require.Contains(t, []string{"1", "2"}, *logs[0].ContainerID)
 
 	// Get up to 5 tasks matching t2In task ID -- receive only 2.
 	logs, _, err = db.TaskLogs(t1In.TaskID, 5, []api.Filter{}, apiv1.OrderBy_ORDER_BY_UNSPECIFIED, nil)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(logs))
+	require.Len(t, logs, 2)
 
 	// Test DeleteTaskLogs.
 	err = db.DeleteTaskLogs([]model.TaskID{t2In.TaskID})
@@ -740,12 +740,12 @@ func TestTaskLogsFlow(t *testing.T) {
 
 	count, err = db.TaskLogsCount(t2In.TaskID, []api.Filter{})
 	require.NoError(t, err)
-	require.Equal(t, 0, count)
+	require.Zero(t, count)
 }
 
 func RequireMockTaskLog(t *testing.T, db *PgDB, tID model.TaskID, suffix string) *model.TaskLog {
 	mockA := RequireMockAllocation(t, db, tID)
-	agentID := fmt.Sprintf("testing-agent-%s", suffix)
+	agentID := "testing-agent-" + suffix
 	containerID := suffix
 	log := &model.TaskLog{
 		TaskID:       string(tID),
@@ -757,7 +757,7 @@ func RequireMockTaskLog(t *testing.T, db *PgDB, tID model.TaskID, suffix string)
 	return log
 }
 
-func allocationSessionByID(t *testing.T, aID model.AllocationID) (*model.AllocationSession, error) {
+func allocationSessionByID(aID model.AllocationID) (*model.AllocationSession, error) {
 	var res model.AllocationSession
 	if err := Bun().NewSelect().Table("allocation_sessions").
 		Where("allocation_id = ?", aID).Scan(context.TODO(), &res); err != nil {

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -103,9 +103,9 @@ func ResolveTestPostgres() (*PgDB, func(), error) {
 
 // MustResolveTestPostgres is the same as ResolveTestPostgres but with panics on errors.
 func MustResolveTestPostgres(t *testing.T) (*PgDB, func()) {
-	pgDB, close, err := ResolveTestPostgres()
+	pgDB, closeDB, err := ResolveTestPostgres()
 	require.NoError(t, err, "failed to connect to postgres")
-	return pgDB, close
+	return pgDB, closeDB
 }
 
 // ResolveNewPostgresDatabase returns a connection to a randomly-named, newly-created database, and
@@ -113,7 +113,7 @@ func MustResolveTestPostgres(t *testing.T) (*PgDB, func()) {
 func ResolveNewPostgresDatabase() (*PgDB, func(), error) {
 	baseURL := os.Getenv("DET_INTEGRATION_POSTGRES_URL")
 	if baseURL == "" {
-		return nil, nil, errors.New("no DET_INTEGRATION_POSTGRES_URL detected")
+		return nil, nil, fmt.Errorf("no DET_INTEGRATION_POSTGRES_URL detected")
 	}
 
 	url, err := url.Parse(baseURL)
@@ -211,9 +211,9 @@ func MigrateTestPostgres(db *PgDB, migrationsPath string, actions ...string) err
 
 // MustSetupTestPostgres returns a ready to use test postgres connection.
 func MustSetupTestPostgres(t *testing.T) (*PgDB, func()) {
-	pgDB, close := MustResolveTestPostgres(t)
+	pgDB, closeDB := MustResolveTestPostgres(t)
 	MustMigrateTestPostgres(t, pgDB, MigrationsFromDB)
-	return pgDB, close
+	return pgDB, closeDB
 }
 
 // RequireMockJob returns a stub job.

--- a/master/internal/db/postgres_trial.go
+++ b/master/internal/db/postgres_trial.go
@@ -345,8 +345,7 @@ func (db *PgDB) UpdateTrialFields(id int, newRunnerMetadata *trialv1.TrialRunner
 }
 
 // TrialRunIDAndRestarts returns the run id and restart count for a trial.
-func (db *PgDB) TrialRunIDAndRestarts(trialID int) (int, int, error) {
-	var runID, restart int
+func (db *PgDB) TrialRunIDAndRestarts(trialID int) (runID int, restart int, err error) {
 	if err := db.sql.QueryRowx(`
 SELECT run_id, restarts
 FROM trials

--- a/master/internal/db/postgres_trial_intg_test.go
+++ b/master/internal/db/postgres_trial_intg_test.go
@@ -415,8 +415,8 @@ type summaryMetrics struct {
 func TestSummaryMetricsInsert(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	trialIDs, expectedTrain, expectedVal := generateSummaryMetricsTestCases(ctx, t, db, false)
 
@@ -428,8 +428,8 @@ func TestSummaryMetricsInsert(t *testing.T) {
 func TestSummaryMetricsInsertRollback(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	trialIDs, expectedTrain, expectedVal := generateSummaryMetricsTestCases(ctx, t, db, true)
 
@@ -441,8 +441,8 @@ func TestSummaryMetricsInsertRollback(t *testing.T) {
 func TestEpochMetricGroups(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -566,8 +566,8 @@ func TestMetricMergeUtil(t *testing.T) {
 func TestMetricMerge(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	mGroup := model.TrainingMetricGroup
 	metricGroup := mGroup.ToString()
@@ -637,8 +637,8 @@ func TestGetAllMetrics(t *testing.T) {
 	// will be returned when you ask for a blank MetricGroup ("")
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -693,8 +693,8 @@ func TestGetAllMetrics(t *testing.T) {
 func TestMetricMergeFail(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	mGroup := model.TrainingMetricGroup
 
@@ -739,8 +739,8 @@ func TestMetricMergeFail(t *testing.T) {
 func TestLatestMetricID(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -789,8 +789,8 @@ func TestLatestMetricID(t *testing.T) {
 func TestTrialByTaskID(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -811,8 +811,8 @@ func TestTrialByTaskID(t *testing.T) {
 func TestUpsertTrialByExternalIDTx(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -851,8 +851,8 @@ func TestUpsertTrialByExternalIDTx(t *testing.T) {
 func TestExperimentsProjectID(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	trial := &model.Trial{
@@ -878,8 +878,8 @@ func TestExperimentsProjectID(t *testing.T) {
 func TestProtoGetTrial(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
@@ -918,7 +918,7 @@ func TestProtoGetTrial(t *testing.T) {
 		1,
 	)
 	require.NoError(t, err, "failed to query trial")
-	require.Equal(t, trResp.WallClockTime, float64(3), "wall clock time is wrong")
+	require.InEpsilon(t, float64(3), trResp.WallClockTime, 0.01, "wall clock time is wrong")
 }
 
 // Covers an issue where checkpoint_view returned multiple records per checkpoint
@@ -929,8 +929,8 @@ func TestProtoGetTrial(t *testing.T) {
 func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
@@ -994,8 +994,8 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 	checkpoints := []*checkpointv1.Checkpoint{}
 	require.NoError(t, db.QueryProto("get_checkpoints_for_experiment", &checkpoints, exp.ID))
 	require.Len(t, checkpoints, 1)
-	require.Equal(t, 10.0, checkpoints[0].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"])
-	require.Equal(t, 50.0, checkpoints[0].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"])
+	require.InEpsilon(t, 10.0, checkpoints[0].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"], 0.01)
+	require.InEpsilon(t, 50.0, checkpoints[0].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"], 0.01)
 
 	// Dummy metrics still happen if no other results at given total_batches.
 	checkpoint2UUID := uuid.New()
@@ -1023,18 +1023,18 @@ func TestAddValidationMetricsDupeCheckpoints(t *testing.T) {
 		return checkpoints[i].Uuid != checkpoint2UUID.String() // Have second checkpoint later.
 	})
 
-	require.Equal(t, 10.0, checkpoints[0].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"])
-	require.Equal(t, 50.0, checkpoints[0].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"])
+	require.InEpsilon(t, 10.0, checkpoints[0].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"], 0.01)
+	require.InEpsilon(t, 50.0, checkpoints[0].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"], 0.01)
 
-	require.Equal(t, nil, checkpoints[1].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"])
-	require.Equal(t, 1.5, checkpoints[1].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"])
+	require.Nil(t, checkpoints[1].Training.TrainingMetrics.AvgMetrics.AsMap()["loss"])
+	require.InEpsilon(t, 1.5, checkpoints[1].Training.ValidationMetrics.AvgMetrics.AsMap()["loss"], 0.01)
 }
 
 func TestBatchesProcessedNRollbacks(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	exp, activeConfig := model.ExperimentModel()
@@ -1049,7 +1049,7 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 
 	dbTr, err := TrialByID(ctx, tr.ID)
 	require.NoError(t, err)
-	require.Equal(t, 0, dbTr.TotalBatches)
+	require.Zero(t, dbTr.TotalBatches)
 
 	a := &model.Allocation{
 		AllocationID: model.AllocationID(fmt.Sprintf("%s-%d", task.TaskID, 0)),
@@ -1153,14 +1153,14 @@ func TestBatchesProcessedNRollbacks(t *testing.T) {
 	metricGroup := "generic-golabi"
 	returnedMetrics, err := GetMetrics(ctx, tr.ID, 0, 10, &metricGroup)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(returnedMetrics))
+	require.Len(t, returnedMetrics, 1)
 }
 
 func TestUpdateTrialRunnerMetadata(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 
 	user := RequireMockUser(t, db)
@@ -1184,8 +1184,8 @@ func TestUpdateTrialRunnerMetadata(t *testing.T) {
 func TestGenericMetricsIO(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	exp, activeConfig := model.ExperimentModel()
 	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
@@ -1200,7 +1200,7 @@ func TestGenericMetricsIO(t *testing.T) {
 
 	dbTr, err := TrialByID(ctx, tr.ID)
 	require.NoError(t, err)
-	require.Equal(t, 0, dbTr.TotalBatches)
+	require.Zero(t, dbTr.TotalBatches)
 
 	a := &model.Allocation{
 		AllocationID: model.AllocationID(fmt.Sprintf("%s-%d", task.TaskID, 0)),
@@ -1266,7 +1266,7 @@ ORDER BY name ASC`, "inference")
 	summaryRows := []*summaryMetrics{}
 	err = Bun().NewRaw(query, tr.ID).Scan(ctx, &summaryRows)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(summaryRows), summaryRows)
+	require.Len(t, summaryRows, 4, summaryRows)
 	require.Equal(t, summaryMetrics{
 		Name:  "aloss",
 		Max:   20,
@@ -1312,8 +1312,8 @@ ORDER BY name ASC`, "inference")
 func TestConcurrentMetricUpdate(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, etc.SetRootPath(RootFromDB))
-	db, close := MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
 	MustMigrateTestPostgres(t, db, MigrationsFromDB)
 	exp, activeConfig := model.ExperimentModel()
 	require.NoError(t, db.AddExperiment(exp, []byte{}, activeConfig))
@@ -1337,7 +1337,7 @@ func TestConcurrentMetricUpdate(t *testing.T) {
 
 		dbTr, err := TrialByID(ctx, tr.ID)
 		require.NoError(t, err)
-		require.Equal(t, 0, dbTr.TotalBatches)
+		require.Zero(t, dbTr.TotalBatches)
 		return &tr
 	}
 

--- a/master/internal/db/postgres_trial_metrics.go
+++ b/master/internal/db/postgres_trial_metrics.go
@@ -190,12 +190,12 @@ FOR UPDATE`,
 	if err != nil {
 		return 0, nil, err
 	}
-	id, err := db.updateRawMetrics(ctx, tx, finalBody, runID, trialID, lastProcessedBatch, mGroup)
+	id, err := db.updateRawMetrics(ctx, tx, finalBody, trialID, lastProcessedBatch, mGroup)
 	return id, mBody, err
 }
 
 func (db *PgDB) updateRawMetrics(ctx context.Context, tx *sqlx.Tx, mBody *metricsBody,
-	runID, trialID int32, lastProcessedBatch *int32, mGroup model.MetricGroup,
+	trialID int32, lastProcessedBatch *int32, mGroup model.MetricGroup,
 ) (int, error) {
 	if err := mGroup.Validate(); err != nil {
 		return 0, err

--- a/master/internal/db/postgres_trial_metrics_test.go
+++ b/master/internal/db/postgres_trial_metrics_test.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,7 +37,7 @@ func TestMetricsBodyToJSON(t *testing.T) {
 	}
 
 	for idx, body := range cases {
-		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			json := body.ToJSONObj()
 			_, ok := (*json)["batch_metrics"]
 			if body.isValidation {

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -197,11 +197,9 @@ func newExperiment(
 func newUnmanagedExperiment(
 	ctx context.Context,
 	idb bun.IDB,
-	m *Master,
 	expModel *model.Experiment,
 	modelDef []byte,
 	activeConfig expconf.ExperimentConfig,
-	taskSpec *tasks.TaskSpec,
 ) (*internalExperiment, []command.LaunchWarning, error) {
 	expModel.State = model.PausedState
 	expModel.Unmanaged = true
@@ -537,8 +535,7 @@ func (e *internalExperiment) PerformSearcherOperations(msg *apiv1.PostSearcherOp
 				ops = append(ops, *op)
 			}
 		case *experimentv1.SearcherOperation_TrialOperation:
-			switch sub := concreteOperation.TrialOperation.GetUnion().(type) {
-			case *experimentv1.TrialOperation_ValidateAfter:
+			if sub, ok := concreteOperation.TrialOperation.GetUnion().(*experimentv1.TrialOperation_ValidateAfter); ok {
 				op, err := searcher.ValidateAfterFromProto(sub)
 				if err != nil {
 					e.syslog.Error(err)

--- a/master/internal/experiment/authz_rbac.go
+++ b/master/internal/experiment/authz_rbac.go
@@ -3,6 +3,7 @@ package experiment
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
@@ -55,7 +56,7 @@ func addExpInfo(
 		{
 			PermissionTypes: []rbacv1.PermissionType{permission},
 			SubjectType:     "experiment",
-			SubjectIDs:      []string{fmt.Sprint(e.ID)},
+			SubjectIDs:      []string{strconv.Itoa(e.ID)},
 		},
 	}
 }
@@ -220,12 +221,11 @@ func (a *ExperimentAuthZRBAC) FilterExperimentLabelsQuery(
 			if permission.ID == int(
 				rbacv1.PermissionType_PERMISSION_TYPE_VIEW_EXPERIMENT_METADATA) {
 				for _, assignment := range roleAssignments {
-					if assignment.Scope.WorkspaceID.Valid {
-						workspaces = append(workspaces, assignment.Scope.WorkspaceID.Int32)
-					} else {
+					if !assignment.Scope.WorkspaceID.Valid {
 						// if permission is global, return without filtering
 						return query, nil
 					}
+					workspaces = append(workspaces, assignment.Scope.WorkspaceID.Int32)
 				}
 			}
 		}

--- a/master/internal/experiment/bulk_action.go
+++ b/master/internal/experiment/bulk_action.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -215,7 +216,7 @@ func ActivateExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -255,7 +256,7 @@ func CancelExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -307,7 +308,7 @@ func KillExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -357,7 +358,7 @@ func PauseExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(expIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -447,7 +448,7 @@ func DeleteExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -549,7 +550,7 @@ func ArchiveExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -650,7 +651,7 @@ func UnarchiveExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -753,7 +754,7 @@ func MoveExperiments(
 		for _, originalID := range experimentIds {
 			if !slices.Contains(visibleIDs, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -890,7 +891,7 @@ func BulkUpdateLogRentention(
 		for _, originalID := range expIDs {
 			if !slices.Contains(editableExperimentIDList, originalID) {
 				results = append(results, ExperimentActionResult{
-					Error: api.NotFoundErrs("experiment", fmt.Sprint(originalID), true),
+					Error: api.NotFoundErrs("experiment", strconv.Itoa(int(originalID)), true),
 					ID:    originalID,
 				})
 			}
@@ -932,7 +933,6 @@ func BulkUpdateLogRentention(
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/experiment/postgres_experiments.go
+++ b/master/internal/experiment/postgres_experiments.go
@@ -3,6 +3,7 @@ package experiment
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ func GetExperimentAndCheckCanDoActions(
 	}
 
 	e, err := db.ExperimentByID(ctx, expID)
-	expNotFound := api.NotFoundErrs("experiment", fmt.Sprint(expID), true)
+	expNotFound := api.NotFoundErrs("experiment", strconv.Itoa(expID), true)
 	if errors.Is(err, db.ErrNotFound) {
 		return nil, model.User{}, expNotFound
 	} else if err != nil {

--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -583,15 +583,15 @@ func (e experimentFilter) toSQL(q *bun.SelectQuery,
 // training.loss.min -> avg_metrics, loss, min
 // group_a.value.last -> group_a, value, last
 // group_b.value.a.last -> group_b, value.a, last .
-func parseMetricsName(str string) (string, string, string, error) {
+func parseMetricsName(str string) (metricGroup string, metricName string, metricQualifier string, err error) {
 	matches := metricIDTemplate.FindStringSubmatch(str)
 	if len(matches) < 4 {
 		return "", "", "", fmt.Errorf("%s is not a valid metrics id", str)
 	}
 
-	metricGroup := matches[1]
-	metricName := matches[2]
-	metricQualifier := matches[3]
+	metricGroup = matches[1]
+	metricName = matches[2]
+	metricQualifier = matches[3]
 
 	if metricGroup == metricIDTraining {
 		metricGroup = metricGroupTraining

--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -26,7 +27,7 @@ func (e *internalExperiment) ToV1Job() (*jobv1.Job, error) {
 
 	j := jobv1.Job{
 		JobId:          e.JobID.String(),
-		EntityId:       fmt.Sprint(e.ID),
+		EntityId:       strconv.Itoa(e.ID),
 		Type:           jobv1.Type_TYPE_EXPERIMENT,
 		SubmissionTime: timestamppb.New(e.StartTime),
 		Username:       e.Username,
@@ -50,7 +51,7 @@ func (e *internalExperiment) SetJobPriority(priority int) error {
 	defer e.mu.Unlock()
 
 	if priority < 1 || priority > 99 {
-		return errors.New("priority must be between 1 and 99")
+		return fmt.Errorf("priority must be between 1 and 99")
 	}
 	err := e.setPriority(&priority, true)
 	if err != nil {

--- a/master/internal/grpcutil/api.go
+++ b/master/internal/grpcutil/api.go
@@ -125,11 +125,11 @@ func RegisterHTTPProxy(ctx context.Context, e *echo.Echo, port int, cert *tls.Ce
 	handler := func(c echo.Context) error {
 		request := c.Request()
 		if cookie, err := c.Cookie("det_jwt"); extConfig.Enabled() && err == nil {
-			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cookie.Value))
+			request.Header.Set("Authorization", "Bearer "+cookie.Value)
 		}
 		if c.Request().Header.Get("Authorization") == "" {
 			if cookie, err := c.Cookie("auth"); err == nil {
-				request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cookie.Value))
+				request.Header.Set("Authorization", "Bearer "+cookie.Value)
 			}
 		}
 		if _, ok := request.URL.Query()["pretty"]; ok {

--- a/master/internal/job/authz_rbac.go
+++ b/master/internal/job/authz_rbac.go
@@ -49,7 +49,6 @@ func (a *JobAuthZRBAC) FilterJobs(
 		case nil:
 			userHasGlobalExpViewPerm = true
 		case authz.PermissionDeniedError:
-			break
 		default:
 			return nil, err
 		}
@@ -62,7 +61,6 @@ func (a *JobAuthZRBAC) FilterJobs(
 		case nil:
 			userHasGlobalNTSCViewPerm = true
 		case authz.PermissionDeniedError:
-			break
 		default:
 			return nil, err
 		}

--- a/master/internal/job/jobservice/jobservice.go
+++ b/master/internal/job/jobservice/jobservice.go
@@ -230,18 +230,18 @@ func (s *Service) UpdateJobQueue(updates []*jobv1.QueueControl) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	errors := make([]string, 0)
+	errs := make([]string, 0)
 
 	for _, update := range updates {
 		if err := s.applyUpdate(update); err != nil {
-			errors = append(errors, err.Error())
+			errs = append(errs, err.Error())
 		}
 	}
 
-	if len(errors) == 1 {
-		return fmt.Errorf(errors[0])
-	} else if len(errors) > 1 {
-		return fmt.Errorf("encountered the following errors: %s", strings.Join(errors, ", "))
+	if len(errs) == 1 {
+		return fmt.Errorf(errs[0])
+	} else if len(errs) > 1 {
+		return fmt.Errorf("encountered the following errors: %s", strings.Join(errs, ", "))
 	}
 
 	return nil

--- a/master/internal/logpattern/logpattern_intg_test.go
+++ b/master/internal/logpattern/logpattern_intg_test.go
@@ -43,7 +43,7 @@ func TestRetryOnDifferentNode(t *testing.T) {
 
 	blocked, err := GetBlockedNodes(ctx, model.TaskID("fake task ID"))
 	require.NoError(t, err)
-	require.Len(t, blocked, 0)
+	require.Empty(t, blocked)
 
 	user := db.RequireMockUser(t, pgDB)
 	exp := db.RequireMockExperiment(t, pgDB, user)
@@ -51,7 +51,7 @@ func TestRetryOnDifferentNode(t *testing.T) {
 
 	blocked, err = GetBlockedNodes(ctx, task.TaskID)
 	require.NoError(t, err)
-	require.Len(t, blocked, 0)
+	require.Empty(t, blocked)
 
 	require.NoError(t, addRetryOnDifferentNode(ctx, task.TaskID, "n0", "regexa", "loga"))
 	require.NoError(t, addRetryOnDifferentNode(ctx, task.TaskID, "n1", "regexa", "logb"))
@@ -95,7 +95,7 @@ func TestShouldRetry(t *testing.T) {
 
 	resp, err := ShouldRetry(ctx, model.TaskID("fake task ID"))
 	require.NoError(t, err)
-	require.Len(t, resp, 0)
+	require.Empty(t, resp)
 
 	user := db.RequireMockUser(t, pgDB)
 	exp := db.RequireMockExperiment(t, pgDB, user)
@@ -103,7 +103,7 @@ func TestShouldRetry(t *testing.T) {
 
 	resp, err = ShouldRetry(ctx, task.TaskID)
 	require.NoError(t, err)
-	require.Len(t, resp, 0)
+	require.Empty(t, resp)
 
 	require.NoError(t, addDontRetry(ctx, task.TaskID, "n0", "regexa", "loga"))
 	require.NoError(t, addDontRetry(ctx, task.TaskID, "n0", "regexb", "logb"))

--- a/master/internal/model/authz_rbac.go
+++ b/master/internal/model/authz_rbac.go
@@ -62,13 +62,12 @@ func (a *ModelAuthZRBAC) CanGetModels(ctx context.Context, curUser model.User, w
 			if permission.ID == int(
 				rbacv1.PermissionType_PERMISSION_TYPE_VIEW_MODEL_REGISTRY) {
 				for _, assignment := range roleAssignments {
-					if assignment.Scope.WorkspaceID.Valid {
-						workspacesIDsWithPermsSet[assignment.Scope.WorkspaceID.Int32] = true
-						workspacesIDsWithPerms = append(workspacesIDsWithPerms, assignment.Scope.WorkspaceID.Int32)
-					} else {
+					if !assignment.Scope.WorkspaceID.Valid {
 						// if permission is global, return true and the list provided by user.
 						return workspaceIDs, nil
 					}
+					workspacesIDsWithPermsSet[assignment.Scope.WorkspaceID.Int32] = true
+					workspacesIDsWithPerms = append(workspacesIDsWithPerms, assignment.Scope.WorkspaceID.Int32)
 				}
 			}
 		}
@@ -270,12 +269,11 @@ func (a *ModelAuthZRBAC) FilterReadableModelsQuery(
 			if permission.ID == int(
 				rbacv1.PermissionType_PERMISSION_TYPE_VIEW_MODEL_REGISTRY) {
 				for _, assignment := range roleAssignments {
-					if assignment.Scope.WorkspaceID.Valid {
-						workspaces = append(workspaces, assignment.Scope.WorkspaceID.Int32)
-					} else {
+					if !assignment.Scope.WorkspaceID.Valid {
 						// if permission is global, return without filtering
 						return query, nil
 					}
+					workspaces = append(workspaces, assignment.Scope.WorkspaceID.Int32)
 				}
 			}
 		}

--- a/master/internal/plugin/oauth/service.go
+++ b/master/internal/plugin/oauth/service.go
@@ -100,9 +100,9 @@ func (s *Service) authorize(c echo.Context) error {
 
 // clientFormHandler verifies a token request by hashing the client ID and secret instead of using
 // the secret from the form directly.
-func clientFormHandler(r *http.Request) (string, string, error) {
-	clientID := r.Form.Get("client_id")
-	clientSecret := r.Form.Get("client_secret")
+func clientFormHandler(r *http.Request) (clientID string, clientSecret string, err error) {
+	clientID = r.Form.Get("client_id")
+	clientSecret = r.Form.Get("client_secret")
 	if clientID == "" || clientSecret == "" {
 		return "", "", oauth2Errors.ErrInvalidClient
 	}

--- a/master/internal/plugin/oidc/service_intg_test.go
+++ b/master/internal/plugin/oidc/service_intg_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -93,7 +92,7 @@ func TestOIDCWorkflow(t *testing.T) {
 			if tt.createDuplicate {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err, db.ErrNotFound)
+				require.ErrorIs(t, err, db.ErrNotFound)
 				newUser, err := s.provisionUser(ctx, claims.AuthenticationClaim, claims.Groups)
 				require.NoError(t, err)
 				u = newUser
@@ -160,9 +159,8 @@ func TestFailToExtractClaims(t *testing.T) {
 func mockService(t *testing.T, url string) *Service {
 	clientID := "123456"
 	clientSecret := "abcdefgh"
-	idpssoURL := fmt.Sprint(url)
 
-	p, err := oidc.NewProvider(context.Background(), idpssoURL)
+	p, err := oidc.NewProvider(context.Background(), url)
 	require.NoError(t, err)
 
 	return &Service{
@@ -171,7 +169,7 @@ func mockService(t *testing.T, url string) *Service {
 			Provider:                    "Okta",
 			ClientID:                    clientID,
 			ClientSecret:                clientSecret,
-			IDPSSOURL:                   idpssoURL,
+			IDPSSOURL:                   url,
 			IDPRecipientURL:             "https://dev-123456.okta.com",
 			AuthenticationClaim:         "email",
 			SCIMAuthenticationAttribute: "userName",
@@ -184,7 +182,7 @@ func mockService(t *testing.T, url string) *Service {
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint:     p.Endpoint(),
-			RedirectURL:  fmt.Sprint(url + "/oidc/callback"),
+			RedirectURL:  url + "/oidc/callback",
 			Scopes:       []string{oidc.ScopeOpenID, "profile", "email", "groups"},
 		},
 	}

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 	"net/url"
 
-	saml "github.com/crewjam/saml"
-	samlsp "github.com/crewjam/saml/samlsp"
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/master/internal/plugin/saml/service_intg_test.go
+++ b/master/internal/plugin/saml/service_intg_test.go
@@ -62,7 +62,7 @@ func TestSAMLWorkflowAutoProvision(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, groups, "abc")
 	require.Contains(t, groups, "bcd")
-	require.Equal(t, len(groups), 3)
+	require.Len(t, groups, 3)
 
 	_, err = user.StartSession(ctx, u)
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestSAMLWorkflowAutoProvision(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, groups2, "abc")
 	require.NotContains(t, groups2, "bcd")
-	require.Equal(t, len(groups2), 2)
+	require.Len(t, groups2, 2)
 
 	_, err = user.StartSession(ctx, u)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestSAMLWorkflowUserProvisioned(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, groups, "abc")
 	require.Contains(t, groups, "bcd")
-	require.Equal(t, len(groups), 3)
+	require.Len(t, groups, 3)
 
 	_, err = user.StartSession(ctx, u)
 	require.NoError(t, err)

--- a/master/internal/populate_metrics.go
+++ b/master/internal/populate_metrics.go
@@ -40,13 +40,13 @@ func makeMetrics() *structpb.Struct {
 	}
 }
 
-func reportNonTrivialMetrics(ctx context.Context, api *apiServer, trialID int32,
+func reportNonTrivialMetrics(ctx context.Context, trialID int32,
 	batches int,
 ) error {
 	fmt.Println("non trivial metrics for", batches, "batches") //nolint:forbidigo
-	N := 5
+	n := 5
 	losses := []float64{}
-	for i := 0; i < N; i++ {
+	for i := 0; i < n; i++ {
 		losses = append(losses, rand.Float64()) //nolint: gosec
 	}
 
@@ -55,7 +55,7 @@ func reportNonTrivialMetrics(ctx context.Context, api *apiServer, trialID int32,
 	}
 
 	factors := []Factor{}
-	for i := 0; i < N; i++ {
+	for i := 0; i < n; i++ {
 		factors = append(factors, Factor{rand.Float64(), rand.Float64() / 10}) //nolint: gosec
 	}
 
@@ -65,7 +65,7 @@ func reportNonTrivialMetrics(ctx context.Context, api *apiServer, trialID int32,
 		if b%printTime == 0 {
 			start = time.Now()
 		}
-		for i := 0; i < N; i++ {
+		for i := 0; i < n; i++ {
 			val := float64(1)
 			if rand.Float64() <= factors[i].a { //nolint: gosec
 				val = float64(-1)
@@ -149,7 +149,7 @@ func reportNonTrivialMetrics(ctx context.Context, api *apiServer, trialID int32,
 	return nil
 }
 
-func reportTrivialMetrics(ctx context.Context, api *apiServer, trialID int32, batches int) error {
+func reportTrivialMetrics(ctx context.Context, trialID int32, batches int) error {
 	fmt.Println("trivial metrics for", batches, "batches") //nolint:forbidigo
 
 	stepsCompleted := int32(batches)
@@ -207,7 +207,6 @@ func PopulateExpTrialsMetrics(pgdb *db.PgDB, masterConfig *config.Config, trivia
 
 	ctx := metadata.NewIncomingContext(context.TODO(),
 		metadata.Pairs("x-user-token", fmt.Sprintf("Bearer %s", resp.Token)))
-
 	// create exp and config
 	maxLength := expconf.NewLengthInBatches(100)
 	maxRestarts := 0
@@ -266,7 +265,7 @@ func PopulateExpTrialsMetrics(pgdb *db.PgDB, masterConfig *config.Config, trivia
 		return err
 	}
 	if trivialMetrics {
-		return reportTrivialMetrics(ctx, api, int32(tr.ID), batches)
+		return reportTrivialMetrics(ctx, int32(tr.ID), batches)
 	}
-	return reportNonTrivialMetrics(ctx, api, int32(tr.ID), batches)
+	return reportNonTrivialMetrics(ctx, int32(tr.ID), batches)
 }

--- a/master/internal/project/authz_rbac.go
+++ b/master/internal/project/authz_rbac.go
@@ -2,7 +2,7 @@ package project
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 
@@ -26,7 +26,7 @@ func logEntryWithProjectTarget(
 ) {
 	pids := make([]string, 0, len(projectIDs))
 	for _, pid := range projectIDs {
-		pids = append(pids, fmt.Sprint(pid))
+		pids = append(pids, strconv.Itoa(int(pid)))
 	}
 
 	fields["userID"] = curUser.ID
@@ -158,14 +158,14 @@ func (a *ProjectAuthZRBAC) CanMoveProject(
 				rbacv1.PermissionType_PERMISSION_TYPE_DELETE_PROJECT,
 			},
 			SubjectType: "workspace",
-			SubjectIDs:  []string{fmt.Sprint(from.Id)},
+			SubjectIDs:  []string{strconv.Itoa(int(from.Id))},
 		},
 		{
 			PermissionTypes: []rbacv1.PermissionType{
 				rbacv1.PermissionType_PERMISSION_TYPE_CREATE_PROJECT,
 			},
 			SubjectType: "workspace",
-			SubjectIDs:  []string{fmt.Sprint(to.Id)},
+			SubjectIDs:  []string{strconv.Itoa(int(to.Id))},
 		},
 	}
 	defer func() {
@@ -193,14 +193,14 @@ func (a *ProjectAuthZRBAC) CanMoveProjectExperiments(
 				rbacv1.PermissionType_PERMISSION_TYPE_DELETE_EXPERIMENT,
 			},
 			SubjectType: "project",
-			SubjectIDs:  []string{fmt.Sprint(from.Id)},
+			SubjectIDs:  []string{strconv.Itoa(int(from.Id))},
 		},
 		{
 			PermissionTypes: []rbacv1.PermissionType{
 				rbacv1.PermissionType_PERMISSION_TYPE_CREATE_EXPERIMENT,
 			},
 			SubjectType: "project",
-			SubjectIDs:  []string{fmt.Sprint(to.Id)},
+			SubjectIDs:  []string{strconv.Itoa(int(to.Id))},
 		},
 	}
 	defer func() {

--- a/master/internal/project/postgres_project_intg_test.go
+++ b/master/internal/project/postgres_project_intg_test.go
@@ -16,8 +16,8 @@ import (
 
 func TestProjectByName(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(internaldb.RootFromDB))
-	db, close := internaldb.MustResolveTestPostgres(t)
-	defer close()
+	db, closeDB := internaldb.MustResolveTestPostgres(t)
+	defer closeDB()
 	internaldb.MustMigrateTestPostgres(t, db, internaldb.MigrationsFromDB)
 
 	// add a workspace, and project

--- a/master/internal/proxy/proxy_intg_test.go
+++ b/master/internal/proxy/proxy_intg_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/determined-ai/determined/master/internal/db"
@@ -72,8 +71,8 @@ func conditionServerUp() bool {
 }
 
 func TestProxyLifecycle(t *testing.T) {
-	pgDB, close := db.MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
+	defer closeDB()
 	db.MustMigrateTestPostgres(t, pgDB, "file://../../static/migrations")
 	require.NoError(t, etc.SetRootPath("../../static/srv"))
 
@@ -111,7 +110,7 @@ func TestProxyLifecycle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// First register the services
 			register(t, tt.proxyTCP, tt.allowUnauthenticated)
-			require.Equal(t, len(serviceIDs), len(DefaultProxy.Summaries()))
+			require.Len(t, DefaultProxy.Summaries(), len(serviceIDs))
 			// Check that service fields are set correctly
 			for id, service := range DefaultProxy.Summaries() {
 				require.Equal(t, service.URL, &u)
@@ -132,18 +131,18 @@ func TestProxyLifecycle(t *testing.T) {
 
 	// Now at the very end, to test clear proxy ...
 	register(t, true, true)
-	require.Equal(t, len(serviceIDs), len(DefaultProxy.Summaries()))
+	require.Len(t, DefaultProxy.Summaries(), len(serviceIDs))
 	// Clear the services by ClearProxy
 	DefaultProxy.ClearProxy()
 	if len(DefaultProxy.Summaries()) != 0 {
 		t.Errorf("failed to clear all proxy services.")
 	}
-	require.Equal(t, 0, len(DefaultProxy.Summaries()))
+	require.Zero(t, len(DefaultProxy.Summaries()))
 }
 
 func TestNewProxyHandler(t *testing.T) {
-	pgDB, close := db.MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
+	defer closeDB()
 	db.MustMigrateTestPostgres(t, pgDB, "file://../../static/migrations")
 	require.NoError(t, etc.SetRootPath("../../static/srv"))
 	// First init the new Proxy
@@ -176,9 +175,9 @@ func TestNewProxyHandler(t *testing.T) {
 	c.SetParamValues("a")
 
 	handler := DefaultProxy.NewProxyHandler("service")
-	assert.NoError(t, handler(c))
+	require.NoError(t, handler(c))
 
 	// Case 2: handler returns error because service name not found
 	handler = DefaultProxy.NewProxyHandler("wrong")
-	assert.Error(t, handler(c))
+	require.Error(t, handler(c))
 }

--- a/master/internal/rbac/authz_rbac.go
+++ b/master/internal/rbac/authz_rbac.go
@@ -2,7 +2,7 @@ package rbac
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	"github.com/uptrace/bun"
 
@@ -19,7 +19,7 @@ type RBACAuthZRBAC struct{}
 func intSliceToStringSlice(ids ...int32) []string {
 	stringIDs := make([]string, 0, len(ids))
 	for _, id := range ids {
-		stringIDs = append(stringIDs, fmt.Sprint(id))
+		stringIDs = append(stringIDs, strconv.Itoa(int(id)))
 	}
 	return stringIDs
 }
@@ -194,7 +194,7 @@ func (a *RBACAuthZRBAC) CanSearchScope(ctx context.Context, curUser model.User,
 ) (err error) {
 	var subjectIDs []string
 	if workspaceID != nil {
-		subjectIDs = append(subjectIDs, fmt.Sprint(*workspaceID))
+		subjectIDs = append(subjectIDs, strconv.Itoa(int(*workspaceID)))
 	}
 
 	fields := audit.ExtractLogFields(ctx)
@@ -249,21 +249,17 @@ func (a *RBACAuthZRBAC) CanAssignRoles(
 	var workspaces []int32
 
 	for _, v := range groupRoleAssignments {
-		if v.RoleAssignment.ScopeWorkspaceId != nil {
-			workspaces = append(workspaces, *v.RoleAssignment.ScopeWorkspaceId)
-		} else {
-			return db.DoesPermissionMatch(ctx, curUser.ID, nil,
-				rbacv1.PermissionType_PERMISSION_TYPE_ASSIGN_ROLES)
+		if v.RoleAssignment.ScopeWorkspaceId == nil {
+			return db.DoesPermissionMatch(ctx, curUser.ID, nil, rbacv1.PermissionType_PERMISSION_TYPE_ASSIGN_ROLES)
 		}
+		workspaces = append(workspaces, *v.RoleAssignment.ScopeWorkspaceId)
 	}
 
 	for _, v := range userRoleAssignments {
-		if v.RoleAssignment.ScopeWorkspaceId != nil {
-			workspaces = append(workspaces, *v.RoleAssignment.ScopeWorkspaceId)
-		} else {
-			return db.DoesPermissionMatch(ctx, curUser.ID, nil,
-				rbacv1.PermissionType_PERMISSION_TYPE_ASSIGN_ROLES)
+		if v.RoleAssignment.ScopeWorkspaceId == nil {
+			return db.DoesPermissionMatch(ctx, curUser.ID, nil, rbacv1.PermissionType_PERMISSION_TYPE_ASSIGN_ROLES)
 		}
+		workspaces = append(workspaces, *v.RoleAssignment.ScopeWorkspaceId)
 	}
 
 	fields := audit.ExtractLogFields(ctx)

--- a/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
+++ b/master/internal/rm/agentrm/agent_resource_manager_intg_test.go
@@ -271,7 +271,7 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := agentRM.GetJobQueueStatsRequest(&apiv1.GetJobQueueStatsRequest{ResourcePools: tt.filteredRPs})
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, len(res.Results))
+			require.Len(t, res.Results, tt.expected)
 		})
 	}
 }

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -72,7 +72,7 @@ func TestAgentStatePersistence(t *testing.T) {
 		ContainersReattached: []aproto.ContainerReattachAck{},
 	}
 	state.agentStarted(started)
-	require.Equal(t, 2, len(state.getSlotsSummary("/myagent")))
+	require.Len(t, state.getSlotsSummary("/myagent"), 2)
 
 	// Run through some container states.
 	tID := model.TaskID(uuid.NewString())
@@ -156,14 +156,14 @@ func TestAgentStatePersistence(t *testing.T) {
 	// And test restoring the existence of containers.
 	err = restored.restoreContainersField()
 	require.NoError(t, err)
-	require.Equal(t, 1, len(restored.containerAllocation))
+	require.Len(t, restored.containerAllocation, 1)
 
 	// And it is correctly kept if it is recovered.
 	err = state.clearUnlessRecovered(map[cproto.ID]aproto.ContainerReattachAck{
 		cID: {Container: container},
 	})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(restored.containerAllocation))
+	require.Len(t, restored.containerAllocation, 1)
 
 	// Containers removed after exit.
 	state.containerStateChanged(aproto.ContainerStateChanged{
@@ -362,14 +362,14 @@ func TestSlotStates(t *testing.T) {
 		drain:   ptrs.Ptr(true),
 	})
 	require.NoError(t, err)
-	require.Equal(t, true, slot.Draining)
-	require.Equal(t, false, slot.Enabled)
+	require.True(t, slot.Draining)
+	require.False(t, slot.Enabled)
 	require.Equal(t, 2, state.numSlots())
 
 	slots = state.patchAllSlotsState(patchAllSlotsState{
 		enabled: ptrs.Ptr(true),
 	})
-	require.Equal(t, 2, len(slots))
+	require.Len(t, slots, 2)
 	for _, s := range slots {
 		require.True(t, s.Enabled)
 	}
@@ -380,10 +380,10 @@ func TestSlotStates(t *testing.T) {
 	require.Equal(t, 1, state.numSlots())
 
 	state.Devices[devices[0]] = nil
-	require.Equal(t, 0, state.numSlots())
+	require.Zero(t, state.numSlots())
 
 	state.disable(false)
-	require.Equal(t, 0, state.numSlots())
+	require.Zero(t, state.numSlots())
 
 	state.enable()
 	require.Equal(t, 2, state.numSlots())

--- a/master/internal/rm/agentrm/fair_share.go
+++ b/master/internal/rm/agentrm/fair_share.go
@@ -229,7 +229,7 @@ func getTotalWeight(states []*groupState) float64 {
 	return total
 }
 
-func accountForPreoffers(preoffers int, offer int) (int, int) {
+func accountForPreoffers(preoffers int, offer int) (int, int) { // nolint: revive
 	if preoffers > 0 {
 		if preoffers == offer {
 			preoffers = 0

--- a/master/internal/rm/agentrm/provisioner/gcp/gcp.go
+++ b/master/internal/rm/agentrm/provisioner/gcp/gcp.go
@@ -135,7 +135,7 @@ func (c *gcpCluster) SlotsPerInstance() int {
 }
 
 func (c *gcpCluster) idFromInstance(inst *compute.Instance) string {
-	return fmt.Sprintf("%v", inst.Name)
+	return inst.Name
 }
 
 func (c *gcpCluster) idFromOperation(op *compute.Operation) string {
@@ -144,7 +144,7 @@ func (c *gcpCluster) idFromOperation(op *compute.Operation) string {
 }
 
 func (c *gcpCluster) agentNameFromInstance(inst *compute.Instance) string {
-	return fmt.Sprintf("%v", inst.Name)
+	return inst.Name
 }
 
 // See https://cloud.google.com/compute/docs/instances/instance-life-cycle.
@@ -251,9 +251,9 @@ func (c *gcpCluster) Terminate(instances []string) {
 
 	var ops []*compute.Operation
 	for _, inst := range instances {
-		ClientCtx := context.Background()
+		clientCtx := context.Background()
 		resp, err := c.client.Instances.Delete(c.config.Project, c.config.Zone, inst).
-			Context(ClientCtx).Do()
+			Context(clientCtx).Do()
 		if err != nil {
 			c.syslog.WithError(err).Errorf("cannot delete GCE instance: %s", inst)
 		} else {

--- a/master/internal/rm/agentrm/provisioner/gcp/gcp_test.go
+++ b/master/internal/rm/agentrm/provisioner/gcp/gcp_test.go
@@ -17,5 +17,5 @@ func TestGCPNodeNameGenGreaterThanMaxLength(t *testing.T) {
 		syslog: logrus.WithField("gcp-cluster", "resourcePool"),
 	}
 	name := cluster.generateInstanceNamePattern()
-	assert.Equal(t, maxInstanceNameLength, len(name))
+	assert.Len(t, name, maxInstanceNameLength)
 }

--- a/master/internal/rm/agentrm/provisioner/scaledecider/scale_decider.go
+++ b/master/internal/rm/agentrm/provisioner/scaledecider/scale_decider.go
@@ -277,40 +277,36 @@ func (s *ScaleDecider) FindInstancesToTerminate() sproto.TerminateDecision {
 
 	// Terminate instances that are idle for a long time.
 	for id := range s.longIdle {
-		if len(s.instances)-len(toTerminate) > s.minInstanceNum {
-			toTerminate[id] = sproto.TerminateLongIdleInstances
-			delete(s.idle, id)
-		} else {
+		if len(s.instances)-len(toTerminate) <= s.minInstanceNum {
 			break
 		}
+		toTerminate[id] = sproto.TerminateLongIdleInstances
+		delete(s.idle, id)
 	}
 
 	// Terminate instances to keep the number of instances less than the desired size.
 	// We start by terminating unfulfilled spot requests, then idle instances, then
 	// disconnected instances, then the most recently provisioned instances
 	for id := range s.pending {
-		if len(s.instances)-len(toTerminate) > s.maxInstanceNum {
-			toTerminate[id] = sproto.InstanceNumberExceedsMaximum
-			delete(s.pending, id)
-		} else {
+		if len(s.instances)-len(toTerminate) <= s.maxInstanceNum {
 			break
 		}
+		toTerminate[id] = sproto.InstanceNumberExceedsMaximum
+		delete(s.pending, id)
 	}
 	for id := range s.idle {
-		if len(s.instances)-len(toTerminate) > s.maxInstanceNum {
-			toTerminate[id] = sproto.InstanceNumberExceedsMaximum
-			delete(s.idle, id)
-		} else {
+		if len(s.instances)-len(toTerminate) <= s.maxInstanceNum {
 			break
 		}
+		toTerminate[id] = sproto.InstanceNumberExceedsMaximum
+		delete(s.idle, id)
 	}
 	for id := range s.disconnected {
-		if len(s.instances)-len(toTerminate) > s.maxInstanceNum {
-			toTerminate[id] = sproto.InstanceNumberExceedsMaximum
-			delete(s.disconnected, id)
-		} else {
+		if len(s.instances)-len(toTerminate) <= s.maxInstanceNum {
 			break
 		}
+		toTerminate[id] = sproto.InstanceNumberExceedsMaximum
+		delete(s.disconnected, id)
 	}
 	instances := make([]*model.Instance, 0, len(s.instances))
 	for _, inst := range s.instances {

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -728,19 +728,20 @@ func (rp *resourcePool) moveJob(
 			return err
 		}
 
-		if priorityChanger, ok := tasklist.GroupPriorityChangeRegistry.Load(jobID); ok {
-			if priorityChanger != nil {
-				if err := priorityChanger(anchorPriority); err != nil {
-					_ = rp.setGroupPriority(sproto.SetGroupPriority{
-						Priority:     oldPriority,
-						ResourcePool: rp.config.PoolName,
-						JobID:        jobID,
-					})
-					return err
-				}
-			}
-		} else {
+		priorityChanger, ok := tasklist.GroupPriorityChangeRegistry.Load(jobID)
+		if !ok {
 			return fmt.Errorf("unable to move job with ID %s", jobID)
+		}
+
+		if priorityChanger != nil {
+			if err := priorityChanger(anchorPriority); err != nil {
+				_ = rp.setGroupPriority(sproto.SetGroupPriority{
+					Priority:     oldPriority,
+					ResourcePool: rp.config.PoolName,
+					JobID:        jobID,
+				})
+				return err
+			}
 		}
 
 		if !tasklist.NeedMove(

--- a/master/internal/rm/dispatcherrm/dispatcher_monitor.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_monitor.go
@@ -14,13 +14,12 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/determined-ai/determined/master/pkg/mathx"
 	"github.com/determined-ai/determined/master/pkg/syncx/mapx"
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
-
-	launcher "github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
 )
 
 //nolint:lll

--- a/master/internal/rm/dispatcherrm/dispatcher_monitor_test.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_monitor_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	launcher "github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
+	"github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gotest.tools/assert"
 

--- a/master/internal/rm/dispatcherrm/dispatcher_resource_manager_test.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_resource_manager_test.go
@@ -531,28 +531,28 @@ func Test_summarizeResourcePool(t *testing.T) {
 
 			res, _ := m.GetResourcePools()
 
-			assert.Equal(t, len(tt.want.pools), len(res.ResourcePools))
+			require.Len(t, res.ResourcePools, len(tt.want.pools))
 			for i, pool := range res.ResourcePools {
-				assert.Equal(t, pool.Name, tt.want.pools[i].Name)
-				assert.Equal(t, pool.SlotType, tt.want.pools[i].SlotType)
-				assert.Equal(t, pool.SlotsAvailable, tt.want.pools[i].SlotsAvailable)
-				assert.Equal(t, pool.SlotsUsed, tt.want.pools[i].SlotsUsed)
-				assert.Equal(t, pool.NumAgents, tt.want.pools[i].NumAgents)
+				require.Equal(t, tt.want.pools[i].Name, pool.Name)
+				require.Equal(t, tt.want.pools[i].SlotType, pool.SlotType)
+				require.Equal(t, tt.want.pools[i].SlotsAvailable, pool.SlotsAvailable)
+				require.Equal(t, tt.want.pools[i].SlotsUsed, pool.SlotsUsed)
+				require.Equal(t, tt.want.pools[i].NumAgents, pool.NumAgents)
 				wantDescription := tt.want.pools[i].Description
 				if wantDescription == "" {
 					wantDescription = tt.want.wlmName + "-managed pool of resources"
 				}
-				assert.Equal(t, pool.Description, wantDescription)
-				assert.Equal(t, pool.Type, resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_STATIC)
-				assert.Equal(t, pool.SlotsPerAgent, tt.want.pools[i].SlotsPerAgent)
-				assert.Equal(t, pool.AuxContainerCapacityPerAgent, int32(0))
-				assert.Equal(t, pool.SchedulerType, tt.want.schedulerType)
-				assert.Equal(t, pool.SchedulerFittingPolicy, tt.want.fittingPolicy)
-				assert.Equal(t, pool.Location, "")
-				assert.Equal(t, pool.InstanceType, "")
-				assert.Equal(t, pool.ImageId, "")
-				assert.Equal(t, pool.ResourceManagerName, expectedName)
-				require.Equal(t, pool.ResourceManagerMetadata, expectedMetadata)
+				require.Equal(t, wantDescription, pool.Description)
+				require.Equal(t, resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_STATIC, pool.Type)
+				require.Equal(t, tt.want.pools[i].SlotsPerAgent, pool.SlotsPerAgent)
+				require.Zero(t, pool.AuxContainerCapacityPerAgent)
+				require.Equal(t, tt.want.schedulerType, pool.SchedulerType)
+				require.Equal(t, tt.want.fittingPolicy, pool.SchedulerFittingPolicy)
+				require.Empty(t, pool.Location)
+				require.Empty(t, pool.InstanceType)
+				require.Empty(t, pool.ImageId)
+				require.Equal(t, expectedName, pool.ResourceManagerName)
+				require.Equal(t, expectedMetadata, pool.ResourceManagerMetadata)
 			}
 		})
 	}

--- a/master/internal/rm/dispatcherrm/dispatcher_state_test.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_state_test.go
@@ -8,16 +8,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/pkg/etc"
-
-	"gotest.tools/assert"
 )
 
 func TestDispatcherStatePersistence(t *testing.T) {
 	assert.NilError(t, etc.SetRootPath(db.RootFromDB))
-	pgDB, close := db.MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
+	defer closeDB()
 	db.MustMigrateTestPostgres(t, pgDB, "file://../../../static/migrations")
 
 	// clear any existing state
@@ -39,7 +40,7 @@ func TestDispatcherStatePersistence(t *testing.T) {
 	assert.Check(t, !state.isAgentEnabled("agent1"))
 	assert.Check(t, state.isAgentEnabled("agentUnknown"))
 
-	assert.ErrorContains(t, state.disableAgent("agent1"), "already disabled")
+	require.ErrorContains(t, state.disableAgent("agent1"), "already disabled")
 	assert.Check(t, !state.isAgentEnabled("agent1"))
 
 	assert.NilError(t, state.enableAgent("agent1"))

--- a/master/internal/rm/dispatcherrm/hpc_resource_details_cache.go
+++ b/master/internal/rm/dispatcherrm/hpc_resource_details_cache.go
@@ -1,11 +1,11 @@
 package dispatcherrm
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/internal/config"
@@ -13,7 +13,7 @@ import (
 
 const hpcResourceDetailsRefreshPeriod = time.Minute
 
-var errHPCDetailsCacheEmpty = errors.New("HPC resource details cache is empty")
+var errHPCDetailsCacheEmpty = fmt.Errorf("HPC resource details cache is empty")
 
 // hpcResources is a data type describing the HPC resources available
 // to Slurm on the Launcher node.
@@ -29,8 +29,8 @@ var errHPCDetailsCacheEmpty = errors.New("HPC resource details cache is empty")
 // - totalAvailableNodes: 293
 // ...more partitions.
 type hpcResources struct {
-	Partitions                  []hpcPartitionDetails `json:"partitions,flow"` //nolint:staticcheck
-	Nodes                       []hpcNodeDetails      `json:"nodes,flow"`      //nolint:staticcheck
+	Partitions                  []hpcPartitionDetails `json:"partitions,flow"` //nolint:staticcheck,revive
+	Nodes                       []hpcNodeDetails      `json:"nodes,flow"`      //nolint:staticcheck,revive
 	DefaultComputePoolPartition string                `json:"defaultComputePoolPartition"`
 	DefaultAuxPoolPartition     string                `json:"defaultAuxPoolPartition"`
 }
@@ -214,14 +214,14 @@ func selectDefaultPools(
 	defaultComputePool *string,
 	defaultAuxPool *string,
 ) (
-	string, string,
+	defaultComputePar string, defaultAuxPar string,
 ) {
 	// The default compute pool is the default partition if it has any GPUS,
 	// otherwise select any partition with GPUs.
 	// The AUX partition, use the default partition if available, otherwise any partition.
 
-	defaultComputePar := "" // Selected default Compute/GPU partition
-	defaultAuxPar := ""     // Selected default Aux partition
+	defaultComputePar = "" // Selected default Compute/GPU partition
+	defaultAuxPar = ""     // Selected default Aux partition
 
 	fallbackComputePar := "" // Fallback Compute/GPU partition (has GPUs)
 	fallbackAuxPar := ""     // Fallback partition if no default

--- a/master/internal/rm/kubernetesrm/informer_intg_test.go
+++ b/master/internal/rm/kubernetesrm/informer_intg_test.go
@@ -2,6 +2,7 @@ package kubernetesrm
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -20,7 +21,7 @@ import (
 
 const namespace = "default"
 
-var errCanceled = errors.New("informer stopped unexpectedly: context canceled")
+var errCanceled = fmt.Errorf("informer stopped unexpectedly: context canceled")
 
 // mockWatcher implements watch.Interface so it can be returned by mocks' calls to Watch.
 type mockWatcher struct {
@@ -84,7 +85,7 @@ func TestPodInformer(t *testing.T) {
 			i, err := newPodInformer(context.TODO(), determinedLabel,
 				"pod", namespace, mockPodInterface, mockPodHandler)
 			assert.NotNil(t, i)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			// Test run().
 			go func() {
@@ -191,7 +192,7 @@ func TestNodeInformer(t *testing.T) {
 			// Test newNodeInformer is created.
 			n, err := newNodeInformer(context.TODO(), mockNode, mockNodeHandler)
 			assert.NotNil(t, n)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			// Test run() & iterate through/apply a set of events received by the informer.
 			go func() {
@@ -272,7 +273,7 @@ func TestEventListener(t *testing.T) {
 			i, err := newEventInformer(context.TODO(), mockEventInterface,
 				namespace, mockEventHandler)
 			assert.NotNil(t, i)
-			assert.Nil(t, err)
+			require.NoError(t, err)
 
 			// Test run() & iterate through/apply a set of events received by the informer.
 			go func() {

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -1335,7 +1335,7 @@ func (j *jobsService) getSlot(agentID string, slotID string) *apiv1.GetSlotRespo
 		// Try converting an index input to a slot and see if that exists (1 to 001).
 		tryIndex, err := strconv.Atoi(slotID)
 		s, ok := slots[model.SortableSlotIndex(tryIndex)]
-		if err == nil && ok {
+		if err != nil || !ok {
 			j.syslog.Warnf("no slot with id %s", slotID)
 			return nil
 		}

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -1334,12 +1334,12 @@ func (j *jobsService) getSlot(agentID string, slotID string) *apiv1.GetSlotRespo
 	if !ok {
 		// Try converting an index input to a slot and see if that exists (1 to 001).
 		tryIndex, err := strconv.Atoi(slotID)
-		if s, ok := slots[model.SortableSlotIndex(tryIndex)]; err == nil && ok {
-			slot = s
-		} else {
+		s, ok := slots[model.SortableSlotIndex(tryIndex)]
+		if err == nil && ok {
 			j.syslog.Warnf("no slot with id %s", slotID)
 			return nil
 		}
+		slot = s
 	}
 	return &apiv1.GetSlotResponse{Slot: slot}
 }

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -292,7 +292,7 @@ func TestGetAgent(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			agentResp := test.jobsService.getAgent(test.wantedAgentID)
 			if agentResp == nil {
-				require.True(t, !test.agentExists)
+				require.False(t, test.agentExists)
 				return
 			}
 			require.Equal(t, test.wantedAgentID, agentResp.Agent.Id)
@@ -405,10 +405,10 @@ func TestGetSlots(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			slotsResp := test.jobsService.getSlots(test.agentID)
 			if slotsResp == nil {
-				require.True(t, !test.agentExists)
+				require.False(t, test.agentExists)
 				return
 			}
-			require.Equal(t, test.wantedSlotsNum, len(slotsResp.Slots))
+			require.Len(t, slotsResp.Slots, test.wantedSlotsNum)
 
 			// Count number of active slots on the node. (Slots allocated to a pod running
 			// a container).
@@ -680,7 +680,7 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := k8sRM.GetJobQueueStatsRequest(&apiv1.GetJobQueueStatsRequest{ResourcePools: tt.filteredRPs})
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, len(res.Results))
+			require.Len(t, res.Results, tt.expected)
 		})
 	}
 }

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -372,15 +372,15 @@ func (k *kubernetesResourcePool) moveJob(
 		oldPriority := g.Priority
 		g.Priority = &anchorPriority
 
-		if priorityChanger, ok := tasklist.GroupPriorityChangeRegistry.Load(jobID); ok {
-			if priorityChanger != nil {
-				if err := priorityChanger(anchorPriority); err != nil {
-					g.Priority = oldPriority
-					return err
-				}
-			}
-		} else {
+		priorityChanger, ok := tasklist.GroupPriorityChangeRegistry.Load(jobID)
+		if !ok {
 			return fmt.Errorf("unable to move job with ID %s", jobID)
+		}
+		if priorityChanger != nil {
+			if err := priorityChanger(anchorPriority); err != nil {
+				g.Priority = oldPriority
+				return err
+			}
 		}
 	}
 

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -159,7 +159,7 @@ func testLaunch(
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -248,7 +248,7 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -298,7 +298,7 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -346,7 +346,7 @@ func TestPodLogStreamer(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -413,7 +413,7 @@ func TestKill(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -491,7 +491,7 @@ func TestExternalKillWhileQueuedFails(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -540,7 +540,6 @@ func TestExternalKillWhileQueuedFails(t *testing.T) {
 		if ok {
 			t.Error("job should've stayed queued")
 			t.FailNow()
-			continue
 		}
 	}
 
@@ -593,7 +592,7 @@ func TestExternalPodDelete(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -680,7 +679,7 @@ func TestReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -729,7 +728,7 @@ func TestReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -865,7 +864,7 @@ func TestNodeWorkflows(t *testing.T) {
 	rp := newTestResourcePool(j)
 
 	resp := j.getAgents()
-	require.Equal(t, 1, len(resp.Agents))
+	require.Len(t, resp.Agents, 1)
 	nodeID := resp.Agents[0].Id
 
 	_, err := rp.jobsService.DisableAgent(&apiv1.DisableAgentRequest{AgentId: nodeID})
@@ -884,7 +883,7 @@ func TestNodeWorkflows(t *testing.T) {
 		j.mu.Unlock()
 
 		resp = j.GetAgents()
-		require.Equal(t, 1, len(resp.Agents))
+		require.Len(t, resp.Agents, 1)
 		return !resp.Agents[0].Enabled
 	}), "GetAgents didn't say %s is disabled, but we just disabled it", nodeID)
 
@@ -908,7 +907,7 @@ func TestNodeWorkflows(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -1025,7 +1024,7 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID).Resources)
 	rp.Admit()
 	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
@@ -1043,9 +1042,9 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.Len(t, rp.GetAllocationSummary(allocationID2).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID2).Resources)
 	rp.Admit()
-	require.Len(t, rp.GetAllocationSummary(allocationID2).Resources, 0)
+	require.Empty(t, rp.GetAllocationSummary(allocationID2).Resources)
 
 	t.Log("and when the first releases it should get scheduled")
 	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: allocationID})

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -707,7 +707,7 @@ func configureInitContainer(
 		Name:    "determined-init-container",
 		Command: []string{path.Join(initContainerWorkDir, etc.K8InitContainerEntryScriptResource)},
 		Args: []string{
-			fmt.Sprintf("%d", numArchives), initContainerTarSrcPath, initContainerTarDstPath,
+			strconv.Itoa(numArchives), initContainerTarSrcPath, initContainerTarDstPath,
 		},
 		Image:           image,
 		ImagePullPolicy: imagePullPolicy,

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -134,23 +134,23 @@ func TestAddNodeDisabledAffinityToPodSpec(t *testing.T) {
 		MatchExpressions, nodeSelectorTerm)
 
 	// Test idempotency.
-	copy := p.DeepCopy()
+	copyPod := p.DeepCopy()
 	addNodeDisabledAffinityToPodSpec(p, "cluster-id")
 	addNodeDisabledAffinityToPodSpec(p, "cluster-id")
-	require.Equal(t, copy, p)
+	require.Equal(t, copyPod, p)
 }
 
 func TestAddDisallowedNodesToPodSpec(t *testing.T) {
 	p := &k8sV1.Pod{}
 	addNodeDisabledAffinityToPodSpec(p, "cluster-id")
 
-	copy := p.DeepCopy()
+	copyPod := p.DeepCopy()
 
 	// No block list adds anything.
 	addDisallowedNodesToPodSpec(&sproto.AllocateRequest{
 		BlockedNodes: nil,
 	}, p)
-	require.Equal(t, copy, p)
+	require.Equal(t, copyPod, p)
 
 	addDisallowedNodesToPodSpec(&sproto.AllocateRequest{
 		BlockedNodes: []string{"a1", "a2"},

--- a/master/internal/rm/kubernetesrm/volumes.go
+++ b/master/internal/rm/kubernetesrm/volumes.go
@@ -3,6 +3,7 @@ package kubernetesrm
 import (
 	"fmt"
 	"path"
+	"strconv"
 
 	"github.com/determined-ai/determined/master/pkg/etc"
 
@@ -147,7 +148,7 @@ func configureAdditionalFilesVolumes(
 			mainContainerVolumeMounts = append(mainContainerVolumeMounts, k8sV1.VolumeMount{
 				Name:      additionalFilesVolumeName,
 				MountPath: path.Join(runArchive.Path, item.Path),
-				SubPath:   path.Join(fmt.Sprintf("%d", idx), item.Path),
+				SubPath:   path.Join(strconv.Itoa(idx), item.Path),
 			})
 		}
 	}

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -1,8 +1,8 @@
 package multirm
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -57,10 +57,10 @@ func TestGetAllocationSummaries(t *testing.T) {
 			for i := 1; i <= tt.managers; i++ {
 				ret := map[model.AllocationID]sproto.AllocationSummary{}
 				for _, alloc := range tt.allocNames {
-					a := alloc + fmt.Sprint(i)
+					a := alloc + strconv.Itoa(i)
 					ret[*model.NewAllocationID(&a)] = sproto.AllocationSummary{}
 				}
-				require.Equal(t, len(ret), len(tt.allocNames))
+				require.Len(t, ret, len(tt.allocNames))
 
 				mockRM := mocks.ResourceManager{}
 				mockRM.On("GetAllocationSummaries").Return(ret, nil)
@@ -72,14 +72,14 @@ func TestGetAllocationSummaries(t *testing.T) {
 
 			allocs, err := m.GetAllocationSummaries()
 			require.NoError(t, err)
-			require.Equal(t, tt.managers*len(tt.allocNames), len(allocs))
+			require.Len(t, allocs, tt.managers*len(tt.allocNames))
 			require.NotNil(t, allocs)
 
 			bogus := "bogus"
 			require.Empty(t, allocs[*model.NewAllocationID(&bogus)])
 
 			for _, name := range tt.allocNames {
-				n := fmt.Sprintf(name + "0")
+				n := name + "0"
 				tmpName := name
 
 				require.NotNil(t, allocs[*model.NewAllocationID(&n)])
@@ -225,7 +225,7 @@ func TestExternalPreemptionPending(t *testing.T) {
 
 func TestIsReattachable(t *testing.T) {
 	val := testMultiRM.IsReattachableOnlyAfterStarted()
-	require.Equal(t, true, val)
+	require.True(t, val)
 }
 
 func TestGetResourcePools(t *testing.T) {
@@ -256,7 +256,7 @@ func TestGetResourcePools(t *testing.T) {
 
 			rps, err := m.GetResourcePools()
 			require.NoError(t, err)
-			require.Equal(t, tt.managers*len(tt.rpNames), len(rps.ResourcePools))
+			require.Len(t, rps.ResourcePools, tt.managers*len(tt.rpNames))
 
 			for _, rp := range rps.ResourcePools {
 				require.Contains(t, tt.rpNames, rp.Name)
@@ -387,7 +387,7 @@ func TestGetJobQueueStatsRequest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := testMultiRM.GetJobQueueStatsRequest(tt.req)
 			require.Equal(t, tt.err, err)
-			require.Equal(t, tt.expectedLen, len(res.Results))
+			require.Len(t, res.Results, tt.expectedLen)
 		})
 	}
 }
@@ -491,7 +491,7 @@ func TestGetAgents(t *testing.T) {
 
 			rps, err := m.GetAgents()
 			require.NoError(t, err)
-			require.Equal(t, tt.managers*len(tt.agentNames), len(rps.Agents))
+			require.Len(t, rps.Agents, tt.managers*len(tt.agentNames))
 
 			for _, rp := range rps.Agents {
 				require.Subset(t, tt.agentNames, rp.ResourcePools)

--- a/master/internal/spec_util_intg_test.go
+++ b/master/internal/spec_util_intg_test.go
@@ -177,5 +177,5 @@ func TestGetTaskSessionToken(t *testing.T) {
 
 	token, err := getTaskSessionToken(ctx, &userModel)
 	require.NoError(t, err, "Error in getTaskSessionToken()")
-	require.Greater(t, len(token), 0)
+	require.NotEmpty(t, token)
 }

--- a/master/internal/storage/service_intg_test.go
+++ b/master/internal/storage/service_intg_test.go
@@ -336,7 +336,7 @@ func TestGroupCheckpointsByStorageIDs(t *testing.T) {
 		storageID0: {checkpoint1.UUID},
 		storageID1: {checkpoint2.UUID, checkpoint3.UUID},
 	}
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for _, a := range actual {
 		id := model.StorageBackendID(0)
 		if a.StorageID != nil {

--- a/master/internal/stream/system_intg_test.go
+++ b/master/internal/stream/system_intg_test.go
@@ -45,10 +45,10 @@ func TestMockSocket(t *testing.T) {
 	actualMsg := StartupMsg{}
 	err := socket.ReadJSON(&actualMsg)
 	require.NoError(t, err)
-	require.Equal(t, actualMsg.Known, expectedMsg.Known)
-	require.Equal(t, actualMsg.Subscribe, expectedMsg.Subscribe)
-	require.Equal(t, actualMsg.SyncID, expectedMsg.SyncID)
-	require.Equal(t, 0, len(socket.outbound))
+	require.Equal(t, expectedMsg.Known, actualMsg.Known)
+	require.Equal(t, expectedMsg.Subscribe, actualMsg.Subscribe)
+	require.Equal(t, expectedMsg.SyncID, actualMsg.SyncID)
+	require.Zero(t, len(socket.outbound))
 
 	// test write
 	err = socket.Write("test")
@@ -67,7 +67,7 @@ func TestMockSocket(t *testing.T) {
 	var msgs []string
 	socket.ReadUntilFound(t, &msgs, []string{"final"})
 	require.NoError(t, err)
-	require.Equal(t, 2, len(msgs))
+	require.Len(t, msgs, 2)
 	require.Equal(t, "test", msgs[0])
 	require.Equal(t, "final", msgs[1])
 }

--- a/master/internal/stream/test_util.go
+++ b/master/internal/stream/test_util.go
@@ -80,7 +80,6 @@ func (s *mockSocket) WriteOutbound(t *testing.T, startup *StartupMsg) {
 	case <-s.closed:
 		t.Error(&websocket.CloseError{Code: websocket.CloseAbnormalClosure})
 	case s.outbound <- startup:
-		break
 	}
 }
 

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -482,7 +482,6 @@ func (a *allocation) validateRendezvous() error {
 
 	switch a.resources.first().Summary().ResourcesType {
 	case sproto.ResourcesTypeDockerContainer, sproto.ResourcesTypeK8sJob:
-		break
 	default:
 		return BehaviorUnsupportedError{Behavior: "rendezvous"}
 	}
@@ -866,7 +865,6 @@ func (a *allocation) restoreResourceFailure(msg *sproto.ResourcesFailedError) {
 		// TODO(DET-8822): This heartbeat can be nil.
 		switch heartbeat := cluster.TheLastBootClusterHeartbeat(); {
 		case a.model.StartTime == nil:
-			break
 		case heartbeat.Before(*a.model.StartTime):
 			a.model.EndTime = a.model.StartTime
 		default:

--- a/master/internal/task/allocation_intg_test.go
+++ b/master/internal/task/allocation_intg_test.go
@@ -68,8 +68,8 @@ func TestAllocation(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			rm, _, close, a := setup(t)
-			defer close()
+			rm, _, closeDB, a := setup(t)
+			defer closeDB()
 
 			// Pre-allocated stage.
 			mockRsvn := func(rID sproto.ResourcesID, agentID string) sproto.Resources {
@@ -183,7 +183,7 @@ func setup(t *testing.T) (
 	var rm mocks.ResourceManager
 
 	// real db.
-	pgDB, close := db.MustSetupTestPostgres(t)
+	pgDB, closeDB := db.MustSetupTestPostgres(t)
 
 	// instantiate the allocation
 	task := db.RequireMockTask(t, pgDB, nil)
@@ -210,7 +210,7 @@ func setup(t *testing.T) (
 	require.True(t, rm.AssertExpectations(t))
 
 	tasklogger.SetDefaultLogger(tasklogger.New(&nullWriter{}))
-	return &rm, pgDB, close, a
+	return &rm, pgDB, closeDB, a
 }
 
 var tickInterval = 10 * time.Millisecond

--- a/master/internal/task/idle/watcher.go
+++ b/master/internal/task/idle/watcher.go
@@ -6,14 +6,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/determined-ai/determined/master/pkg/ptrs"
-	"github.com/determined-ai/determined/master/pkg/syncx/waitgroupx"
-
 	log "github.com/sirupsen/logrus"
 
-	"github.com/determined-ai/determined/master/internal/sproto"
-
 	"github.com/determined-ai/determined/master/internal/proxy"
+	"github.com/determined-ai/determined/master/internal/sproto"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/syncx/waitgroupx"
 )
 
 var syslog = log.WithField("component", "idle-watcher")

--- a/master/internal/task/rendezvous_test.go
+++ b/master/internal/task/rendezvous_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/internal/task/taskmodel"
-
-	"github.com/davecgh/go-spew/spew"
-	"github.com/google/uuid"
-	"gotest.tools/assert"
-
 	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/device"
@@ -110,13 +110,13 @@ func TestRendezvousValidation(t *testing.T) {
 	}, rendezvousTimeoutDuration)
 
 	_, err := r.watch(sproto.ResourcesID(cproto.NewID()))
-	assert.ErrorContains(t, err, "stale resources")
+	require.ErrorContains(t, err, "stale resources")
 
 	_, err = r.watch(c1)
 	assert.NilError(t, err)
 
 	_, err = r.watch(c1)
-	assert.ErrorContains(t, err, "resources already rendezvoused")
+	require.ErrorContains(t, err, "resources already rendezvoused")
 }
 
 func TestTerminationInRendezvous(t *testing.T) {
@@ -180,7 +180,7 @@ func TestRendezvousTimeout(t *testing.T) {
 	r.resources[c1].Started = &sproto.ResourcesStarted{Addresses: addressesFromContainerID(c1)}
 	r.try()
 
-	assert.ErrorContains(t, r.checkTimeout(),
+	require.ErrorContains(t, r.checkTimeout(),
 		"some containers are taking a long time")
 }
 

--- a/master/internal/task/tasklogger/logger_test.go
+++ b/master/internal/task/tasklogger/logger_test.go
@@ -134,7 +134,7 @@ func TestTaskLoggerConcurrent(t *testing.T) {
 			return false
 		},
 	)
-	require.Equal(t, len(written), len(in))
+	require.Len(t, written, len(in))
 	require.ElementsMatch(t, written, in)
 }
 

--- a/master/internal/templates/api.go
+++ b/master/internal/templates/api.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
@@ -341,7 +342,7 @@ func canCreateTemplateWorkspace(ctx context.Context, user *model.User, workspace
 	case err != nil:
 		return fmt.Errorf("failed to check workspace %d: %w", workspaceID, err)
 	case !exists:
-		return api.NotFoundErrs("workspace", fmt.Sprint(workspaceID), true)
+		return api.NotFoundErrs("workspace", strconv.Itoa(int(workspaceID)), true)
 	}
 
 	permErr, err := AuthZProvider.Get().CanCreateTemplate(

--- a/master/internal/templates/api_intg_test.go
+++ b/master/internal/templates/api_intg_test.go
@@ -80,7 +80,7 @@ func TestGetTemplates(t *testing.T) {
 	t.Run("GetTemplates without any templates", func(t *testing.T) {
 		resp, err := api.GetTemplates(ctx, &apiv1.GetTemplatesRequest{})
 		require.NoError(t, err)
-		require.Len(t, resp.Templates, 0)
+		require.Empty(t, resp.Templates)
 	})
 
 	inputNames := []string{

--- a/master/internal/templates/service_intg_test.go
+++ b/master/internal/templates/service_intg_test.go
@@ -108,7 +108,7 @@ func TestDeleteWorkspaceTemplates(t *testing.T) {
 
 	n, err = workspaceTemplatesCount(ctx, 1)
 	require.NoError(t, err)
-	require.Equal(t, 0, n)
+	require.Zero(t, n)
 }
 
 func workspaceTemplatesCount(ctx context.Context, workspaceID int) (int, error) {

--- a/master/internal/trials/postgres_trials.go
+++ b/master/internal/trials/postgres_trials.go
@@ -165,12 +165,12 @@ func MetricsTimeSeries(trialID int32, startTime time.Time,
 		}
 		var epoch *float64
 		if results[i]["epoch"] != nil {
-			if e, ok := results[i]["epoch"].(float64); ok {
-				epoch = &e
-			} else {
+			e, ok := results[i]["epoch"].(float64)
+			if !ok {
 				return nil, fmt.Errorf(
 					"metric 'epoch' has nonnumeric value reported value='%v'", results[i]["epoch"])
 			}
+			epoch = &e
 		}
 		var endTime time.Time
 		if results[i]["time"] == nil {
@@ -454,8 +454,7 @@ func ProtoGetTrialsPlusTx(
 			"task_ids",
 		}
 		for _, field := range jsonFields {
-			switch sVal := resMap[field].(type) {
-			case string:
+			if sVal, ok := resMap[field].(string); ok {
 				resMap[field] = []byte(sVal)
 			}
 		}

--- a/master/internal/trials/postgres_trials_intg_test.go
+++ b/master/internal/trials/postgres_trials_intg_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMarkLostTrials(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := db.MustResolveTestPostgres(t)
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
 
 	user := db.RequireMockUser(t, pgDB)
 	// TODO(ilia): it'd be useful to cleanup the user, but we can't because of a foreign key
@@ -70,7 +70,7 @@ func TestMarkLostTrials(t *testing.T) {
 
 		require.NoError(t, err)
 
-		close()
+		closeDB()
 	})
 
 	trials := map[int][]int{}

--- a/master/internal/trials/utils.go
+++ b/master/internal/trials/utils.go
@@ -2,7 +2,7 @@ package trials
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -26,7 +26,7 @@ func CanGetTrialsExperimentAndCheckCanDoAction(ctx context.Context,
 		return err
 	}
 
-	trialNotFound := api.NotFoundErrs("trial", fmt.Sprint(trialID), true)
+	trialNotFound := api.NotFoundErrs("trial", strconv.Itoa(trialID), true)
 	exp, err := db.ExperimentByTrialID(ctx, trialID)
 	if errors.Is(err, db.ErrNotFound) {
 		return trialNotFound

--- a/master/internal/user/passwords.go
+++ b/master/internal/user/passwords.go
@@ -26,7 +26,7 @@ func ReplicateClientSideSaltAndHash(password string) string {
 		return password
 	}
 	sum := sha512.Sum512([]byte(clientSidePasswordSalt + password))
-	return fmt.Sprintf("%x", sum)
+	return fmt.Sprintf("%x", sum) // nolint: perfsprint
 }
 
 // SetUserPassword sets the password of the user with the given username to the plaintext string provided.

--- a/master/internal/user/postgres_users_intg_test.go
+++ b/master/internal/user/postgres_users_intg_test.go
@@ -122,7 +122,7 @@ func TestUserAddDuplicate(t *testing.T) {
 	require.Equal(t, err, db.ErrDuplicateRecord)
 
 	if pgerr, ok := errors.Cause(err).(*pgconn.PgError); ok {
-		require.Equal(t, pgerr.Code, db.CodeUniqueViolation)
+		require.Equal(t, db.CodeUniqueViolation, pgerr.Code)
 	}
 }
 
@@ -231,7 +231,7 @@ func TestDeleteSessionByToken(t *testing.T) {
 	exists, err := db.Bun().NewSelect().Table("user_sessions").
 		Where("user_id = ?", userID).Exists(context.TODO())
 	require.False(t, exists)
-	require.ErrorAs(t, errors.New("Receive unexpected error: bun: Model(nil)"), &err)
+	require.NoError(t, err)
 }
 
 func TestDeleteSessionByID(t *testing.T) {
@@ -244,7 +244,7 @@ func TestDeleteSessionByID(t *testing.T) {
 	exists, err := db.Bun().NewSelect().Table("user_sessions").
 		Where("user_id = ?", userID).Exists(context.TODO())
 	require.False(t, exists)
-	require.ErrorAs(t, errors.New("Receive unexpected error: bun: Model(nil)"), &err)
+	require.NoError(t, err)
 }
 
 func TestUpdateUsername(t *testing.T) {
@@ -573,5 +573,5 @@ func TestUpdateUserSettings(t *testing.T) {
 
 	out, err = GetUserSetting(context.Background(), u.ID)
 	require.NoError(t, err)
-	require.Len(t, out, 0, "found user web settings when all should be deleted")
+	require.Empty(t, out, "found user web settings when all should be deleted")
 }

--- a/master/internal/usergroup/authz_rbac.go
+++ b/master/internal/usergroup/authz_rbac.go
@@ -2,7 +2,7 @@ package usergroup
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	"github.com/uptrace/bun"
 
@@ -87,7 +87,7 @@ func CanViewGroup(ctx context.Context, userBelongsTo model.UserID, gid int) (err
 				rbacv1.PermissionType_PERMISSION_TYPE_ASSIGN_ROLES,
 			},
 			SubjectType: "group",
-			SubjectIDs:  []string{fmt.Sprint(gid)},
+			SubjectIDs:  []string{strconv.Itoa(gid)},
 		},
 	}
 	defer func() {

--- a/master/internal/usergroup/group_intg_test.go
+++ b/master/internal/usergroup/group_intg_test.go
@@ -20,14 +20,14 @@ import (
 
 func TestUserGroups(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := db.MustResolveTestPostgres(t)
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
 	db.MustMigrateTestPostgres(t, pgDB, pathToMigrations)
 
 	t.Cleanup(func() {
 		cleanUp(ctx, t)
-		close()
+		closeDB()
 	})
-	setUp(ctx, t, pgDB)
+	setUp(ctx, t)
 
 	t.Run("group creation", func(t *testing.T) {
 		_, _, err := AddGroupWithMembers(ctx, testGroup)
@@ -100,7 +100,7 @@ func TestUserGroups(t *testing.T) {
 		require.NoError(t, err, "failed to search for groups that user belongs to")
 
 		index := groupsContain(groups, testGroup.ID)
-		require.Equal(t, 2, len(groups), "group search returned wrong count")
+		require.Len(t, groups, 2, "group search returned wrong count")
 		require.NotEqual(t, -1, index,
 			"Group user was added to not found when searching by user membership")
 	})
@@ -234,7 +234,7 @@ func TestUserGroups(t *testing.T) {
 		foundGroup := groups[index]
 		require.Equal(t, answerGroups[0].Name, foundGroup.Name,
 			"Expected found group to have the same name as the first answerGroup")
-		require.Equal(t, 1, len(groups), "Expected no more than one group to have been returned")
+		require.Len(t, groups, 1, "Expected no more than one group to have been returned")
 
 		groups, _, count, err = SearchGroups(ctx, "", 0, 1, 2)
 		require.NoError(t, err, "failed to search for groups")
@@ -261,8 +261,8 @@ func TestUserGroups(t *testing.T) {
 
 		groups, _, count, err := SearchGroups(ctx, tempGroupName, 0, 0, 0)
 		require.NoError(t, err, "error searching for groups to verify rollback")
-		require.Equal(t, 0, count, "should be zero matching groups in the DB")
-		require.Equal(t, 0, len(groups), "should be zero matching groups returned")
+		require.Zero(t, count, "should be zero matching groups in the DB")
+		require.Zero(t, len(groups), "should be zero matching groups returned")
 	})
 
 	t.Run("update groups and memberships", func(t *testing.T) {
@@ -292,14 +292,14 @@ func TestUserGroups(t *testing.T) {
 		users, name, err := UpdateGroupAndMembers(ctx, testGroup.ID, "newName",
 			[]model.UserID{updateTestUser1.ID}, []model.UserID{})
 		require.NoError(t, err, "failed to update group")
-		require.Equal(t, name, "newName", "group name not updated properly")
+		require.Equal(t, "newName", name, "group name not updated properly")
 		index := usersContain(users, updateTestUser1.ID)
 		require.NotEqual(t, -1, index, "group users not updated properly")
 
 		users, name, err = UpdateGroupAndMembers(ctx, testGroup.ID, "anotherNewName",
 			[]model.UserID{updateTestUser2.ID}, []model.UserID{updateTestUser1.ID})
 		require.NoError(t, err, "failed to update group")
-		require.Equal(t, name, "anotherNewName", "group name not updated properly")
+		require.Equal(t, "anotherNewName", name, "group name not updated properly")
 		index = usersContain(users, updateTestUser1.ID)
 		require.Equal(t, -1, index, "group users not removed properly")
 		index = usersContain(users, updateTestUser2.ID)
@@ -309,19 +309,19 @@ func TestUserGroups(t *testing.T) {
 		require.Error(t, err, "succeeded when update should have failed")
 		group, err := GroupByIDTx(ctx, nil, testGroup.ID)
 		require.NoError(t, err, "getting groups by ID failed")
-		require.Equal(t, group.Name, "anotherNewName", "group name should not be updated")
+		require.Equal(t, "anotherNewName", group.Name, "group name should not be updated")
 
 		_, _, err = UpdateGroupAndMembers(ctx, testGroup.ID, "testGroup", []model.UserID{-500}, nil)
 		require.Error(t, err, "succeeded when update should have failed")
 		group, err = GroupByIDTx(ctx, nil, testGroup.ID)
 		require.NoError(t, err, "getting groups by ID failed")
-		require.Equal(t, group.Name, "anotherNewName", "group name should not be updated")
+		require.Equal(t, "anotherNewName", group.Name, "group name should not be updated")
 
 		users, name, err = UpdateGroupAndMembers(ctx, testGroup.ID, "testGroup", nil,
 			[]model.UserID{updateTestUser2.ID, -500})
 		require.NoError(t, err, "failed to update group")
-		require.Equal(t, name, "testGroup", "group name not updated properly")
-		require.GreaterOrEqual(t, 0, len(users), "group users not updated properly")
+		require.Equal(t, "testGroup", name, "group name not updated properly")
+		require.Empty(t, users, "group users not updated properly")
 		index = usersContain(users, updateTestUser1.ID)
 		require.Equal(t, -1, index, "group users not removed properly")
 		index = usersContain(users, updateTestUser2.ID)
@@ -410,7 +410,7 @@ const (
 	pathToMigrations = "file://../../static/migrations"
 )
 
-func setUp(ctx context.Context, t *testing.T, pgDB *db.PgDB) {
+func setUp(ctx context.Context, t *testing.T) {
 	_, err := user.Add(ctx, &testUser, nil)
 	require.NoError(t, err, "failure creating user in setup")
 

--- a/master/internal/webhooks/postgres_webhook_intg_test.go
+++ b/master/internal/webhooks/postgres_webhook_intg_test.go
@@ -67,10 +67,10 @@ func TestWebhooks(t *testing.T) {
 		webhooks, err := GetWebhooks(ctx)
 		webhookFourResponse := getWebhookByID(webhooks, testWebhookFour.ID)
 		require.NoError(t, err, "unable to get webhooks")
-		require.Equal(t, len(webhooks), 2, "did not retrieve two webhooks")
-		require.Equal(t, getWebhookIds(webhooks), expectedWebhookIds,
+		require.Len(t, webhooks, 2, "did not retrieve two webhooks")
+		require.Equal(t, expectedWebhookIds, getWebhookIds(webhooks),
 			"get request returned incorrect webhook Ids")
-		require.Equal(t, len(webhooks), 2, "did not retrieve two webhooks")
+		require.Len(t, webhooks, 2, "did not retrieve two webhooks")
 		require.Equal(t, webhookFourResponse.URL, testWebhookFour.URL,
 			"returned webhook url did not match")
 		require.Equal(t, webhookFourResponse.WebhookType, testWebhookFour.WebhookType,
@@ -90,7 +90,7 @@ func TestWebhooks(t *testing.T) {
 		webhooks, err := GetWebhooks(ctx)
 		require.NoError(t, err)
 		createdWebhook := getWebhookByID(webhooks, testWebhookTwo.ID)
-		require.Equal(t, len(createdWebhook.Triggers), len(testTriggersTwo),
+		require.Len(t, createdWebhook.Triggers, len(testTriggersTwo),
 			"did not retriee correct number of triggers")
 	})
 
@@ -195,7 +195,7 @@ func TestWebhookScanLogs(t *testing.T) {
 		require.NoError(t, manager.scanLogs(ctx, logs))
 
 		require.Equal(t, 1, countEventsForURL(ctx, t, w0.URL))
-		require.Equal(t, 0, countEventsForURL(ctx, t, w1.URL))
+		require.Zero(t, countEventsForURL(ctx, t, w1.URL))
 		require.Equal(t, 1, countEventsForURL(ctx, t, w2.URL))
 	}
 }
@@ -330,7 +330,7 @@ func TestReportExperimentStateChanged(t *testing.T) {
 			State: model.CanceledState,
 		}, config))
 
-		require.Equal(t, 0, countEventsForURL(ctx, t, w.URL))
+		require.Zero(t, countEventsForURL(ctx, t, w.URL))
 	})
 
 	t.Run("no match triggers for event type", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestReportExperimentStateChanged(t *testing.T) {
 			State: model.CanceledState,
 		}, config))
 
-		require.Equal(t, 0, countEventsForURL(ctx, t, w.URL))
+		require.Zero(t, countEventsForURL(ctx, t, w.URL))
 	})
 
 	clearWebhooksTables(ctx, t)
@@ -489,8 +489,8 @@ func mockWebhook() *Webhook {
 
 func TestDequeueEvents(t *testing.T) {
 	ctx := context.Background()
-	pgDB, close := db.MustResolveTestPostgres(t)
-	defer close()
+	pgDB, closeDB := db.MustResolveTestPostgres(t)
+	defer closeDB()
 	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
 	clearWebhooksTables(ctx, t)
 
@@ -522,7 +522,7 @@ func TestDequeueEvents(t *testing.T) {
 		batch, err := dequeueEvents(ctx, maxEventBatchSize)
 		require.NoError(t, batch.commit())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(batch.events))
+		require.Len(t, batch.events, 1)
 	})
 
 	t.Run("dequeueing and consuming a full batch of events should work", func(t *testing.T) {
@@ -534,7 +534,7 @@ func TestDequeueEvents(t *testing.T) {
 		batch, err := dequeueEvents(ctx, maxEventBatchSize)
 		require.NoError(t, batch.commit())
 		require.NoError(t, err)
-		require.Equal(t, maxEventBatchSize, len(batch.events))
+		require.Len(t, batch.events, maxEventBatchSize)
 	})
 
 	t.Run("rolling back an event should work, and it should be reconsumed", func(t *testing.T) {
@@ -548,7 +548,7 @@ func TestDequeueEvents(t *testing.T) {
 		batch, err = dequeueEvents(ctx, maxEventBatchSize)
 		require.NoError(t, batch.commit())
 		require.NoError(t, err)
-		require.Equal(t, 1, len(batch.events))
+		require.Len(t, batch.events, 1)
 	})
 }
 

--- a/master/internal/webhooks/shipper.go
+++ b/master/internal/webhooks/shipper.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -218,7 +219,7 @@ func generateWebhookRequest(
 	}
 	key := []byte(conf.GetMasterConfig().Webhooks.SigningKey)
 	signedPayload := generateSignedPayload(req, t, key)
-	req.Header.Add("X-Determined-AI-Signature-Timestamp", fmt.Sprintf("%v", t))
+	req.Header.Add("X-Determined-AI-Signature-Timestamp", strconv.FormatInt(t, 10))
 	req.Header.Add("X-Determined-AI-Signature", signedPayload)
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
 	return req, nil

--- a/master/internal/webhooks/shipper_test.go
+++ b/master/internal/webhooks/shipper_test.go
@@ -57,8 +57,8 @@ func TestShipper(t *testing.T) {
 		key := []byte("testsigningkey")
 		signedPayload := generateSignedPayload(req, ts, key)
 
-		require.Equal(t, signedPayload,
-			"899cc042278415da7d91605ffefe81376d64a4d842aa5663cd614f497f88910f")
+		require.Equal(t, "899cc042278415da7d91605ffefe81376d64a4d842aa5663cd614f497f88910f",
+			signedPayload)
 	})
 
 	t.Log("setup test webhook receiver")
@@ -201,7 +201,7 @@ func TestShipper(t *testing.T) {
 		t.Log("waitgroup closed, checking results")
 		require.ElementsMatch(t, maps.Keys(expected), maps.Keys(actual), "missing events for exps")
 		for expID, events := range actual {
-			require.Equalf(t, 3, len(events), "missing events for exp %d", expID)
+			require.Len(t, events, 3, "missing events for exp %d", expID)
 			for _, sends := range events {
 				require.GreaterOrEqual(t, sends, 1, "event was not sent at least once")
 				require.LessOrEqual(t, sends, 3, "event was not sent an excessive number of times")

--- a/master/internal/workspace/authz_rbac.go
+++ b/master/internal/workspace/authz_rbac.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -22,7 +23,7 @@ func init() {
 }
 
 // ErrLookup is the error returned when a user's permissions couldn't be looked up.
-var ErrLookup = errors.New("error looking up user's permissions")
+var ErrLookup = fmt.Errorf("error looking up user's permissions")
 
 // WorkspaceAuthZRBAC is the RBAC implementation of WorkspaceAuthZ.
 type WorkspaceAuthZRBAC struct{}
@@ -163,7 +164,7 @@ func (r *WorkspaceAuthZRBAC) CanGetWorkspaceID(
 		{
 			PermissionTypes: []rbacv1.PermissionType{workspacePermission},
 			SubjectType:     "workspace",
-			SubjectIDs:      []string{fmt.Sprint(workspaceID)},
+			SubjectIDs:      []string{strconv.Itoa(int(workspaceID))},
 		},
 	}
 	defer func() {
@@ -462,7 +463,7 @@ func addWorkspaceInfo(
 		{
 			PermissionTypes: permissions,
 			SubjectType:     "workspace",
-			SubjectIDs:      []string{fmt.Sprint(workspace.Id)},
+			SubjectIDs:      []string{strconv.Itoa(int(workspace.Id))},
 		},
 	}
 }

--- a/master/pkg/check/check_test.go
+++ b/master/pkg/check/check_test.go
@@ -3,6 +3,7 @@ package check
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -31,7 +32,7 @@ func TestTrue(t *testing.T) {
 			if tc.msg == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.msg)
+				require.Error(t, err, tc.msg)
 			}
 		})
 	}
@@ -61,7 +62,7 @@ func TestFalse(t *testing.T) {
 			if tc.msg == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.msg)
+				require.Error(t, err, tc.msg)
 			}
 		})
 	}
@@ -101,7 +102,7 @@ func TestEqual(t *testing.T) {
 			if tc.msg == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.msg)
+				require.Error(t, err, tc.msg)
 			}
 		})
 	}
@@ -133,7 +134,7 @@ func TestGreaterThanOrEqualTo(t *testing.T) {
 			if tc.msg == "" {
 				assert.NilError(t, err)
 			} else {
-				assert.Error(t, err, tc.msg)
+				require.Error(t, err, tc.msg)
 			}
 		})
 	}

--- a/master/pkg/check/validate_test.go
+++ b/master/pkg/check/validate_test.go
@@ -3,7 +3,7 @@ package check
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testcase1 struct {
@@ -34,11 +34,11 @@ func TestMethodSets(t *testing.T) {
 		A: false,
 	}
 	err := Validate(case1)
-	assert.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
+	require.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
 	err = Validate(&case1)
-	assert.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
+	require.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
 	err = Validate(case2)
-	assert.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
+	require.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
 	err = Validate(&case2)
-	assert.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
+	require.ErrorContains(t, err, "error found at root: field A must be true: expected true, got false")
 }

--- a/master/pkg/checkpoints/archive/tar_archive_writer_test.go
+++ b/master/pkg/checkpoints/archive/tar_archive_writer_test.go
@@ -54,7 +54,7 @@ func TestSimpleTar(t *testing.T) {
 	require.Equal(t, "bar", string(result))
 	size, err = tr.Read(result)
 	require.Equal(t, io.EOF, err)
-	require.Equal(t, 0, size)
+	require.Zero(t, size)
 	_, err = tr.Next()
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, buf.writeCount, buf.readCount)
@@ -122,7 +122,7 @@ func TestTarDryRun(t *testing.T) {
 
 	_, err = tr.Next()
 	require.Equal(t, io.EOF, err)
-	require.Equal(t, buf.Len(), 0)
+	require.Zero(t, buf.Len())
 	require.Equal(t, buf.writeCount, buf.readCount)
 	require.Equal(t, buf.writeCount, contentLength)
 }

--- a/master/pkg/errors/errors_test.go
+++ b/master/pkg/errors/errors_test.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorTimeoutRetry(t *testing.T) {
 	testErr := fmt.Errorf("test error")
 	errInfo := NewStickyError(30*time.Second, 3)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, errInfo.SetError(fmt.Errorf("tmp error %d", i)), nil)
+		require.NoError(t, errInfo.SetError(fmt.Errorf("tmp error %d", i)))
 	}
 
 	assert.Equal(t, errInfo.SetError(testErr), testErr)
@@ -22,7 +23,7 @@ func TestErrorTimeoutRetry(t *testing.T) {
 	_ = errInfo.SetError(nil)
 
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, errInfo.SetError(fmt.Errorf("tmp after set error %d", i)), nil)
+		require.NoError(t, errInfo.SetError(fmt.Errorf("tmp after set error %d", i)))
 	}
 
 	assert.Equal(t, errInfo.SetError(testErr), testErr)
@@ -37,13 +38,13 @@ func TestErrorTimeoutRetry(t *testing.T) {
 	assert.Equal(t, errInfo.Error(), testErr)
 
 	errInfo.time = time.Now().Add(-31 * time.Second)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 
 	errInfo.time = time.Now().Add(-48 * time.Hour)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 
 	for i := 0; i < 3; i++ {
-		assert.Equal(t, errInfo.SetError(fmt.Errorf("tmp after timeout error %d", i)), nil)
+		require.NoError(t, errInfo.SetError(fmt.Errorf("tmp after timeout error %d", i)))
 	}
 
 	_ = errInfo.SetError(testErr)
@@ -52,15 +53,15 @@ func TestErrorTimeoutRetry(t *testing.T) {
 
 func TestErrorNoTimeoutNoRetry(t *testing.T) {
 	errInfo := NewStickyError(0, 0)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 
 	for i := 0; i < 100; i++ {
-		assert.Equal(t, errInfo.SetError(fmt.Errorf("tmp error %d", i)), nil)
+		require.NoError(t, errInfo.SetError(fmt.Errorf("tmp error %d", i)))
 	}
 
 	errInfo.time = time.Now().Add(-60 * time.Second)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 
 	errInfo.time = time.Now().Add(-48 * time.Hour)
-	assert.Equal(t, errInfo.Error(), nil)
+	require.NoError(t, errInfo.Error())
 }

--- a/master/pkg/logger/log_buffer.go
+++ b/master/pkg/logger/log_buffer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/logv1"
 )
 
-func computeSlice(startID int, endID int, limit int, totalEntries int, capacity int) (int, int) {
+func computeSlice(startID int, endID int, limit int, totalEntries int, capacity int) (startIdx int, entryCount int) {
 	if endID < -1 || startID < -1 || limit < -1 {
 		return 0, 0
 	}

--- a/master/pkg/mathx/mathx_test.go
+++ b/master/pkg/mathx/mathx_test.go
@@ -8,20 +8,20 @@ import (
 )
 
 func TestMin(t *testing.T) {
-	require.Equal(t, Min(1, 2, 3), 1)
-	require.Equal(t, Min(math.MinInt64, 2, 3), math.MinInt64)
-	require.Equal(t, Min(math.MaxInt64, 2, 3), 2)
+	require.Equal(t, 1, Min(1, 2, 3))
+	require.Equal(t, math.MinInt64, Min(math.MinInt64, 2, 3))
+	require.Equal(t, 2, Min(math.MaxInt64, 2, 3))
 }
 
 func TestMax(t *testing.T) {
-	require.Equal(t, Max(1, 2, 3), 3)
-	require.Equal(t, Max(math.MinInt64, 2, 3), 3)
-	require.Equal(t, Max(math.MaxInt64, 2, 3), math.MaxInt64)
+	require.Equal(t, 3, Max(1, 2, 3))
+	require.Equal(t, 3, Max(math.MinInt64, 2, 3))
+	require.Equal(t, math.MaxInt64, Max(math.MaxInt64, 2, 3))
 }
 
 func TestClamp(t *testing.T) {
-	require.Equal(t, Clamp(1, 2, 3), 2)
-	require.Equal(t, Clamp(1, 4, 3), 3)
-	require.Equal(t, Clamp(1, 0, 3), 1)
+	require.Equal(t, 2, Clamp(1, 2, 3))
+	require.Equal(t, 3, Clamp(1, 4, 3))
+	require.Equal(t, 1, Clamp(1, 0, 3))
 	require.Panics(t, func() { Clamp(3, 0, 1) })
 }

--- a/master/pkg/model/agent_test.go
+++ b/master/pkg/model/agent_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestSortableSlotIndex(t *testing.T) {
-	require.Equal(t, SortableSlotIndex(2), "002")
-	require.Equal(t, SortableSlotIndex(16), "016")
+	require.Equal(t, "002", SortableSlotIndex(2))
+	require.Equal(t, "016", SortableSlotIndex(16))
 
 	// Do we actually sort?
 	var gpuIndexes []string

--- a/master/pkg/model/metrics_test.go
+++ b/master/pkg/model/metrics_test.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,7 +63,7 @@ func TestMetricIdentifierDeserialize(t *testing.T) {
 		},
 	}
 	for idx, tt := range tests {
-		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			got, err := DeserializeMetricIdentifier(tt.args.s)
 			if tt.wantErr {
 				require.Error(t, err, "Expected error with arg %v", tt.args.s)

--- a/master/pkg/model/scim_user.go
+++ b/master/pkg/model/scim_user.go
@@ -102,7 +102,7 @@ type SCIMUser struct {
 func (u SCIMUser) Validate() []error {
 	var errs []error
 	if len(u.Username) == 0 {
-		errs = append(errs, errors.New("missing userName"))
+		errs = append(errs, fmt.Errorf("missing userName"))
 	}
 
 	return errs
@@ -119,7 +119,7 @@ func (u *SCIMUser) Sanitize() {
 // invariants.
 func (u SCIMUser) ValidateChanges() error {
 	if !u.ID.Valid {
-		return errors.New("missing ID")
+		return fmt.Errorf("missing ID")
 	}
 
 	return nil
@@ -164,7 +164,7 @@ const clientSidePasswordSalt = "GubPEmmotfiK9TMD6Zdw" // #nosec G101
 // unrecognizable sha512 hash from the frontend.
 func replicateClientSideSaltAndHash(password string) string {
 	sum := sha512.Sum512([]byte(clientSidePasswordSalt + password))
-	return fmt.Sprintf("%x", sum)
+	return fmt.Sprintf("%x", sum) // nolint: perfsprint
 }
 
 // SCIMUsers is a list of users in SCIM.

--- a/master/pkg/model/task_container_defaults_test.go
+++ b/master/pkg/model/task_container_defaults_test.go
@@ -58,18 +58,17 @@ func TestEnvironmentVarsDefaultMerging(t *testing.T) {
 
 	defaults.MergeIntoExpConfig(&conf)
 
-	require.Equal(t, conf.RawEnvironment.RawEnvironmentVariables,
-		&expconf.EnvironmentVariablesMap{
-			RawCPU:  []string{"cpu=default", "cpu=expconf"},
-			RawCUDA: []string{"cuda=default", "extra=expconf"},
-			RawROCM: []string{"rocm=default"},
-		})
+	require.Equal(t, &expconf.EnvironmentVariablesMap{
+		RawCPU:  []string{"cpu=default", "cpu=expconf"},
+		RawCUDA: []string{"cuda=default", "extra=expconf"},
+		RawROCM: []string{"rocm=default"},
+	}, conf.RawEnvironment.RawEnvironmentVariables)
 
-	require.Equal(t, *conf.RawSlurmConfig.RawGpuType, expGpuType)
-	require.Equal(t, *conf.RawSlurmConfig.RawSlotsPerNode, expSlurmSlotsPerNode)
-	require.Equal(t, conf.RawSlurmConfig.SbatchArgs(), []string{"-SlrumTaskDefault", "-SlrumExpConf"})
-	require.Equal(t, *conf.RawPbsConfig.RawSlotsPerNode, defaultSlotsPerNode)
-	require.Equal(t, conf.RawPbsConfig.SbatchArgs(), []string{"-WpbsTaskDefault", "-PbsExpConf"})
+	require.Equal(t, expGpuType, *conf.RawSlurmConfig.RawGpuType)
+	require.Equal(t, expSlurmSlotsPerNode, *conf.RawSlurmConfig.RawSlotsPerNode)
+	require.Equal(t, []string{"-SlrumTaskDefault", "-SlrumExpConf"}, conf.RawSlurmConfig.SbatchArgs())
+	require.Equal(t, defaultSlotsPerNode, *conf.RawPbsConfig.RawSlotsPerNode)
+	require.Equal(t, []string{"-WpbsTaskDefault", "-PbsExpConf"}, conf.RawPbsConfig.SbatchArgs())
 }
 
 func TestTaskContainerDefaultsConfigMerging(t *testing.T) {

--- a/master/pkg/schemas/copy_test.go
+++ b/master/pkg/schemas/copy_test.go
@@ -113,7 +113,7 @@ func (g *G) Copy() G {
 // Wrong number of outputs is not Copyable.
 // type H int // defined in merge_test.go
 
-func (h H) Copy() (H, H) {
+func (h H) Copy() (h1 H, h2 H) {
 	return H(0), H(1)
 }
 

--- a/master/pkg/schemas/defaults_test.go
+++ b/master/pkg/schemas/defaults_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v2"
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/ptrs"
@@ -40,10 +41,10 @@ func (b BindMountV0) CompletenessValidator() *jsonschema.Schema {
 
 func TestFillEmptyDefaults(t *testing.T) {
 	assertDefaults := func(b BindMountV0) {
-		assert.Assert(t, b.ReadOnly != nil)
-		assert.Assert(t, *b.ReadOnly == false)
-		assert.Assert(t, b.Propagation != nil)
-		assert.Assert(t, *b.Propagation == rprivate)
+		require.NotNil(t, b.ReadOnly)
+		require.False(t, *b.ReadOnly)
+		require.NotNil(t, b.Propagation)
+		require.Equal(t, rprivate, *b.Propagation)
 	}
 
 	obj := BindMountV0{}
@@ -64,8 +65,8 @@ func TestFillEmptyDefaults(t *testing.T) {
 func TestNonEmptyDefaults(t *testing.T) {
 	obj := BindMountV0{ReadOnly: ptrs.Ptr(true), Propagation: ptrs.Ptr("asdf")}
 	out := WithDefaults(obj)
-	assert.Assert(t, *out.ReadOnly == true)
-	assert.Assert(t, *out.Propagation == "asdf")
+	require.True(t, *out.ReadOnly)
+	require.Equal(t, "asdf", *out.Propagation)
 }
 
 func TestArrayOfDefautables(t *testing.T) {
@@ -77,10 +78,10 @@ func TestArrayOfDefautables(t *testing.T) {
 	out := WithDefaults(obj)
 
 	for _, b := range out {
-		assert.Assert(t, b.ReadOnly != nil)
-		assert.Assert(t, *b.ReadOnly == false)
-		assert.Assert(t, b.Propagation != nil)
-		assert.Assert(t, *b.Propagation == rprivate)
+		require.NotNil(t, b.ReadOnly)
+		require.False(t, *b.ReadOnly)
+		require.NotNil(t, b.Propagation)
+		require.Equal(t, rprivate, *b.Propagation)
 	}
 }
 
@@ -108,7 +109,7 @@ func (g *G) WithDefaults() G {
 // Wrong number of outputs is not Defaultable.
 // type H int // defined in merge_test.go
 
-func (h H) WithDefaults() (H, H) {
+func (h H) WithDefaults() (h0 H, h1 H) {
 	return H(0), H(1)
 }
 

--- a/master/pkg/schemas/expconf/legacy.go
+++ b/master/pkg/schemas/expconf/legacy.go
@@ -40,9 +40,7 @@ func getCheckpointStorage(raw map[string]interface{}) (CheckpointStorageConfig, 
 
 	csOnly := raw["checkpoint_storage"]
 
-	// Special case for hdfs.
-	switch m := csOnly.(type) {
-	case map[string]any:
+	if m, ok := csOnly.(map[string]any); ok {
 		if t, ok := m["type"].(string); ok && t == "hdfs" {
 			var saveExpBest, saveTrialBest, saveTrialLatest *int
 			var i float64
@@ -178,32 +176,32 @@ func getHyperparameters(raw map[string]interface{}) (Hyperparameters, error) {
 func getLegacySearcher(raw map[string]interface{}) (LegacySearcher, error) {
 	searcher := raw["searcher"]
 	if searcher == nil {
-		return LegacySearcher{}, errors.New("searcher field missing")
+		return LegacySearcher{}, fmt.Errorf("searcher field missing")
 	}
 
 	tsearcher, ok := searcher.(map[string]interface{})
 	if !ok {
-		return LegacySearcher{}, errors.New("searcher field is not a map")
+		return LegacySearcher{}, fmt.Errorf("searcher field is not a map")
 	}
 
 	name, ok := tsearcher["name"]
 	if !ok {
-		return LegacySearcher{}, errors.New("searcher.name missing")
+		return LegacySearcher{}, fmt.Errorf("searcher.name missing")
 	}
 
 	tname, ok := name.(string)
 	if !ok {
-		return LegacySearcher{}, errors.New("searcher.name is not a string")
+		return LegacySearcher{}, fmt.Errorf("searcher.name is not a string")
 	}
 
 	metric, ok := tsearcher["metric"]
 	if !ok {
-		return LegacySearcher{}, errors.New("searcher.metric missing")
+		return LegacySearcher{}, fmt.Errorf("searcher.metric missing")
 	}
 
 	tmetric, ok := metric.(string)
 	if !ok {
-		return LegacySearcher{}, errors.New("searcher.metric is not a string")
+		return LegacySearcher{}, fmt.Errorf("searcher.metric is not a string")
 	}
 
 	// smallerIsBetter has always had a default, and always the same one
@@ -211,7 +209,7 @@ func getLegacySearcher(raw map[string]interface{}) (LegacySearcher, error) {
 	if smallerIsBetter, ok := tsearcher["smaller_is_better"]; ok && smallerIsBetter != nil {
 		tsmallerIsBetter, ok = smallerIsBetter.(bool)
 		if !ok {
-			return LegacySearcher{}, errors.New("searcher.smaller_is_better is not a boolean")
+			return LegacySearcher{}, fmt.Errorf("searcher.smaller_is_better is not a boolean")
 		}
 	}
 

--- a/master/pkg/schemas/expconf/legacy.go
+++ b/master/pkg/schemas/expconf/legacy.go
@@ -40,6 +40,7 @@ func getCheckpointStorage(raw map[string]interface{}) (CheckpointStorageConfig, 
 
 	csOnly := raw["checkpoint_storage"]
 
+	// Special case for hdfs.
 	if m, ok := csOnly.(map[string]any); ok {
 		if t, ok := m["type"].(string); ok && t == "hdfs" {
 			var saveExpBest, saveTrialBest, saveTrialLatest *int

--- a/master/pkg/schemas/extensions/union.go
+++ b/master/pkg/schemas/extensions/union.go
@@ -180,8 +180,7 @@ func UnionExtension() jsonschema.Extension {
 // it doesn't fully match.  unionKey allows us to select the correct error message to show to the
 // user from the union type.
 func evaluateUnionKey(key JSON, instance JSON) bool {
-	switch tKey := key.(type) {
-	case string:
+	if tKey, ok := key.(string); ok {
 		// Parse the string and evaluate.
 		switch {
 		case tKey == "always":
@@ -257,5 +256,6 @@ func evaluateUnionKey(key JSON, instance JSON) bool {
 			return ok
 		}
 	}
+
 	panic(fmt.Sprintf("invalid unionKey: %v", key))
 }

--- a/master/pkg/schemas/merge_test.go
+++ b/master/pkg/schemas/merge_test.go
@@ -89,7 +89,7 @@ func (g *G) Merge(g2 G) G {
 // Wrong number of outputs is not Mergable.
 type H int
 
-func (h H) Merge(h2 H) (H, H) {
+func (h H) Merge(h2 H) (h0 H, h1 H) {
 	return H(0), H(1)
 }
 

--- a/master/pkg/searcher/asha.go
+++ b/master/pkg/searcher/asha.go
@@ -222,17 +222,16 @@ func (s *asyncHalvingSearch) promoteAsync(
 		) {
 			s.TrialRungs[promotionID] = rungIndex + 1
 			nextRung.OutstandingTrials++
-			if !s.EarlyExitTrials[promotionID] {
-				unitsNeeded := mathx.Max(nextRung.UnitsNeeded-rung.UnitsNeeded, 1)
-				ops = append(ops, NewValidateAfter(promotionID, unitsNeeded))
-				addedTrainWorkload = true
-				s.PendingTrials++
-			} else {
+			if s.EarlyExitTrials[promotionID] {
 				// We make a recursive call that will behave the same
 				// as if we'd actually run the promoted job and received
 				// the worse possible result in return.
 				return s.promoteAsync(ctx, promotionID, ashaExitedMetricValue)
 			}
+			unitsNeeded := mathx.Max(nextRung.UnitsNeeded-rung.UnitsNeeded, 1)
+			ops = append(ops, NewValidateAfter(promotionID, unitsNeeded))
+			addedTrainWorkload = true
+			s.PendingTrials++
 		}
 	}
 

--- a/master/pkg/searcher/custom_search_test.go
+++ b/master/pkg/searcher/custom_search_test.go
@@ -33,7 +33,7 @@ func TestCustomSearchMethod(t *testing.T) {
 	ctx := context{rand: rand}
 
 	queue := customSearchMethod.(CustomSearchMethod).getSearcherEventQueue()
-	require.Equal(t, 0, len(queue.events))
+	require.Zero(t, len(queue.events))
 
 	var expEvents []*experimentv1.SearcherEvent
 	var ids idMaker
@@ -129,7 +129,7 @@ func TestCustomSearchMethod(t *testing.T) {
 	// Set customSearcherProgress.
 	searcherProgress := 0.4
 	customSearchMethod.(CustomSearchMethod).setCustomSearcherProgress(searcherProgress)
-	require.Equal(t, searcherProgress, customSearchMethod.progress(nil, nil))
+	require.InEpsilon(t, searcherProgress, customSearchMethod.progress(nil, nil), 0.01)
 
 	// Check removeUpto.
 	err = queue.RemoveUpTo(2)

--- a/master/pkg/searcher/simulate.go
+++ b/master/pkg/searcher/simulate.go
@@ -2,9 +2,9 @@ package searcher
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,7 +37,7 @@ func (s SimulationResults) MarshalJSON() ([]byte, error) {
 	for _, ops := range s {
 		var keyParts []string
 		for _, op := range ops {
-			keyParts = append(keyParts, fmt.Sprintf("%d", op.Length))
+			keyParts = append(keyParts, strconv.FormatUint(op.Length, 10))
 		}
 		summary[strings.Join(keyParts, " ")]++
 	}

--- a/master/pkg/searcher/tournament.go
+++ b/master/pkg/searcher/tournament.go
@@ -140,8 +140,7 @@ func (s *tournamentSearch) Unit() expconf.Unit {
 
 func (s *tournamentSearch) markCreates(subSearchID int, operations []Operation) []Operation {
 	for _, operation := range operations {
-		switch operation := operation.(type) {
-		case Create:
+		if operation, ok := operation.(Create); ok {
 			s.TrialTable[operation.RequestID] = subSearchID
 		}
 	}

--- a/master/pkg/syncx/mapx/mapx_test.go
+++ b/master/pkg/syncx/mapx/mapx_test.go
@@ -60,5 +60,5 @@ func TestMapx(t *testing.T) {
 	}
 
 	testMap.Clear()
-	assert.Equal(t, 0, testMap.Len())
+	assert.Empty(t, testMap.Len())
 }

--- a/master/pkg/syncx/queue/queue_test.go
+++ b/master/pkg/syncx/queue/queue_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestQueue(t *testing.T) {
 	q := queue.New[int]()
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 
 	q.Put(1)
 	require.Equal(t, 1, q.Len())
@@ -26,7 +26,7 @@ func TestQueue(t *testing.T) {
 	require.Equal(t, 1, q.Len())
 
 	require.Equal(t, 2, q.Get())
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 
 	done := make(chan struct{})
 	go func() {
@@ -48,13 +48,13 @@ func TestQueue(t *testing.T) {
 	case <-done:
 	}
 
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 }
 
 func TestQueueMultipleBlockedReaders(t *testing.T) {
 	t.Log("creating queue with max size 1")
 	q := queue.New[int]()
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 
 	t.Log("launch goroutines to add 3 elements")
 	var mu sync.Mutex
@@ -115,15 +115,15 @@ func TestQueueMultipleBlockedReaders(t *testing.T) {
 		default:
 		}
 	}
-	require.Equal(t, len(in), numDone, "all goroutines should have unblocked")
+	require.Len(t, in, numDone, "all goroutines should have unblocked")
 
 	require.ElementsMatch(t, in, out, "should have gotten all values")
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 }
 
 func TestQueueConcurrent(t *testing.T) {
 	q := queue.New[int]()
-	require.Equal(t, 0, q.Len())
+	require.Zero(t, q.Len())
 
 	var in []int
 	for i := 0; i < 100; i++ {

--- a/master/pkg/tasks/dispatcher_task.go
+++ b/master/pkg/tasks/dispatcher_task.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/sirupsen/logrus"
-	launcher "github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
+	"github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -800,7 +800,7 @@ func getEnvVarsForLauncherManifest(
 	m["DET_MASTER"] = fmt.Sprintf("%s://%s:%d", masterScheme, masterHost, masterPort)
 	m["DET_MASTER_HOST"] = masterHost
 	m["DET_MASTER_IP"] = masterHost
-	m["DET_MASTER_PORT"] = fmt.Sprintf("%d", masterPort)
+	m["DET_MASTER_PORT"] = strconv.Itoa(masterPort)
 	m["DET_CLUSTER_ID"] = taskSpec.ClusterID
 	// On non-zero exit of any component/step of the sbatch job, terminate with an error
 	m["SLURM_KILL_BAD_EXIT"] = "1"

--- a/master/pkg/tasks/dispatcher_task_test.go
+++ b/master/pkg/tasks/dispatcher_task_test.go
@@ -12,7 +12,8 @@ import (
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/sirupsen/logrus"
-	launcher "github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
+	"github.com/stretchr/testify/require"
+	"github.hpe.com/hpe/hpc-ard-launcher-go/launcher"
 	"gotest.tools/assert"
 
 	"github.com/determined-ai/determined/master/pkg/archive"
@@ -723,7 +724,7 @@ func Test_ToDispatcherManifest(t *testing.T) {
 			}
 			slurmOpts := expconf.SlurmConfig{
 				RawSlotsPerNode: nil,
-				RawGpuType:      &tt.gpuType,
+				RawGpuType:      ptrs.Ptr(tt.gpuType),
 				RawSbatchArgs:   tt.Slurm,
 			}
 			pbsOpts := expconf.PbsConfig{
@@ -749,7 +750,7 @@ func Test_ToDispatcherManifest(t *testing.T) {
 				tt.isPbsScheduler, nil, nil)
 
 			if tt.wantErr {
-				assert.ErrorContains(t, err, tt.errorContains)
+				require.ErrorContains(t, err, tt.errorContains)
 			} else {
 				assert.NilError(t, err)
 				assert.DeepEqual(t, manifest.GetWarehouseMetadata(), *launcher.NewWarehouseMetadata())
@@ -822,7 +823,7 @@ func Test_ToDispatcherManifest(t *testing.T) {
 					}
 				}
 
-				if tt.gresSupported == false {
+				if !tt.gresSupported {
 					assert.Assert(t, gpus == nil)
 				}
 			}
@@ -1184,7 +1185,7 @@ func Test_preventRunDeterminedMount(t *testing.T) {
 	}
 	volumes, _, _, err := getDataVolumes(arg)
 	assert.Equal(t, len(volumes), 0)
-	assert.ErrorContains(t, err, "/run/determined/workdir")
+	require.ErrorContains(t, err, "/run/determined/workdir")
 }
 
 func Test_addTmpFs(t *testing.T) {

--- a/master/pkg/tasks/dispatcher_verification_test.go
+++ b/master/pkg/tasks/dispatcher_verification_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 )
 
@@ -22,7 +23,7 @@ func validateEnvironmentResult(expected []string, t *testing.T, err []error) {
 	} else {
 		assert.Assert(t, len(err) > 0, "Expected some errors", expected)
 		for i, msg := range expected {
-			assert.ErrorContains(t, err[i], msg)
+			require.ErrorContains(t, err[i], msg)
 		}
 	}
 }

--- a/master/pkg/tasks/task.go
+++ b/master/pkg/tasks/task.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	docker "github.com/docker/docker/api/types/container"
@@ -223,7 +224,7 @@ func (t TaskSpec) EnvVars() map[string]string {
 		e["DET_USE_TLS"] = "false"
 	}
 
-	e["DET_SEGMENT_ENABLED"] = fmt.Sprintf("%v", t.SegmentEnabled)
+	e["DET_SEGMENT_ENABLED"] = strconv.FormatBool(t.SegmentEnabled)
 	if t.SegmentEnabled {
 		e["DET_SEGMENT_API_KEY"] = t.SegmentAPIKey
 	}

--- a/master/pkg/union/tag.go
+++ b/master/pkg/union/tag.go
@@ -12,7 +12,7 @@ const unionTag = "union"
 // parseUnionStructTag parses the "union" struct tag. The format of the struct tag is "key,value"
 // where key is the key is the common union type name for all the union type values and value is
 // the name of the fields union type.
-func parseUnionStructTag(tagValue string) (string, string, error) {
+func parseUnionStructTag(tagValue string) (key string, value string, err error) {
 	switch parsed := strings.Split(tagValue, ","); {
 	case len(parsed) == 2:
 		return parsed[0], parsed[1], nil

--- a/master/pkg/ws/ws.go
+++ b/master/pkg/ws/ws.go
@@ -232,7 +232,7 @@ func (s *WebSocket[TIn, TOut]) closeGraceful() error {
 	}
 
 	select {
-	case <-time.After(closeDeadline.Sub(time.Now())):
+	case <-time.After(closeDeadline.Sub(time.Now())): // nolint: gosimple
 		return fmt.Errorf("did not close within the deadline")
 	case <-s.Done:
 	}

--- a/master/test/integration/api/api_checkpoints_test.go
+++ b/master/test/integration/api/api_checkpoints_test.go
@@ -75,7 +75,7 @@ func testGetCheckpoint(
 
 	conv := &protoconverter.ProtoConverter{}
 
-	runTestCase := func(t *testing.T, tc testCase, id int) {
+	runTestCase := func(t *testing.T, tc testCase) {
 		t.Run(tc.name, func(t *testing.T) {
 			experiment, trial, allocation := createPrereqs(t, pgDB)
 
@@ -149,8 +149,8 @@ func testGetCheckpoint(
 		})
 	}
 
-	for idx, tc := range testCases {
-		runTestCase(t, tc, idx)
+	for _, tc := range testCases {
+		runTestCase(t, tc)
 	}
 }
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
RM-169



## Description
Upgrade the golangci linter to version 1.57.2.

Includes the following changes (not exhaustive):
- Replace a switch with only one case with an if-then.
- In some cases, fmt.Sprintf can be replaced with strconv.Itoa.
- Variables should be renamed to avoid redefinition of any built-in functions. (i.e., a function named `close` should be renamed to `closeDB`).
- In tests with `require` statments, require that the `expected` value come before the `actual`.
- In workflows with `if cond{foo()}  return bar`, replace this with `if !cond {return bar} foo()`.
- Remove unused function parameters & return values.
- Remove useless `break`s in case clauses.
- Variables named `*Ids` should be renamed to `*IDs`.
- Lowercase all unexported variables & functions.
- For functions that return several variables of the same type, name the variables.

Additionally, whenever I came across cases of `errors.New(...)` in files I was already changing, I replaced these with `fmt.Errorf(...)` -- as this is best practice, in our pursuit to remove the errors pkg from our code base. I didn't go out of my way to replace all instances of `errors.New` as I wanted to limit the scope of this ticket.

Allows the following new linters: 
- [gosimple](https://github.com/dominikh/go-tools/tree/master/simple)
- gosec: inspects source code for security problems; i.e., implicit memory aliasing in for loop.
-  depguard: check if package imports are in a list of acceptable packages, as specified in the `.golangci.yml`.
- testifylint: checks usage of github.com/stretchr/testify; enable blank-import bool-compare, compares, empty, error-is-as, error-nil, expected-actual, float-compare, len, negative-positive, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, suite-thelper, useless-asser. Disable go-require. (see [source code ](https://github.com/Antonboom/testifylint/tree/master/internal/checkers)for more context).
- revive: fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.

Disable the following linters: `tagalign, protogetter, inamedparam, nakedret` & a subset of the `revive` sub-linters. See the yaml file for more context.

Clean up the golang yaml (master/.golangci.yml), updating the code & removing deprecated mentions.
## Test Plan
N/A -- pass current circleCI checks.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ