### PR TITLE
fix: tensorboard metric overwrites and sync throttle [MD-328] [MD-291]

### DIFF
--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -96,7 +96,14 @@ class TensorboardManager(metaclass=abc.ABCMeta):
         # Only sync a maximum of once per second to play nice with cloud storage request quotas.
         if time.time() - self.last_sync < 1:
             return
+        self._sync(selector, mangler, rank)
 
+    def _sync(
+        self,
+        selector: Callable[[pathlib.Path], bool] = lambda _: True,
+        mangler: Callable[[pathlib.Path, int], pathlib.Path] = lambda p, __: p,
+        rank: int = 0,
+    ) -> None:
         paths = self.to_sync(selector)
         path_list = []
         for path in paths:
@@ -121,7 +128,7 @@ class TensorboardManager(metaclass=abc.ABCMeta):
 
     def close(self) -> None:
         if self.sync_on_close:
-            self.sync()
+            self._sync()
         if self.upload_thread is not None and self.upload_thread.is_alive():
             self.upload_thread.close()
 

--- a/harness/determined/tensorboard/base.py
+++ b/harness/determined/tensorboard/base.py
@@ -93,6 +93,10 @@ class TensorboardManager(metaclass=abc.ABCMeta):
         mangler: Callable[[pathlib.Path, int], pathlib.Path] = lambda p, __: p,
         rank: int = 0,
     ) -> None:
+        # Only sync a maximum of once per second to play nice with cloud storage request quotas.
+        if time.time() - self.last_sync < 1:
+            return
+
         paths = self.to_sync(selector)
         path_list = []
         for path in paths:

--- a/harness/determined/tensorboard/metric_writers/pytorch.py
+++ b/harness/determined/tensorboard/metric_writers/pytorch.py
@@ -25,7 +25,9 @@ class _TorchWriter(det_tensorboard.MetricWriter):
     def __init__(self) -> None:
         super().__init__()
 
-        self.writer: SummaryWriter = SummaryWriter(log_dir=tensorboard.get_base_path({}))  # type: ignore
+        self.writer: Any = tensorboard.SummaryWriter(
+            log_dir=det_tensorboard.get_base_path({})
+        )  # type: ignore
 
     def add_scalar(self, name: str, value: Union[int, float, np.number], step: int) -> None:
         self.writer.add_scalar(name, value, step)

--- a/harness/determined/tensorboard/metric_writers/pytorch.py
+++ b/harness/determined/tensorboard/metric_writers/pytorch.py
@@ -25,9 +25,7 @@ class _TorchWriter(det_tensorboard.MetricWriter):
     def __init__(self) -> None:
         super().__init__()
 
-        self.writer: Any = tensorboard.SummaryWriter(
-            log_dir=det_tensorboard.get_base_path({})
-        )  # type: ignore
+        self.writer: SummaryWriter = SummaryWriter(log_dir=tensorboard.get_base_path({}))  # type: ignore
 
     def add_scalar(self, name: str, value: Union[int, float, np.number], step: int) -> None:
         self.writer.add_scalar(name, value, step)

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -161,7 +161,8 @@ class MockTensorBoardManager(tensorboard.TensorboardManager):
             async_upload=async_upload,
             sync_on_close=sync_on_close,
         )
-        self._sync_times = []
+        # Record timestamps `self._sync_impl` is called for mock tests.
+        self._sync_times: List[float] = []
 
     def _sync_impl(self, path_info_list: List[tensorboard.base.PathUploadInfo]) -> None:
         self._sync_times.append(time.time())
@@ -178,6 +179,7 @@ def test_sync_throttles_uploads() -> None:
         base_path=BASE_PATH, sync_path=pathlib.Path("mock-tb-sync-path")
     )
 
+    # Call `sync()` at different time intervals.
     for _ in range(5):
         mock_tensorboard_manager.sync()
 

--- a/harness/tests/tensorboard/test_base.py
+++ b/harness/tests/tensorboard/test_base.py
@@ -1,4 +1,6 @@
 import pathlib
+import time
+from typing import List
 from unittest import mock
 
 import pytest
@@ -143,3 +145,48 @@ def test_upload_thread_normal_case() -> None:
     upload_thread.close()
 
     assert upload_function.call_count == 2
+
+
+class MockTensorBoardManager(tensorboard.TensorboardManager):
+    def __init__(
+        self,
+        base_path: pathlib.Path,
+        sync_path: pathlib.Path,
+        async_upload: bool = True,
+        sync_on_close: bool = True,
+    ) -> None:
+        super().__init__(
+            base_path=base_path,
+            sync_path=sync_path,
+            async_upload=async_upload,
+            sync_on_close=sync_on_close,
+        )
+        self._sync_times = []
+
+    def _sync_impl(self, path_info_list: List[tensorboard.base.PathUploadInfo]) -> None:
+        self._sync_times.append(time.time())
+
+    def delete(self) -> None:
+        return
+
+
+def test_sync_throttles_uploads() -> None:
+    """
+    Test that `TensorBoardManager.sync()` throttles uploads to a maximum of once per second.
+    """
+    mock_tensorboard_manager = MockTensorBoardManager(
+        base_path=BASE_PATH, sync_path=pathlib.Path("mock-tb-sync-path")
+    )
+
+    for _ in range(5):
+        mock_tensorboard_manager.sync()
+
+    for _ in range(5):
+        mock_tensorboard_manager.sync()
+        time.sleep(0.5)
+
+    # Verify that the recorded sync times are all at least 1 second apart.
+    sync_times = mock_tensorboard_manager._sync_times
+    assert len(sync_times) > 1
+    sync_intervals = [sync_times[i] - sync_times[i - 1] for i in range(1, len(sync_times))]
+    assert all(sync_interval > 1 for sync_interval in sync_intervals)

--- a/harness/tests/tensorboard/test_metric_writers.py
+++ b/harness/tests/tensorboard/test_metric_writers.py
@@ -39,7 +39,7 @@ def test_batch_metric_writer(mock_get_base_path: mock.MagicMock, tmp_path: pathl
 
     validation_period = 2
 
-    num_steps = 20
+    num_steps = 6
 
     for i in range(num_steps):
         step = i + 1
@@ -56,7 +56,7 @@ def test_batch_metric_writer(mock_get_base_path: mock.MagicMock, tmp_path: pathl
     val_events = []
 
     # Read event files saved and verify all metrics are written.
-    event_files = sorted(list(tmp_path.iterdir()))
+    event_files = sorted(tmp_path.iterdir())
     for file in event_files:
         for event in summary_iterator.summary_iterator(str(file)):
             # TensorFlow injects an event containing metadata at the start of every tfevent

--- a/harness/tests/tensorboard/test_metric_writers.py
+++ b/harness/tests/tensorboard/test_metric_writers.py
@@ -39,20 +39,14 @@ def test_batch_metric_writer(mock_get_base_path: mock.MagicMock, tmp_path: pathl
 
     validation_period = 2
 
-    for i in range(10):
+    num_steps = 100
+
+    for i in range(num_steps):
         step = i + 1
         batch_writer.on_train_step_end(steps_completed=i, metrics={"x": step})
         if i % validation_period == 0:
             batch_writer.on_validation_step_end(steps_completed=i, metrics={"x": step})
-
-    # Sleep for 1 second to make subsequent metrics write to a new file.
-    time.sleep(1)
-
-    for i in range(10, 20):
-        step = i + 1
-        batch_writer.on_train_step_end(steps_completed=i, metrics={"x": step})
-        if i % validation_period == 0:
-            batch_writer.on_validation_step_end(steps_completed=i, metrics={"x": step})
+        time.sleep((int(time.time()) + 1) - time.time())
 
     train_events = []
     val_events = []
@@ -71,12 +65,11 @@ def test_batch_metric_writer(mock_get_base_path: mock.MagicMock, tmp_path: pathl
                 elif event_data.tag == "Determined/val_x":
                     val_events.append(event_data.simple_value)
 
-    assert len(event_files) == 2
-    assert len(train_events) == 20
-    assert len(val_events) == 20 / validation_period
+    assert len(train_events) == num_steps
+    assert len(val_events) == num_steps / validation_period
 
-    for i in range(20):
+    for i in range(num_steps):
         assert i + 1 in train_events
 
-    for i in range(1, 20, validation_period):
+    for i in range(1, num_steps, validation_period):
         assert i in val_events


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

Fixes two separate issues
1. Metrics being overwritten by the TensorBoard metric writer. In some cases we reset a file handle then immediately write another event destined for the same file handle, which overwrites the file. To accurately batch writes to once per second, we need to track two timestamps, one before the write, and one after.
2. Tensorboard sync to cloud storage happening more than once per second will hit cloud storage quotas, so throttle them to at most once per second. Though this issue has been surfaced for GCS, this fix would effectively throttle uploads for all tensorboard managers since I don't see a good reason why we'd need to sync that often.

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ