### PR TITLE
DO NOT MERGE. THIS IS A TEST

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -31,6 +31,12 @@ module.exports = {
         'no-fallthrough': 'off',
       },
     },
+    {
+      files: ['**/src/e2e/**'],
+      rules: {
+        '@typescript-eslint/no-floating-promises': 'error',
+      },
+    },
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/webui/react/src/e2e/fixtures/auth.fixture.ts
+++ b/webui/react/src/e2e/fixtures/auth.fixture.ts
@@ -33,7 +33,7 @@ export class AuthFixture {
     const detAuth = this.signInPage.detAuth;
     if (!(await detAuth.pwLocator.isVisible())) {
       await this.#page.goto('/');
-      expect(detAuth.pwLocator).toBeVisible();
+      await expect(detAuth.pwLocator).toBeVisible();
     }
     await detAuth.username.pwLocator.fill(username);
     await detAuth.password.pwLocator.fill(password);

--- a/webui/react/src/e2e/models/hew/DataGrid.ts
+++ b/webui/react/src/e2e/models/hew/DataGrid.ts
@@ -290,7 +290,7 @@ export class HeadRow extends NamedComponent {
           if (index === null) throw new Error();
           this.#columnDefs.set(await cell.innerText(), +index);
         } catch {
-          Promise.reject(
+          await Promise.reject(
             new Error(`All header cells should have the attribute ${'aria-colindex'}`),
           );
         }

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -61,7 +61,7 @@ test.describe('Projects', () => {
           .pwLocator.click({ button: 'right' });
         await workspacesPage.nav.sidebar.actionMenu.delete.pwLocator.click();
         await workspacesPage.deleteModal.nameConfirmation.pwLocator.fill(wsCreatedWithButton); // wrong name
-        expect(workspacesPage.deleteModal.footer.submit.pwLocator).toBeDisabled();
+        await expect(workspacesPage.deleteModal.footer.submit.pwLocator).toBeDisabled();
         await workspacesPage.deleteModal.nameConfirmation.pwLocator.fill(wsCreatedWithSidebar);
         await workspacesPage.deleteModal.footer.submit.pwLocator.click();
       }
@@ -84,9 +84,11 @@ test.describe('Projects', () => {
         'fromButton',
       );
 
-      expect(workspacesPage.nav.sidebar.sidebarItem(wsCreatedWithButton).pwLocator).toBeVisible();
+      await expect(
+        workspacesPage.nav.sidebar.sidebarItem(wsCreatedWithButton).pwLocator,
+      ).toBeVisible();
       await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
-      expect(workspacesPage.list.cardWithName(wsCreatedWithButton).pwLocator).toBeVisible();
+      await expect(workspacesPage.list.cardWithName(wsCreatedWithButton).pwLocator).toBeVisible();
     });
     await test.step('Create a workspace through the sidebar', async () => {
       await workspacesPage.nav.sidebar.workspaces.pwLocator.hover();
@@ -96,9 +98,11 @@ test.describe('Projects', () => {
         'fromSidebar',
       );
 
-      expect(workspacesPage.nav.sidebar.sidebarItem(wsCreatedWithSidebar).pwLocator).toBeVisible();
+      await expect(
+        workspacesPage.nav.sidebar.sidebarItem(wsCreatedWithSidebar).pwLocator,
+      ).toBeVisible();
       await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
-      expect(workspacesPage.list.cardWithName(wsCreatedWithSidebar).pwLocator).toBeVisible();
+      await expect(workspacesPage.list.cardWithName(wsCreatedWithSidebar).pwLocator).toBeVisible();
     });
 
     await test.step('Create projects', async () => {});

--- a/webui/react/src/e2e/tests/userManagement.spec.ts
+++ b/webui/react/src/e2e/tests/userManagement.spec.ts
@@ -209,7 +209,7 @@ test.describe('User Management', () => {
           }).toPass({ timeout: 10_000 });
           // search for users created this session and wait for table stable
           await userManagementPage.search.pwLocator.fill(usernamePrefix + sessionRandomHash);
-          await expect(async () => {
+          expect(async () => {
             expect(
               await userManagementPage.table.table.filterRows(async (row) => {
                 return (await row.user.name.pwLocator.textContent())?.indexOf(usernamePrefix) === 0;


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ