### PR TITLE
chore: improve messaging for e2e tests

### DIFF
--- a/e2e_tests/tests/cluster/managed_cluster.py
+++ b/e2e_tests/tests/cluster/managed_cluster.py
@@ -114,7 +114,9 @@ class ManagedCluster(abstract_cluster.Cluster):
     def ensure_agent_ok(self) -> None:
         sess = api_utils.user_session()
         agent_data = get_agent_data(sess)
-        assert len(agent_data) == 1
+        assert (
+            len(agent_data) == 1
+        ), f"expected agent_data for 1, instead found {len(agent_data)} agents:\n{agent_data}\n"
         assert agent_data[0]["enabled"] is True
         assert agent_data[0]["draining"] is False
 

--- a/e2e_tests/tests/cluster/test_rbac.py
+++ b/e2e_tests/tests/cluster/test_rbac.py
@@ -29,15 +29,15 @@ def create_workspaces_with_users(
     Set up workspaces and users with the provided role assignments.
     For example the following sets up 2 workspaces and 2 users referenced
     with the integer ids 1 and 2. User 1 has the roles Editor and Viewer on
-    workspace 1 and the role Viewer on workspace 2. User 2 has the role Viewer
-    on workspace 1 and no roles on workspace 2.
+    workspace 1 and workspace 2. User 2 has the role Viewer on workspace 1
+    and no roles on workspace 2.
     perm_assigments = [
         [
             (1, ["Editor", "Viewer"]),
             (2, ["Viewer"]),
         ],
         [
-            (1, ["Viewer"]),
+            (1, ["Editor", "Viewer"]),
         ]
     ]
     """

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -428,13 +428,13 @@ def wait_for_experiment_workload_progress(
 def experiment_has_completed_workload(sess: api.Session, experiment_id: int) -> bool:
     trials = experiment_trials(sess, experiment_id)
 
-    if not any(trials):
-        return False
+    if any(trials):
+        for t in trials:
+            for s in t.workloads:
+                if s.training is not None or s.validation is not None:
+                    return True
+            print(f"trial for experiment {experiment_id} is in the {t.trial.state} state")
 
-    for t in trials:
-        for s in t.workloads:
-            if s.training is not None or s.validation is not None:
-                return True
     return False
 
 

--- a/e2e_tests/tests/experiment/experiment.py
+++ b/e2e_tests/tests/experiment/experiment.py
@@ -428,12 +428,11 @@ def wait_for_experiment_workload_progress(
 def experiment_has_completed_workload(sess: api.Session, experiment_id: int) -> bool:
     trials = experiment_trials(sess, experiment_id)
 
-    if any(trials):
-        for t in trials:
-            for s in t.workloads:
-                if s.training is not None or s.validation is not None:
-                    return True
-            print(f"trial for experiment {experiment_id} is in the {t.trial.state} state")
+    for t in trials:
+        for s in t.workloads:
+            if s.training is not None or s.validation is not None:
+                return True
+        print(f"trial for experiment {experiment_id} is in the {t.trial.state} state")
 
     return False
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
To help better identify e2e test flakes, add some logging statements to expose information about the particular failure event. Additionally, this changes the comment to `create_workspaces_with_users` to add more clarity for its usage.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ