### PR TITLE
test: skip a `useTypedParams` test case due to flakiness

### DIFF
--- a/webui/react/src/hooks/useTypedParams.test.tsx
+++ b/webui/react/src/hooks/useTypedParams.test.tsx
@@ -150,7 +150,9 @@ describe('useTypedParams', () => {
         .afterEach(() => navSpy.mockClear()),
     );
   });
-  it('does not touch params that are not in the codec', async () => {
+  // TODO(SKIP): skip this test case because this has been flaky on CI
+  // revisit here to fix the flakiness
+  it.skip('does not touch params that are not in the codec', async () => {
     await fc.assert(
       fc
         .asyncProperty(


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
https://hpe-aiatscale.slack.com/archives/C04C9JXB1C2/p1714588016489469


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- CI should pass
- `src/hooks/useTypedParams.test.tsx > useTypedParams > does not touch params that are not in the codec` test case should be skipped


## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ