### PR TITLE
chore: option to use cli populated determined session

### DIFF
--- a/harness/determined/cli/dev.py
+++ b/harness/determined/cli/dev.py
@@ -313,6 +313,17 @@ def call_bindings(args: argparse.Namespace) -> None:
         )
 
 
+def execute_with_session(args: argparse.Namespace) -> None:
+    sess = cli.setup_session(args)
+
+    original_argv = sys.argv
+    sys.argv = ["det-cli"] + args.args
+    with open(args.script, "r") as file:
+        script_content = file.read()
+    exec(script_content, {"cli_session": sess, "global_session": sess})
+    sys.argv = original_argv
+
+
 args_description = [
     cli.Cmd(
         "dev",
@@ -320,6 +331,19 @@ args_description = [
         argparse.SUPPRESS,
         [
             cli.Cmd("auth-token", token, "print the active user's auth token", []),
+            cli.Cmd(
+                "execute",
+                execute_with_session,
+                "execute a python script with pre-configured session: `cli_session`",
+                [
+                    cli.Arg("script", help="path to the script to execute"),
+                    cli.Arg(
+                        "args",
+                        nargs=argparse.REMAINDER,
+                        help="arguments to pass to the function, positional or kw=value",
+                    ),
+                ],
+            ),
             cli.Cmd(
                 "c|url",
                 curl,


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

often times the first barrier to interacting with det in a quick way when developing or debugging is preparing the session object. the cli already does this and gives users various options to configure the process. the goal here is to allow devs to reuse that here in a semi stable and detached way without having to rely on the py sdk

add an option to execute a python script utilizing a cli configured determined session
provider a global session


```python
#!/usr/bin/env python3

import determined.common.api.bindings as b

jobs = b.get_GetJobs(cli_session).jobs
for job in jobs:
    print(job)

```
det dev execute myscript.py


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ