### PR TITLE
chore: log health check failures in master logs

### DIFF
--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -208,6 +208,7 @@ func (m *Master) healthCheck(ctx context.Context) model.HealthCheck {
 	hc.Database = model.Healthy
 	_, err := db.Bun().NewSelect().Table("cluster_id").Exists(ctx)
 	if err != nil {
+		log.WithError(err).Error("database marked as unhealthy")
 		hc.Database = model.Unhealthy
 	}
 

--- a/master/internal/rm/dispatcherrm/dispatcher_resource_manager.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_resource_manager.go
@@ -265,6 +265,7 @@ func (m *DispatcherResourceManager) HealthCheck() []model.ResourceManagerHealth 
 	status := model.Healthy
 	_, err := m.apiClient.getVersion(context.TODO(), m.syslog.WithField("caller", "HealthCheck"))
 	if err != nil {
+		m.syslog.WithError(err).Error("dispatcher resource manager marked as unhealthy")
 		status = model.Unhealthy
 	}
 

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -695,6 +695,7 @@ func TestHealthCheck(t *testing.T) {
 			podInterfaces: map[string]typedV1.PodInterface{
 				"namespace": mockPodInterface,
 			},
+			syslog: logrus.WithField("namespace", "test"),
 		},
 	}
 

--- a/master/internal/rm/kubernetesrm/pods.go
+++ b/master/internal/rm/kubernetesrm/pods.go
@@ -323,6 +323,7 @@ func (p *pods) HealthStatus() model.HealthStatus {
 	for _, podInterface := range p.podInterfaces {
 		_, err := podInterface.List(context.TODO(), metaV1.ListOptions{Limit: 1})
 		if err != nil {
+			p.syslog.WithError(err).Error("kubernetes resource manager marked as unhealthy")
 			return model.Unhealthy
 		}
 		return model.Healthy


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Add master logs for failed health checks.


## Test Plan
 
 Run devcluster, delete cluster_id table and look to see it is logged


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ