### PR TITLE
test: revert runner size test-e2e-cpu

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4459,8 +4459,8 @@ workflows:
           name: test-e2e-cpu
           requires:
             - build-go-ee
-          parallelism: 9
-          resource-class: large
+          parallelism: 6
+          resource-class: xlarge
           tf2: true
           mark: e2e_cpu
 


### PR DESCRIPTION

## PR TITLE test: revert runner size test-e2e-cpu
## Ticket
infeng-672


## Description
the change in `INFENG-598: Ensure tests are sufficiently parallel or scale down resource classes` caused issues for test-ee2-cpu (probably) and needs to be reverted.



## Test Plan
ci passes



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ