### PR TITLE
test: log in with the api rather than through the UI for most react tests

### DIFF
--- a/webui/react/.gitignore
+++ b/webui/react/.gitignore
@@ -27,6 +27,7 @@ done.stamp
 /test-results/
 /playwright-report/
 /playwright/.cache/
+state.json
 src/e2e/test-results/
 src/e2e/playwright-report/
 src/e2e/junit-results.xml

--- a/webui/react/src/e2e/fixtures/api.auth.fixture.ts
+++ b/webui/react/src/e2e/fixtures/api.auth.fixture.ts
@@ -1,10 +1,4 @@
-import {
-  APIRequest,
-  APIRequestContext,
-  Browser,
-  BrowserContext,
-  Page,
-} from '@playwright/test';
+import { APIRequest, APIRequestContext, Browser, BrowserContext, Page } from '@playwright/test';
 
 export class ApiAuthFixture {
   apiContext: APIRequestContext | undefined; // DNJ TODO - how to not have undefined

--- a/webui/react/src/e2e/fixtures/api.auth.fixture.ts
+++ b/webui/react/src/e2e/fixtures/api.auth.fixture.ts
@@ -7,58 +7,58 @@ import {
 } from '@playwright/test';
 
 export class ApiAuthFixture {
-    apiContext: APIRequestContext | undefined; // DNJ TODO - how to not have undefined
-    readonly request: APIRequest;
-    readonly browser: Browser;
-    _page: Page | undefined;
-    get page() {
-        if (this._page === undefined) {
-            throw new Error("Accessing page object before initialization in authentication")
-        }
-        return this._page;
+  apiContext: APIRequestContext | undefined; // DNJ TODO - how to not have undefined
+  readonly request: APIRequest;
+  readonly browser: Browser;
+  _page: Page | undefined;
+  get page(): Page {
+    if (this._page === undefined) {
+      throw new Error('Accessing page object before initialization in authentication');
     }
-    readonly #STATE_FILE = 'state.json';
-    readonly #USERNAME: string;
-    readonly #PASSWORD: string;
-    context: BrowserContext | undefined;
-    constructor(request: APIRequest, browser: Browser, existingPage: Page | undefined = undefined) {
-        if (process.env.PW_USER_NAME === undefined) {
-            throw new Error('username must be defined');
-        }
-        if (process.env.PW_PASSWORD === undefined) {
-            throw new Error('password must be defined');
-        }
-        this.#USERNAME = process.env.PW_USER_NAME;
-        this.#PASSWORD = process.env.PW_PASSWORD;
-        this.request = request;
-        this.browser = browser;
-        this._page = existingPage;
+    return this._page;
+  }
+  readonly #STATE_FILE = 'state.json';
+  readonly #USERNAME: string;
+  readonly #PASSWORD: string;
+  context: BrowserContext | undefined;
+  constructor(request: APIRequest, browser: Browser, existingPage: Page | undefined = undefined) {
+    if (process.env.PW_USER_NAME === undefined) {
+      throw new Error('username must be defined');
     }
+    if (process.env.PW_PASSWORD === undefined) {
+      throw new Error('password must be defined');
+    }
+    this.#USERNAME = process.env.PW_USER_NAME;
+    this.#PASSWORD = process.env.PW_PASSWORD;
+    this.request = request;
+    this.browser = browser;
+    this._page = existingPage;
+  }
 
-    async login() {
-        this.apiContext = await this.request.newContext();
-        await this.apiContext.post(`/api/v1/auth/login`, {
-            data: {
-                username: this.#USERNAME,
-                password: this.#PASSWORD,
-                isHashed: false
-            }
-        });
-        // Save cookie state into the file.
-        const state = await this.apiContext.storageState({ path: this.#STATE_FILE });        
-        if (this._page !== undefined){
-            // add cookies to current page's existing context
-            this.context = this._page.context();
-            this.context.addCookies(state.cookies);
-        }else{
-            // Create a new context for the browser with the saved token.
-            this.context = await this.browser.newContext({ storageState: this.#STATE_FILE });
-            this._page = await this.context.newPage();
-        }
+  async login(): Promise<void> {
+    this.apiContext = await this.request.newContext();
+    await this.apiContext.post('/api/v1/auth/login', {
+      data: {
+        isHashed: false,
+        password: this.#PASSWORD,
+        username: this.#USERNAME,
+      },
+    });
+    // Save cookie state into the file.
+    const state = await this.apiContext.storageState({ path: this.#STATE_FILE });
+    if (this._page !== undefined) {
+      // add cookies to current page's existing context
+      this.context = this._page.context();
+      await this.context.addCookies(state.cookies);
+    } else {
+      // Create a new context for the browser with the saved token.
+      this.context = await this.browser.newContext({ storageState: this.#STATE_FILE });
+      this._page = await this.context.newPage();
     }
+  }
 
-    async logout() {
-        await this.apiContext?.dispose();
-        await this.context?.close();
-    }
+  async logout(): Promise<void> {
+    await this.apiContext?.dispose();
+    await this.context?.close();
+  }
 }

--- a/webui/react/src/e2e/fixtures/api.auth.fixture.ts
+++ b/webui/react/src/e2e/fixtures/api.auth.fixture.ts
@@ -1,0 +1,49 @@
+import {
+  APIRequest,
+  APIRequestContext,
+  Browser,
+  BrowserContext,
+} from '@playwright/test';
+
+export class ApiAuthFixture {
+    apiContext: APIRequestContext | undefined; // DNJ TODO - how to not have undefined
+    readonly request: APIRequest;
+    readonly #STATE_FILE = 'state.json';
+    readonly #USERNAME: string;
+    readonly #PASSWORD: string;
+    context: BrowserContext | undefined;
+    constructor(request: APIRequest) {
+        if (process.env.PW_USER_NAME === undefined) {
+            throw new Error('username must be defined');
+        }
+        if (process.env.PW_PASSWORD === undefined) {
+            throw new Error('password must be defined');
+        }
+        this.#USERNAME = process.env.PW_USER_NAME;
+        this.#PASSWORD = process.env.PW_PASSWORD;
+        this.request = request;
+    }
+
+    async login(browser: Browser) {
+
+        this.apiContext = await this.request.newContext({
+            httpCredentials: {
+                username: this.#USERNAME,
+                password: this.#PASSWORD
+            }
+        });
+        await this.apiContext.get(`/login`);
+        // Save cookie state into the file.
+        await this.apiContext.storageState({ path: this.#STATE_FILE });
+        // Create a new context for the browser with the saved token.
+        this.context = await browser.newContext({ storageState: this.#STATE_FILE });
+    }
+
+    async useContext(){
+
+    }
+    async logout() {
+        this.apiContext?.dispose();
+        this.context?.close();
+    }
+}

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -1,13 +1,7 @@
-import {
-  BaseComponent,
-  CanBeParent,
-} from 'e2e/models/BaseComponent';
-import { BasePage } from 'e2e/models/BasePage';
+import { expect, Page } from '@playwright/test';
 
-import {
-  expect,
-  Page,
-} from '@playwright/test';
+import { BaseComponent, CanBeParent } from 'e2e/models/BaseComponent';
+import { BasePage } from 'e2e/models/BasePage';
 
 export class DevFixture {
   readonly #page: Page;

--- a/webui/react/src/e2e/fixtures/dev.fixture.ts
+++ b/webui/react/src/e2e/fixtures/dev.fixture.ts
@@ -1,14 +1,20 @@
-import { expect, Page } from '@playwright/test';
-
-import { BaseComponent, CanBeParent } from 'e2e/models/BaseComponent';
+import {
+  BaseComponent,
+  CanBeParent,
+} from 'e2e/models/BaseComponent';
 import { BasePage } from 'e2e/models/BasePage';
+
+import {
+  expect,
+  Page,
+} from '@playwright/test';
 
 export class DevFixture {
   readonly #page: Page;
   constructor(readonly page: Page) {
     this.#page = page;
   }
-
+  // tells the frontend where to find the backend if built for a different url. Incidentally reloads and logs out of Determined.
   async setServerAddress(): Promise<void> {
     await this.#page.goto('/');
     await this.#page.evaluate(`dev.setServerAddress("${process.env.PW_SERVER_ADDRESS}")`);

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 
+import { ApiAuthFixture } from './api.auth.fixture';
 import { AuthFixture } from './auth.fixture';
 import { DevFixture } from './dev.fixture';
 import { UserFixture } from './user.fixture';
@@ -7,6 +8,7 @@ import { UserFixture } from './user.fixture';
 type CustomFixtures = {
   dev: DevFixture;
   auth: AuthFixture;
+  apiAuth: ApiAuthFixture;
   user: UserFixture;
 };
 
@@ -15,6 +17,11 @@ export const test = base.extend<CustomFixtures>({
   auth: async ({ page }, use) => {
     const auth = new AuthFixture(page);
     await use(auth);
+  },
+
+  apiAuth: async ({ playwright }, use) => {
+    const apiAuth = new ApiAuthFixture(playwright.request);
+    await use(apiAuth);
   },
 
   dev: async ({ page }, use) => {

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -16,7 +16,7 @@ type CustomFixtures = {
 // https://playwright.dev/docs/test-fixtures
 export const test = base.extend<CustomFixtures>({
   // get the auth but allow yourself to log in through the api manually.
-apiAuth: async ({ playwright, browser }, use) => {
+  apiAuth: async ({ playwright, browser }, use) => {
     const apiAuth = new ApiAuthFixture(playwright.request, browser);
     await use(apiAuth);
   },
@@ -27,14 +27,14 @@ apiAuth: async ({ playwright, browser }, use) => {
   },
 
   // get a page already logged in
-authedPage: async ({ playwright, browser, dev }, use) => {
+  authedPage: async ({ playwright, browser, dev }, use) => {
     await dev.setServerAddress();
     const apiAuth = new ApiAuthFixture(playwright.request, browser, dev.page);
     await apiAuth.login();
     await use(apiAuth.page);
   },
 
-dev: async ({ page }, use) => {
+  dev: async ({ page }, use) => {
     const dev = new DevFixture(page);
     await use(dev);
   },

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -1,7 +1,4 @@
-import {
-  test as base,
-  Page,
-} from '@playwright/test';
+import { test as base, Page } from '@playwright/test';
 
 import { ApiAuthFixture } from './api.auth.fixture';
 import { AuthFixture } from './auth.fixture';
@@ -18,17 +15,26 @@ type CustomFixtures = {
 
 // https://playwright.dev/docs/test-fixtures
 export const test = base.extend<CustomFixtures>({
-  auth: async ({ page }, use) => {
-    const auth = new AuthFixture(page);
-    await use(auth);
-  },
   // get the auth but allow yourself to log in through the api manually.
-  apiAuth: async ({ playwright, browser }, use) => {
+apiAuth: async ({ playwright, browser }, use) => {
     const apiAuth = new ApiAuthFixture(playwright.request, browser);
     await use(apiAuth);
   },
 
-  dev: async ({ page }, use) => {
+  auth: async ({ page }, use) => {
+    const auth = new AuthFixture(page);
+    await use(auth);
+  },
+
+  // get a page already logged in
+authedPage: async ({ playwright, browser, dev }, use) => {
+    await dev.setServerAddress();
+    const apiAuth = new ApiAuthFixture(playwright.request, browser, dev.page);
+    await apiAuth.login();
+    await use(apiAuth.page);
+  },
+
+dev: async ({ page }, use) => {
     const dev = new DevFixture(page);
     await use(dev);
   },
@@ -37,12 +43,4 @@ export const test = base.extend<CustomFixtures>({
     const user = new UserFixture(page);
     await use(user);
   },
-  // get a page already logged in
-  authedPage: async ({ playwright, browser, dev }, use) => {
-    await dev.setServerAddress();
-    const apiAuth = new ApiAuthFixture(playwright.request, browser, dev.page);
-    await apiAuth.login();
-    await use(apiAuth.page);
-  },
-
 });

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -1,4 +1,7 @@
-import { test as base } from '@playwright/test';
+import {
+  test as base,
+  Page,
+} from '@playwright/test';
 
 import { ApiAuthFixture } from './api.auth.fixture';
 import { AuthFixture } from './auth.fixture';
@@ -10,6 +13,7 @@ type CustomFixtures = {
   auth: AuthFixture;
   apiAuth: ApiAuthFixture;
   user: UserFixture;
+  authedPage: Page;
 };
 
 // https://playwright.dev/docs/test-fixtures
@@ -18,9 +22,9 @@ export const test = base.extend<CustomFixtures>({
     const auth = new AuthFixture(page);
     await use(auth);
   },
-
-  apiAuth: async ({ playwright }, use) => {
-    const apiAuth = new ApiAuthFixture(playwright.request);
+  // get the auth but allow yourself to log in through the api manually.
+  apiAuth: async ({ playwright, browser }, use) => {
+    const apiAuth = new ApiAuthFixture(playwright.request, browser);
     await use(apiAuth);
   },
 
@@ -32,5 +36,11 @@ export const test = base.extend<CustomFixtures>({
   user: async ({ page }, use) => {
     const user = new UserFixture(page);
     await use(user);
+  },
+  // get a page already logged in
+  authedPage: async ({ playwright, browser }, use) => {
+    const apiAuth = new ApiAuthFixture(playwright.request, browser);
+    await apiAuth.login();
+    await use(apiAuth.page);
   },
 });

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -38,9 +38,11 @@ export const test = base.extend<CustomFixtures>({
     await use(user);
   },
   // get a page already logged in
-  authedPage: async ({ playwright, browser }, use) => {
-    const apiAuth = new ApiAuthFixture(playwright.request, browser);
+  authedPage: async ({ playwright, browser, dev }, use) => {
+    await dev.setServerAddress();
+    const apiAuth = new ApiAuthFixture(playwright.request, browser, dev.page);
     await apiAuth.login();
     await use(apiAuth.page);
   },
+
 });

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -1,10 +1,9 @@
+import { expect } from '@playwright/test';
+
 import { test } from 'e2e/fixtures/global-fixtures';
 import { ProjectDetails } from 'e2e/models/pages/ProjectDetails';
 
-import { expect } from '@playwright/test';
-
 test.describe('Experiement List', () => {
-
   test('Navigate to Experiment List', async ({ authedPage }) => {
     const projectDetailsPage = new ProjectDetails(authedPage);
     await projectDetailsPage.gotoProject();

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -1,25 +1,21 @@
-import { expect } from '@playwright/test';
-
 import { test } from 'e2e/fixtures/global-fixtures';
 import { ProjectDetails } from 'e2e/models/pages/ProjectDetails';
 
-test.describe('Experiement List', () => {
-  test.beforeEach(async ({ auth, dev }) => {
-    await dev.setServerAddress();
-    await auth.login();
-  });
+import { expect } from '@playwright/test';
 
-  test('Navigate to Experiment List', async ({ page }) => {
-    const projectDetailsPage = new ProjectDetails(page);
+test.describe('Experiement List', () => {
+
+  test('Navigate to Experiment List', async ({ authedPage }) => {
+    const projectDetailsPage = new ProjectDetails(authedPage);
     await projectDetailsPage.gotoProject();
-    await expect(page).toHaveTitle(projectDetailsPage.title);
+    await expect(authedPage).toHaveTitle(projectDetailsPage.title);
     await expect(projectDetailsPage.f_experiemntList.tableActionBar.pwLocator).toBeVisible();
   });
 
-  test.skip('Click around the data grid', async ({ page }) => {
+  test.skip('Click around the data grid', async ({ authedPage }) => {
     // This test expects a project to have been deployed.
     // This test.skip is useful to show an example of what tests can do
-    const projectDetailsPage = new ProjectDetails(page);
+    const projectDetailsPage = new ProjectDetails(authedPage);
     await projectDetailsPage.gotoProject();
     await expect(projectDetailsPage.f_experiemntList.dataGrid.rows.pwLocator).toHaveCount(1);
     await projectDetailsPage.f_experiemntList.dataGrid.setColumnHeight();
@@ -33,6 +29,6 @@ test.describe('Experiement List', () => {
     await projectDetailsPage.f_experiemntList.dataGrid.headRow.clickSelectDropdown();
     await projectDetailsPage.f_experiemntList.dataGrid.headRow.selectDropdown.select5.pwLocator.click();
     await row.clickColumn('ID');
-    await page.waitForURL(/overview/);
+    await authedPage.waitForURL(/overview/);
   });
 });

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -1,17 +1,15 @@
+import { expect } from '@playwright/test';
+
 import { test } from 'e2e/fixtures/global-fixtures';
 import { BasePage } from 'e2e/models/BasePage';
 import { UserManagement } from 'e2e/models/pages/Admin/UserManagement';
 import { SignIn } from 'e2e/models/pages/SignIn';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
 
-import { expect } from '@playwright/test';
-
 test.describe('Navigation', () => {
-
   test('Sidebar Navigation', async ({ authedPage, auth }) => {
     // we need any page to access the sidebar, and i haven't modeled the homepage yet
     const userManagementPage = new UserManagement(authedPage);
-
 
     await test.step('Login steps', async () => {
       await expect(authedPage).toHaveTitle(BasePage.getTitle('Home'));

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -1,33 +1,30 @@
-import { expect } from '@playwright/test';
-
 import { test } from 'e2e/fixtures/global-fixtures';
 import { BasePage } from 'e2e/models/BasePage';
 import { UserManagement } from 'e2e/models/pages/Admin/UserManagement';
 import { SignIn } from 'e2e/models/pages/SignIn';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
 
+import { expect } from '@playwright/test';
+
 test.describe('Navigation', () => {
-  test.beforeEach(async ({ dev }) => {
-    await dev.setServerAddress();
-  });
+  const USERNAME = process.env.PW_USER_NAME ?? '';
 
-  test('Sidebar Navigation', async ({ page, auth }) => {
+
+  test('Sidebar Navigation', async ({ authedPage, auth }) => {
     // we need any page to access the sidebar, and i haven't modeled the homepage yet
-    const userManagementPage = new UserManagement(page);
+    const userManagementPage = new UserManagement(authedPage);
 
-    await page.goto('/');
 
     await test.step('Login steps', async () => {
-      await auth.login();
-      await expect(page).toHaveTitle(BasePage.getTitle('Home'));
-      await expect(page).toHaveURL(/dashboard/);
+      await expect(authedPage).toHaveTitle(BasePage.getTitle('Home'));
+      await expect(authedPage).toHaveURL(/dashboard/);
     });
 
     await test.step('Navigate to Uncategorized', async () => {
       await userManagementPage.nav.sidebar.uncategorized.pwLocator.click();
       const expectedURL = /projects\/1\/experiments/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(BasePage.getTitle('Uncategorized Experiments'));
+      await authedPage.waitForURL(expectedURL);
+      await expect.soft(authedPage).toHaveTitle(BasePage.getTitle('Uncategorized Experiments'));
     });
 
     await test.step('Navigate to Model Registry', async () => {
@@ -39,29 +36,29 @@ test.describe('Navigation', () => {
     await test.step('Navigate to Tasks', async () => {
       await userManagementPage.nav.sidebar.tasks.pwLocator.click();
       const expectedURL = /tasks/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(BasePage.getTitle('Tasks'));
+      await authedPage.waitForURL(expectedURL);
+      await expect.soft(authedPage).toHaveTitle(BasePage.getTitle('Tasks'));
     });
 
     await test.step('Navigate to Webhooks', async () => {
       await userManagementPage.nav.sidebar.webhooks.pwLocator.click();
       const expectedURL = /webhooks/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(BasePage.getTitle('Webhooks'));
+      await authedPage.waitForURL(expectedURL);
+      await expect.soft(authedPage).toHaveTitle(BasePage.getTitle('Webhooks'));
     });
 
     await test.step('Navigate to Cluster', async () => {
       await userManagementPage.nav.sidebar.cluster.pwLocator.click();
       const expectedURL = /clusters/;
-      await page.waitForURL(expectedURL);
-      await expect.soft(page).toHaveTitle(BasePage.getTitle('Cluster'));
+      await authedPage.waitForURL(expectedURL);
+      await expect.soft(authedPage).toHaveTitle(BasePage.getTitle('Cluster'));
     });
 
     await test.step('Navigate to Workspaces', async () => {
-      const workspacesPage = new Workspaces(page);
+      const workspacesPage = new Workspaces(authedPage);
       await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
-      await page.waitForURL(workspacesPage.getUrlRegExp());
-      await expect.soft(page).toHaveTitle(workspacesPage.title);
+      await authedPage.waitForURL(workspacesPage.getUrlRegExp());
+      await expect.soft(authedPage).toHaveTitle(workspacesPage.title);
     });
 
     await test.step('Navigate to Admin', async () => {
@@ -74,9 +71,9 @@ test.describe('Navigation', () => {
 
     await test.step('Navigate to Logout', async () => {
       await auth.logout();
-      const signInPage = new SignIn(page);
-      await expect.soft(page).toHaveTitle(signInPage.title);
-      await expect.soft(page).toHaveURL(signInPage.getUrlRegExp());
+      const signInPage = new SignIn(authedPage);
+      await expect.soft(authedPage).toHaveTitle(signInPage.title);
+      await expect.soft(authedPage).toHaveURL(signInPage.getUrlRegExp());
     });
   });
 });

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -7,7 +7,6 @@ import { Workspaces } from 'e2e/models/pages/Workspaces';
 import { expect } from '@playwright/test';
 
 test.describe('Navigation', () => {
-  const USERNAME = process.env.PW_USER_NAME ?? '';
 
   test('Sidebar Navigation', async ({ authedPage, auth }) => {
     // we need any page to access the sidebar, and i haven't modeled the homepage yet
@@ -28,8 +27,8 @@ test.describe('Navigation', () => {
 
     await test.step('Navigate to Model Registry', async () => {
       await userManagementPage.nav.sidebar.modelRegistry.pwLocator.click();
-      await page.waitForURL(/models/);
-      await expect.soft(page).toHaveTitle(BasePage.getTitle('Model Registry'));
+      await authedPage.waitForURL(/models/);
+      await expect.soft(authedPage).toHaveTitle(BasePage.getTitle('Model Registry'));
     });
 
     await test.step('Navigate to Tasks', async () => {
@@ -61,11 +60,11 @@ test.describe('Navigation', () => {
     });
 
     await test.step('Navigate to Admin', async () => {
-      const userManagementPage = new UserManagement(page);
+      const userManagementPage = new UserManagement(authedPage);
       await userManagementPage.nav.sidebar.headerDropdown.pwLocator.click();
       await userManagementPage.nav.sidebar.headerDropdown.admin.pwLocator.click();
-      await page.waitForURL(userManagementPage.getUrlRegExp());
-      await expect.soft(page).toHaveTitle(userManagementPage.title);
+      await authedPage.waitForURL(userManagementPage.getUrlRegExp());
+      await expect.soft(authedPage).toHaveTitle(userManagementPage.title);
     });
 
     await test.step('Navigate to Logout', async () => {

--- a/webui/react/src/e2e/tests/navigation.spec.ts
+++ b/webui/react/src/e2e/tests/navigation.spec.ts
@@ -9,7 +9,6 @@ import { expect } from '@playwright/test';
 test.describe('Navigation', () => {
   const USERNAME = process.env.PW_USER_NAME ?? '';
 
-
   test('Sidebar Navigation', async ({ authedPage, auth }) => {
     // we need any page to access the sidebar, and i haven't modeled the homepage yet
     const userManagementPage = new UserManagement(authedPage);

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -38,13 +38,12 @@ test.describe('Projects', () => {
     return fullName;
   };
 
-  test.beforeEach(async ({ dev, authedPage }) => {
-    await dev.setServerAddress();
+  test.beforeEach(async ({ authedPage }) => {
     await expect(authedPage).toHaveTitle(BasePage.getTitle('Home'));
     await expect(authedPage).toHaveURL(/dashboard/);
   });
 
-  test.afterEach(async ({ apiAuth, page: authedPage }) => {
+  test.afterEach(async ( { authedPage }) => {
     const workspacesPage = new Workspaces(authedPage);
     await test.step('Delete a workspace', async () => {
       if (wsCreatedWithButton !== '') {
@@ -68,10 +67,9 @@ test.describe('Projects', () => {
         await workspacesPage.deleteModal.footer.submit.pwLocator.click();
       }
     });
-    await apiAuth.logout();
   });
 
-  test('Projects and Workspaces CRUD', async ({ page: authedPage }) => {
+  test('Projects and Workspaces CRUD', async ({ authedPage }) => {
     const workspacesPage = new Workspaces(authedPage);
 
     await test.step('Navigate to Workspaces', async () => {

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -1,10 +1,13 @@
-import { expect } from '@playwright/test';
-
 import { test } from 'e2e/fixtures/global-fixtures';
 import { BasePage } from 'e2e/models/BasePage';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
-import { randId, safeName } from 'e2e/utils/naming';
+import {
+  randId,
+  safeName,
+} from 'e2e/utils/naming';
+
+import { expect } from '@playwright/test';
 
 test.describe('Projects', () => {
   test.setTimeout(120_000);
@@ -35,15 +38,14 @@ test.describe('Projects', () => {
     return fullName;
   };
 
-  test.beforeEach(async ({ dev, auth, page }) => {
+  test.beforeEach(async ({ dev, authedPage }) => {
     await dev.setServerAddress();
-    await auth.login();
-    await expect(page).toHaveTitle(BasePage.getTitle('Home'));
-    await expect(page).toHaveURL(/dashboard/);
+    await expect(authedPage).toHaveTitle(BasePage.getTitle('Home'));
+    await expect(authedPage).toHaveURL(/dashboard/);
   });
 
-  test.afterEach(async ({ page }) => {
-    const workspacesPage = new Workspaces(page);
+  test.afterEach(async ({ apiAuth, page: authedPage }) => {
+    const workspacesPage = new Workspaces(authedPage);
     await test.step('Delete a workspace', async () => {
       if (wsCreatedWithButton !== '') {
         await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
@@ -66,15 +68,16 @@ test.describe('Projects', () => {
         await workspacesPage.deleteModal.footer.submit.pwLocator.click();
       }
     });
+    await apiAuth.logout();
   });
 
-  test('Projects and Workspaces CRUD', async ({ page }) => {
-    const workspacesPage = new Workspaces(page);
+  test('Projects and Workspaces CRUD', async ({ page: authedPage }) => {
+    const workspacesPage = new Workspaces(authedPage);
 
     await test.step('Navigate to Workspaces', async () => {
       await workspacesPage.nav.sidebar.workspaces.pwLocator.click();
-      await page.waitForURL(`**/${workspacesPage.url}?**`); // glob pattern for query params
-      await expect.soft(page).toHaveTitle(workspacesPage.title);
+      await authedPage.waitForURL(`**/${workspacesPage.url}?**`); // glob pattern for query params
+      await expect.soft(authedPage).toHaveTitle(workspacesPage.title);
     });
 
     await test.step('Create a workspace', async () => {

--- a/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
+++ b/webui/react/src/e2e/tests/projectsWorkspaces.spec.ts
@@ -1,13 +1,10 @@
+import { expect } from '@playwright/test';
+
 import { test } from 'e2e/fixtures/global-fixtures';
 import { BasePage } from 'e2e/models/BasePage';
 import { WorkspaceCreateModal } from 'e2e/models/components/WorkspaceCreateModal';
 import { Workspaces } from 'e2e/models/pages/Workspaces';
-import {
-  randId,
-  safeName,
-} from 'e2e/utils/naming';
-
-import { expect } from '@playwright/test';
+import { randId, safeName } from 'e2e/utils/naming';
 
 test.describe('Projects', () => {
   test.setTimeout(120_000);
@@ -43,7 +40,7 @@ test.describe('Projects', () => {
     await expect(authedPage).toHaveURL(/dashboard/);
   });
 
-  test.afterEach(async ( { authedPage }) => {
+  test.afterEach(async ({ authedPage }) => {
     const workspacesPage = new Workspaces(authedPage);
     await test.step('Delete a workspace', async () => {
       if (wsCreatedWithButton !== '') {


### PR DESCRIPTION
## test: log in with the api rather than through the UI for most react tests

## Ticket
infeng-671


## Description
Previously for all our tests we logged in by navigating to the UI and logging in. It will be faster and have less code to just auto-login through the API and apply the cookie to the browser.

More stuff coming in user management with the next ticket, but this is a self-contained start.

## Test Plan
ran manually and CI should pass.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ