### PR TITLE
ci: don't run test-e2e-longrunning tests on main

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4797,18 +4797,19 @@ workflows:
     jobs:
       # Build and publish artifacts used in tests
       - build-helm:
-          filters: *any-upstream
+          filters: *upstream-feature-branch
       - build-proto:
-          filters: *any-upstream
+          filters: *upstream-feature-branch
       - build-react:
           dev-mode: true
-          filters: *any-upstream
+          filters: *upstream-feature-branch
       - build-docs:
-          filters: *any-upstream
+          filters: *upstream-feature-branch
           requires:
             - build-helm
             - build-proto
       - build-go:
+          filters: *upstream-feature-branch
           context: github-read
       - package-and-push-system-dev-ee:
           requires:
@@ -4817,7 +4818,7 @@ workflows:
           context:
             - determined-ee
             - github-read
-          filters: *any-upstream
+          filters: *upstream-feature-branch
 
       - package-and-push-system-local:
           context: github-read
@@ -5196,6 +5197,7 @@ workflows:
 
       - test-e2e-slurm:
           name: test-e2e-slurm-misconfigured
+          filters: *upstream-feature-branch
           slack-mentions: "${SLACK_USER_ID}"
           requires:
             - package-and-push-system-local-ee
@@ -5240,6 +5242,7 @@ workflows:
 
       - test-e2e-slurm:
           name: test-e2e-slurm-gpu
+          filters: *upstream-feature-branch
           slack-mentions: "${SLACK_USER_ID}"
           mark: "e2e_slurm_gpu"
           requires:
@@ -5248,6 +5251,7 @@ workflows:
 
       # Singularity over SLURM test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5263,6 +5267,7 @@ workflows:
 
       # Podman over SLURM test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5279,6 +5284,7 @@ workflows:
 
       # Enroot over SLURM test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5295,6 +5301,7 @@ workflows:
 
       # Singularity over PBS test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5311,6 +5318,7 @@ workflows:
 
       # Podman over PBS test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5329,6 +5337,7 @@ workflows:
 
       # Enroot over PBS test on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.
@@ -5346,6 +5355,7 @@ workflows:
 
       # Podman over SLURM test using Agent on GCP
       - test-e2e-hpc-gcp:
+          filters: *upstream-feature-branch
           context:
             # Provides the GITHUB_USERNAME and GITHUB_TOKEN enviroment variable
             # that's required by the "gh" command for authentication.


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

test-e2e workflows will already have them. test-e2e-longrunning is pure duplication on main. 


## Test Plan

See if main is still running these after this lands


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ