### PR TITLE
feat: require initial passwords on new cluster-up [DET-10197]

### DIFF
--- a/.circleci/devcluster/custom-agent-version.devcluster.yaml
+++ b/.circleci/devcluster/custom-agent-version.devcluster.yaml
@@ -6,6 +6,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/double-priority.devcluster.yaml
+++ b/.circleci/devcluster/double-priority.devcluster.yaml
@@ -23,6 +23,7 @@ stages:
           cache_dir: /tmp/determined-cache
         launch_error: false
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
         resource_manager:

--- a/.circleci/devcluster/double-reattach.devcluster.yaml
+++ b/.circleci/devcluster/double-reattach.devcluster.yaml
@@ -6,6 +6,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/double.devcluster.yaml
+++ b/.circleci/devcluster/double.devcluster.yaml
@@ -23,6 +23,7 @@ stages:
           cache_dir: /tmp/determined-cache
         launch_error: false
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
         resource_manager:

--- a/.circleci/devcluster/elastic.devcluster.yaml
+++ b/.circleci/devcluster/elastic.devcluster.yaml
@@ -9,6 +9,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/multi-k8s.devcluster.yaml
+++ b/.circleci/devcluster/multi-k8s.devcluster.yaml
@@ -9,6 +9,8 @@ stages:
         - sh: cp ~/.kube/config /tmp/defaultrm-kubeconf && kubectl config use-context defaultrm --kubeconfig=/tmp/defaultrm-kubeconf
         - sh: cp ~/.kube/config /tmp/additionalrm-kubeconf && kubectl config use-context additionalrm --kubeconfig=/tmp/additionalrm-kubeconf
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/oauth.devcluster.yaml
+++ b/.circleci/devcluster/oauth.devcluster.yaml
@@ -26,6 +26,7 @@ stages:
         cache: 
           cache_dir: /tmp/determined-cache
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
 

--- a/.circleci/devcluster/perftest.devcluster.yaml
+++ b/.circleci/devcluster/perftest.devcluster.yaml
@@ -21,6 +21,7 @@ stages:
           cache_dir: /tmp/determined-cache
         launch_error: false
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
         resource_manager:

--- a/.circleci/devcluster/port-registry.devcluster.yaml
+++ b/.circleci/devcluster/port-registry.devcluster.yaml
@@ -6,6 +6,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/postgres-with-ssl.devcluster.yaml
+++ b/.circleci/devcluster/postgres-with-ssl.devcluster.yaml
@@ -51,6 +51,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         db:
           host: localhost
           port: 5432

--- a/.circleci/devcluster/priority.devcluster.yaml
+++ b/.circleci/devcluster/priority.devcluster.yaml
@@ -15,6 +15,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         port: 8082
         db:
           host: localhost

--- a/.circleci/devcluster/rbac-model-registry.yaml
+++ b/.circleci/devcluster/rbac-model-registry.yaml
@@ -22,6 +22,7 @@ stages:
         cache: 
           cache_dir: /tmp/determined-cache
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
             type: rbac

--- a/.circleci/devcluster/react.devcluster.yaml
+++ b/.circleci/devcluster/react.devcluster.yaml
@@ -8,6 +8,8 @@ stages:
       pre:
         - sh: make -C tools prep-root
       config_file:
+        security:
+          initial_user_password: $INITIAL_USER_PASSWORD
         port: 8082
         db:
           host: localhost

--- a/.circleci/devcluster/saml.devcluster.yaml
+++ b/.circleci/devcluster/saml.devcluster.yaml
@@ -23,6 +23,7 @@ stages:
           cache_dir: /tmp/determined-cache
         launch_error: false
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             rbac_ui_enabled: true
         resource_manager:

--- a/.circleci/devcluster/single-rbac.devcluster.yaml
+++ b/.circleci/devcluster/single-rbac.devcluster.yaml
@@ -22,6 +22,7 @@ stages:
         cache: 
           cache_dir: /tmp/determined-cache
         security:
+          initial_user_password: $INITIAL_USER_PASSWORD
           authz:
             type: rbac
             rbac_ui_enabled: true

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2025,9 +2025,9 @@ jobs:
           port: "8082"
       - run:
           environment:
-            PW_PASSWORD: ${INITIAL_USER_PASSWORD} # temporary until DET-10197 is merged and we can set PW_PASSWORD in circleci
             PW_EE: << parameters.ee >>
-          command: npm run e2e --prefix webui/react -- << parameters.playwright-options >>
+          # setting PW_PASSWORD is temporary until DET-10197 is merged and we can set PW_PASSWORD in circleci
+          command: PW_PASSWORD=${INITIAL_USER_PASSWORD} npm run e2e --prefix webui/react -- << parameters.playwright-options >>
       - store_artifacts:
           path: webui/react/src/e2e/playwright-report
       - store_artifacts:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -5518,6 +5518,7 @@ workflows:
           context:
             - playwright
             - github-read
+            - dev-ci-cluster-default-user-credentials
 
   release:
     jobs:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4107,6 +4107,7 @@ workflows:
           context:
             - playwright
             - github-read
+            - dev-ci-cluster-default-user-credentials
           filters: *any-upstream
       - build-docs:
           requires:
@@ -4195,6 +4196,7 @@ workflows:
           context:
             - playwright
             - github-read
+            - dev-ci-cluster-default-user-credentials
           filters: *any-upstream
       - build-docs:
           requires:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2025,6 +2025,7 @@ jobs:
           port: "8082"
       - run:
           environment:
+            PW_PASSWORD: ${INITIAL_USER_PASSWORD} # temporary until DET-10197 is merged and we can set PW_PASSWORD in circleci
             PW_EE: << parameters.ee >>
           command: npm run e2e --prefix webui/react -- << parameters.playwright-options >>
       - store_artifacts:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4442,6 +4442,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-rbac
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4450,6 +4452,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-cpu
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 6
@@ -4459,6 +4463,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-cpu-double
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 5
@@ -4470,6 +4476,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-cpu-oauth
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4479,6 +4487,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4488,6 +4498,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-managed-devcluster
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 4
@@ -4501,6 +4513,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-multi-k8s
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4512,6 +4526,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-port-registry
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4521,6 +4537,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-cpu-elastic
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4531,6 +4549,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4541,6 +4561,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4551,6 +4573,8 @@ workflows:
 
       - test-e2e:
           name: test-e2e-old-agent-versions
+          context:
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1
@@ -4573,8 +4597,10 @@ workflows:
           extra-pytest-flags: "--no-compare-stats"
 
       - test-e2e:
-          context: okta
           name: test-e2e-saml
+          context:
+            - okta
+            - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
           parallelism: 1

--- a/docs/release-notes/cli-requires-initial-password.rst
+++ b/docs/release-notes/cli-requires-initial-password.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+**Breaking Changes**
+
+-  master: on new deployments, the service will log an error and abort startup if no
+   initialUserPassword is found in config.
+
+To allow users to continue leaning on other reasonable default settings with CLI commands like `det
+deploy local cluster-up`, an --initial-user-password flag is provided.

--- a/docs/release-notes/cli-requires-initial-password.rst
+++ b/docs/release-notes/cli-requires-initial-password.rst
@@ -1,9 +1,9 @@
 :orphan:
 
-**Breaking Changes**
+Breaking Changes
 
--  master: on new deployments, the service will log an error and abort startup if no
-   initialUserPassword is found in config.
+-  Master: On new deployments, the service will log an error and abort startup if no
+   ``initialUserPassword`` is found in the configuration.
 
-To allow users to continue leaning on other reasonable default settings with CLI commands like `det
-deploy local cluster-up`, an --initial-user-password flag is provided.
+To ensure users can still rely on reasonable default settings with CLI commands like ``det deploy
+local cluster-up``, an ``--initial-user-password`` flag is now provided.

--- a/e2e_tests/tests/cluster/test_users.py
+++ b/e2e_tests/tests/cluster/test_users.py
@@ -113,7 +113,7 @@ def test_create_user_sdk() -> None:
 @pytest.mark.e2e_cpu
 def test_logout() -> None:
     # Make sure that a logged out session cannot be reused.
-    sess = api_utils.make_session("determined", "")
+    sess = api_utils.make_session("determined", conf.USER_PASSWORD)
 
     bindings.post_Logout(sess)
     with pytest.raises(errors.UnauthenticatedException):

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -55,6 +55,7 @@ def test_run_custom_searcher_experiment(tmp_path: pathlib.Path) -> None:
 @pytest.mark.e2e_cpu_2a
 def test_run_random_searcher_exp() -> None:
     sess = api_utils.user_session()
+    client._determined = client.Determined._from_session(sess)
     config = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
     config["searcher"] = {
         "name": "custom",

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -33,6 +33,7 @@ def check_trial_state(
 @pytest.mark.e2e_cpu
 def test_run_custom_searcher_experiment(tmp_path: pathlib.Path) -> None:
     sess = api_utils.user_session()
+    client._determined = client.Determined._from_session(sess)
     # example searcher script
     config = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
     config["searcher"] = {

--- a/e2e_tests/tests/experiment/test_custom_searcher.py
+++ b/e2e_tests/tests/experiment/test_custom_searcher.py
@@ -44,7 +44,7 @@ def test_run_custom_searcher_experiment(tmp_path: pathlib.Path) -> None:
     config["name"] = "single"
     config["description"] = "custom searcher"
     search_method = searchers.SingleSearchMethod(config, 500)
-    search_runner = searcher.LocalSearchRunner(search_method, tmp_path)
+    search_runner = searcher.LocalSearchRunner(search_method, tmp_path, session=sess)
     experiment_id = search_runner.run(config, model_dir=conf.fixtures_path("no_op"))
 
     assert client._determined is not None
@@ -73,7 +73,9 @@ def test_run_random_searcher_exp() -> None:
         search_method = searchers.RandomSearchMethod(
             max_trials, max_concurrent_trials, max_length, test_type="noop"
         )
-        search_runner = searcher.LocalSearchRunner(search_method, pathlib.Path(searcher_dir))
+        search_runner = searcher.LocalSearchRunner(
+            search_method, pathlib.Path(searcher_dir), session=sess
+        )
         experiment_id = search_runner.run(config, model_dir=conf.fixtures_path("no_op"))
 
     response = bindings.get_GetExperiment(sess, experimentId=experiment_id)
@@ -291,7 +293,9 @@ def test_resume_random_searcher_exp(exceptions: List[str]) -> None:
         search_method = searchers.RandomSearchMethod(
             max_trials, max_concurrent_trials, max_length, test_type="noop"
         )
-        search_runner = searcher.LocalSearchRunner(search_method, pathlib.Path(searcher_dir))
+        search_runner = searcher.LocalSearchRunner(
+            search_method, pathlib.Path(searcher_dir), session=sess
+        )
         experiment_id = search_runner.run(config, model_dir=conf.fixtures_path("no_op"))
 
     assert search_runner.state.last_event_id == 41

--- a/e2e_tests/tests/experiment/test_unmanaged.py
+++ b/e2e_tests/tests/experiment/test_unmanaged.py
@@ -18,6 +18,8 @@ def _run_unmanaged_script(cmd: List, env_to_add: Optional[dict] = None) -> None:
     master_url = conf.make_master_url()
     env = os.environ.copy()
     env["DET_MASTER"] = master_url
+    env["DET_USER"] = "determined"
+    env["DET_PASS"] = conf.USER_PASSWORD
 
     if env_to_add is not None:
         env.update(env_to_add)

--- a/harness/determined/deploy/local/cli.py
+++ b/harness/determined/deploy/local/cli.py
@@ -20,6 +20,7 @@ def handle_cluster_up(args: argparse.Namespace) -> None:
     cluster_utils.cluster_up(
         num_agents=args.agents,
         port=args.master_port,
+        initial_user_password=args.initial_user_password,
         master_config_path=args.master_config_path,
         storage_host_path=args.storage_host_path,
         cluster_name=args.cluster_name,
@@ -49,6 +50,7 @@ def handle_master_up(args: argparse.Namespace) -> None:
 
     cluster_utils.master_up(
         port=args.master_port,
+        initial_user_password=args.initial_user_password,
         master_config_path=args.master_config_path,
         storage_host_path=args.storage_host_path,
         master_name=args.master_name,
@@ -132,6 +134,12 @@ args_description = cli.Cmd(
                         default=None,
                         help="Storage location for cluster data (e.g. checkpoints)",
                     ),
+                ),
+                cli.Arg(
+                    "--initial-user-password",
+                    type=str,
+                    default=None,
+                    help="Initial password for admin/determined users",
                 ),
                 cli.Arg(
                     "--agents",
@@ -229,6 +237,12 @@ args_description = cli.Cmd(
                         default=None,
                         help="Storage location for cluster data (e.g. checkpoints)",
                     ),
+                ),
+                cli.Arg(
+                    "--initial-user-password",
+                    type=str,
+                    default=None,
+                    help="Initial password for admin/determined users",
                 ),
                 cli.Arg(
                     "--master-port",

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -140,6 +140,7 @@ def _wait_for_container(container_name: str, timeout: int = 100) -> None:
 
 def master_up(
     port: int,
+    initial_user_password: Optional[str],
     master_config_path: Optional[pathlib.Path],
     storage_host_path: pathlib.Path,
     master_name: Optional[str],
@@ -163,6 +164,13 @@ def master_up(
             master_conf = util.yaml_safe_load(f)
     else:
         master_conf = MASTER_CONF_DEFAULT
+        make_temp_conf = True
+
+    if master_conf.get("security") is None:
+        master_conf["security"] = {}
+
+    if initial_user_password is not None:
+        master_conf["security"]["initial_user_password"] = initial_user_password
         make_temp_conf = True
 
     if storage_host_path is not None:
@@ -343,6 +351,7 @@ def remove_network(network_name: str) -> None:
 def cluster_up(
     num_agents: int,
     port: int,
+    initial_user_password: Optional[str],
     master_config_path: Optional[pathlib.Path],
     storage_host_path: pathlib.Path,
     cluster_name: str,
@@ -358,6 +367,7 @@ def cluster_up(
     cluster_down(cluster_name, delete_db)
     master_up(
         port=port,
+        initial_user_password=initial_user_password,
         master_config_path=master_config_path,
         storage_host_path=storage_host_path,
         master_name=f"{cluster_name}_{MASTER_NAME}",

--- a/harness/determined/searcher/_search_runner.py
+++ b/harness/determined/searcher/_search_runner.py
@@ -254,7 +254,7 @@ class LocalSearchRunner(SearchRunner):
         self,
         search_method: searcher.SearchMethod,
         searcher_dir: Optional[pathlib.Path] = None,
-        session: api.Session = None,
+        session: Optional[api.Session] = None,
     ):
         super().__init__(search_method)
         self.state_path = None
@@ -312,8 +312,9 @@ class LocalSearchRunner(SearchRunner):
         # TODO: remove typing suppression when mypy #14473 is resolved
         client._require_singleton(lambda: None)()  # type: ignore
         assert client._determined is not None
-        session = self.session
-        if not session:
+        if self.session:
+            session = self.session
+        else:
             session = client._determined._session
         self.run_experiment(experiment_id, session, operations)
         return experiment_id

--- a/harness/determined/searcher/_search_runner.py
+++ b/harness/determined/searcher/_search_runner.py
@@ -254,9 +254,11 @@ class LocalSearchRunner(SearchRunner):
         self,
         search_method: searcher.SearchMethod,
         searcher_dir: Optional[pathlib.Path] = None,
+        session: api.Session = None,
     ):
         super().__init__(search_method)
         self.state_path = None
+        self.session = session
 
         self.searcher_dir = searcher_dir or pathlib.Path.cwd()
         if not self.searcher_dir.exists():
@@ -310,7 +312,9 @@ class LocalSearchRunner(SearchRunner):
         # TODO: remove typing suppression when mypy #14473 is resolved
         client._require_singleton(lambda: None)()  # type: ignore
         assert client._determined is not None
-        session = client._determined._session
+        session = self.session
+        if not session:
+            session = client._determined._session
         self.run_experiment(experiment_id, session, operations)
         return experiment_id
 

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1142,16 +1142,17 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	}
 
 	if isBrandNewCluster {
-		if password := m.config.Security.InitialUserPassword; password == "" {
-			log.Warn("This cluster was deployed without a default password for the built-in `determined` " +
+		password := m.config.Security.InitialUserPassword
+		if password == "" {
+			log.Error("This cluster was deployed without a default password for the built-in `determined` " +
 				"and `admin` users. You should set one using `det user change-password`. New clusters can be " +
 				"deployed with default passwords set using the `security.initial_user_password` setting.")
-		} else {
-			for _, username := range user.BuiltInUsers {
-				err := user.SetUserPassword(ctx, username, password)
-				if err != nil {
-					return fmt.Errorf("could not update default user password: %w", err)
-				}
+			return errors.New("could not deploy without default password")
+		}
+		for _, username := range user.BuiltInUsers {
+			err := user.SetUserPassword(ctx, username, password)
+			if err != nil {
+				return fmt.Errorf("could not update default user password: %w", err)
 			}
 		}
 	}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1144,8 +1144,8 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 	if isBrandNewCluster {
 		password := m.config.Security.InitialUserPassword
 		if password == "" {
-			log.Error("This cluster was deployed without a default password for the built-in `determined` " +
-				"and `admin` users. New clusters can be deployed with default passwords set using the " +
+			log.Error("This cluster was deployed without an initial password for the built-in `determined` " +
+				"and `admin` users. New clusters can be deployed with initial passwords set using the " +
 				"`security.initial_user_password` setting.")
 			return errors.New("could not deploy without default password")
 		}

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1145,8 +1145,8 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 		password := m.config.Security.InitialUserPassword
 		if password == "" {
 			log.Error("This cluster was deployed without a default password for the built-in `determined` " +
-				"and `admin` users. You should set one using `det user change-password`. New clusters can be " +
-				"deployed with default passwords set using the `security.initial_user_password` setting.")
+				"and `admin` users. New clusters can be deployed with default passwords set using the " +
+				"`security.initial_user_password` setting.")
 			return errors.New("could not deploy without default password")
 		}
 		for _, username := range user.BuiltInUsers {

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1147,7 +1147,7 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 			log.Error("This cluster was deployed without an initial password for the built-in `determined` " +
 				"and `admin` users. New clusters can be deployed with initial passwords set using the " +
 				"`security.initial_user_password` setting.")
-			return errors.New("could not deploy without default password")
+			return errors.New("could not deploy without initial password")
 		}
 		for _, username := range user.BuiltInUsers {
 			err := user.SetUserPassword(ctx, username, password)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10197]

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
BREAKING CHANGE: on new deployments, `master` will log an error and abort startup if no `initialUserPassword` is found in config.

To allow users to continue leaning on other reasonable default settings with something like `det deploy local cluster-up`, an `--initial-user-password` flag is provided in the CLI.

Unlike helm, these commands tend to be fairly fast and transparent -- they only try to start master once, and if it errors out, they dump the logs, so the error message details are pretty visible and easy to fix.

Scenarios I've manually tested:
- Launch a new cluster with `det deploy local cluster-up` not providing a password (fails to start)
- Launch a new cluster with `det deploy local cluster-up --initial-user-password='TestPassword1'` (works)
- Launch the local cluster not providing a password, after it has already started before (works)
- Delete the old cluster, database, and volume backup, then launch new cluster with `TestPassword2` in master config file (works)

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
e2e tests have been updated as part of this, so manual release party testing is most likely not required.

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10197]: https://hpe-aiatscale.atlassian.net/browse/DET-10197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ