### PR TITLE
docs: Reformat grid tables

### DIFF
--- a/docs/model-dev-guide/prepare-container/custom-env.rst
+++ b/docs/model-dev-guide/prepare-container/custom-env.rst
@@ -98,15 +98,18 @@ GPU-specific versions of each library are automatically selected when running on
 Default Images
 ==============
 
-+-------------+-------------------------------------------------------------------------------+
-| Environment | File Name                                                                     |
-+=============+===============================================================================+
-| CPUs        | ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``                           |
-+-------------+-------------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``                          |
-+-------------+-------------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4``        |
-+-------------+-------------------------------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   -  -  Environment
+      -  File Name
+   -  -  CPUs
+      -  ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``
+   -  -  NVIDIA GPUs
+      -  ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``
+   -  -  AMD GPUs
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-0.26.4``
 
 .. _custom-docker-images:
 

--- a/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/deploy-cluster/slurm/singularity.rst
@@ -4,6 +4,9 @@
  Provide a Container Image Cache
 #################################
 
+This page intentionally duplicates :ref:`slurm-image-config`. For the most recent updates, visit
+:ref:`slurm-image-config`.
+
 When the cluster does not have Internet access or if you want to provide a local cache of container
 images to improve performance, you can download the desired container images to a shared directory
 and then reference them using file system paths instead of Docker registry references.
@@ -23,15 +26,18 @@ container runtime in use.
 Each version of Determined utilizes specifically-tagged Docker containers. The image tags referenced
 by default in this version of Determined are described below.
 
-+-------------+--------------------------------------------------------------------------+
-| Environment | File Name                                                                |
-+=============+==========================================================================+
-| CPUs        | ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``                      |
-+-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``                     |
-+-------------+--------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
-+-------------+--------------------------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   -  -  Environment
+      -  File Name
+   -  -  CPUs
+      -  ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``
+   -  -  NVIDIA GPUs
+      -  ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``
+   -  -  AMD GPUs
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``
 
 See :ref:`set-environment-images` for the images Docker Hub location, and add each tagged image
 needed by your experiments to the image cache.

--- a/docs/setup-cluster/slurm/singularity.rst
+++ b/docs/setup-cluster/slurm/singularity.rst
@@ -23,15 +23,18 @@ container runtime in use.
 Each version of Determined utilizes specifically-tagged Docker containers. The image tags referenced
 by default in this version of Determined are described below.
 
-+-------------+--------------------------------------------------------------------------+
-| Environment | File Name                                                                |
-+=============+==========================================================================+
-| CPUs        | ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``                      |
-+-------------+--------------------------------------------------------------------------+
-| NVIDIA GPUs | ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``                     |
-+-------------+--------------------------------------------------------------------------+
-| AMD GPUs    | ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``  |
-+-------------+--------------------------------------------------------------------------+
+.. list-table::
+   :widths: 25 75
+   :header-rows: 1
+
+   -  -  Environment
+      -  File Name
+   -  -  CPUs
+      -  ``determinedai/pytorch-tensorflow-cpu-dev:8b3bea3``
+   -  -  NVIDIA GPUs
+      -  ``determinedai/pytorch-tensorflow-cuda-dev:8b3bea3``
+   -  -  AMD GPUs
+      -  ``determinedai/environments:rocm-5.0-pytorch-1.10-tf-2.7-rocm-622d512``
 
 See :ref:`set-environment-images` for the images Docker Hub location, and add each tagged image
 needed by your experiments to the image cache.


### PR DESCRIPTION
## Description

- switch from grid to list
 - list is more tolerant of content changes
 - help prevent having to perform manual intervention when running bumpenvs process

## Note

**Singularity**

The duplicated page `deploy-cluster/slurm/singularity.rst` is meant to be a copy of `slurm/singularity.rst`, and so the default docker image table has been updated in both to match `slurm/singularity.rst`.

There are duplicates of the `singularity.rst` page because moving the page from `deploy-cluster/slurm/singularity.rst` to `slurm/singularity.rst` breaks the bumpenvs process noted in #8180 .