### PR TITLE
fix: det ckpt download from s3.

### DIFF
--- a/harness/determined/common/storage/boto3_credential_manager.py
+++ b/harness/determined/common/storage/boto3_credential_manager.py
@@ -45,13 +45,13 @@ class RefreshableSharedCredentials(credentials.Credentials):  # type: ignore
         self._load_and_set_credentials()
 
     def _load_and_set_credentials(self) -> None:
-        credentials = self._credentials_provider.load()
+        creds = self._credentials_provider.load()
         self._last_loaded = self._credentials_modified_time()
-        self.access_key = credentials.access_key
-        self.secret_key = credentials.secret_key
-        self.token = credentials.token
+        self.access_key = creds.access_key
+        self.secret_key = creds.secret_key
+        self.token = creds.token
         self._frozen_credentials = credentials.ReadOnlyCredentials(
-            credentials.access_key, credentials.secret_key, credentials.token
+            creds.access_key, creds.secret_key, creds.token
         )
 
     def _credentials_file(self) -> Any:


### PR DESCRIPTION
## Description

`det checkpoint download` for s3 backends was failing to some attribute error due to bad imports refactoring.

## Test Plan

Run `det checkpoint download <ckpt uuid>` against a checkpoint on s3.
Bug to add an autotest: https://hpe-aiatscale.atlassian.net/browse/MD-408

## Checklist

- [x] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ