### PR TITLE
chore: remove step for authenticated master session check to use standard script

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3774,16 +3774,6 @@ jobs:
           name: Set initial user password
           command: |
             echo "export INITIAL_USER_PASSWORD=${INITIAL_USER_PASSWORD}" >> $BASH_ENV
-      - run:
-          name: Wait for master connection
-          command: |
-            set +o pipefail
-            export DET_USER=admin DET_PASS=${INITIAL_USER_PASSWORD}
-            export DET_MASTER_TLS_CERT=${MASTER_TLS_CERT} DET_MASTER_CERT_NAME=${MASTER_CERT_NAME}
-            for i in {1..10}; do
-              yes | det -m https://${MASTER_HOST}:${MASTER_PORT} user whoami | grep "logged in" && break || \
-              echo "Trying to connect to master host again in 5 seconds" && sleep 5
-            done
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: ${MASTER_HOST}
@@ -3791,7 +3781,7 @@ jobs:
           master-port: ${MASTER_PORT:-8080}
           master-cert: ${MASTER_TLS_CERT}
           master-cert-name: ${MASTER_CERT_NAME}
-          wait-for-master: false
+          wait-for-master: true
       - store_test_results:
           path: /tmp/test-results/
 


### PR DESCRIPTION
chore: remove step for authenticated master session check to use standard script

## Ticket
No ticket.

## Description
`test-e2e-gke-shared-cluster` adds a step that waits for the master connection using an authenticated determined session, verifying that valid authenticated requests during the test runs are expected to succeed. 
Remove this step to use the standard script that tests the master connection with an unauth session, as this achieves the main goal of the step, which is to ensure that the master is accessible prior to running test cases.


## Test Plan
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ