### PR TITLE
feat: disableable rbac audit logging

### DIFF
--- a/master/cmd/determined-master/main.go
+++ b/master/cmd/determined-master/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	log "github.com/sirupsen/logrus"
 
+	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/pkg/logger"
 )
 
 func main() {
-	logger.SetLogrus(*logger.DefaultConfig())
+	logger.SetLogrus(*config.DefaultLoggerConfig())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.WithError(err).Fatal("fatal error running Determined master")

--- a/master/internal/config/authz_config.go
+++ b/master/internal/config/authz_config.go
@@ -25,9 +25,10 @@ const (
 
 // AuthZConfig is a authz-related section of master config.
 type AuthZConfig struct {
-	Type          string  `json:"type"`
-	FallbackType  *string `json:"fallback"`
-	RBACUIEnabled *bool   `json:"rbac_ui_enabled"`
+	Type             string  `json:"type"`
+	FallbackType     *string `json:"fallback"`
+	RBACUIEnabled    *bool   `json:"rbac_ui_enabled"`
+	AuditLogDisabled bool    `json:"audit_log_disabled"`
 	// Removed: this option is removed and will not have any effect.
 	StrictNTSCEnabled      bool                         `json:"_strict_ntsc_enabled"`
 	AssignWorkspaceCreator AssignWorkspaceCreatorConfig `json:"workspace_creator_assign_role"`

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/determined-ai/determined/master/pkg/config"
-	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
@@ -94,7 +93,7 @@ type PachydermConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		ConfigFile:            "",
-		Log:                   *logger.DefaultConfig(),
+		Log:                   *DefaultLoggerConfig(),
 		DB:                    *DefaultDBConfig(),
 		TaskContainerDefaults: *model.DefaultTaskContainerDefaults(),
 		TensorBoardTimeout:    5 * 60,
@@ -147,7 +146,7 @@ func DefaultConfig() *Config {
 // environment variables and command line arguments.
 type Config struct {
 	ConfigFile            string                            `json:"config_file"`
-	Log                   logger.Config                     `json:"log"`
+	Log                   LoggerConfig                      `json:"log"`
 	DB                    DBConfig                          `json:"db"`
 	TensorBoardTimeout    int                               `json:"tensorboard_timeout"`
 	NotebookTimeout       *int                              `json:"notebook_timeout"`

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/config/provconfig"
 	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/config"
-	"github.com/determined-ai/determined/master/pkg/logger"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
@@ -87,7 +86,7 @@ integrations:
     address: foo
 `
 	expected := Config{
-		Log: logger.Config{
+		Log: LoggerConfig{
 			Level: "info",
 			Color: false,
 		},
@@ -231,7 +230,7 @@ db:
   port: "3000"
 `
 	expected := Config{
-		Log: logger.Config{
+		Log: LoggerConfig{
 			Level: "info",
 			Color: false,
 		},
@@ -267,7 +266,7 @@ checkpoint_storage:
   bucket: my_bucket
 `
 	expected := Config{
-		Log: logger.Config{
+		Log: LoggerConfig{
 			Level: "info",
 			Color: false,
 		},

--- a/master/internal/config/logger.go
+++ b/master/internal/config/logger.go
@@ -1,0 +1,25 @@
+package config
+
+import "github.com/sirupsen/logrus"
+
+// LoggerConfig is the configuration of logger.
+type LoggerConfig struct {
+	Level string `json:"level"`
+	Color bool   `json:"color"`
+}
+
+// Validate implements the check.Validatable interface.
+func (c LoggerConfig) Validate() []error {
+	if _, err := logrus.ParseLevel(c.Level); err != nil {
+		return []error{err}
+	}
+	return nil
+}
+
+// DefaultLoggerConfig returns the default configuration of logger.
+func DefaultLoggerConfig() *LoggerConfig {
+	return &LoggerConfig{
+		Level: "info",
+		Color: true,
+	}
+}

--- a/master/pkg/logger/config.go
+++ b/master/pkg/logger/config.go
@@ -4,32 +4,12 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/internal/config"
 )
 
-// DefaultConfig returns the default configuration of logger.
-func DefaultConfig() *Config {
-	return &Config{
-		Level: "info",
-		Color: true,
-	}
-}
-
-// Config is the configuration of logger.
-type Config struct {
-	Level string `json:"level"`
-	Color bool   `json:"color"`
-}
-
-// Validate implements the check.Validatable interface.
-func (c Config) Validate() []error {
-	if _, err := logrus.ParseLevel(c.Level); err != nil {
-		return []error{err}
-	}
-	return nil
-}
-
 // SetLogrus sets logrus globally.
-func SetLogrus(c Config) {
+func SetLogrus(c config.LoggerConfig) {
 	level, err := logrus.ParseLevel(c.Level)
 	if err != nil {
 		panic(fmt.Sprintf("invalid log level: %s", c.Level))

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -38,6 +38,11 @@ stages:
 
       # config_file is just a master.yaml
       config_file:
+        # security:
+        #   authz:
+        #     type: rbac
+        #     audit_log_disabled: true
+
         db:
           host: localhost
           port: 5432


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

I got annoyed with how noisy audit logging was, so I added a config for disabling it. Existing configs should work as they did previously, because leaving this unset (or setting it to false) keeps audit logging.

Additionally, I left a commented-out RBAC config in `tools/devcluster.yaml` so people can quickly toggle RBAC during development.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Audit logging should still happen unless it's explicitly disbled in config.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
