### PR TITLE
feat: SDK methods to fetch pachyderm configs [MD-406]

### DIFF
--- a/harness/determined/common/experimental/checkpoint/_checkpoint.py
+++ b/harness/determined/common/experimental/checkpoint/_checkpoint.py
@@ -449,6 +449,23 @@ class Checkpoint:
         for d in resp.metrics:
             yield metrics.TrialMetrics._from_bindings(d, group)
 
+    def get_pachyderm_commit(self) -> str:
+        """Return the Pachyderm commit ID associated with this checkpoint."""
+        if not self.training:
+            # In the case that Checkpoint was constructed manually, reload to populate attributes.
+            self.reload()
+        assert self.training  # for mypy
+
+        try:
+            exp_conf = self.training.experiment_config
+            pachyderm_commit = exp_conf["integrations"]["pachyderm"]["dataset"]["commit"]
+            return str(pachyderm_commit)
+        except (KeyError, TypeError):
+            raise ValueError(
+                f"Pachyderm configuration not found for checkpoint {self.uuid}, "
+                f"experiment {self.training.experiment_id}"
+            )
+
     def __repr__(self) -> str:
         if self.training is not None:
             return (

--- a/harness/determined/common/experimental/experiment.py
+++ b/harness/determined/common/experimental/experiment.py
@@ -633,6 +633,23 @@ class Experiment:
             experimentId=self._id,
         )
 
+    def get_pachyderm_config(self) -> Dict[str, Any]:
+        """Return the Pachyderm configuration for this experiment.
+
+        Pachyderm configs are defined in `integrations.pachyderm` in the experiment config.
+        """
+        if not self.config:
+            # In the case that Experiment was constructed manually, reload to populate attributes.
+            self.reload()
+        assert self.config  # for mypy
+
+        try:
+            pach_config = self.config["integrations"]["pachyderm"]
+            assert pach_config  # for mypy
+            return dict(pach_config)
+        except (KeyError, TypeError):
+            raise ValueError(f"No Pachyderm configuration found for experiment {self.id}.")
+
     def __repr__(self) -> str:
         return "Experiment(id={})".format(self.id)
 

--- a/harness/determined/common/experimental/trial.py
+++ b/harness/determined/common/experimental/trial.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 
 from determined.common import api, util
 from determined.common.api import bindings, logs
-from determined.common.experimental import checkpoint, metrics
+from determined.common.experimental import checkpoint, experiment, metrics
 
 # TODO (MLG-1087): move OrderBy to experimental.client namespace
 from determined.common.experimental._util import OrderBy  # noqa: I2041
@@ -523,6 +523,16 @@ class Trial:
             stacklevel=2,
         )
         return _stream_validation_metrics(self._session, [self.id])
+
+    def get_experiment(self) -> "experiment.Experiment":
+        """Return the parent :class:`~determined.experimental.Experiment` for this trial."""
+        if not self.experiment_id:
+            # In the case that Trial was constructed manually, reload to populate attributes.
+            self.reload()
+
+        assert self.experiment_id  # for mypy
+        resp = bindings.get_GetExperiment(session=self._session, experimentId=self.experiment_id)
+        return experiment.Experiment._from_bindings(resp.experiment, self._session)
 
     @classmethod
     def _from_bindings(cls, trial_bindings: bindings.trialv1Trial, session: api.Session) -> "Trial":


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
We want to expose pachyderm configs from the expconf for pachyderm integrations in the python SDK. These are basically just convenience methods for getting a specific field out of the experiment config. Pachyderm configs were added to the expconf in #8933 and take the following structure:
```
    integrations:
      pachyderm: 
        pachd:
          host: localhost
          port: 80
        proxy:
          scheme: http
          host: localhost
          port: 80
        dataset:
          branch: br
          commit: commit-hash
          project: proj
          repo: repo-name
          token: tkn
```
these are expected to be populated mostly manually by users today



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Submit an experiment that a) has the `integrations: pachyderm` config defined in the expconf, and b) creates at least 1 checkpoint.
For example, using the Core API script at `examples/tutorials/core_api/2_checkpoints.py`, with the following expconf:
`pach.yaml`
```yaml
name: metrics
entrypoint: python3 2_checkpoints.py

searcher:
   name: single
   metric: x
   max_length: 1

max_restarts: 0

integrations:
  pachyderm:
    pachd:
      host: localhost
      port: 80
    proxy:
      scheme: http
      host: localhost
      port: 80
    dataset:
      branch: pach-branch
      commit: test-pach-commit-id-12345
      project: pach-project
      repo: pach-repo
      token: testpachtoken123
```
- after the exp completes, take note of the exp ID and trial ID, then run a script that tests the new python SDK methods:
```
import json

from determined import experimental


DET_MASTER = "XXXXX"
USER = "determined"
PASSWORD = "******"


def main():
    client = experimental.Determined(
        master=DET_MASTER,
        user=USER,
        password=PASSWORD,
    )
    experiment_id = 6503
    trial_id = 44486

    trial = client.get_trial(trial_id=trial_id)
    exp = trial.get_experiment()
    assert exp.id == experiment_id

    pach_conf = exp.get_pachyderm_config()
    print(json.dumps(pach_conf, indent=4))

    ckpt = trial.list_checkpoints()[0]
    print(ckpt.get_pachyderm_commit())


if __name__ == "__main__":
    main()
```
the commit and configs that are printed should match what was submitted in the experiment config.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ