### PR TITLE
fix: remove pod labels with potentially incompatible names

### DIFF
--- a/docs/release-notes/pod-label-bugfix.rst
+++ b/docs/release-notes/pod-label-bugfix.rst
@@ -2,4 +2,4 @@
 
 **Bug Fixes**
 
--  Kubernetes: Remove pod labels that could have characters incompatible with Kubernetes naming requirements. This change will not affect Determined functionality.
+-  Kubernetes: Fix an issue introduced in 0.32.0 where workspaces with names incompatible with Kubernetes naming requirements would cause jobs in that workspace to fail. 

--- a/docs/release-notes/pod-label-bugfix.rst
+++ b/docs/release-notes/pod-label-bugfix.rst
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Fix an issue introduced in 0.32.0 where workspaces with names incompatible with Kubernetes naming requirements would cause jobs in that workspace to fail. 
+-  Kubernetes: Fix an issue introduced in 0.32.0 where workspaces with names incompatible with
+   Kubernetes naming requirements would cause jobs in that workspace to fail.

--- a/docs/release-notes/pod-label-bugfix.rst
+++ b/docs/release-notes/pod-label-bugfix.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Remove pod labels that could have characters incompatible with Kubernetes naming requirements. This change will not affect Determined functionality.

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -368,12 +368,6 @@ func (p *pod) configurePodSpec(
 	if podSpec.ObjectMeta.Labels == nil {
 		podSpec.ObjectMeta.Labels = make(map[string]string)
 	}
-	if p.submissionInfo.taskSpec.Owner != nil {
-		// Owner label will disappear if Owner is somehow nil.
-		podSpec.ObjectMeta.Labels[userLabel] = p.submissionInfo.taskSpec.Owner.Username
-	}
-	podSpec.ObjectMeta.Labels[workspaceLabel] = p.submissionInfo.taskSpec.Workspace
-	podSpec.ObjectMeta.Labels[resourcePoolLabel] = p.req.ResourcePool
 	podSpec.ObjectMeta.Labels[taskTypeLabel] = string(p.submissionInfo.taskSpec.TaskType)
 	podSpec.ObjectMeta.Labels[taskIDLabel] = p.submissionInfo.taskSpec.TaskID
 	podSpec.ObjectMeta.Labels[containerIDLabel] = p.submissionInfo.taskSpec.ContainerID

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -246,13 +246,10 @@ func TestDeterminedLabels(t *testing.T) {
 
 	// define expectations
 	expectedLabels := map[string]string{
-		determinedLabel:   taskSpec.AllocationID,
-		userLabel:         taskSpec.Owner.Username,
-		workspaceLabel:    taskSpec.Workspace,
-		resourcePoolLabel: p.req.ResourcePool,
-		taskTypeLabel:     string(taskSpec.TaskType),
-		taskIDLabel:       taskSpec.TaskID,
-		containerIDLabel:  taskSpec.ContainerID,
+		determinedLabel:  taskSpec.AllocationID,
+		taskTypeLabel:    string(taskSpec.TaskType),
+		taskIDLabel:      taskSpec.TaskID,
+		containerIDLabel: taskSpec.ContainerID,
 	}
 	for k, v := range taskSpec.ExtraPodLabels {
 		expectedLabels[labelPrefix+k] = v


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[RM-278]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-278]: https://hpe-aiatscale.atlassian.net/browse/RM-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ