### PR TITLE
refactor: rename multiRM to more intuitive name

### DIFF
--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -58,7 +58,7 @@ func (m *MultiRMRouter) GetAllocationSummaries() (
 
 // Allocate routes an AllocateRequest to the specified RM.
 func (m *MultiRMRouter) Allocate(req sproto.AllocateRequest) (*sproto.ResourcesSubscription, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (m *MultiRMRouter) Allocate(req sproto.AllocateRequest) (*sproto.ResourcesS
 
 // Release routes an allocation release request.
 func (m *MultiRMRouter) Release(req sproto.ResourcesReleased) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -79,7 +79,7 @@ func (m *MultiRMRouter) Release(req sproto.ResourcesReleased) {
 
 // ValidateResources routes a validation request for a specified resource manager/pool.
 func (m *MultiRMRouter) ValidateResources(req sproto.ValidateResourcesRequest) ([]command.LaunchWarning, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (m *MultiRMRouter) NotifyContainerRunning(req sproto.NotifyContainerRunning
 
 // SetGroupMaxSlots routes a SetGroupMaxSlots request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupMaxSlots(req sproto.SetGroupMaxSlots) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -113,7 +113,7 @@ func (m *MultiRMRouter) SetGroupMaxSlots(req sproto.SetGroupMaxSlots) {
 
 // SetGroupWeight routes a SetGroupWeight request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupWeight(req sproto.SetGroupWeight) error {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (m *MultiRMRouter) SetGroupWeight(req sproto.SetGroupWeight) error {
 
 // SetGroupPriority routes a SetGroupPriority request to a specified resource manager/pool.
 func (m *MultiRMRouter) SetGroupPriority(req sproto.SetGroupPriority) error {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (m *MultiRMRouter) ExternalPreemptionPending(sproto.PendingPreemption) erro
 
 // IsReattachableOnlyAfterStarted routes a IsReattachableOnlyAfterStarted call to a specified resource manager/pool.
 func (m *MultiRMRouter) IsReattachableOnlyAfterStarted() bool {
-	resolvedRMName, err := m.getRM("")
+	resolvedRMName, err := m.getRMName("")
 	if err != nil {
 		m.syslog.WithError(err)
 		return false // Not sure what else to return here.
@@ -167,7 +167,7 @@ func (m *MultiRMRouter) GetResourcePools() (*apiv1.GetResourcePoolsResponse, err
 
 // GetDefaultComputeResourcePool routes a GetDefaultComputeResourcePool to the specified resource manager.
 func (m *MultiRMRouter) GetDefaultComputeResourcePool() (rm.ResourcePoolName, error) {
-	resolvedRMName, err := m.getRM("")
+	resolvedRMName, err := m.getRMName("")
 	if err != nil {
 		return "", err
 	}
@@ -177,7 +177,7 @@ func (m *MultiRMRouter) GetDefaultComputeResourcePool() (rm.ResourcePoolName, er
 
 // GetDefaultAuxResourcePool routes a GetDefaultAuxResourcePool to the specified resource manager.
 func (m *MultiRMRouter) GetDefaultAuxResourcePool() (rm.ResourcePoolName, error) {
-	resolvedRMName, err := m.getRM("")
+	resolvedRMName, err := m.getRMName("")
 	if err != nil {
 		return "", err
 	}
@@ -187,7 +187,7 @@ func (m *MultiRMRouter) GetDefaultAuxResourcePool() (rm.ResourcePoolName, error)
 
 // ValidateResourcePool routes a ValidateResourcePool call to the specified resource manager.
 func (m *MultiRMRouter) ValidateResourcePool(rpName rm.ResourcePoolName) error {
-	resolvedRMName, err := m.getRM(rpName)
+	resolvedRMName, err := m.getRMName(rpName)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (m *MultiRMRouter) ValidateResourcePool(rpName rm.ResourcePoolName) error {
 func (m *MultiRMRouter) ResolveResourcePool(rpName rm.ResourcePoolName, workspace, slots int) (
 	rm.ResourcePoolName, error,
 ) {
-	resolvedRMName, err := m.getRM(rpName)
+	resolvedRMName, err := m.getRMName(rpName)
 	if err != nil {
 		return rpName, err
 	}
@@ -212,7 +212,7 @@ func (m *MultiRMRouter) TaskContainerDefaults(
 	rpName rm.ResourcePoolName,
 	fallbackConfig model.TaskContainerDefaultsConfig,
 ) (model.TaskContainerDefaultsConfig, error) {
-	resolvedRMName, err := m.getRM(rpName)
+	resolvedRMName, err := m.getRMName(rpName)
 	if err != nil {
 		return model.TaskContainerDefaultsConfig{}, err
 	}
@@ -222,7 +222,7 @@ func (m *MultiRMRouter) TaskContainerDefaults(
 
 // GetJobQ routes a GetJobQ call to a specified resource manager/pool.
 func (m *MultiRMRouter) GetJobQ(rpName rm.ResourcePoolName) (map[model.JobID]*sproto.RMJobInfo, error) {
-	resolvedRMName, err := m.getRM(rpName)
+	resolvedRMName, err := m.getRMName(rpName)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (m *MultiRMRouter) GetJobQueueStatsRequest(req *apiv1.GetJobQueueStatsReque
 
 // MoveJob routes a MoveJob call to a specified resource manager/pool.
 func (m *MultiRMRouter) MoveJob(req sproto.MoveJob) error {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func (m *MultiRMRouter) MoveJob(req sproto.MoveJob) error {
 
 // RecoverJobPosition routes a RecoverJobPosition call to a specified resource manager/pool.
 func (m *MultiRMRouter) RecoverJobPosition(req sproto.RecoverJobPosition) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.ResourcePool))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.ResourcePool))
 	if err != nil {
 		m.syslog.WithError(err)
 		return
@@ -271,7 +271,7 @@ func (m *MultiRMRouter) RecoverJobPosition(req sproto.RecoverJobPosition) {
 
 // GetExternalJobs routes a GetExternalJobs request to a specified resource manager.
 func (m *MultiRMRouter) GetExternalJobs(rpName rm.ResourcePoolName) ([]*jobv1.Job, error) {
-	resolvedRMName, err := m.getRM(rpName)
+	resolvedRMName, err := m.getRMName(rpName)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (m *MultiRMRouter) GetAgents() (*apiv1.GetAgentsResponse, error) {
 
 // GetAgent routes a GetAgent request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetAgent(req *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (m *MultiRMRouter) GetAgent(req *apiv1.GetAgentRequest) (*apiv1.GetAgentRes
 
 // EnableAgent routes an EnableAgent request to the specified resource manager & agent.
 func (m *MultiRMRouter) EnableAgent(req *apiv1.EnableAgentRequest) (*apiv1.EnableAgentResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func (m *MultiRMRouter) EnableAgent(req *apiv1.EnableAgentRequest) (*apiv1.Enabl
 func (m *MultiRMRouter) DisableAgent(req *apiv1.DisableAgentRequest) (
 	*apiv1.DisableAgentResponse, error,
 ) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func (m *MultiRMRouter) DisableAgent(req *apiv1.DisableAgentRequest) (
 
 // GetSlots routes an GetSlots request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetSlots(req *apiv1.GetSlotsRequest) (*apiv1.GetSlotsResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (m *MultiRMRouter) GetSlots(req *apiv1.GetSlotsRequest) (*apiv1.GetSlotsRes
 
 // GetSlot routes an GetSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (m *MultiRMRouter) GetSlot(req *apiv1.GetSlotRequest) (*apiv1.GetSlotRespon
 
 // EnableSlot routes an EnableSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.EnableSlotResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (m *MultiRMRouter) EnableSlot(req *apiv1.EnableSlotRequest) (*apiv1.EnableS
 
 // DisableSlot routes an DisableSlot request to the specified resource manager & agent.
 func (m *MultiRMRouter) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.DisableSlotResponse, error) {
-	resolvedRMName, err := m.getRM(rm.ResourcePoolName(req.AgentId))
+	resolvedRMName, err := m.getRMName(rm.ResourcePoolName(req.AgentId))
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (m *MultiRMRouter) DisableSlot(req *apiv1.DisableSlotRequest) (*apiv1.Disab
 	return m.rms[resolvedRMName].DisableSlot(req)
 }
 
-func (m *MultiRMRouter) getRM(rpName rm.ResourcePoolName) (string, error) {
+func (m *MultiRMRouter) getRMName(rpName rm.ResourcePoolName) (string, error) {
 	// If not given RP name, route to default RM.
 	if rpName == "" {
 		m.syslog.Tracef("RM undefined, routing to default resource manager")

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -679,7 +679,7 @@ func TestGetRMName(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			rmName, err := mockMultiRM.getRM(tt.rpName)
+			rmName, err := mockMultiRM.getRMName(tt.rpName)
 			require.Equal(t, tt.expectedRMName, rmName)
 			require.Equal(t, tt.err, err)
 		})


### PR DESCRIPTION
<!---
refactor: rename multiRM to more intuitive name
-->
## Ticket
DET-10289


## Description
Currently, `getRM` only returns the name of the desired resource manager, rather than the resource manager itself. Rename this to `getRMName` so that getRM can be implemented to retrieve the desired resource manager, as its function name suggests.

Ref [here](https://github.com/determined-ai/determined/pull/9226/files#r1585220300), where we use `getRM` to return the resource manager needed to provision resources within its corresponding cluster.

## Test Plan
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ