### PR TITLE
chore: amd gpus on k8s

### DIFF
--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -212,10 +212,8 @@ func (k *KubernetesResourceManagerConfig) UnmarshalJSON(data []byte) error {
 func (k KubernetesResourceManagerConfig) Validate() []error {
 	var checkSlotType error
 	switch k.SlotType {
-	case device.CPU, device.CUDA:
+	case device.CPU, device.CUDA, device.ROCM:
 		break
-	case device.ROCM:
-		checkSlotType = errors.Errorf("rocm slot_type is not supported yet on k8s")
 	default:
 		checkSlotType = errors.Errorf("slot_type must be either cuda or cpu")
 	}

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -59,7 +59,20 @@ func (p *pod) configureResourcesRequirements() k8sV1.ResourceRequirements {
 			},
 		}
 	case device.ROCM:
-		panic("ROCm is not supported on k8s yet")
+		if p.slots > 0 {
+			return k8sV1.ResourceRequirements{
+				Limits: map[k8sV1.ResourceName]resource.Quantity{
+					ResourceTypeAMD: *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
+				},
+				Requests: map[k8sV1.ResourceName]resource.Quantity{
+					ResourceTypeAMD: *resource.NewQuantity(int64(p.slots), resource.DecimalSI),
+				},
+			}
+		}
+		return k8sV1.ResourceRequirements{
+			Limits:   map[k8sV1.ResourceName]resource.Quantity{},
+			Requests: map[k8sV1.ResourceName]resource.Quantity{},
+		}
 	case device.CUDA: // default to CUDA-backed slots.
 		fallthrough
 	default:


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ