### PR TITLE
feat: add pod labels with proper validation

### DIFF
--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -351,13 +351,17 @@ func (p *pod) createPriorityClass(name string, priority int32) error {
 	return err
 }
 
-const maxChars int = 63
-const fmtAlphaNumeric string = "A-Za-z0-9"
-const fmtAllowedChars string = fmtAlphaNumeric + `\.\-_`
+const (
+	maxChars        int    = 63
+	fmtAlphaNumeric string = "A-Za-z0-9"
+	fmtAllowedChars string = fmtAlphaNumeric + `\.\-_`
+)
 
-var regDisallowedSpecialChars = regexp.MustCompile("[^" + fmtAllowedChars + "]")
-var regLeadingNonAlphaNumeric = regexp.MustCompile("^[^" + fmtAlphaNumeric + "]+")
-var regTrailingNonAlphaNumeric = regexp.MustCompile("[^" + fmtAlphaNumeric + "]+$")
+var (
+	regDisallowedSpecialChars  = regexp.MustCompile("[^" + fmtAllowedChars + "]")
+	regLeadingNonAlphaNumeric  = regexp.MustCompile("^[^" + fmtAlphaNumeric + "]+")
+	regTrailingNonAlphaNumeric = regexp.MustCompile("[^" + fmtAlphaNumeric + "]+$")
+)
 
 func validatePodLabelValue(value string) string {
 	errs := validation.IsValidLabelValue(value)

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -378,13 +378,13 @@ func validatePodLabelValue(value string) string {
 
 	// 2. truncate to 63 characters
 	if len(fixedValue) > maxChars {
-		fixedValue = string(fixedValue[:maxChars])
+		fixedValue = fixedValue[:maxChars]
 	}
 
 	// 3. strip ending non-alphanumeric characters
 	fixedValue = regTrailingNonAlphaNumeric.ReplaceAllString(fixedValue, "")
 
-	log.Warnf(
+	log.Debugf(
 		"conform to Kubernetes pod label value standards: reformatting %s to %s",
 		value, fixedValue,
 	)

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -352,9 +352,10 @@ func (p *pod) createPriorityClass(name string, priority int32) error {
 }
 
 const (
-	maxChars        int    = 63
-	fmtAlphaNumeric string = "A-Za-z0-9"
-	fmtAllowedChars string = fmtAlphaNumeric + `\.\-_`
+	maxChars             int    = 63
+	fmtAlphaNumeric      string = "A-Za-z0-9"
+	fmtAllowedChars      string = fmtAlphaNumeric + `\.\-_`
+	defaultPodLabelValue string = "invalid_value"
 )
 
 var (
@@ -363,25 +364,25 @@ var (
 	regTrailingNonAlphaNumeric = regexp.MustCompile("[^" + fmtAlphaNumeric + "]+$")
 )
 
-func validatePodLabelValue(value string) string {
+func validatePodLabelValue(value string) (string, error) {
 	errs := validation.IsValidLabelValue(value)
 	if len(errs) == 0 {
-		return value
+		return value, nil
 	}
 
-	// label value is not valid; attempt to fix it
-	// 0. convert dis-allowed special characters to underscore
+	// Label value is not valid; attempt to fix it.
+	// 0. Convert dis-allowed special characters to underscore.
 	fixedValue := regDisallowedSpecialChars.ReplaceAllString(value, "_")
 
-	// 1. strip leading non-alphanumeric characters
+	// 1. Strip leading non-alphanumeric characters.
 	fixedValue = regLeadingNonAlphaNumeric.ReplaceAllString(fixedValue, "")
 
-	// 2. truncate to 63 characters
+	// 2. Truncate to 63 characters.
 	if len(fixedValue) > maxChars {
 		fixedValue = fixedValue[:maxChars]
 	}
 
-	// 3. strip ending non-alphanumeric characters
+	// 3. Strip ending non-alphanumeric characters.
 	fixedValue = regTrailingNonAlphaNumeric.ReplaceAllString(fixedValue, "")
 
 	log.Debugf(
@@ -389,7 +390,13 @@ func validatePodLabelValue(value string) string {
 		value, fixedValue,
 	)
 
-	return fixedValue
+	// Final validation check, return error if still not valid for safety.
+	errs = validation.IsValidLabelValue(fixedValue)
+	if len(errs) != 0 {
+		return "", errors.New("pod label value is not valid")
+	}
+
+	return fixedValue, nil
 }
 
 func (p *pod) configurePodSpec(
@@ -413,10 +420,31 @@ func (p *pod) configurePodSpec(
 	}
 	if p.submissionInfo.taskSpec.Owner != nil {
 		// Owner label will disappear if Owner is somehow nil.
-		podSpec.ObjectMeta.Labels[userLabel] = validatePodLabelValue(p.submissionInfo.taskSpec.Owner.Username)
+		labelValue, err := validatePodLabelValue(p.submissionInfo.taskSpec.Owner.Username)
+		if err != nil {
+			labelValue = defaultPodLabelValue
+			log.Warnf("unable to reformat username=%s to Kubernetes standards; using %s",
+				p.submissionInfo.taskSpec.Owner.Username, labelValue)
+		}
+		podSpec.ObjectMeta.Labels[userLabel] = labelValue
 	}
-	podSpec.ObjectMeta.Labels[workspaceLabel] = validatePodLabelValue(p.submissionInfo.taskSpec.Workspace)
-	podSpec.ObjectMeta.Labels[resourcePoolLabel] = validatePodLabelValue(p.req.ResourcePool)
+
+	labelValue, err := validatePodLabelValue(p.submissionInfo.taskSpec.Workspace)
+	if err != nil {
+		labelValue = defaultPodLabelValue
+		log.Warnf("unable to reformat workspace=%s to Kubernetes standards; using %s",
+			p.submissionInfo.taskSpec.Workspace, labelValue)
+	}
+	podSpec.ObjectMeta.Labels[workspaceLabel] = labelValue
+
+	labelValue, err = validatePodLabelValue(p.req.ResourcePool)
+	if err != nil {
+		labelValue = defaultPodLabelValue
+		log.Warnf("unable to reformat resource_pool=%s to Kubernetes standards; using %s",
+			p.req.ResourcePool, labelValue)
+	}
+	podSpec.ObjectMeta.Labels[resourcePoolLabel] = labelValue
+
 	podSpec.ObjectMeta.Labels[taskTypeLabel] = string(p.submissionInfo.taskSpec.TaskType)
 	podSpec.ObjectMeta.Labels[taskIDLabel] = p.submissionInfo.taskSpec.TaskID
 	podSpec.ObjectMeta.Labels[containerIDLabel] = p.submissionInfo.taskSpec.ContainerID
@@ -424,7 +452,11 @@ func (p *pod) configurePodSpec(
 
 	// If map is not populated, labels will be missing and observability will be impacted.
 	for k, v := range p.submissionInfo.taskSpec.ExtraPodLabels {
-		podSpec.ObjectMeta.Labels[labelPrefix+k] = validatePodLabelValue(v)
+		labelValue, err := validatePodLabelValue(v)
+		if err != nil {
+			labelValue = defaultPodLabelValue
+		}
+		podSpec.ObjectMeta.Labels[labelPrefix+k] = labelValue
 	}
 
 	p.modifyPodSpec(podSpec, scheduler)

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -233,7 +233,10 @@ func TestValidatePodLabelValues(t *testing.T) {
 		{"invalid chars", "letters contain *@ other chars -=%", "letters_contain____other_chars"},
 		{"invalid leading chars", "-%4-simpleCharacters0", "4-simpleCharacters0"},
 		{"invalid trailing chars", "simple-Characters4%-.#", "simple-Characters4"},
-		{"invalid too many chars", "simpleCharactersGoesOnForWayTooLong36384042444648505254565860-_AndThenSome", "simpleCharactersGoesOnForWayTooLong36384042444648505254565860"},
+		{
+			"invalid too many chars", "simpleCharactersGoesOnForWayTooLong36384042444648505254565860-_AndThenSome",
+			"simpleCharactersGoesOnForWayTooLong36384042444648505254565860",
+		},
 		{"invalid email-style input", "name@domain.com", "name_domain.com"},
 		{"invalid chars only", "-.*$%#$...", ""},
 	}

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -243,14 +243,15 @@ func TestValidatePodLabelValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			testOutput := validatePodLabelValue(tt.input)
+			testOutput, err := validatePodLabelValue(tt.input)
+			require.NoError(t, err)
 			require.Equal(t, tt.output, testOutput, tt.name+" failed")
 		})
 	}
 }
 
 func TestDeterminedLabels(t *testing.T) {
-	// fill out task spec
+	// Fill out task spec.
 	taskSpec := tasks.TaskSpec{
 		Owner:       createUser(),
 		Workspace:   "test-workspace",
@@ -272,7 +273,7 @@ func TestDeterminedLabels(t *testing.T) {
 		},
 	}
 
-	// define expectations
+	// Define expectations.
 	expectedLabels := map[string]string{
 		determinedLabel:   taskSpec.AllocationID,
 		userLabel:         taskSpec.Owner.Username,
@@ -289,7 +290,7 @@ func TestDeterminedLabels(t *testing.T) {
 	spec := p.configurePodSpec(make([]k8sV1.Volume, 1), k8sV1.Container{},
 		k8sV1.Container{}, make([]k8sV1.Container, 1), &k8sV1.Pod{}, "scheduler")
 
-	// confirm pod spec has required labels
+	// Confirm pod spec has required labels.
 	require.NotNil(t, spec)
 	require.Equal(t, expectedLabels, spec.ObjectMeta.Labels)
 }

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -245,7 +245,6 @@ func TestValidatePodLabelValues(t *testing.T) {
 			assert.Equal(t, tt.output, testOutput, tt.name+" failed")
 		})
 	}
-
 }
 
 func TestDeterminedLabels(t *testing.T) {

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/determined-ai/determined/master/internal/sproto"
@@ -242,7 +241,7 @@ func TestValidatePodLabelValues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			testOutput := validatePodLabelValue(tt.input)
-			assert.Equal(t, tt.output, testOutput, tt.name+" failed")
+			require.Equal(t, tt.output, testOutput, tt.name+" failed")
 		})
 	}
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[RM-279]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Kubernetes restricts pod label values: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set 

Pods labels on Determined resources should conform to Kubernetes standards, or the workload will not be scheduled. If Determined resource names used in pod labels don't conform to standards, the name is updated.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

1. Create a workspace or user containing spaces. Include as many random/special characters as you'd like!
2. Start a workload as that user or in that workspace.
3. Confirm the workload is scheduled and runs/works.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-279]: https://hpe-aiatscale.atlassian.net/browse/RM-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ