### PR TITLE
test: Remove flakiness of KillRun test

### DIFF
--- a/e2e_tests/tests/fixtures/no_op/grid-long-run.yaml
+++ b/e2e_tests/tests/fixtures/no_op/grid-long-run.yaml
@@ -1,0 +1,24 @@
+name: grid_long_run
+checkpoint_storage:
+  type: shared_fs
+  host_path: /tmp
+  storage_path: determined-integration-checkpoints
+hyperparameters:
+  training_batch_seconds: 1
+  unique_id:
+      type:  categorical
+      vals:
+        - 1
+        - 2
+        - 3
+        - 4
+  
+searcher:
+  name: grid
+  metric: validation_error
+  max_length:
+    batches: 10
+reproducibility:
+  experiment_seed: 999
+max_restarts: 0
+entrypoint: model_def:NoOpTrial

--- a/e2e_tests/tests/fixtures/no_op/grid-long-run.yaml
+++ b/e2e_tests/tests/fixtures/no_op/grid-long-run.yaml
@@ -4,7 +4,7 @@ checkpoint_storage:
   host_path: /tmp
   storage_path: determined-integration-checkpoints
 hyperparameters:
-  training_batch_seconds: 1
+  training_batch_seconds: 99999
   unique_id:
       type:  categorical
       vals:

--- a/e2e_tests/tests/run/test_api.py
+++ b/e2e_tests/tests/run/test_api.py
@@ -144,8 +144,8 @@ def test_run_kill_filter() -> None:
     searchResp = bindings.get_SearchRuns(sess, filter=runFilter)
 
     # validate response
-    assert len(killResp.results) > 0
     assert len(searchResp.runs) > 0
+    assert len(killResp.results) > 0
     assert len(killResp.results) == len(searchResp.runs)
     for res in killResp.results:
         assert res.error == ""

--- a/e2e_tests/tests/run/test_api.py
+++ b/e2e_tests/tests/run/test_api.py
@@ -104,8 +104,8 @@ def test_run_kill_filter() -> None:
     sess = api_utils.user_session()
     exp_id = exp.create_experiment(
         sess,
-        conf.fixtures_path("mnist_pytorch/adaptive_short.yaml"),
-        conf.fixtures_path("mnist_pytorch"),
+        conf.fixtures_path("no_op/grid-long-run.yaml"),
+        conf.fixtures_path("no_op"),
     )
 
     runFilter = (
@@ -121,12 +121,12 @@ def test_run_kill_filter() -> None:
         "value": %s
       },
       {
-        "columnName": "hp.n_filters2",
+        "columnName": "hp.unique_id",
         "kind": "field",
         "location": "LOCATION_TYPE_RUN_HYPERPARAMETERS",
         "operator": ">=",
         "type": "COLUMN_TYPE_NUMBER",
-        "value": 40
+        "value": 3
       }
     ],
     "conjunction": "and",


### PR DESCRIPTION
## Ticket
DET-10294


## Description
Fix the flakiness of the kill run test by creating a new fixture that generates 4 runs with a deterministic hyperparameter and filter on that hyperparameter in the test. Addtionally we want to ensure that the experiment runs for long enough for the trials to be killed



## Test Plan
e2e test should pass after multiple runs
4 runs with a distinct "unique_id" hyperparameter of 1, 2, 3 & 4


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

