### PR TITLE
chore: remove stdlib errors package from lint blocklist

### DIFF
--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -45,7 +45,6 @@ linters-settings:
     list-type: blacklist
     include-go-root: true
     packages:
-      - errors
       - gopkg.in/yaml.v2
       - github.com/dgrijalva/jwt-go
   dupl:


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
We've had the stdlib `errors` package disallowed [since at least April of 2020](https://github.com/determined-ai/determined/blame/main/master/.golangci.yml#L48). More recently, we decided to stop using `github.com/pkg/errors`, which is a good thing IMO. But we need the stdlib `errors` for stuff like `errors.Is`, so this removes it from the list of disallowed packages.



## Test Plan
None, it's a linting/CI change.
