### PR TITLE
chore: don't use a seperate schema for views_and_triggers

### DIFF
--- a/master/internal/db/migrations.go
+++ b/master/internal/db/migrations.go
@@ -135,6 +135,7 @@ func (db *PgDB) readDBCodeAndCheckIfDifferent(dbCodeDir string) (map[string]stri
 		if err != nil {
 			return nil, false, fmt.Errorf("reading view definition file '%s': %w", filePath, err)
 		}
+
 		fileNamesToSQL[f.Name()] = string(b)
 		allCode += string(b)
 	}
@@ -161,7 +162,7 @@ func (db *PgDB) readDBCodeAndCheckIfDifferent(dbCodeDir string) (map[string]stri
 		return nil, false, fmt.Errorf("getting hash from views_and_triggers_hash: %w", err)
 	}
 	if databaseHash == ourHash {
-		return fileNamesToSQL, false, nil
+		return fileNamesToSQL, true, nil
 	}
 
 	// Update our hash and return we need to create views and triggers.

--- a/master/internal/db/migrations.go
+++ b/master/internal/db/migrations.go
@@ -118,7 +118,7 @@ func ensureMigrationUpgrade(tx *pg.Tx) error {
 
 func (db *PgDB) readDBCodeAndCheckIfDifferent(
 	dbCodeDir string,
-) (map[string]string, string, bool, error) {
+) (dbCodeFiles map[string]string, hash string, needToUpdateDBCode bool, err error) {
 	upDir := filepath.Join(dbCodeDir, "up")
 	files, err := os.ReadDir(upDir)
 	if err != nil {
@@ -144,8 +144,8 @@ func (db *PgDB) readDBCodeAndCheckIfDifferent(
 
 	// I didn't want to get into deciding when to apply database or code or not but integration
 	// tests make it really hard to not do this.
-	hash := sha256.Sum256([]byte(allCode))
-	ourHash := hex.EncodeToString(hash[:])
+	hashSHA := sha256.Sum256([]byte(allCode))
+	ourHash := hex.EncodeToString(hashSHA[:])
 
 	// Check if the views_and_triggers_hash table exists. If it doesn't return that we need to create db code.
 	var tableExists bool

--- a/master/internal/db/postgres.go
+++ b/master/internal/db/postgres.go
@@ -175,48 +175,12 @@ type PgDB struct {
 	URL     string
 }
 
-func setSearchPath(sql *sqlx.DB) error {
-	// In integration tests, multiple processes can be running this code at once, which can lead to
-	// errors because PostgreSQL ALTER DATABASE can do weird things.
-	if testOnlyDBLock != nil {
-		cleanup := testOnlyDBLock(sql)
-		defer cleanup()
-	}
-
-	if _, err := sql.Exec(`DO $$
-BEGIN
-   execute 'ALTER DATABASE "'||current_database()||'" SET SEARCH_PATH TO public,determined_code';
-END
-$$;`); err != nil {
-		return fmt.Errorf("setting search path on db connection: %w", err)
-	}
-
-	return nil
-}
-
 // ConnectPostgres connects to a Postgres database.
 func ConnectPostgres(url string) (*PgDB, error) {
-	return connectPostgres(url, true)
-}
-
-func connectPostgres(url string, firstTime bool) (*PgDB, error) {
 	numTries := 0
 	for {
 		sql, err := sqlx.Connect("pgx", url)
 		if err == nil {
-			if firstTime {
-				// On first connection set the search path, close the connection and reconnect.
-				// There is a little bit of a chicken and egg problem with setting search path.
-				// We need to actually reconnect for this to take affect.
-				if err := setSearchPath(sql); err != nil {
-					return nil, err
-				}
-				if err := sql.Close(); err != nil {
-					return nil, err
-				}
-				return connectPostgres(url, false)
-			}
-
 			db := &PgDB{sql: sql, queries: &StaticQueryMap{}, URL: url}
 			initTheOneBun(db)
 			return db, nil

--- a/master/static/views_and_triggers/README.md
+++ b/master/static/views_and_triggers/README.md
@@ -12,15 +12,14 @@ If you need to change views / other db code, just change them and the changes wi
 
 If you need to delete views / other db code, just delete them from the file.
 
-If you need to add a view, just make sure you add it into the ```determined_code``` schema (aka do ```CREATE VIEW determined_code.test ...```). Exception are triggers inherit from the table, therefore just create them without the schema name. The procedure being executed should still be in the ```determined_code``` so that way when the ```determined_code``` schema get's dropped the trigger will get cascaded.
+If you need to add a view add it in a ```.sql``` file in the ```up``` folder and add a delete statement in the ``down.sql`` in this directory.
 
 ### How does dbviews_and_triggers work?
 
-On everytime the Determined master starts up
+On everytime the Determined master starts up we check if the database views have changed.
 
-- The Postgres schema ```determined_code``` will be dropped if it exists.
+- The ``down.sql`` file runs.
 - Migrations run as they did before ```determined_code``` was added.
-- The Postgres schema ```determined_code``` will be recreated.
 - All SQL files in the ``views_and_triggers`` will be run in lexicographical order.
 
 ### Limitations

--- a/master/static/views_and_triggers/down.sql
+++ b/master/static/views_and_triggers/down.sql
@@ -1,0 +1,34 @@
+DROP VIEW IF EXISTS proto_checkpoints_view;
+DROP VIEW IF EXISTS checkpoints_view;
+
+DROP VIEW IF EXISTS trials;
+
+DROP VIEW IF EXISTS steps;
+DROP VIEW IF EXISTS validations;
+DROP VIEW IF EXISTS validation_metrics;
+
+DROP FUNCTION IF EXISTS abort_checkpoint_delete CASCADE;
+DROP FUNCTION IF EXISTS autoupdate_exp_best_trial_metrics CASCADE;
+DROP FUNCTION IF EXISTS autoupdate_exp_best_trial_metrics_on_delete CASCADE;
+DROP FUNCTION IF EXISTS autoupdate_user_image_deleted CASCADE;
+DROP FUNCTION IF EXISTS autoupdate_user_image_modified CASCADE;
+DROP FUNCTION IF EXISTS get_raw_metric CASCADE;
+DROP FUNCTION IF EXISTS get_signed_metric CASCADE;
+DROP FUNCTION IF EXISTS page_info CASCADE;
+DROP FUNCTION IF EXISTS proto_time CASCADE;
+DROP FUNCTION IF EXISTS retention_timestamp CASCADE;
+DROP FUNCTION IF EXISTS set_modified_time CASCADE;
+DROP FUNCTION IF EXISTS stream_model_change CASCADE;
+DROP FUNCTION IF EXISTS stream_model_notify CASCADE;
+DROP FUNCTION IF EXISTS stream_model_seq_modify CASCADE;
+DROP FUNCTION IF EXISTS stream_model_version_change CASCADE;
+DROP FUNCTION IF EXISTS stream_model_version_change_by_model CASCADE;
+DROP FUNCTION IF EXISTS stream_model_version_notify CASCADE;
+DROP FUNCTION IF EXISTS stream_model_version_seq_modify CASCADE;
+DROP FUNCTION IF EXISTS stream_model_version_seq_modify_by_model CASCADE;
+DROP FUNCTION IF EXISTS stream_project_change CASCADE;
+DROP FUNCTION IF EXISTS stream_project_notify CASCADE;
+DROP FUNCTION IF EXISTS stream_project_seq_modify CASCADE;
+DROP FUNCTION IF EXISTS try_float8_cast CASCADE;
+
+DROP AGGREGATE IF EXISTS jsonb_collect(jsonb);

--- a/master/static/views_and_triggers/up/checkpoints.sql
+++ b/master/static/views_and_triggers/up/checkpoints.sql
@@ -1,4 +1,4 @@
-CREATE VIEW determined_code.checkpoints_view AS
+CREATE VIEW checkpoints_view AS
 SELECT c.id,
     c.uuid,
     c.task_id,
@@ -24,7 +24,7 @@ SELECT c.id,
      LEFT JOIN raw_validations v ON ((c.metadata ->> 'steps_completed'::text)::integer) = v.total_batches AND r.id = v.trial_id AND NOT v.archived
      LEFT JOIN raw_steps s ON ((c.metadata ->> 'steps_completed'::text)::integer) = s.total_batches AND r.id = s.trial_id AND NOT s.archived;
 
-CREATE VIEW determined_code.proto_checkpoints_view AS
+CREATE VIEW proto_checkpoints_view AS
 SELECT c.uuid,
     c.task_id,
     c.allocation_id,
@@ -36,7 +36,7 @@ SELECT c.uuid,
     jsonb_build_object('trial_id', c.trial_id, 'experiment_id', c.experiment_id, 'experiment_config', c.experiment_config, 'hparams', c.hparams, 'training_metrics', jsonb_build_object('avg_metrics', c.training_metrics -> 'avg_metrics'::text, 'batch_metrics', c.training_metrics -> 'batch_metrics'::text), 'validation_metrics', json_build_object('avg_metrics', c.validation_metrics), 'searcher_metric', c.searcher_metric) AS training
    FROM checkpoints_view c;
 
-CREATE FUNCTION determined_code.abort_checkpoint_delete() RETURNS trigger
+CREATE FUNCTION abort_checkpoint_delete() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/master/static/views_and_triggers/up/model.sql
+++ b/master/static/views_and_triggers/up/model.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION determined_code.stream_model_change() RETURNS trigger
+CREATE FUNCTION stream_model_change() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -18,7 +18,7 @@ CREATE TRIGGER stream_model_trigger_d BEFORE DELETE ON models FOR EACH ROW EXECU
 CREATE TRIGGER stream_model_trigger_iu AFTER INSERT OR UPDATE OF name, description, creation_time, last_updated_time, metadata, labels, user_id, archived, notes, workspace_id ON models FOR EACH ROW EXECUTE PROCEDURE stream_model_change();
 
 
-CREATE FUNCTION determined_code.stream_model_notify(before jsonb, after jsonb) RETURNS integer
+CREATE FUNCTION stream_model_notify(before jsonb, after jsonb) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -39,7 +39,7 @@ return 0;
 END;
 $$;
 
-CREATE FUNCTION determined_code.stream_model_seq_modify() RETURNS trigger
+CREATE FUNCTION stream_model_seq_modify() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -50,7 +50,7 @@ $$;
 CREATE TRIGGER stream_model_trigger_seq BEFORE INSERT OR UPDATE OF name, description, creation_time, last_updated_time, metadata, labels, user_id, archived, notes, workspace_id ON models FOR EACH ROW EXECUTE PROCEDURE stream_model_seq_modify();
 
 
-CREATE FUNCTION determined_code.stream_model_version_change() RETURNS trigger
+CREATE FUNCTION stream_model_version_change() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -76,7 +76,7 @@ CREATE TRIGGER stream_model_version_trigger_d BEFORE DELETE ON model_versions FO
 CREATE TRIGGER stream_model_version_trigger_iu AFTER INSERT OR UPDATE OF name, version, checkpoint_uuid, last_updated_time, metadata, labels, user_id, model_id, notes, comment ON model_versions FOR EACH ROW EXECUTE PROCEDURE stream_model_version_change();
 
 
-CREATE FUNCTION determined_code.stream_model_version_change_by_model() RETURNS trigger
+CREATE FUNCTION stream_model_version_change_by_model() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -93,7 +93,7 @@ END;
 $$;
 CREATE TRIGGER stream_model_version_trigger_by_model_iu BEFORE UPDATE OF workspace_id ON models FOR EACH ROW EXECUTE PROCEDURE stream_model_version_change_by_model();
 
-CREATE FUNCTION determined_code.stream_model_version_notify(before jsonb, after jsonb) RETURNS integer
+CREATE FUNCTION stream_model_version_notify(before jsonb, after jsonb) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -114,7 +114,7 @@ return 0;
 END;
 $$;
 
-CREATE FUNCTION determined_code.stream_model_version_seq_modify() RETURNS trigger
+CREATE FUNCTION stream_model_version_seq_modify() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -124,7 +124,7 @@ END;
 $$;
 CREATE TRIGGER stream_model_version_trigger_seq BEFORE INSERT OR UPDATE OF name, version, checkpoint_uuid, last_updated_time, metadata, labels, user_id, model_id, notes, comment ON model_versions FOR EACH ROW EXECUTE PROCEDURE stream_model_version_seq_modify();
 
-CREATE FUNCTION determined_code.stream_model_version_seq_modify_by_model() RETURNS trigger
+CREATE FUNCTION stream_model_version_seq_modify_by_model() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/master/static/views_and_triggers/up/project.sql
+++ b/master/static/views_and_triggers/up/project.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION determined_code.stream_project_change() RETURNS trigger
+CREATE FUNCTION stream_project_change() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -17,7 +17,7 @@ $$;
 CREATE TRIGGER stream_project_trigger_d BEFORE DELETE ON projects FOR EACH ROW EXECUTE PROCEDURE stream_project_change();
 CREATE TRIGGER stream_project_trigger_iu AFTER INSERT OR UPDATE OF name, description, archived, created_at, notes, workspace_id, user_id, immutable, state ON projects FOR EACH ROW EXECUTE PROCEDURE stream_project_change();
 
-CREATE FUNCTION determined_code.stream_project_notify(before jsonb, after jsonb) RETURNS integer
+CREATE FUNCTION stream_project_notify(before jsonb, after jsonb) RETURNS integer
     LANGUAGE plpgsql
     AS $$
 DECLARE
@@ -38,7 +38,7 @@ return 0;
 END;
 $$;
 
-CREATE FUNCTION determined_code.stream_project_seq_modify() RETURNS trigger
+CREATE FUNCTION stream_project_seq_modify() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/master/static/views_and_triggers/up/users.sql
+++ b/master/static/views_and_triggers/up/users.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION determined_code.autoupdate_user_image_deleted() RETURNS trigger
+CREATE FUNCTION autoupdate_user_image_deleted() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -8,7 +8,7 @@ END;
 $$;
 CREATE TRIGGER autoupdate_user_image_deleted BEFORE DELETE ON user_profile_images FOR EACH ROW EXECUTE PROCEDURE autoupdate_user_image_deleted();
 
-CREATE FUNCTION determined_code.autoupdate_user_image_modified() RETURNS trigger
+CREATE FUNCTION autoupdate_user_image_modified() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
@@ -18,7 +18,7 @@ END;
 $$;
 CREATE TRIGGER autoupdate_user_image_modified BEFORE INSERT OR UPDATE ON user_profile_images FOR EACH ROW EXECUTE PROCEDURE autoupdate_user_image_modified();
 
-CREATE FUNCTION determined_code.set_modified_time() RETURNS trigger
+CREATE FUNCTION set_modified_time() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN

--- a/master/static/views_and_triggers/up/util.sql
+++ b/master/static/views_and_triggers/up/util.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION determined_code.page_info(total bigint, "offset" integer, "limit" integer) RETURNS json
+CREATE FUNCTION page_info(total bigint, "offset" integer, "limit" integer) RETURNS json
     LANGUAGE sql IMMUTABLE
     AS $$
 WITH start_index AS (
@@ -22,7 +22,7 @@ SELECT row_to_json(p)
 FROM page_info p
 $$;
 
-CREATE FUNCTION determined_code.proto_time(ts timestamp with time zone) RETURNS json
+CREATE FUNCTION proto_time(ts timestamp with time zone) RETURNS json
     LANGUAGE sql IMMUTABLE STRICT
     AS $$
     SELECT json_build_object(
@@ -33,7 +33,7 @@ CREATE FUNCTION determined_code.proto_time(ts timestamp with time zone) RETURNS 
     )
 $$;
 
-CREATE FUNCTION determined_code.retention_timestamp() RETURNS timestamp with time zone
+CREATE FUNCTION retention_timestamp() RETURNS timestamp with time zone
     LANGUAGE plpgsql
     AS $$
     BEGIN
@@ -41,7 +41,7 @@ CREATE FUNCTION determined_code.retention_timestamp() RETURNS timestamp with tim
     END
     $$;
 
-CREATE FUNCTION determined_code.try_float8_cast(text) RETURNS double precision
+CREATE FUNCTION try_float8_cast(text) RETURNS double precision
     LANGUAGE sql IMMUTABLE STRICT
     AS $_$
             SELECT
@@ -52,7 +52,7 @@ CREATE FUNCTION determined_code.try_float8_cast(text) RETURNS double precision
                 END;
         $_$;
 
-CREATE AGGREGATE determined_code.jsonb_collect(jsonb) (
+CREATE AGGREGATE jsonb_collect(jsonb) (
     SFUNC = jsonb_concat,
     STYPE = jsonb,
     INITCOND = '{}'


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
 
Instead of making ```views_and_triggers``` use a separate schema just require people to manually drop them.

Using a separate schema requires us to set the search path requiring extra permissions. Avoid needing more database permissions with this change.

## Test Plan

intg passes


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ