### PR TITLE
chore: check non-multiples of slots per pod for kubernetes rm [MD-403]

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -371,21 +371,13 @@ func (k *ResourceManager) ValidateResources(
 		return nil, nil
 	}
 
-	if msg.IsSingleNode {
-		rp, err := k.poolByName(msg.ResourcePool)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"validating request for (%s, %d): %w", msg.ResourcePool, msg.Slots, err)
-		}
-		resp := rp.ValidateResources(msg)
-		if !resp.Fulfillable {
-			return nil, errors.New("request unfulfillable, please try requesting less slots")
-		}
-		return nil, nil
-	} else if err := k.resourcePoolExists(msg.ResourcePool); err != nil {
-		return nil, fmt.Errorf("%s is an invalid resource pool", msg.ResourcePool)
+	rp, err := k.poolByName(msg.ResourcePool)
+	if err != nil {
+		return nil, fmt.Errorf("could not find resource pool with name %s", msg.ResourcePool)
 	}
-	return nil, nil
+
+	err = rp.ValidateResources(msg)
+	return nil, err
 }
 
 // getResourcePoolRef gets an actor ref to a resource pool by name.

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -571,14 +571,12 @@ func TestAssignResources(t *testing.T) {
 	groups[allocateReq.JobID] = &tasklist.Group{
 		JobID: allocateReq.JobID,
 	}
-	mockPods := createMockPodsService(make(map[string]*k8sV1.Node), device.CUDA, true)
+	mockPods := createMockJobsService(make(map[string]*k8sV1.Node), device.CUDA, true)
 	poolRef := &kubernetesResourcePool{
 		poolConfig:                &config.ResourcePoolConfig{PoolName: "pool"},
-		podsService:               mockPods,
+		jobsService:               mockPods,
 		reqList:                   taskList,
 		groups:                    groups,
-		allocationIDToContainerID: map[model.AllocationID]cproto.ID{},
-		containerIDtoAllocationID: map[string]model.AllocationID{},
 		jobIDToAllocationID:       map[model.JobID]model.AllocationID{},
 		allocationIDToJobID:       map[model.AllocationID]model.JobID{},
 		slotsUsedPerGroup:         map[*tasklist.Group]int{},
@@ -789,7 +787,7 @@ func TestROCmJobsService(t *testing.T) {
 	}
 }
 
-func TestValidateResources(t *testing.T) {
+func TestRMValidateResources(t *testing.T) {
 	resourcePool := &kubernetesResourcePool{
 		poolConfig:     &config.ResourcePoolConfig{PoolName: "test-pool"},
 		maxSlotsPerPod: 4,

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -588,10 +588,10 @@ func TestAssignResources(t *testing.T) {
 		name           string
 		slotsRequested int
 		maxSlotsPerPod int
-		expPodSlots    []int
+		expSlots       []int
 	}{
 		{"slots < max_slots_per_pod", 1, 2, []int{1}},
-		{"slots multiple of max_slots_per_pod", 6, 2, []int{2, 2, 2}},
+		{"slots multiple of max_slots_per_pod", 6, 2, []int{6}},
 		{"invalid slots request", 3, 2, []int{}},
 	}
 	for _, c := range cases {
@@ -606,7 +606,7 @@ func TestAssignResources(t *testing.T) {
 				podSlotsAllocated = append(podSlotsAllocated, v.Summary().Slots())
 				delete(resourcesAllocated.Resources, k)
 			}
-			require.Equal(t, c.expPodSlots, podSlotsAllocated)
+			require.Equal(t, c.expSlots, podSlotsAllocated)
 		})
 	}
 }

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -451,23 +451,26 @@ func (k *kubernetesResourcePool) jobQInfo() map[model.JobID]*sproto.RMJobInfo {
 func (k *kubernetesResourcePool) assignResources(
 	req *sproto.AllocateRequest,
 ) {
-	err := k.ValidateResources(sproto.ValidateResourcesRequest{
-		ResourcePool: req.ResourcePool, Slots: req.SlotsNeeded, IsSingleNode: req.FittingRequirements.SingleAgent,
-	})
-	if err != nil {
-		k.syslog.WithField("allocation-id", req.AllocationID).WithError(err)
-		rmevents.Publish(req.AllocationID, &sproto.InvalidResourcesRequestError{
-			Cause: err,
-		})
-		return
-	}
-
 	numPods := 1
 	slotsPerPod := req.SlotsNeeded
+	if req.SlotsNeeded > 1 {
+		if k.maxSlotsPerPod == 0 {
+			k.syslog.WithField("allocation-id", req.AllocationID).Error(
+				"set max_slots_per_pod > 0 to schedule tasks with slots")
+			return
+		}
 
-	if req.SlotsNeeded > k.maxSlotsPerPod {
-		numPods = req.SlotsNeeded / k.maxSlotsPerPod
-		slotsPerPod = k.maxSlotsPerPod
+		if req.SlotsNeeded > k.maxSlotsPerPod {
+			if req.SlotsNeeded%k.maxSlotsPerPod != 0 {
+				k.syslog.WithField("allocation-id", req.AllocationID).Errorf(
+					"task number of slots (%d) is not schedulable on the configured "+
+						"max_slots_per_pod (%d)", req.SlotsNeeded, k.maxSlotsPerPod)
+				return
+			}
+
+			numPods = req.SlotsNeeded / k.maxSlotsPerPod
+			slotsPerPod = k.maxSlotsPerPod
+		}
 	}
 
 	group := k.groups[req.JobID]

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -1108,15 +1108,17 @@ func TestValidateResources(t *testing.T) {
 	rp := newTestResourcePool(newTestJobsService(t))
 
 	cases := []struct {
-		name        string
-		slots       int
-		fulfillable bool
+		name           string
+		slots          int
+		maxSlotsPerPod int
+		fulfillable    bool
 	}{
-		{"valid", 1, true},
-		{"invalid", 100, false},
+		{"valid", 1, 2, true},
+		{"invalid, not divisible", 10, 3, false},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			rp.maxSlotsPerPod = tt.maxSlotsPerPod
 			res := rp.ValidateResources(sproto.ValidateResourcesRequest{
 				Slots: tt.slots,
 			})

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -1120,7 +1120,11 @@ func TestValidateResources(t *testing.T) {
 			res := rp.ValidateResources(sproto.ValidateResourcesRequest{
 				Slots: tt.slots,
 			})
-			require.Equal(t, tt.fulfillable, res.Fulfillable)
+			if tt.fulfillable {
+				require.NoError(t, res)
+			} else {
+				require.ErrorContains(t, res, "invalid resource request")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

Error out earlier for Kubernetes clusters when slots requested are not a multiple of `max_slots_per_pod`

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

On a kubernetes cluster with `max_slots_per_pod` configured as > 1, submit an experiment with `slots_per_trial` as a non-multiple of `max_slots_per_pod` (i.e. `slots_per_trial=2`, `max_slots_per_pod=3`). experiment should error out upon creation. 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ