### PR TITLE
docs: add exp config for unmanaged example #2.

### DIFF
--- a/examples/features/unmanaged/2.yaml
+++ b/examples/features/unmanaged/2.yaml
@@ -1,0 +1,15 @@
+name: unmanaged-2
+entrypoint: python3 2_checkpoints.py
+
+# Use the single-searcher to run just one instance of the training script
+searcher:
+   name: single
+   # metric is required but it shouldn't hurt to ignore it at this point.
+   metric: x
+   # max_length is ignored if the training script ignores it.
+   max_length: 1
+
+max_restarts: 0
+
+resources:
+  slots_per_trial: 0


### PR DESCRIPTION
## Description

Add an exp config file for unmanaged example #2 for "checkpoints". It is trivial, but I had a support conversation about it. Let's add to avoid that conversation in the future.

## Test Plan

N/A

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ