### PR TITLE
docs: Describe config templates WebUI

### DIFF
--- a/docs/model-dev-guide/dtrain/config-templates.rst
+++ b/docs/model-dev-guide/dtrain/config-templates.rst
@@ -8,7 +8,7 @@ In a typical organization, many Determined configuration files will share simila
 cause redundancy. For example, all training workloads run at a given organization might use the same
 checkpoint storage configuration. One way to reduce this redundancy is to use *configuration
 templates*. This feature allows users to consolidate settings shared across many experiments into a
-single YAML file that can be referenced by configurations needings those settings.
+single YAML file that can be referenced by configurations needing those settings.
 
 Each configuration template has a unique name and is stored by the Determined master. If a
 configuration employs a template, the effective configuration of the task will be the outcome of
@@ -97,6 +97,47 @@ To launch the experiment with the template:
 .. code:: bash
 
    $ det experiment create --template template-tf-gpu mnist_tf_const.yaml <model_code>
+
+There are two ways to manage templates: via the WebUI and CLI.
+
+**************************************
+ Managing Templates through the WebUI
+**************************************
+
+You can managing configuration templates including listing, creating, updating, and deleting
+templates through the WebUI. To do you'll need at least ``CanCreateTemplate`` permissions. Users
+without this permission can still view and use templates.
+
+Creating Templates
+==================
+
+-  Sign in to the cluster.
+-  Select the **Templates** panel.
+-  Select **Add New Template**.
+
+Alternatively, you can manage templates when launching JupyterLab.
+
+Provide the following information:
+
+-  Template Name: This will be the primary key and globally unique
+-  Workspace: Select a workspace that user has permission to create template
+-  If under Workspace -> Templates tab, the workspace if preselected and disabled
+-  Template content: A CodeEditor in YAML like the one in Experiment Fork modal, no additional
+   validation enforced
+
+Managing Templates
+==================
+
+To view, edit, or delete a template:
+
+-  Select the template you want to modify.
+
+Name: Sortable, Searchable, editable Workspace: Filterable, editable (Need backend support)
+
+Actions
+
+Edit: With our current API, only the config is editable Permission: CanUpdateTemplate Delete:
+Permission: CanDeleteTemplate
 
 ************************************
  Managing Templates through the CLI

--- a/docs/model-dev-guide/dtrain/config-templates.rst
+++ b/docs/model-dev-guide/dtrain/config-templates.rst
@@ -4,21 +4,19 @@
  Configuration Templates
 #########################
 
-In a typical organization, many Determined configuration files will share similar settings. This can
-cause redundancy. For example, all training workloads run at a given organization might use the same
-checkpoint storage configuration. One way to reduce this redundancy is to use *configuration
-templates*. This feature allows users to consolidate settings shared across many experiments into a
-single YAML file that can be referenced by configurations needing those settings.
+In a typical organization, many Determined configuration files often share similar settings, leading
+to redundancy. For example, all training workloads might use the same checkpoint storage
+configuration. To reduce this redundancy, Determined offers *configuration templates*.
 
-Each configuration template has a unique name and is stored by the Determined master. If a
-configuration employs a template, the effective configuration of the task will be the outcome of
-merging the two YAML files (the configuration file and the template). The semantics of this merge
-operation are described below. Determined stores this effective configuration to ensure future
-changes to a template do not affect the reproducibility of experiments that used a previous version
-of the configuration template.
+These templates allow users to consolidate shared settings into a single YAML file that can be
+referenced by multiple configurations. Each configuration template has a unique name and is stored
+by the Determined master.
 
-A single configuration file can use at most one configuration template. A configuration template
-cannot itself use another configuration template.
+When a configuration uses a template, the final configuration of the task is the result of merging
+the two YAML files (the configuration of the task and the template). This merge ensures that future
+changes to a template do not affect the reproducibility of experiments that used an earlier version
+of the template. A single configuration file can use only one configuration template. Configuration
+templates cannot reference other templates.
 
 ************************************************************
  Leveraging Templates to Simplify Experiment Configurations
@@ -104,40 +102,36 @@ There are two ways to manage templates: via the WebUI and CLI.
  Managing Templates through the WebUI
 **************************************
 
-You can managing configuration templates including listing, creating, updating, and deleting
-templates through the WebUI. To do you'll need at least ``CanCreateTemplate`` permissions. Users
-without this permission can still view and use templates.
+You can create or manage a configuration template using the WebUI. You will need at least the
+``CanCreateTemplate`` permission to create or manage templates. Users without this permission can
+still view and use templates.
 
-Creating Templates
-==================
+Create a Configuration Template
+===============================
 
--  Sign in to the cluster.
--  Select the **Templates** panel.
--  Select **Add New Template**.
+To create a configuration template:
 
-Alternatively, you can manage templates when launching JupyterLab.
+-  Go to the **Templates** pane and then select **Add New Template**.
+
+Alternatively, you can create templates from the **Templates** tab in your Workspace or when
+launching JupyterLab.
 
 Provide the following information:
 
--  Template Name: This will be the primary key and globally unique
--  Workspace: Select a workspace that user has permission to create template
--  If under Workspace -> Templates tab, the workspace if preselected and disabled
--  Template content: A CodeEditor in YAML like the one in Experiment Fork modal, no additional
-   validation enforced
+-  **Name**: The template name will be the primary key. It must be globally unique.
+-  **Workspace**: Choose a workspace for which you have permissions to create templates.
+-  **Config**: This is a code editor for entering your YAML configuration.
 
-Managing Templates
-==================
+Manage a Configuration Template
+===============================
 
-To view, edit, or delete a template:
+To view, edit, or delete a configuration template:
 
--  Select the template you want to modify.
+-  Go to the **Templates** pane and then choose the template you want to manage.
+-  Choose an action from the actions menu.
 
-Name: Sortable, Searchable, editable Workspace: Filterable, editable (Need backend support)
-
-Actions
-
-Edit: With our current API, only the config is editable Permission: CanUpdateTemplate Delete:
-Permission: CanDeleteTemplate
+Alternatively, you can manage templates from the **Templates** tab in your Workspace or when
+launching JupyterLab.
 
 ************************************
  Managing Templates through the CLI


### PR DESCRIPTION
Describe how users can now create and manage configuration templates via the WebUI (in addition to CLI).

See: #9383 

Release: 0.33.x

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ