### PR TITLE
chore: Update docker retag scripts

### DIFF
--- a/tools/scripts/retag-bumpenvs-yaml.py
+++ b/tools/scripts/retag-bumpenvs-yaml.py
@@ -27,6 +27,13 @@ def run(old_tag: str, new_tag: str, yaml_path: str, release: bool) -> None:
     for image_type in conf:
         if old_tag not in conf[image_type]["new"]:
             continue
+        elif ":" not in conf[image_type]["new"]:
+            # AMIS/GCP images do not contain :
+            continue
+        elif "environments:" in conf[image_type]["new"]:
+            # exempt legacy environments repo
+            continue
+
         replace_image(conf[image_type], new_tag, release)
 
     with open(yaml_path, "w") as f:
@@ -37,9 +44,8 @@ def replace_image(subconf: dict, new_tag: str, release: bool) -> None:
     old_tag = subconf["new"].split(":")[-1]
     subconf["old"] = subconf["new"]
     if release:
-        subconf["new"] = subconf["new"].replace("-dev:" + old_tag, ":" + new_tag)
-    else:
-        subconf["new"] = subconf["new"].replace(old_tag, new_tag)
+        subconf["new"] = subconf["new"].replace("-dev:", ":")
+    subconf["new"] = subconf["new"].replace(old_tag, new_tag)
 
 
 if __name__ == "__main__":

--- a/tools/scripts/update-docker-tags.sh
+++ b/tools/scripts/update-docker-tags.sh
@@ -2,7 +2,7 @@
 # Retags all docker images from latest Environments build
 # tools/scripts/update-docker-tags.sh NEW_VERSION [--release]
 
-if [ "$#" -lt 1 ] || [ ! -z "$2" -a "$2" != "--release"  ] || [ "$#" -gt 2 ]; then
+if [ "$#" -lt 1 ] || [ ! -z "$2" -a "$2" != "--release" ] || [ "$#" -gt 2 ]; then
     echo "usage: $0 NEW_VERSION [--release]" >&2
     exit 1
 fi
@@ -23,7 +23,7 @@ export IMAGES=$(grep -oP "(?<=new: ).*(?=,)" tools/scripts/bumpenvs.yaml | grep 
 # update tags on dockerhub
 for NAME in $IMAGES; do
     if [ "$2" == "--release" ]; then
-        if [ -z $(echo $NAME | grep -oP '.*(?=-dev:)') ];then
+        if [ -z $(echo $NAME | grep -oP '.*(?=-dev:)') ]; then
             export NEW_NAME="$(echo $NAME | grep -o '.*:')$NEW_TAG"
         else
             export NEW_NAME="$(echo $NAME | grep -oP '.*(?=-dev:)'):$NEW_TAG"

--- a/tools/scripts/update-docker-tags.sh
+++ b/tools/scripts/update-docker-tags.sh
@@ -2,7 +2,7 @@
 # Retags all docker images from latest Environments build
 # tools/scripts/update-docker-tags.sh NEW_VERSION [--release]
 
-if [ "$#" -lt 1 ] || [ ! -z "$2" -a "$2" != "--release" ] || [ "$#" -gt 2 ]; then
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ] || [ -n "$2" && "$2" != "--release" ]; then
     echo "usage: $0 NEW_VERSION [--release]" >&2
     exit 1
 fi
@@ -22,14 +22,9 @@ export IMAGES=$(grep -oP "(?<=new: ).*(?=,)" tools/scripts/bumpenvs.yaml | grep 
 
 # update tags on dockerhub
 for NAME in $IMAGES; do
+    NEW_NAME=${NAME%%:*}:$NEW_TAG
     if [ "$2" == "--release" ]; then
-        if [ -z $(echo $NAME | grep -oP '.*(?=-dev:)') ]; then
-            export NEW_NAME="$(echo $NAME | grep -o '.*:')$NEW_TAG"
-        else
-            export NEW_NAME="$(echo $NAME | grep -oP '.*(?=-dev:)'):$NEW_TAG"
-        fi
-    else
-        export NEW_NAME="$(echo $NAME | grep -o '.*:')$NEW_TAG"
+        NEW_NAME=${NEW_NAME/-dev:/:}
     fi
     echo "Adding $NEW_NAME (clone of $NAME) to docker repo"
     docker buildx imagetools create $NAME --tag $NEW_NAME

--- a/tools/scripts/update-docker-tags.sh
+++ b/tools/scripts/update-docker-tags.sh
@@ -2,7 +2,7 @@
 # Retags all docker images from latest Environments build
 # tools/scripts/update-docker-tags.sh NEW_VERSION [--release]
 
-if [ "$#" -lt 1 ] || [ "$2" != "--release" ] || [ "$#" -gt 2 ]; then
+if [ "$#" -lt 1 ] || [ ! -z "$2" -a "$2" != "--release"  ] || [ "$#" -gt 2 ]; then
     echo "usage: $0 NEW_VERSION [--release]" >&2
     exit 1
 fi
@@ -18,12 +18,16 @@ export OLD_TAG=$(cat tools/scripts/environments-target.txt)
 export NEW_TAG="$1"
 
 # get list of images to replace via OLD_TAG in bumpenvs.yaml
-export IMAGES=$(grep -oP "(?<=new: ).*(?=,)" tools/scripts/bumpenvs.yaml | grep -F $OLD_TAG)
+export IMAGES=$(grep -oP "(?<=new: ).*(?=,)" tools/scripts/bumpenvs.yaml | grep -F :$OLD_TAG)
 
 # update tags on dockerhub
 for NAME in $IMAGES; do
     if [ "$2" == "--release" ]; then
-        export NEW_NAME="$(echo $NAME | grep -oP '.*(?=-dev:)'):$NEW_TAG"
+        if [ -z $(echo $NAME | grep -oP '.*(?=-dev:)') ];then
+            export NEW_NAME="$(echo $NAME | grep -o '.*:')$NEW_TAG"
+        else
+            export NEW_NAME="$(echo $NAME | grep -oP '.*(?=-dev:)'):$NEW_TAG"
+        fi
     else
         export NEW_NAME="$(echo $NAME | grep -o '.*:')$NEW_TAG"
     fi
@@ -42,7 +46,7 @@ else
     python tools/scripts/retag-bumpenvs-yaml.py tools/scripts/bumpenvs.yaml $OLD_TAG $NEW_TAG
 fi
 echo "Performing bumpenvs"
-python -m tools/scripts/bumpenvs.py tools/scripts/bumpenvs.yaml
+python tools/scripts/bumpenvs.py tools/scripts/bumpenvs.yaml
 
 # check to see if update-docker-tags.py resulted in any file changes or not
 if [[ -z "$(git status --porcelain)" ]]; then


### PR DESCRIPTION
## Ticket
None



## Description
A few updates to release party helper scripts for updating our docker image tags.



## Test Plan
cut rcs and cut releases in release party. requires dockerhub credentials.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ