### PR TITLE
new naming scheme for added gw resources

### DIFF
--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -161,6 +161,8 @@ func (p *pod) configureProxyResources() []gatewayProxyResource {
 			p.submissionInfo.taskSpec.TaskType, shortTaskID, shortAllocID, portIndex, uuidStr)
 		sharedName := tooLong[:min(63, len(tooLong)-1)]
 		return sharedName
+		// TODO: use for section name in the listeners as well? `/` is an invalid char for section
+		// name.
 	}
 
 	var resources []gatewayProxyResource

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -151,18 +151,29 @@ func (p *pod) configureProxyResources() []gatewayProxyResource {
 			- taskid and allocid include dashes.
 			$TASK_TYPE/$TASK_ID[:10]/$ALLOCATION_ID[:10]/P$PORT_INDEX/randombits
 		*/
+		const maxLen = 63
+		const separator = ":"
+
+		description := p.submissionInfo.taskSpec.Description[:min(10,
+			len(p.submissionInfo.taskSpec.Description))]
 		shortTaskID := p.submissionInfo.taskSpec.TaskID[:min(10,
-			len(p.submissionInfo.taskSpec.TaskID)-1)]
+			len(p.submissionInfo.taskSpec.TaskID))]
 		shortAllocID := p.submissionInfo.taskSpec.AllocationID[max(0,
 			len(p.submissionInfo.taskSpec.AllocationID)-10):]
 		uuidStr := uuid.New().String()
 
-		tooLong := fmt.Sprintf("%s/%s/%s/P%d/%s",
-			p.submissionInfo.taskSpec.TaskType, shortTaskID, shortAllocID, portIndex, uuidStr)
-		sharedName := tooLong[:min(63, len(tooLong)-1)]
+		components := []string{
+			string(p.submissionInfo.taskSpec.TaskType),
+			description,
+			shortTaskID,
+			shortAllocID,
+			fmt.Sprintf("P%d", portIndex),
+			uuidStr,
+		}
+
+		tooLong := strings.Join(components, separator)
+		sharedName := tooLong[:min(maxLen, len(tooLong))]
 		return sharedName
-		// TODO: use for section name in the listeners as well? `/` is an invalid char for section
-		// name.
 	}
 
 	var resources []gatewayProxyResource


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
https://hpe-aiatscale.atlassian.net/browse/RM-276


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
maybe keep the task description/name instead of task id? but with that the names could vary a lot in shape.
maybe we cut off the first n chars of the name?

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ