### PR TITLE
fix: master checks db newness before migrating [DET-10312]

### DIFF
--- a/master/cmd/determined-master/migrate.go
+++ b/master/cmd/determined-master/migrate.go
@@ -52,7 +52,7 @@ func runMigrate(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	if _, err = database.Migrate(config.DB.Migrations, config.DB.ViewsAndTriggers, args); err != nil {
+	if err = database.Migrate(config.DB.Migrations, config.DB.ViewsAndTriggers, args); err != nil {
 		return errors.Wrap(err, "running migrations")
 	}
 

--- a/master/cmd/determined-master/populate_metrics.go
+++ b/master/cmd/determined-master/populate_metrics.go
@@ -39,7 +39,7 @@ func runPopulate(cmd *cobra.Command, args []string) error {
 	}
 
 	masterConfig := config.GetMasterConfig()
-	database, _, err := db.Setup(&masterConfig.DB)
+	database, err := db.Setup(&masterConfig.DB)
 	if err != nil {
 		return err
 	}

--- a/master/internal/db/database.go
+++ b/master/internal/db/database.go
@@ -15,7 +15,7 @@ import (
 
 // DB is an interface for _all_ the functionality packed into the DB.
 type DB interface {
-	Migrate(migrationURL, codeURL string, actions []string) (isNew bool, err error)
+	Migrate(migrationURL, codeURL string, actions []string) error
 	Close() error
 	GetOrCreateClusterID(telemetryID string) (string, error)
 	TrialExperimentAndRequestID(id int) (int, model.RequestID, error)

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -196,7 +196,7 @@ func MigrateTestPostgres(db *PgDB, migrationsPath string, actions ...string) err
 	if len(actions) == 0 {
 		actions = []string{"up"}
 	}
-	_, err := db.Migrate(
+	err := db.Migrate(
 		migrationsPath, strings.ReplaceAll(migrationsPath+"/../views_and_triggers", "file://", ""), actions)
 	if err != nil {
 		return fmt.Errorf("failed to migrate postgres: %w", err)

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -6,6 +6,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/go-pg/migrations/v8"
+	"github.com/go-pg/pg/v10"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
@@ -83,24 +85,61 @@ func Connect(opts *config.DBConfig) (*PgDB, error) {
 	return db, nil
 }
 
-// Setup connects to the database and run any necessary migrations.
-func Setup(opts *config.DBConfig) (db *PgDB, isNew bool, err error) {
-	db, err = Connect(opts)
+// IsNew checks to see if the database's migration tracking tables have been
+// created, and if so, if it's above version 0. It returns `false` if the current
+// version exists and is higher than zero, `true` otherwise.
+// This is not guaranteed to be accurate if the database is otherwise in a bad or
+// incomplete state. If an error is returned, the bool should be ignored.
+func IsNew(opts *config.DBConfig) (bool, error) {
+	dbURL := fmt.Sprintf(cnxTpl, opts.User, opts.Password, opts.Host, opts.Port, opts.Name)
+	dbURL += fmt.Sprintf(sslTpl, opts.SSLMode, opts.SSLRootCert)
+	pgOpts, err := makeGoPgOpts(dbURL)
 	if err != nil {
-		return db, false, err
+		return false, err
 	}
 
-	isNew, err = db.Migrate(opts.Migrations, opts.ViewsAndTriggers, []string{"up"})
+	pgConn := pg.Connect(pgOpts)
+	defer func() {
+		if errd := pgConn.Close(); errd != nil {
+			log.Errorf("error closing pg connection: %s", errd)
+		}
+	}()
+
+	exist, err := tablesExist(pgConn, []string{"gopg_migrations", "schema_migrations"})
 	if err != nil {
-		return nil, false, fmt.Errorf("error running migrations: %s", err)
+		return false, err
+	}
+	if !exist["gopg_migrations"] || !exist["schema_migrations"] {
+		return true, nil
+	}
+
+	collection := migrations.NewCollection()
+	collection.DisableSQLAutodiscover(true)
+	version, err := collection.Version(pgConn)
+	if err != nil {
+		return false, err
+	}
+	return version == 0, nil
+}
+
+// Setup connects to the database and run any necessary migrations.
+func Setup(opts *config.DBConfig) (db *PgDB, err error) {
+	db, err = Connect(opts)
+	if err != nil {
+		return db, err
+	}
+
+	err = db.Migrate(opts.Migrations, opts.ViewsAndTriggers, []string{"up"})
+	if err != nil {
+		return nil, fmt.Errorf("error running migrations: %s", err)
 	}
 
 	if err = InitAuthKeys(); err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if err = initAllocationSessions(context.TODO()); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return db, isNew, nil
+	return db, nil
 }

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -109,7 +109,7 @@ func IsNew(opts *config.DBConfig) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if !exist["gopg_migrations"] || !exist["schema_migrations"] {
+	if !exist["gopg_migrations"] {
 		return true, nil
 	}
 

--- a/master/test/testutils/fixtures.go
+++ b/master/test/testutils/fixtures.go
@@ -135,7 +135,7 @@ func ConnectMaster(c *config.Config) (apiv1.DeterminedClient, error) {
 		}
 
 		cl = apiv1.NewDeterminedClient(clConn)
-		_, err = cl.Login(context.Background(), &apiv1.LoginRequest{Username: defaultUsername})
+		_, err = cl.Login(context.Background(), &apiv1.LoginRequest{Username: defaultUsername, Password: DefaultUserPassword})
 		if err == nil {
 			return cl, nil
 		}

--- a/master/test/testutils/fixtures.go
+++ b/master/test/testutils/fixtures.go
@@ -198,7 +198,7 @@ func CurrentLogstashElasticIndex() string {
 // APICredentials takes a context and a connected apiv1.DeterminedClient and returns a context
 // with credentials or an error if unable to login with defaults.
 func APICredentials(ctx context.Context, cl apiv1.DeterminedClient) (context.Context, error) {
-	resp, err := cl.Login(context.TODO(), &apiv1.LoginRequest{Username: defaultUsername})
+	resp, err := cl.Login(context.TODO(), &apiv1.LoginRequest{Username: defaultUsername, Password: DefaultUserPassword})
 	if err != nil {
 		return nil, fmt.Errorf("failed to login: %w", err)
 	}

--- a/master/test/testutils/fixtures.go
+++ b/master/test/testutils/fixtures.go
@@ -32,8 +32,13 @@ import (
 )
 
 const (
+	// DefaultUserPassword is the password that will be set for determined and admin users in tests.
+	DefaultUserPassword = "TestPassword1"
 	defaultUsername     = "determined"
 	defaultMasterConfig = `
+security:
+  initial_user_password: TestPassword1
+
 checkpoint_storage:
   type: shared_fs
   host_path: /tmp


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10312]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Since creating the admin user without a password is a migration step, we need to check for invalid configuration (missing initial password) before the migration is run, but wait to apply the configuration until after the migration is run. This therefore splits the previous admin password configuration into two separate steps.

Due to the way this straddles the usual place Bun would be initialized, I didn't Bun-ify anything as part of this, and did a little bit of redundant config parsing to avoid doing anything that could call `initTheOneBun()` twice.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
This attempts to solve an issue that was found testing #9314 .

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10312]: https://hpe-aiatscale.atlassian.net/browse/DET-10312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ