### PR TITLE
fix: add Admin Settings to NavigationTabbar (ET-194)

### DIFF
--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -65,7 +65,7 @@ const NavigationTabbar: React.FC = () => {
 
   const showNavigation = isAuthenticated && ui.showChrome;
 
-  const { canCreateWorkspace } = usePermissions();
+  const { canCreateWorkspace, canAdministrateUsers } = usePermissions();
 
   const WorkspaceCreateModal = useModal(WorkspaceCreateModalComponent);
 
@@ -141,17 +141,25 @@ const NavigationTabbar: React.FC = () => {
     },
     {
       icon: 'settings',
-      label: 'Settings',
+      label: 'User Settings',
       onClick: () => setShowSettings(true),
     },
+  ];
+
+  if (canAdministrateUsers) {
+    overflowActionsTop.push({
+      icon: 'group',
+      label: 'Admin Settings',
+      path: paths.admin(),
+    });
+  }
+
+  const overflowActionsBottom: OverflowActionProps[] = [
     {
       icon: 'user',
       label: 'Sign out',
       onClick: (e: AnyMouseEvent) => handlePathUpdate(e, paths.logout()),
     },
-  ];
-
-  const overflowActionsBottom: OverflowActionProps[] = [
     {
       external: true,
       icon: 'docs',

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -139,22 +139,22 @@ const NavigationTabbar: React.FC = () => {
         </div>
       ),
     },
-    {
-      icon: 'settings',
-      label: 'User Settings',
-      onClick: () => setShowSettings(true),
-    },
   ];
 
   if (canAdministrateUsers) {
     overflowActionsTop.push({
       icon: 'group',
       label: 'Admin Settings',
-      path: paths.admin(),
+      onClick: (e: AnyMouseEvent) => handlePathUpdate(e, paths.admin()),
     });
   }
 
   const overflowActionsBottom: OverflowActionProps[] = [
+    {
+      icon: 'settings',
+      label: 'User Settings',
+      onClick: () => setShowSettings(true),
+    },
     {
       icon: 'user',
       label: 'Sign out',


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-194


## Description
Adds "Admin Settings" to mobile navigation menu (if user has admin permissions)
Also renames "Settings" option to "User Settings"

## Test Plan
- Open app in mobile mode.
- Click three-dot menu on lower right.
- User with admin permissions should see "Admin Settings" option which leads to Admin Settings page
- User without admin permissions should not see that option


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ