### PR TITLE
fix: add feature gate for checking for blank admin/determined password [DET-10197]

### DIFF
--- a/docs/release-notes/cli-requires-initial-password.rst
+++ b/docs/release-notes/cli-requires-initial-password.rst
@@ -1,9 +1,0 @@
-:orphan:
-
-Breaking Changes
-
--  Master: On new deployments, the service will log an error and abort startup if no
-   ``initialUserPassword`` is found in the configuration.
-
-To ensure users can still rely on reasonable default settings with CLI commands like ``det deploy
-local cluster-up``, an ``--initial-user-password`` flag is now provided.

--- a/master/internal/core_intg_test.go
+++ b/master/internal/core_intg_test.go
@@ -136,6 +136,9 @@ func TestRun(t *testing.T) {
 			}
 			// listen on any available port, we don't care
 			m.config.Port = 0
+			m.config.FeatureSwitches = []string{
+				"prevent_blank_password",
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			gRPCLogInitDone := make(chan struct{})


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10197]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Effectively removes service-side checking for blank passwords on default user accounts, by putting it behind a feature switch.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
`det deploy local` commands etc. don't stall for up to 10 minutes

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10197]: https://hpe-aiatscale.atlassian.net/browse/DET-10197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ