### PR TITLE
fix: set the defaults for shared_fs mount in genai correctly

### DIFF
--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -705,6 +705,7 @@ args_description = cli.Cmd(
                 cli.Arg(
                     "--genai-shared-fs-mount-path",
                     type=str,
+                    default="/run/determined/workdir/shared_fs",
                     help="Specifies the path to mount the shared filesystem used for datasets in"
                     + " GenAI. Defaults to `/run/determined/workdir/shared_fs`",
                 ),

--- a/harness/determined/deploy/aws/templates/lore.yaml
+++ b/harness/determined/deploy/aws/templates/lore.yaml
@@ -228,7 +228,7 @@ Parameters:
   GenAISharedFSMountPath:
     Type: String
     Description: GenAI shared file system mount path
-    Default: latest
+    Default: /run/determined/workdir/shared_fs
 
   MountEFSId:
     Type: String


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
We were not setting the default for the shared_fs mount dir correctly in `det deploy aws --deployment-type genai`

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ