### PR TITLE
feat: remove genai from experimental feature list and enable via `/master` feature switches [GAS-1016]

### DIFF
--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -3,15 +3,16 @@ import Icon, { IconName } from 'hew/Icon';
 import { useModal } from 'hew/Modal';
 import Spinner from 'hew/Spinner';
 import { Loadable } from 'hew/utils/loadable';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState} from 'react';
 import { useLocation } from 'react-router-dom';
+import LogoGenAI from 'assets/images/logo-genai.svg?url';
 
 import ActionSheet, { ActionItem } from 'components/ActionSheet';
 import Link, { Props as LinkProps } from 'components/Link';
 import useUI from 'components/ThemeProvider';
 import UserSettings from 'components/UserSettings';
 import usePermissions from 'hooks/usePermissions';
-import { handlePath, paths } from 'routes/utils';
+import {handlePath, paths, serverAddress} from 'routes/utils';
 import authStore from 'stores/auth';
 import clusterStore from 'stores/cluster';
 import determinedStore, { BrandingType } from 'stores/determinedInfo';
@@ -23,6 +24,7 @@ import { AnyMouseEvent, routeToReactUrl } from 'utils/routes';
 import css from './NavigationTabbar.module.scss';
 import UserBadge from './UserBadge';
 import WorkspaceCreateModalComponent from './WorkspaceCreateModal';
+import useFeature from "../hooks/useFeature";
 
 interface ToolbarItemProps extends LinkProps {
   badge?: number;
@@ -66,6 +68,7 @@ const NavigationTabbar: React.FC = () => {
   const showNavigation = isAuthenticated && ui.showChrome;
 
   const { canCreateWorkspace, canAdministrateUsers } = usePermissions();
+  const gasLinkOn = useFeature().isOn('genai');
 
   const WorkspaceCreateModal = useModal(WorkspaceCreateModalComponent);
 
@@ -122,7 +125,7 @@ const NavigationTabbar: React.FC = () => {
 
   interface OverflowActionProps {
     external?: boolean;
-    icon?: IconName;
+    icon?: IconName | JSX.Element;
     label: string;
     onClick?: (e: AnyMouseEvent) => void;
     path?: string;
@@ -182,6 +185,16 @@ const NavigationTabbar: React.FC = () => {
       popout: true,
     },
   ];
+
+    if (gasLinkOn) {
+      overflowActionsBottom.push({
+        external: true,
+        icon: <img alt="GenAI Studio" height={24} src={LogoGenAI} width={24} />,
+        label: 'GenAI',
+        path: serverAddress('/genai'),
+        popout: true,
+      });
+  }
 
   return (
     <>

--- a/webui/react/src/components/NavigationTabbar.tsx
+++ b/webui/react/src/components/NavigationTabbar.tsx
@@ -3,16 +3,17 @@ import Icon, { IconName } from 'hew/Icon';
 import { useModal } from 'hew/Modal';
 import Spinner from 'hew/Spinner';
 import { Loadable } from 'hew/utils/loadable';
-import React, { useCallback, useEffect, useState} from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import LogoGenAI from 'assets/images/logo-genai.svg?url';
 
+import LogoGenAI from 'assets/images/logo-genai.svg?url';
 import ActionSheet, { ActionItem } from 'components/ActionSheet';
 import Link, { Props as LinkProps } from 'components/Link';
 import useUI from 'components/ThemeProvider';
 import UserSettings from 'components/UserSettings';
+import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
-import {handlePath, paths, serverAddress} from 'routes/utils';
+import { handlePath, paths, serverAddress } from 'routes/utils';
 import authStore from 'stores/auth';
 import clusterStore from 'stores/cluster';
 import determinedStore, { BrandingType } from 'stores/determinedInfo';
@@ -24,7 +25,6 @@ import { AnyMouseEvent, routeToReactUrl } from 'utils/routes';
 import css from './NavigationTabbar.module.scss';
 import UserBadge from './UserBadge';
 import WorkspaceCreateModalComponent from './WorkspaceCreateModal';
-import useFeature from "../hooks/useFeature";
 
 interface ToolbarItemProps extends LinkProps {
   badge?: number;
@@ -186,14 +186,14 @@ const NavigationTabbar: React.FC = () => {
     },
   ];
 
-    if (gasLinkOn) {
-      overflowActionsBottom.push({
-        external: true,
-        icon: <img alt="GenAI Studio" height={24} src={LogoGenAI} width={24} />,
-        label: 'GenAI',
-        path: serverAddress('/genai'),
-        popout: true,
-      });
+  if (gasLinkOn) {
+    overflowActionsBottom.push({
+      external: true,
+      icon: <img alt="GenAI Studio" height={24} src={LogoGenAI} width={24} />,
+      label: 'GenAI',
+      path: serverAddress('/genai'),
+      popout: true,
+    });
   }
 
   return (

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -275,33 +275,33 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
             <Section divider title="Experimental">
               <div className={css.section}>
                 {Object.entries(FEATURES)
-                  .filter(([_, description]) => !description.noUserControl)
+                  .filter(([, description]) => !description.noUserControl)
                   .map(([feature, description]) => (
-                  <InlineForm<boolean>
-                    initialValue={
-                      savedFeatureSettings?.[feature as ValidFeature] ?? description.defaultValue
-                    }
-                    key={feature}
-                    label={
-                      <Row>
-                        {description.friendlyName}
-                        <Column align="right">
-                          <Icon name="info" showTooltip title={description.description} />
-                        </Column>
-                      </Row>
-                    }
-                    valueFormatter={(value) => (value ? 'On' : 'Off')}
-                    onSubmit={(val) => {
-                      userSettings.set(FeatureSettingsConfig, FEATURE_SETTINGS_PATH, {
-                        [feature]: val,
-                      });
-                    }}>
-                    <Select searchable={false}>
-                      <Option value={true}>On</Option>
-                      <Option value={false}>Off</Option>
-                    </Select>
-                  </InlineForm>
-                ))}
+                    <InlineForm<boolean>
+                      initialValue={
+                        savedFeatureSettings?.[feature as ValidFeature] ?? description.defaultValue
+                      }
+                      key={feature}
+                      label={
+                        <Row>
+                          {description.friendlyName}
+                          <Column align="right">
+                            <Icon name="info" showTooltip title={description.description} />
+                          </Column>
+                        </Row>
+                      }
+                      valueFormatter={(value) => (value ? 'On' : 'Off')}
+                      onSubmit={(val) => {
+                        userSettings.set(FeatureSettingsConfig, FEATURE_SETTINGS_PATH, {
+                          [feature]: val,
+                        });
+                      }}>
+                      <Select searchable={false}>
+                        <Option value={true}>On</Option>
+                        <Option value={false}>Off</Option>
+                      </Select>
+                    </InlineForm>
+                  ))}
               </div>
             </Section>
             <Section title="Advanced">

--- a/webui/react/src/components/UserSettings.tsx
+++ b/webui/react/src/components/UserSettings.tsx
@@ -274,7 +274,9 @@ const UserSettings: React.FC<Props> = ({ show, onClose }: Props) => {
             </Section>
             <Section divider title="Experimental">
               <div className={css.section}>
-                {Object.entries(FEATURES).map(([feature, description]) => (
+                {Object.entries(FEATURES)
+                  .filter(([_, description]) => !description.noUserControl)
+                  .map(([feature, description]) => (
                   <InlineForm<boolean>
                     initialValue={
                       savedFeatureSettings?.[feature as ValidFeature] ?? description.defaultValue

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -19,6 +19,7 @@ type FeatureDescription = {
   friendlyName: string;
   description: string;
   defaultValue: boolean;
+  noUserControl?: boolean;
 };
 
 export const FEATURES: Record<ValidFeature, FeatureDescription> = {
@@ -37,6 +38,7 @@ export const FEATURES: Record<ValidFeature, FeatureDescription> = {
     defaultValue: false,
     description: 'Enable links to Generative AI Studio',
     friendlyName: 'Generative AI Studio (genai)',
+    noUserControl: true,
   },
   rp_binding: {
     defaultValue: true,
@@ -89,6 +91,8 @@ const IsOn = (
   // Read from config settings
   featureSwitches.includes(feature) && (isOn = true);
   featureSwitches.includes(`-${feature}`) && (isOn = false);
+
+  if (FEATURES[feature]?.noUserControl) return isOn;
 
   // Read from user settings
   if (settings && feature in settings) {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->

Nav Bar
<img width="240" alt="Screenshot 2024-05-28 at 3 19 52 PM" src="https://github.com/determined-ai/determined/assets/220971/0d9908fb-6700-4ccb-86ad-235612351b85">

Tab Bar
<img width="323" alt="Screenshot 2024-06-03 at 4 44 56 PM" src="https://github.com/determined-ai/determined/assets/220971/ddadcd9c-cebc-4a5d-a698-e474802e4020">



Removed `genai` from Experimentals list of features.
<img width="699" alt="Screenshot 2024-05-29 at 4 19 04 PM" src="https://github.com/determined-ai/determined/assets/220971/bf93f388-ac37-4698-a046-15c8fef2067b">


## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

[GAS-1016](https://hpe-aiatscale.atlassian.net/browse/GAS-1016)

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Removes the user control of turning on/off genai from the Experimental list of features under user settings. The `noUserControl` flag makes the feature purely controlled by the backend `featureSwitches`, where if it is included in there, then it is enabled.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

- Check that the `GenAI` feature does NOT show up on the `Experimentals` list of features under user settings.
- Check that url query param `f_genai=true` does not turn GenAI on in an MLDE cluster that does not have genai enabled.
- Check that if the cluster has `genai` returned by the `/master` endpoint (featureSwitches) then it appears in the sidebar.
- Also check that if the cluster does NOT have `genai` returned by the `/aster` endpoint (featureSwitches) then it does NOT appear in the side bar.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[GAS-1016]: https://hpe-aiatscale.atlassian.net/browse/GAS-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ