### PR TITLE
chore: INFENG-724: Remove model_hub examples from .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -30,10 +30,4 @@ values =
 
 [bumpversion:file:helm/charts/determined/Chart.yaml]
 
-[bumpversion:glob:model_hub/examples/huggingface/*/*.yaml]
-
-[bumpversion:glob:model_hub/examples/mmdetection/*.yaml]
-
-[bumpversion:glob:model_hub/examples/mmdetection/hydra/configs/config.yaml]
-
 [bumpversion:file:docs/_static/version-switcher/versions.json]


### PR DESCRIPTION
## Ticket

INFENG-724

## Description
This changeset removes some unnecessary glob patterns from `.bumpversion.cfg`. The files/directories referenced no longer exist. They examples were first moved to another directory in #8140, and then deleted entirely in #8153.

## Test Plan

Look through `model_hub/` and note there is no `examples/` subdirectory, nor is there any Makefile or other automation that subsequently creates it. Additionally, see the two PRs referenced above, and note that the files themselves were moved and deleted.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.