### PR TITLE
fix: job queue's allocated slots should be correct after restarts

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -131,7 +131,7 @@ func New(
 			t := time.NewTicker(podSubmissionInterval)
 			defer t.Stop()
 			for range t.C {
-				rp.Schedule()
+				rp.Admit()
 			}
 		}()
 		k.pools[poolConfig.PoolName] = rp

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -44,8 +44,8 @@ type kubernetesResourcePool struct {
 
 	jobsService *jobsService
 
-	queuePositions tasklist.JobSortState
-	reschedule     bool
+	queuePositions       tasklist.JobSortState
+	tryAdmitPendingTasks bool
 
 	db *db.PgDB
 
@@ -77,7 +77,7 @@ func newResourcePool(
 func (k *kubernetesResourcePool) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	k.getOrCreateGroup(msg.JobID).MaxSlots = msg.MaxSlots
 }
@@ -85,7 +85,7 @@ func (k *kubernetesResourcePool) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 func (k *kubernetesResourcePool) AllocateRequest(msg sproto.AllocateRequest) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	k.addTask(msg)
 }
@@ -93,7 +93,7 @@ func (k *kubernetesResourcePool) AllocateRequest(msg sproto.AllocateRequest) {
 func (k *kubernetesResourcePool) ResourcesReleased(msg sproto.ResourcesReleased) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	k.resourcesReleased(msg)
 }
@@ -101,7 +101,7 @@ func (k *kubernetesResourcePool) ResourcesReleased(msg sproto.ResourcesReleased)
 func (k *kubernetesResourcePool) JobSchedulingStateChanged(msg jobSchedulingStateChanged) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	for it := k.reqList.Iterator(); it.Next(); {
 		req := it.Value()
@@ -121,7 +121,7 @@ func (k *kubernetesResourcePool) PendingPreemption(msg sproto.PendingPreemption)
 func (k *kubernetesResourcePool) GetJobQ() map[model.JobID]*sproto.RMJobInfo {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	return k.jobQInfo()
 }
@@ -129,7 +129,7 @@ func (k *kubernetesResourcePool) GetJobQ() map[model.JobID]*sproto.RMJobInfo {
 func (k *kubernetesResourcePool) GetJobQStats() *jobv1.QueueStats {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	return tasklist.JobStats(k.reqList)
 }
@@ -137,7 +137,7 @@ func (k *kubernetesResourcePool) GetJobQStats() *jobv1.QueueStats {
 func (k *kubernetesResourcePool) GetJobQStatsAPI(msg *apiv1.GetJobQueueStatsRequest) *apiv1.GetJobQueueStatsResponse {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	resp := &apiv1.GetJobQueueStatsResponse{
 		Results: make([]*apiv1.RPQueueStat, 0),
@@ -152,7 +152,7 @@ func (k *kubernetesResourcePool) GetJobQStatsAPI(msg *apiv1.GetJobQueueStatsRequ
 func (k *kubernetesResourcePool) SetGroupWeight(msg sproto.SetGroupWeight) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	return rmerrors.UnsupportedError("set group weight is unsupported in k8s")
 }
@@ -160,7 +160,7 @@ func (k *kubernetesResourcePool) SetGroupWeight(msg sproto.SetGroupWeight) error
 func (k *kubernetesResourcePool) SetGroupPriority(msg sproto.SetGroupPriority) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	group := k.getOrCreateGroup(msg.JobID)
 	// Check if there is already a submitted task in this group for which
@@ -191,7 +191,7 @@ func (k *kubernetesResourcePool) SetGroupPriority(msg sproto.SetGroupPriority) e
 func (k *kubernetesResourcePool) MoveJob(msg sproto.MoveJob) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	return k.moveJob(msg.ID, msg.Anchor, msg.Ahead)
 }
@@ -199,7 +199,7 @@ func (k *kubernetesResourcePool) MoveJob(msg sproto.MoveJob) error {
 func (k *kubernetesResourcePool) DeleteJob(msg sproto.DeleteJob) sproto.DeleteJobResponse {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	// For now, there is nothing to cleanup in k8s.
 	return sproto.EmptyDeleteJobResponse()
@@ -208,7 +208,7 @@ func (k *kubernetesResourcePool) DeleteJob(msg sproto.DeleteJob) sproto.DeleteJo
 func (k *kubernetesResourcePool) RecoverJobPosition(msg sproto.RecoverJobPosition) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	k.queuePositions.RecoverJobPosition(msg.JobID, msg.JobPosition)
 }
@@ -223,7 +223,7 @@ func (k *kubernetesResourcePool) GetAllocationSummaries() map[model.AllocationID
 func (k *kubernetesResourcePool) getResourceSummary() (*resourceSummary, error) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	slotsUsed := 0
 	for _, slotsUsedByGroup := range k.slotsUsedPerGroup {
@@ -249,20 +249,20 @@ func (k *kubernetesResourcePool) ValidateResources(
 ) sproto.ValidateResourcesResponse {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.reschedule = true
+	k.tryAdmitPendingTasks = true
 
 	fulfillable := k.maxSlotsPerPod >= msg.Slots
 	return sproto.ValidateResourcesResponse{Fulfillable: fulfillable}
 }
 
-func (k *kubernetesResourcePool) Schedule() {
+func (k *kubernetesResourcePool) Admit() {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
-	if k.reschedule {
-		k.schedulePendingTasks()
+	if k.tryAdmitPendingTasks {
+		k.admitPendingTasks()
 	}
-	k.reschedule = false
+	k.tryAdmitPendingTasks = false
 }
 
 func (k *kubernetesResourcePool) summarizePods() (*computeUsageSummary, error) {
@@ -593,7 +593,7 @@ func (k *kubernetesResourcePool) getOrCreateGroup(jobID model.JobID) *tasklist.G
 	return g
 }
 
-func (k *kubernetesResourcePool) schedulePendingTasks() {
+func (k *kubernetesResourcePool) admitPendingTasks() {
 	for it := k.reqList.Iterator(); it.Next(); {
 		req := it.Value()
 		group := k.groups[req.JobID]

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -108,7 +108,7 @@ func (k *kubernetesResourcePool) JobSchedulingStateChanged(msg jobSchedulingStat
 		if req.AllocationID == msg.AllocationID {
 			req.State = msg.State
 			if sproto.ScheduledStates[req.State] {
-				k.allocationIDToRunningPods[msg.AllocationID] += msg.NumPods
+				k.allocationIDToRunningPods[msg.AllocationID] = msg.NumPods
 			}
 		}
 	}

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -220,6 +220,13 @@ func (k *kubernetesResourcePool) GetAllocationSummaries() map[model.AllocationID
 	return k.reqList.TaskSummaries(k.groups, kubernetesScheduler)
 }
 
+func (k *kubernetesResourcePool) GetAllocationSummary(id model.AllocationID) *sproto.AllocationSummary {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	return k.reqList.TaskSummary(id, k.groups, kubernetesScheduler)
+}
+
 func (k *kubernetesResourcePool) getResourceSummary() (*resourceSummary, error) {
 	k.mu.Lock()
 	defer k.mu.Unlock()

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -159,10 +159,10 @@ func testLaunch(
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -250,10 +250,10 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -293,7 +293,7 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	require.Equal(t, sproto.Running, change.ResourcesState)
 	require.NotNil(t, change.ResourcesStarted)
 
-	// Remake all component and "reattach" to this new resource pool. This saves
+	// Remake all components and "reattach" to this new resource pool. This saves
 	// us from needing to made the k8s code do graceful shutdown, but we should
 	// do it anyway someday.
 	rp = newTestResourcePool(newTestJobsService(t))
@@ -302,10 +302,10 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	reallocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -352,10 +352,10 @@ func TestPodLogStreamer(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -421,10 +421,10 @@ func TestKill(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -501,10 +501,10 @@ func TestExternalKillWhileQueuedFails(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -605,10 +605,10 @@ func TestExternalPodDelete(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -694,10 +694,10 @@ func TestReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -736,7 +736,7 @@ func TestReattach(t *testing.T) {
 	require.Equal(t, sproto.Running, change.ResourcesState)
 	require.NotNil(t, change.ResourcesStarted)
 
-	// Remake all component and "reattach" to this new resource pool. This saves
+	// Remake all components and "reattach" to this new resource pool. This saves
 	// us from needing to made the k8s code do graceful shutdown, but we should
 	// do it anyway someday.
 	rp = newTestResourcePool(newTestJobsService(t))
@@ -745,10 +745,10 @@ func TestReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	reallocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -795,6 +795,7 @@ func TestJobQueueReattach(t *testing.T) {
 		ResourcePool:      "default",
 	}
 	rp.AllocateRequest(allocateReq)
+	rp.Admit()
 
 	jobq := rp.GetJobQ()
 	require.Len(t, jobq, 1)
@@ -807,16 +808,9 @@ func TestJobQueueReattach(t *testing.T) {
 	require.Equal(t, 0, info.AllocatedSlots)
 	require.Equal(t, 2, info.RequestedSlots)
 
-	require.True(t, rp.reschedule)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
-
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
 	require.Len(t, allocated.Resources, 1)
-
 	for _, res := range allocated.Resources {
 		conf := expconf.ExperimentConfig{ //nolint:exhaustruct
 			RawEnvironment: &expconf.EnvironmentConfigV0{ //nolint:exhaustruct
@@ -838,16 +832,12 @@ func TestJobQueueReattach(t *testing.T) {
 		defer res.Kill(nil)
 		require.NoError(t, err)
 	}
-
 	change := poll[*sproto.ResourcesStateChanged](ctx, t, sub)
 	require.Equal(t, sproto.Pulling, change.ResourcesState)
-
 	change = poll[*sproto.ResourcesStateChanged](ctx, t, sub)
 	require.Equal(t, sproto.Starting, change.ResourcesState)
-
 	change = poll[*sproto.ResourcesStateChanged](ctx, t, sub)
 	require.Equal(t, sproto.Running, change.ResourcesState)
-	require.NotNil(t, change.ResourcesStarted)
 
 	jobq = rp.GetJobQ()
 	require.Len(t, jobq, 1)
@@ -859,7 +849,7 @@ func TestJobQueueReattach(t *testing.T) {
 	require.Equal(t, 2, info.AllocatedSlots)
 	require.Equal(t, 2, info.RequestedSlots)
 
-	// Remake all component and "reattach" to this new resource pool. This saves
+	// Remake all components and "reattach" to this new resource pool. This saves
 	// us from needing to made the k8s code do graceful shutdown, but we should
 	// do it anyway someday.
 	rp = newTestResourcePool(newTestJobsService(t))
@@ -867,22 +857,7 @@ func TestJobQueueReattach(t *testing.T) {
 	sub = rmevents.Subscribe(allocationID)
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
-
-	jobq = rp.GetJobQ()
-	require.Len(t, jobq, 1)
-	for _, tmp := range jobq {
-		info = tmp
-		break
-	}
-	require.Equal(t, sproto.SchedulingStateQueued, info.State)
-	require.Equal(t, 0, info.AllocatedSlots)
-	require.Equal(t, 2, info.RequestedSlots)
-
-	require.True(t, rp.reschedule)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	rp.Admit()
 
 	reallocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.True(t, reallocated.Recovered)
@@ -898,16 +873,6 @@ func TestJobQueueReattach(t *testing.T) {
 	}), "job isn' showing scheduling within 5s of being reattached")
 	require.Equal(t, 2, reattachInfo.AllocatedSlots)
 	require.Equal(t, 2, reattachInfo.RequestedSlots)
-
-	for _, res := range reallocated.Resources {
-		res.Kill(nil)
-	}
-
-	for state := sproto.Assigned; state != sproto.Terminated; {
-		change := poll[*sproto.ResourcesStateChanged](ctx, t, sub)
-		require.True(t, state.BeforeOrEqual(change.ResourcesState))
-		state = change.ResourcesState
-	}
 }
 
 func TestNodeWorkflows(t *testing.T) {
@@ -961,10 +926,10 @@ func TestNodeWorkflows(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
@@ -1082,10 +1047,10 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID))
 
 	t.Log("but the second shouldn't")
@@ -1102,16 +1067,16 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID2))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocationID2))
 
 	t.Log("and when the first releases it should get scheduled")
 	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: allocationID})
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocationID2))
 }
 
@@ -1206,10 +1171,10 @@ func TestSchedule(t *testing.T) {
 	_, ok := rp.reqList.TaskByID(allocReq.AllocationID)
 	require.True(t, ok)
 
-	require.True(t, rp.reschedule)
+	require.True(t, rp.tryAdmitPendingTasks)
 	require.False(t, rp.reqList.IsScheduled(allocID))
-	rp.Schedule()
-	require.False(t, rp.reschedule)
+	rp.Admit()
+	require.False(t, rp.tryAdmitPendingTasks)
 	require.True(t, rp.reqList.IsScheduled(allocID))
 }
 

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -159,11 +159,9 @@ func testLaunch(
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -250,11 +248,9 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -302,11 +298,9 @@ func TestPodLogStreamerReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	reallocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.True(t, reallocated.Recovered)
@@ -352,11 +346,9 @@ func TestPodLogStreamer(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -421,11 +413,9 @@ func TestKill(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -501,11 +491,9 @@ func TestExternalKillWhileQueuedFails(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -605,11 +593,9 @@ func TestExternalPodDelete(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -694,11 +680,9 @@ func TestReattach(t *testing.T) {
 	}
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -745,11 +729,9 @@ func TestReattach(t *testing.T) {
 	allocateReq.Restore = true
 	rp.AllocateRequest(allocateReq)
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	reallocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.True(t, reallocated.Recovered)
@@ -926,11 +908,9 @@ func TestNodeWorkflows(t *testing.T) {
 		ResourcePool:      "default",
 	})
 
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	allocated := poll[*sproto.ResourcesAllocated](ctx, t, sub)
 	require.NotNil(t, allocated)
@@ -1001,20 +981,18 @@ func TestAllocateAndReleaseBeforeStarted(t *testing.T) {
 		AllocationID: allocID,
 		JobID:        model.NewJobID(),
 		Name:         uuid.NewString(),
-		BlockedNodes: []string{uuid.NewString(), uuid.NewString()},
 	}
 	rp.AllocateRequest(allocReq)
-	req, ok := rp.reqList.TaskByID(allocID)
-	require.True(t, ok)
-	require.Equal(t, allocReq, *req)
+	summary := rp.GetAllocationSummary(allocID)
+	require.NotNil(t, summary)
+	require.Equal(t, allocReq.Name, summary.Name)
 
 	rp.ResourcesReleased(sproto.ResourcesReleased{
 		AllocationID: allocID,
 		ResourcePool: rp.poolConfig.PoolName,
 	})
-	req, ok = rp.reqList.TaskByID(allocID)
-	require.False(t, ok)
-	require.Nil(t, req)
+	summary = rp.GetAllocationSummary(allocID)
+	require.Nil(t, summary)
 }
 
 func TestGroupMaxSlots(t *testing.T) {
@@ -1047,11 +1025,9 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID))
+	require.Len(t, rp.GetAllocationSummary(allocationID).Resources, 1)
 
 	t.Log("but the second shouldn't")
 	id2 := uuid.NewString()
@@ -1067,17 +1043,14 @@ func TestGroupMaxSlots(t *testing.T) {
 		SlotsNeeded:       1,
 		ResourcePool:      "default",
 	})
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID2))
+	require.Len(t, rp.GetAllocationSummary(allocationID2).Resources, 0)
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocationID2))
+	require.Len(t, rp.GetAllocationSummary(allocationID2).Resources, 0)
 
 	t.Log("and when the first releases it should get scheduled")
 	rp.ResourcesReleased(sproto.ResourcesReleased{AllocationID: allocationID})
 	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocationID2))
+	require.Len(t, rp.GetAllocationSummary(allocationID2).Resources, 1)
 }
 
 func TestPendingPreemption(t *testing.T) {
@@ -1151,31 +1124,6 @@ func TestValidateResources(t *testing.T) {
 			require.Equal(t, tt.fulfillable, res.Fulfillable)
 		})
 	}
-}
-
-func TestSchedule(t *testing.T) {
-	// TODO RM-301
-	t.Skip("skipping test until flake fixed")
-	rp := newTestResourcePool(newTestJobsService(t))
-	jobID := model.NewJobID()
-	allocID := model.AllocationID(jobID)
-
-	allocReq := sproto.AllocateRequest{
-		AllocationID: allocID,
-		JobID:        jobID,
-		Preemptible:  true,
-		State:        sproto.SchedulingStateQueued,
-	}
-	rp.AllocateRequest(allocReq)
-
-	_, ok := rp.reqList.TaskByID(allocReq.AllocationID)
-	require.True(t, ok)
-
-	require.True(t, rp.tryAdmitPendingTasks)
-	require.False(t, rp.reqList.IsScheduled(allocID))
-	rp.Admit()
-	require.False(t, rp.tryAdmitPendingTasks)
-	require.True(t, rp.reqList.IsScheduled(allocID))
 }
 
 func poll[T sproto.ResourcesEvent](ctx context.Context, t *testing.T, sub *sproto.ResourcesSubscription) T {


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
What it says on the tin.

..but I also renamed `Schedule` to `Admit` because it's not scheduling, just deciding to admit tasks to Kubernetes to be scheduled (and from that, `reschedule` is now `tryAdmitPendingTasks`). My test had a call to schedule followed by an assertion that the job queue's state said we were queued. The name couldn't stand any longer lol.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Has automated testing.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ