### PR TITLE
fix: job state shows as scheduled when resources are allocated

### DIFF
--- a/docs/release-notes/job-state.rst
+++ b/docs/release-notes/job-state.rst
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Job state will now correctly show as "SCHEDULED" once all pods have been assigned to nodes. Previously, jobs would remain in state "QUEUED" until all pods were in phase "Running".
+-  Kubernetes: Job state will now correctly show as "SCHEDULED" once all pods have been assigned to
+   nodes. Previously, jobs would remain in state "QUEUED" until all pods were in phase "Running".

--- a/docs/release-notes/job-state.rst
+++ b/docs/release-notes/job-state.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Kubernetes: Job state will now correctly show as "SCHEDULED" once all pods have been assigned to nodes. Previously, jobs would remain in state "QUEUED" until all pods were in phase "Running".

--- a/docs/release-notes/job-state.rst
+++ b/docs/release-notes/job-state.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  Kubernetes: Job state will now correctly show as "SCHEDULED" once all pods have been assigned to
-   nodes. Previously, jobs would remain in state "QUEUED" until all pods were in phase "Running".
+-  Kubernetes: Fix an issue where where jobs would remain in "QUEUED" state until all pods were
+   running. Jobs will now correctly show as "SCHEDULED" once all pods have been assigned to nodes.

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -588,7 +588,7 @@ func (j *job) preparePodUpdateMessage(msgText string) string {
 }
 
 // PodScheduled checks pod conditions to determine if a pod has been scheduled onto a node.
-func PodScheduled(pod k8sV1.Pod) bool {
+func podScheduled(pod k8sV1.Pod) bool {
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == k8sV1.PodScheduled {
 			return condition.Status == k8sV1.ConditionTrue
@@ -609,7 +609,7 @@ func (j *job) getPodState(pod k8sV1.Pod) (cproto.State, error) {
 			return cproto.Terminated, nil
 		}
 
-		if PodScheduled(pod) {
+		if podScheduled(pod) {
 			return cproto.Starting, nil
 		}
 		return cproto.Assigned, nil

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -587,6 +587,16 @@ func (j *job) preparePodUpdateMessage(msgText string) string {
 	return msgText
 }
 
+// PodScheduled checks pod conditions to determine if a pod has been scheduled onto a node.
+func PodScheduled(pod k8sV1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == k8sV1.PodScheduled {
+			return condition.Status == k8sV1.ConditionTrue
+		}
+	}
+	return false
+}
+
 func (j *job) getPodState(pod k8sV1.Pod) (cproto.State, error) {
 	switch pod.Status.Phase {
 	case k8sV1.PodPending:
@@ -599,10 +609,8 @@ func (j *job) getPodState(pod k8sV1.Pod) (cproto.State, error) {
 			return cproto.Terminated, nil
 		}
 
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == k8sV1.PodScheduled && condition.Status == k8sV1.ConditionTrue {
-				return cproto.Starting, nil
-			}
+		if PodScheduled(pod) {
+			return cproto.Starting, nil
 		}
 		return cproto.Assigned, nil
 

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -979,7 +979,7 @@ func (j *jobsService) updatePodSchedulingState(jobName string, pod k8sV1.Pod) {
 
 	// A nodename in the spec is a request to be scheduled onto a node but it is not guaranteed.
 	states[pod.Name] = sproto.SchedulingStateQueued
-	if PodScheduled(pod) {
+	if podScheduled(pod) {
 		states[pod.Name] = sproto.SchedulingStateScheduled
 	}
 	j.jobNameToPodNameToSchedulingState[jobName] = states

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -961,7 +961,6 @@ func (j *jobsService) podDeletedCallback(obj any) {
 // jobSchedulingState is a roll-up of the sceduling states of its individual pods.
 func (j *jobsService) jobSchedulingState(jobName string) sproto.SchedulingState {
 	states, ok := j.jobNameToPodNameToSchedulingState[jobName]
-
 	if !ok {
 		return sproto.SchedulingStateQueued
 	}

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -977,7 +977,7 @@ func (j *jobsService) updatePodSchedulingState(jobName string, pod k8sV1.Pod) {
 		states = make(map[string]sproto.SchedulingState)
 	}
 
-	// A nodename in the spec is a request to be scheduled onto a node but it is not guaranteed.
+	// The field pod.Spec.NodeName is a request to be scheduled onto a node but it is not guaranteed.
 	states[pod.Name] = sproto.SchedulingStateQueued
 	if podScheduled(pod) {
 		states[pod.Name] = sproto.SchedulingStateScheduled

--- a/master/internal/rm/kubernetesrm/jobs_test.go
+++ b/master/internal/rm/kubernetesrm/jobs_test.go
@@ -132,7 +132,6 @@ func TestJobScheduledStatus(t *testing.T) {
 	actualState = js.jobSchedulingState(jobName)
 	expectedState = sproto.SchedulingStateScheduled
 	require.Equal(t, expectedState, actualState)
-
 }
 
 func TestTaintTolerated(t *testing.T) {

--- a/master/internal/rm/kubernetesrm/jobs_test.go
+++ b/master/internal/rm/kubernetesrm/jobs_test.go
@@ -14,6 +14,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/determined-ai/determined/master/internal/mocks"
+	"github.com/determined-ai/determined/master/internal/sproto"
 )
 
 func TestGetNonDetPods(t *testing.T) {
@@ -63,16 +64,72 @@ func TestGetNonDetPods(t *testing.T) {
 	ns2.On("List", mock.Anything, mock.Anything).Once().
 		Return(&k8sV1.PodList{Items: append(hiddenPods, expectedPods[1])}, nil)
 
-	p := jobsService{
+	js := jobsService{
 		podInterfaces: map[string]typedV1.PodInterface{
 			"ns1": ns1,
 			"ns2": ns2,
 		},
 	}
 
-	actualPods, err := p.getNonDetPods()
+	actualPods, err := js.getNonDetPods()
 	require.NoError(t, err)
 	require.ElementsMatch(t, expectedPods, actualPods)
+}
+
+func TestJobScheduledStatus(t *testing.T) {
+	pendingPod := k8sV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "test-pod",
+		},
+		Status: k8sV1.PodStatus{
+			Conditions: make([]k8sV1.PodCondition, 0),
+		},
+	}
+	notScheduledPod := k8sV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "test-pod",
+		},
+		Status: k8sV1.PodStatus{
+			Conditions: []k8sV1.PodCondition{
+				{
+					Type:   k8sV1.PodScheduled,
+					Status: k8sV1.ConditionFalse,
+				},
+			},
+		},
+	}
+	scheduledPod := k8sV1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "test-pod",
+		},
+		Status: k8sV1.PodStatus{
+			Conditions: []k8sV1.PodCondition{
+				{
+					Type:   k8sV1.PodScheduled,
+					Status: k8sV1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	js := jobsService{
+		jobNameToPodNameToSchedulingState: make(map[string]map[string]sproto.SchedulingState),
+	}
+	jobName := "test-job"
+	js.updatePodSchedulingState(jobName, pendingPod)
+	actualState := js.jobSchedulingState(jobName)
+	expectedState := sproto.SchedulingStateQueued
+	require.Equal(t, expectedState, actualState)
+
+	js.updatePodSchedulingState(jobName, notScheduledPod)
+	actualState = js.jobSchedulingState(jobName)
+	expectedState = sproto.SchedulingStateQueued
+	require.Equal(t, expectedState, actualState)
+
+	js.updatePodSchedulingState(jobName, scheduledPod)
+	actualState = js.jobSchedulingState(jobName)
+	expectedState = sproto.SchedulingStateScheduled
+	require.Equal(t, expectedState, actualState)
 }
 
 func TestTaintTolerated(t *testing.T) {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[RM-166]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Kubernetes job status on the Cluster Page will correctly reflect the state of workloads. Once all Kubernetes pods are scheduled on nodes, the job state will be reflected as "scheduled" rather than "queued".


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

None needed.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-166]: https://hpe-aiatscale.atlassian.net/browse/RM-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ