### PR TITLE
chore: deprecate PPC64/POWER builds

### DIFF
--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -11,7 +11,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -123,37 +122,21 @@ dockers:
     extra_files:
       - packaging/entrypoint.sh
       - packaging/LICENSE
-  # # ppc64
-  # - goos: linux
-  #   goarch: ppc64
-  #   use: buildx
-  #   build_flag_templates:
-  #     - --platform=linux/ppc64le
-  #     - --builder=buildx-build
-  #   image_templates:
-  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-  #   extra_files:
-  #     - packaging/entrypoint.sh
-  #     - packaging/LICENSE
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/agent/.goreleaser.yml
+++ b/agent/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
+      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -123,37 +123,37 @@ dockers:
     extra_files:
       - packaging/entrypoint.sh
       - packaging/LICENSE
-  # ppc64
-  - goos: linux
-    goarch: ppc64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/ppc64le
-      - --builder=buildx-build
-    image_templates:
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-    extra_files:
-      - packaging/entrypoint.sh
-      - packaging/LICENSE
+  # # ppc64
+  # - goos: linux
+  #   goarch: ppc64
+  #   use: buildx
+  #   build_flag_templates:
+  #     - --platform=linux/ppc64le
+  #     - --builder=buildx-build
+  #   image_templates:
+  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+  #   extra_files:
+  #     - packaging/entrypoint.sh
+  #     - packaging/LICENSE
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/agent/.goreleaser_ee.yml
+++ b/agent/.goreleaser_ee.yml
@@ -13,7 +13,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -125,37 +124,21 @@ dockers:
     extra_files:
       - packaging/entrypoint.sh
       - packaging/LICENSE
-  # # ppc64
-  # - goos: linux
-  #   goarch: ppc64
-  #   use: buildx
-  #   build_flag_templates:
-  #     - --platform=linux/ppc64le
-  #     - --builder=buildx-build
-  #   image_templates:
-  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-  #   extra_files:
-  #     - packaging/entrypoint.sh
-  #     - packaging/LICENSE
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/agent/.goreleaser_ee.yml
+++ b/agent/.goreleaser_ee.yml
@@ -13,7 +13,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
+      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -125,37 +125,37 @@ dockers:
     extra_files:
       - packaging/entrypoint.sh
       - packaging/LICENSE
-  # ppc64
-  - goos: linux
-    goarch: ppc64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/ppc64le
-      - --builder=buildx-build
-    image_templates:
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-    extra_files:
-      - packaging/entrypoint.sh
-      - packaging/LICENSE
+  # # ppc64
+  # - goos: linux
+  #   goarch: ppc64
+  #   use: buildx
+  #   build_flag_templates:
+  #     - --platform=linux/ppc64le
+  #     - --builder=buildx-build
+  #   image_templates:
+  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+  #   extra_files:
+  #     - packaging/entrypoint.sh
+  #     - packaging/LICENSE
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -9,7 +9,7 @@ FULL_COMMIT = $(shell git rev-parse HEAD)
 SHORT_COMMIT = $(shell git rev-parse HEAD | head -c9)
 PROJECT_NAME = determined-agent
 EE_PROJECT_NAME = hpe-mlde-agent
-ARCHS = amd64 arm64 ppc64
+ARCHS = amd64 arm64
 MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
 EE_MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
 
@@ -91,7 +91,6 @@ buildx:
 	{ \
 		platforms=(); \
 		for arch in $(ARCHS); do \
-			[ $$arch == "ppc64" ] && arch="ppc64le"; \
 			platforms+=("linux/$$arch"); \
 		done; \
 		platform_list=$$(IFS=, ; echo "$${platforms[*]}"); \

--- a/docs/release-notes/deprecate-ppc64
+++ b/docs/release-notes/deprecate-ppc64
@@ -1,0 +1,5 @@
+:orphan:
+
+**Deprecations**
+
+-  Machine Architectures: Deprecate PPC64/POWER builds architecture as part of deprecating underutilized AgentRM features. Users can’t use Determined on PPC64 architecture anymore.

--- a/docs/release-notes/deprecate-ppc64
+++ b/docs/release-notes/deprecate-ppc64
@@ -1,5 +1,0 @@
-:orphan:
-
-**Deprecations**
-
--  Machine Architectures: Deprecate PPC64/POWER builds architecture as part of deprecating underutilized AgentRM features. Users can’t use Determined on PPC64 architecture anymore.

--- a/docs/release-notes/deprecate-ppc64.rst
+++ b/docs/release-notes/deprecate-ppc64.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Deprecations**
+
+-  Machine Architectures: Due to underutilized AgentRM features, support for PPC64/POWER builds is deprecated. Users should transition to ARM64/AMD64.

--- a/docs/release-notes/deprecate-ppc64.rst
+++ b/docs/release-notes/deprecate-ppc64.rst
@@ -2,4 +2,5 @@
 
 **Deprecations**
 
--  Machine Architectures: Due to underutilized AgentRM features, support for PPC64/POWER builds is deprecated. Users should transition to ARM64/AMD64.
+-  Machine Architectures: Due to underutilized AgentRM features, support for PPC64/POWER builds is
+   deprecated. Users should transition to ARM64/AMD64.

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -19,7 +19,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
   - main: ./cmd/determined-gotmpl
     id: determined-gotmpl
     binary: determined-gotmpl
@@ -29,7 +28,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -182,41 +180,41 @@ dockers:
       - determined-master
       - determined-gotmpl
   # ppc64
-  - goos: linux
-    goarch: ppc64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/ppc64le
-      - --builder=buildx-build
-    image_templates:
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-    extra_files:
-      - "packaging/master.yaml"
-      - "packaging/LICENSE"
-      - "build"
-      - "static"
-    ids:
-      - determined-master
-      - determined-gotmpl
+  # - goos: linux
+  #   goarch: ppc64
+  #   use: buildx
+  #   build_flag_templates:
+  #     - --platform=linux/ppc64le
+  #     - --builder=buildx-build
+  #   image_templates:
+  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+  #   extra_files:
+  #     - "packaging/master.yaml"
+  #     - "packaging/LICENSE"
+  #     - "build"
+  #     - "static"
+  #   ids:
+  #     - determined-master
+  #     - determined-gotmpl
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/master/.goreleaser.yml
+++ b/master/.goreleaser.yml
@@ -179,42 +179,21 @@ dockers:
     ids:
       - determined-master
       - determined-gotmpl
-  # ppc64
-  # - goos: linux
-  #   goarch: ppc64
-  #   use: buildx
-  #   build_flag_templates:
-  #     - --platform=linux/ppc64le
-  #     - --builder=buildx-build
-  #   image_templates:
-  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-  #   extra_files:
-  #     - "packaging/master.yaml"
-  #     - "packaging/LICENSE"
-  #     - "build"
-  #     - "static"
-  #   ids:
-  #     - determined-master
-  #     - determined-gotmpl
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/master/.goreleaser_ee.yml
+++ b/master/.goreleaser_ee.yml
@@ -23,7 +23,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
+      # - ppc64
   - main: ./cmd/determined-gotmpl
     id: determined-gotmpl
     binary: determined-gotmpl
@@ -33,7 +33,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - ppc64
+      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -187,42 +187,42 @@ dockers:
     ids:
       - determined-ee-master
       - determined-gotmpl
-  # ppc64
-  - goos: linux
-    goarch: ppc64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/ppc64le
-      - --builder=buildx-build
-    image_templates:
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-    extra_files:
-      - "packaging/master.yaml"
-      - "packaging/LICENSE"
-      - "build"
-      - "static"
-    ids:
-      - determined-ee-master
-      - determined-gotmpl
+  # # ppc64
+  # - goos: linux
+  #   goarch: ppc64
+  #   use: buildx
+  #   build_flag_templates:
+  #     - --platform=linux/ppc64le
+  #     - --builder=buildx-build
+  #   image_templates:
+  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+  #   extra_files:
+  #     - "packaging/master.yaml"
+  #     - "packaging/LICENSE"
+  #     - "build"
+  #     - "static"
+  #   ids:
+  #     - determined-ee-master
+  #     - determined-gotmpl
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
+      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/master/.goreleaser_ee.yml
+++ b/master/.goreleaser_ee.yml
@@ -23,7 +23,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      # - ppc64
   - main: ./cmd/determined-gotmpl
     id: determined-gotmpl
     binary: determined-gotmpl
@@ -33,7 +32,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      # - ppc64
 
 archives:
   - wrap_in_directory: "true"
@@ -187,42 +185,21 @@ dockers:
     ids:
       - determined-ee-master
       - determined-gotmpl
-  # # ppc64
-  # - goos: linux
-  #   goarch: ppc64
-  #   use: buildx
-  #   build_flag_templates:
-  #     - --platform=linux/ppc64le
-  #     - --builder=buildx-build
-  #   image_templates:
-  #     - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
-  #   extra_files:
-  #     - "packaging/master.yaml"
-  #     - "packaging/LICENSE"
-  #     - "build"
-  #     - "static"
-  #   ids:
-  #     - determined-ee-master
-  #     - determined-gotmpl
 
 docker_manifests:
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"
   - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-      # - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-ppc64"

--- a/master/Makefile
+++ b/master/Makefile
@@ -16,7 +16,7 @@ FULL_COMMIT = $(shell git rev-parse HEAD)
 SHORT_COMMIT = $(shell git rev-parse HEAD | head -c9)
 PROJECT_NAME = determined-master
 EE_PROJECT_NAME = hpe-mlde-master
-ARCHS = amd64 arm64 ppc64
+ARCHS = amd64 arm64
 ARCH_SMALL = amd64-shared-cluster
 MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
 EE_MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
@@ -221,7 +221,6 @@ buildx:
 	{ \
 		platforms=(); \
 		for arch in $(ARCHS); do \
-			[ $$arch == "ppc64" ] && arch="ppc64le"; \
 			platforms+=("linux/$$arch"); \
 		done; \
 		platform_list=$$(IFS=, ; echo "$${platforms[*]}"); \


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[[RM-294](https://hpe-aiatscale.atlassian.net/browse/RM-294)]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Deprecate PPC64/POWER builds. Note: This is not just AgentRM specific, but will be deprecated for all RMs 

Potential Impact: Built for a single OSS [~3 years ago](https://determined-community.slack.com/archives/CV37XVAGL/p1617206888020800), haven’t heard of customers using it since. Users can’t use Determined on PPC64 architecture anymore 

Packages with our code do not support power pc. Ok to remove in Q3 / 0.33.1.

Current AgentRM deprecation document linked [here](https://hpe.sharepoint.com/:w:/r/teams/detai/_layouts/15/Doc.aspx?sourcedoc=%7BD5D9B85A-7371-42C5-AAF6-4DAD09D2EF98%7D&file=Pruning%20Under-utilized%20AgentRM%20Features%20(Needs%20Feedback%20for%20Commitment%20of%20Work).docx&action=default&mobileredirect=true).
No active customers use PPC64 architecture anymore. Hence it is safe to deprecate. [Here](https://hpe-aiatscale.slack.com/archives/C02PV33GSN5/p1710880143328809?thread_ts=1710863001.723729&cid=C02PV33GSN5) are more information about it.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

1. Tried to build an image and upload to circle CI. Images didn't have PPC64 OS arch 

## Checklist

- [X] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [X] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DET-294]: https://hpe-aiatscale.atlassian.net/browse/DET-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-294]: https://hpe-aiatscale.atlassian.net/browse/RM-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ