### PR TITLE
fix: run columns mismatching sort/filter columns for run table

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -129,7 +129,7 @@ var defaultRunsTableColumns = []*projectv1.ProjectColumn{
 		Column:      "projectId",
 		DisplayName: "Project ID",
 		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
-		Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+		Type:        projectv1.ColumnType_COLUMN_TYPE_NUMBER,
 	},
 	{
 		Column:      "externalRunId",

--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -60,6 +60,12 @@ var defaultRunsTableColumns = []*projectv1.ProjectColumn{
 		Type:        projectv1.ColumnType_COLUMN_TYPE_DATE,
 	},
 	{
+		Column:      "endTime",
+		DisplayName: "End Time",
+		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
+		Type:        projectv1.ColumnType_COLUMN_TYPE_DATE,
+	},
+	{
 		Column:      "duration",
 		DisplayName: "Duration",
 		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
@@ -116,6 +122,12 @@ var defaultRunsTableColumns = []*projectv1.ProjectColumn{
 	{
 		Column:      "externalExperimentId",
 		DisplayName: "External Experiment ID",
+		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
+		Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+	},
+	{
+		Column:      "projectId",
+		DisplayName: "Project ID",
 		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
 		Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 	},

--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -192,7 +192,7 @@ func sortRuns(sortString *string, runQuery *bun.SelectQuery) error {
 		"checkpointSize":        "checkpoint_size",
 		"checkpointCount":       "checkpoint_count",
 		"duration":              "duration",
-		"searcherMetricsVal":    "r.searcher_metric_val",
+		"searcherMetricsVal":    "r.searcher_metric_value",
 		"externalExperimentId":  "e.external_experiment_id",
 		"externalRunId":         "r.external_run_id",
 		"experimentId":          "e.id",

--- a/master/internal/api_runs_intg_test.go
+++ b/master/internal/api_runs_intg_test.go
@@ -131,7 +131,7 @@ func TestSearchRunsSortAndFilterAllDefaultColumns(t *testing.T) {
 		filter := fmt.Sprintf(`{"filterGroup":{"children":[{"columnName":"%s","kind":"field",`+
 			`"location":"%s","operator":"=","type":"%s","value":null}],`+
 			`"conjunction":"and","kind":"group"},"showArchived":false}`, c.Column, c.Location.String(), c.Type.String())
-		resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
+		_, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
 			ProjectId: req.ProjectId,
 			Sort:      ptrs.Ptr(c.Column + "=asc"),
 			Filter:    ptrs.Ptr(filter),
@@ -139,7 +139,6 @@ func TestSearchRunsSortAndFilterAllDefaultColumns(t *testing.T) {
 
 		require.NoError(t, err)
 	}
-
 }
 
 func TestSearchRunsSort(t *testing.T) {

--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -156,7 +156,7 @@ func runColumnNameToSQL(columnName string) (string, error) {
 		"checkpointCount":       "e.checkpoint_count",
 		"searcherMetricsVal":    "r.searcher_metric_value",
 		"externalExperimentId":  "e.external_experiment_id",
-		"externalTrialId":       "r.external_run_id",
+		"externalRunId":         "r.external_run_id",
 		"experimentId":          "e.id",
 	}
 	var exists bool

--- a/master/internal/experiment_filter.go
+++ b/master/internal/experiment_filter.go
@@ -158,6 +158,8 @@ func runColumnNameToSQL(columnName string) (string, error) {
 		"externalExperimentId":  "e.external_experiment_id",
 		"externalRunId":         "r.external_run_id",
 		"experimentId":          "e.id",
+		"isExpMultitrial":       "e.config->'searcher'->>'name' != 'single'",
+		"parentArchived":        "(w.archived OR p.archived)",
 	}
 	var exists bool
 	col, exists := filterExperimentColMap[columnName]


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
ET-295


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Adding missing columns for GetColumns, filter & sort for Run Table
Including new test that checks is all default columns returned have valid sort and filter paths (except tags)


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Sort & filter on all columns(except tags) in the Run Table and verify results


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ