### PR TITLE
Reattach gateways

### DIFF
--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -308,6 +308,12 @@ def set_proxy_address(sess: api.Session, allocation_id: str) -> None:
 
 
 def set_proxy_address_kubernetes(sess: api.Session, allocation_id: str) -> None:
+    # When using a gateway, we know the static IP in advance so we don't want to tell the
+    # master the pod IP. Handling this on the master side gets a little tricky with restore.
+    # For example we send this proxy address before master sends the allocation its address.
+    if os.environ.get("DET_PROXY_THROUGH_GATEWAY") == "true":
+        return
+
     pod_ip_str = os.environ.get("DET_KUBERNETES_POD_IP")
     assert pod_ip_str, "Unable to complete rendezvous without DET_KUBERNETES_POD_IP"
 

--- a/master/internal/rm/kubernetesrm/gateway_service.go
+++ b/master/internal/rm/kubernetesrm/gateway_service.go
@@ -14,6 +14,7 @@ import (
 	alphaGateway "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1alpha2"
 
 	"github.com/determined-ai/determined/master/internal/config"
+	"github.com/determined-ai/determined/master/pkg/model"
 )
 
 // I wanted to do this all in patches, but Gateways don't yet support strategic merge patch.
@@ -33,11 +34,8 @@ type gatewayService struct {
 type gatewayResourceComm struct {
 	requestedPorts     int
 	resourceDescriptor proxyResourceGenerator
+	allocationID       model.AllocationID
 	reportResources    func([]gatewayProxyResource)
-}
-
-func genSectionName(gwPort int) string {
-	return fmt.Sprintf("section-%d", gwPort)
 }
 
 func newGatewayService(
@@ -62,7 +60,7 @@ func newGatewayService(
 // PortMap is a map of internal pod ports to external gateway ports.
 type PortMap map[int]int
 
-func (g *gatewayService) generateAndAddListeners(count int) ([]int, error) {
+func (g *gatewayService) generateAndAddListeners(allocationID model.AllocationID, count int) ([]int, error) {
 	var ports []int
 	if err := g.updateGateway(func(gateway *gatewayTyped.Gateway) error {
 		var err error
@@ -72,7 +70,7 @@ func (g *gatewayService) generateAndAddListeners(count int) ([]int, error) {
 			return err
 		}
 		for i := 0; i < count; i++ {
-			listeners[i] = createListenerForPod(ports[i])
+			listeners[i] = createListenerForPod(allocationID, ports[i])
 		}
 		gateway.Spec.Listeners = append(gateway.Spec.Listeners, listeners...)
 		return nil
@@ -114,6 +112,25 @@ func (g *gatewayService) freePorts(ports []int) error {
 		return fmt.Errorf("freeing ports %v from gateway: %w", ports, err)
 	}
 	return nil
+}
+
+func (g *gatewayService) getProxyPorts(allocationID model.AllocationID) ([]int, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	gateway, err := g.gatewayInterface.Get(context.TODO(), g.gatewayName, metaV1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting gateway for proxy ports: %w", err)
+	}
+
+	var ports []int
+	for _, listener := range gateway.Spec.Listeners {
+		if string(getAllocationIDFromListenerName(string(listener.Name))) == string(allocationID) {
+			ports = append(ports, int(listener.Port))
+		}
+	}
+
+	return ports, nil
 }
 
 /*

--- a/master/internal/rm/kubernetesrm/gateway_service_test.go
+++ b/master/internal/rm/kubernetesrm/gateway_service_test.go
@@ -35,7 +35,7 @@ func TestGatewayServiceAddListeners(t *testing.T) {
 	toReturn := &gatewayTyped.Gateway{
 		Spec: gatewayTyped.GatewaySpec{
 			Listeners: []gatewayTyped.Listener{
-				createListenerForPod(1),
+				createListenerForPod("alloc", 1),
 			},
 		},
 	}
@@ -43,16 +43,16 @@ func TestGatewayServiceAddListeners(t *testing.T) {
 	expected := &gatewayTyped.Gateway{
 		Spec: gatewayTyped.GatewaySpec{
 			Listeners: []gatewayTyped.Listener{
-				createListenerForPod(1),
-				createListenerForPod(2),
-				createListenerForPod(3),
+				createListenerForPod("alloc", 1),
+				createListenerForPod("alloc", 2),
+				createListenerForPod("alloc", 3),
 			},
 		},
 	}
 
 	gatewayMock.On("Get", mock.Anything, "gatewayname", metaV1.GetOptions{}).Return(toReturn, nil)
 	gatewayMock.On("Update", mock.Anything, expected, metaV1.UpdateOptions{}).Return(nil, nil)
-	ports, err := g.generateAndAddListeners(2)
+	ports, err := g.generateAndAddListeners("alloc", 2)
 	require.Len(t, ports, 2)
 	require.Equal(t, []int{2, 3}, ports)
 	require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestGatewayServicePickPorts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			listeners := []gatewayTyped.Listener{}
 			for _, port := range tc.usedPorts {
-				listeners = append(listeners, createListenerForPod(port))
+				listeners = append(listeners, createListenerForPod("alloc", port))
 			}
 			gatewayGetReturn := &gatewayTyped.Gateway{
 				Spec: gatewayTyped.GatewaySpec{

--- a/master/internal/rm/kubernetesrm/gateway_spec.go
+++ b/master/internal/rm/kubernetesrm/gateway_spec.go
@@ -24,19 +24,32 @@ func createListenerForPod(allocationID model.AllocationID, gwPort int) gatewayTy
 	return gatewayListener
 }
 
-func generateListenerName(allocationID model.AllocationID, port int) string {
-	return fmt.Sprintf("%d-det-%s", port, allocationID)
-}
-
-func getAllocationIDFromListenerName(listenerName string) string {
-	if !strings.Contains(listenerName, "det") {
-		return ""
-	}
-
-	lastHyphenIndex := strings.LastIndex(listenerName, "det-")
+func stripIndexFromSharedName(n string) string {
+	lastHyphenIndex := strings.LastIndex(n, "-")
 	if lastHyphenIndex == -1 {
 		return ""
 	}
 
-	return listenerName[lastHyphenIndex+len("det-"):]
+	return n[:lastHyphenIndex]
+}
+
+func generateListenerName(allocationID model.AllocationID, port int) string {
+	return fmt.Sprintf("%d-determined-%s", port, allocationID)
+}
+
+func listenerIsDetermined(listenerName string) bool {
+	return strings.Contains(listenerName, "determined")
+}
+
+func getAllocationIDFromListenerName(listenerName string) string {
+	if !listenerIsDetermined(listenerName) {
+		return ""
+	}
+
+	lastHyphenIndex := strings.LastIndex(listenerName, "determined-")
+	if lastHyphenIndex == -1 {
+		return ""
+	}
+
+	return listenerName[lastHyphenIndex+len("determined-"):]
 }

--- a/master/internal/rm/kubernetesrm/gateway_spec.go
+++ b/master/internal/rm/kubernetesrm/gateway_spec.go
@@ -38,7 +38,7 @@ func generateListenerName(allocationID model.AllocationID, port int) string {
 }
 
 func listenerIsDetermined(listenerName string) bool {
-	return strings.Contains(listenerName, "determined")
+	return strings.Contains(listenerName, "determined-")
 }
 
 func getAllocationIDFromListenerName(listenerName string) string {

--- a/master/internal/rm/kubernetesrm/gateway_spec.go
+++ b/master/internal/rm/kubernetesrm/gateway_spec.go
@@ -1,14 +1,18 @@
 package kubernetesrm
 
 import (
+	"fmt"
+	"strings"
+
 	gatewayTyped "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 )
 
-func createListenerForPod(gwPort int) gatewayTyped.Listener {
+func createListenerForPod(allocationID model.AllocationID, gwPort int) gatewayTyped.Listener {
 	gatewayListener := gatewayTyped.Listener{
-		Name:     gatewayTyped.SectionName(genSectionName(gwPort)),
+		Name:     gatewayTyped.SectionName(generateListenerName(allocationID, gwPort)),
 		Port:     gatewayTyped.PortNumber(gwPort),
 		Protocol: "TCP",
 		AllowedRoutes: &gatewayTyped.AllowedRoutes{
@@ -18,4 +22,21 @@ func createListenerForPod(gwPort int) gatewayTyped.Listener {
 		},
 	}
 	return gatewayListener
+}
+
+func generateListenerName(allocationID model.AllocationID, port int) string {
+	return fmt.Sprintf("%d-det-%s", port, allocationID)
+}
+
+func getAllocationIDFromListenerName(listenerName string) string {
+	if !strings.Contains(listenerName, "det") {
+		return ""
+	}
+
+	lastHyphenIndex := strings.LastIndex(listenerName, "det-")
+	if lastHyphenIndex == -1 {
+		return ""
+	}
+
+	return listenerName[lastHyphenIndex+len("det-"):]
 }

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -320,6 +320,7 @@ func (j *job) makeGatewayComms(spec *tasks.TaskSpec) *gatewayResourceComm {
 	return &gatewayResourceComm{
 		resourceDescriptor: *resourceGenerator,
 		reportResources:    updateResources,
+		allocationID:       j.req.AllocationID,
 		requestedPorts:     len(j.req.ProxyPorts),
 	}
 }

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -472,7 +472,7 @@ func (j *jobsService) deleteDoomedKubernetesResources() error {
 	if j.exposeProxyConfig != nil {
 		services, err := j.listServicesInAllNamespaces(context.TODO(), listOptions)
 		if err != nil {
-			return fmt.Errorf("listing exisitng services: %w", err)
+			return fmt.Errorf("listing existing services: %w", err)
 		}
 		for _, s := range services {
 			if resourceIsSaved(s.Namespace, stripIndexFromSharedName(s.Name)) {
@@ -486,7 +486,7 @@ func (j *jobsService) deleteDoomedKubernetesResources() error {
 		savedGatewayPorts := make(map[int]bool)
 		tcpRoutes, err := j.listTCPRoutesInAllNamespaces(context.TODO(), listOptions)
 		if err != nil {
-			return fmt.Errorf("listing exisitng services: %w", err)
+			return fmt.Errorf("listing existing services: %w", err)
 		}
 		for _, t := range tcpRoutes {
 			if resourceIsSaved(t.Namespace, stripIndexFromSharedName(t.Name)) {
@@ -744,10 +744,10 @@ func (j *jobsService) recreateGatewayProxyResources(
 	for _, port := range gatewayPorts {
 		var tcpRoute *alphaGatewayTyped.TCPRoute
 		for _, t := range tcpRoutes {
+			t := t
 			if len(t.Spec.ParentRefs) > 0 &&
 				t.Spec.ParentRefs[0].Port != nil &&
 				int(*t.Spec.ParentRefs[0].Port) == port {
-
 				tcpRoute = &t
 				break
 			}
@@ -758,6 +758,7 @@ func (j *jobsService) recreateGatewayProxyResources(
 
 		var service *k8sV1.Service
 		for _, s := range services {
+			s := s
 			if s.Name == tcpRoute.Name {
 				service = &s
 				break

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -552,7 +552,6 @@ func (j *jobsService) SummarizeResources(poolName string) (*computeUsageSummary,
 }
 
 func (j *jobsService) ReattachJob(msg reattachJobRequest) (reattachJobResponse, error) {
-	// TODO(RM-270/gateways) make reattach works for gateways.
 	j.mu.Lock()
 	defer j.mu.Unlock()
 	return j.reattachJob(msg)

--- a/master/internal/rm/kubernetesrm/request_queue.go
+++ b/master/internal/rm/kubernetesrm/request_queue.go
@@ -2,6 +2,7 @@ package kubernetesrm
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 
 	batchV1 "k8s.io/api/batch/v1"
@@ -203,6 +204,21 @@ func keyForDelete(msg deleteKubernetesResources) requestID {
 	if msg.configMapName != "" {
 		return requestID(msg.namespace + "/" + msg.configMapName)
 	}
+	if len(msg.serviceNames) > 0 {
+		return requestID(msg.namespace + "/" + strings.Join(msg.serviceNames, ","))
+	}
+	if len(msg.tcpRouteNames) > 0 {
+		return requestID(msg.namespace + "/" + strings.Join(msg.tcpRouteNames, ","))
+	}
+	if len(msg.gatewayPortsToFree) > 0 {
+		var stringPorts []string
+		for _, p := range msg.gatewayPortsToFree {
+			stringPorts = append(stringPorts, strconv.Itoa(p))
+		}
+
+		return requestID(msg.namespace + "/" + strings.Join(stringPorts, ","))
+	}
+
 	panic("invalid deleteKubernetesResources message")
 }
 

--- a/master/internal/rm/kubernetesrm/request_workers.go
+++ b/master/internal/rm/kubernetesrm/request_workers.go
@@ -104,7 +104,9 @@ func (r *requestProcessingWorker) receiveCreateKubernetesResources(
 	// Do we / should we delete created resources?
 	if msg.gw != nil {
 		if msg.gw.requestedPorts > 0 {
-			if ports, err = r.gatewayService.generateAndAddListeners(msg.gw.requestedPorts); err != nil {
+			if ports, err = r.gatewayService.generateAndAddListeners(
+				msg.gw.allocationID, msg.gw.requestedPorts,
+			); err != nil {
 				r.syslog.WithError(err).Errorf("error patching gateway for job %s", msg.jobSpec.Name)
 				r.failures <- resourceCreationFailed{jobName: msg.jobSpec.Name, err: err}
 				return

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -130,6 +130,10 @@ func (j *job) configureEnvVars(
 
 	envVarsMap["DET_KUBERNETES_JOB_PARALLELISM"] = strconv.Itoa(j.numPods)
 
+	if j.exposeProxyConfig != nil {
+		envVarsMap["DET_PROXY_THROUGH_GATEWAY"] = "true"
+	}
+
 	envVars := make([]k8sV1.EnvVar, 0, len(envVarsMap))
 	for envVarKey, envVarValue := range envVarsMap {
 		envVars = append(envVars, k8sV1.EnvVar{Name: envVarKey, Value: envVarValue})

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -207,10 +207,12 @@ func (j *job) configureProxyResources(t *tasks.TaskSpec) *proxyResourceGenerator
 					CommonRouteSpec: alphaGatewayTyped.CommonRouteSpec{
 						ParentRefs: []alphaGatewayTyped.ParentReference{
 							{
-								Namespace:   ptrs.Ptr(alphaGatewayTyped.Namespace(j.exposeProxyConfig.GatewayNamespace)),
-								Name:        alphaGatewayTyped.ObjectName(j.exposeProxyConfig.GatewayName),
-								Port:        ptrs.Ptr(alphaGatewayTyped.PortNumber(gwPort)),
-								SectionName: ptrs.Ptr(alphaGatewayTyped.SectionName(genSectionName(gwPort))),
+								Namespace: ptrs.Ptr(alphaGatewayTyped.Namespace(j.exposeProxyConfig.GatewayNamespace)),
+								Name:      alphaGatewayTyped.ObjectName(j.exposeProxyConfig.GatewayName),
+								Port:      ptrs.Ptr(alphaGatewayTyped.PortNumber(gwPort)),
+								SectionName: ptrs.Ptr(alphaGatewayTyped.SectionName(
+									generateListenerName(model.AllocationID(t.AllocationID), gwPort),
+								)),
 							},
 						},
 					},
@@ -230,7 +232,7 @@ func (j *job) configureProxyResources(t *tasks.TaskSpec) *proxyResourceGenerator
 				},
 			}
 
-			gatewayListener := createListenerForPod(gwPort)
+			gatewayListener := createListenerForPod(model.AllocationID(t.AllocationID), gwPort)
 
 			resources = append(resources, gatewayProxyResource{
 				podPort:         proxyPort.Port,

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -266,6 +266,38 @@ func TestAddDisallowedNodesToPodSpec(t *testing.T) {
 	}
 }
 
+func TestDetProxyThroughGatewayEnv(t *testing.T) {
+	env := expconf.EnvironmentConfig{
+		RawEnvironmentVariables: &expconf.EnvironmentVariablesMap{
+			RawCPU: []string{},
+		},
+	}
+
+	t.Run("with gateway", func(t *testing.T) {
+		j := job{
+			exposeProxyConfig: &config.InternalTaskGatewayConfig{},
+		}
+
+		actual, err := j.configureEnvVars(make(map[string]string), env, device.CPU)
+		require.NoError(t, err)
+		require.Contains(t, actual, k8sV1.EnvVar{Name: "DET_PROXY_THROUGH_GATEWAY", Value: "true"})
+	})
+
+	t.Run("without gateway", func(t *testing.T) {
+		j := job{
+			exposeProxyConfig: nil,
+		}
+
+		actual, err := j.configureEnvVars(make(map[string]string), env, device.CPU)
+		require.NoError(t, err)
+		var keys []string
+		for _, a := range actual {
+			keys = append(keys, a.Name)
+		}
+		require.NotContains(t, keys, "DET_PROXY_THROUGH_GATEWAY")
+	})
+}
+
 func TestLaterEnvironmentVariablesGetSet(t *testing.T) {
 	dontBe := k8sV1.EnvVar{Name: "var", Value: "dontbe"}
 	shouldBe := k8sV1.EnvVar{Name: "var", Value: "shouldbe"}

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -300,6 +300,12 @@ func TestDetProxyThroughGatewayEnv(t *testing.T) {
 	})
 }
 
+func TestStripIndexFromSharedName(t *testing.T) {
+	require.Equal(t, "1-2-3", stripIndexFromSharedName("1-2-3-4"))
+	require.Equal(t, "", stripIndexFromSharedName("-"))
+	require.Equal(t, "", stripIndexFromSharedName(""))
+}
+
 func TestListenerName(t *testing.T) {
 	t.Run("allocationID", func(t *testing.T) {
 		allocationID := "abc-cde"

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -116,10 +116,12 @@ func TestConfigureProxyResources(t *testing.T) {
 			CommonRouteSpec: alphaGatewayTyped.CommonRouteSpec{
 				ParentRefs: []alphaGatewayTyped.ParentReference{
 					{
-						Namespace:   ptrs.Ptr(alphaGatewayTyped.Namespace("gatewaynamespace")),
-						Name:        alphaGatewayTyped.ObjectName("gatewayname"),
-						Port:        ptrs.Ptr(alphaGatewayTyped.PortNumber(12345)),
-						SectionName: ptrs.Ptr(alphaGatewayTyped.SectionName(genSectionName(12345))),
+						Namespace: ptrs.Ptr(alphaGatewayTyped.Namespace("gatewaynamespace")),
+						Name:      alphaGatewayTyped.ObjectName("gatewayname"),
+						Port:      ptrs.Ptr(alphaGatewayTyped.PortNumber(12345)),
+						SectionName: ptrs.Ptr(alphaGatewayTyped.SectionName(
+							generateListenerName("allocID", 12345),
+						)),
 					},
 				},
 			},
@@ -139,7 +141,7 @@ func TestConfigureProxyResources(t *testing.T) {
 		},
 	}
 
-	listener := createListenerForPod(12345)
+	listener := createListenerForPod("allocID", 12345)
 
 	require.Equal(t, []gatewayProxyResource{
 		{
@@ -295,6 +297,27 @@ func TestDetProxyThroughGatewayEnv(t *testing.T) {
 			keys = append(keys, a.Name)
 		}
 		require.NotContains(t, keys, "DET_PROXY_THROUGH_GATEWAY")
+	})
+}
+
+func TestListenerName(t *testing.T) {
+	t.Run("allocationID", func(t *testing.T) {
+		allocationID := "abc-cde"
+		require.Equal(t, allocationID, getAllocationIDFromListenerName(
+			generateListenerName(model.AllocationID(allocationID), 1234),
+		))
+	})
+
+	t.Run("non determined", func(t *testing.T) {
+		require.Empty(t, getAllocationIDFromListenerName("mygatewayport"))
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		require.Empty(t, getAllocationIDFromListenerName("mygatewayport"))
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		require.Empty(t, getAllocationIDFromListenerName("det-"))
 	})
 }
 

--- a/master/internal/task/allocation.go
+++ b/master/internal/task/allocation.go
@@ -136,8 +136,6 @@ type allocation struct {
 	rendezvous *rendezvous
 	// proxy state
 	proxies []string
-	// Records if we got a proxy address from resources started.
-	gotProxyAddressInResourcesStarted bool
 
 	logCtx          detLogger.Context
 	restored        bool
@@ -328,14 +326,6 @@ func (a *allocation) Signal(sig AllocationSignal, reason string) {
 func (a *allocation) SetProxyAddress(ctx context.Context, address string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-
-	// This is used in K8s to tell if we need to save the proxy address or not. Normally
-	// we rely on the pods posting their proxy address to the allocation. In some cases,
-	// we want to instead go through a gateway to access the task. We know this in advance
-	// so we don't need to wait for the pods to post their address.
-	if a.gotProxyAddressInResourcesStarted {
-		return nil
-	}
 
 	if len(a.req.ProxyPorts) == 0 {
 		a.syslog.Debug("no ports to proxy, skipping proxy registration.")
@@ -775,7 +765,6 @@ func (a *allocation) resourcesStateChanged(msg *sproto.ResourcesStateChanged) {
 		}
 		if len(a.req.ProxyPorts) > 0 && msg.ResourcesStarted.Addresses != nil &&
 			a.resources[msg.ResourcesID].Rank == 0 {
-			a.gotProxyAddressInResourcesStarted = true
 			a.registerProxies(msg.ResourcesStarted.Addresses)
 			a.closers = append(a.closers, a.unregisterProxies)
 		}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ