### PR TITLE
chore: change cluster name in jobService and resourcePool initialization

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -124,7 +124,8 @@ func New(
 		if k.config.DefaultNamespace == "" {
 			k.config.DefaultNamespace = defaultNamespace
 		}
-		rp := newResourcePool(maxSlotsPerPod, &poolConfig, k.jobsService, k.db, k.config.DefaultNamespace, k.config.Name)
+		rp := newResourcePool(maxSlotsPerPod, &poolConfig, k.jobsService, k.db,
+			k.config.DefaultNamespace, k.config.ClusterName)
 		go func() {
 			t := time.NewTicker(podSubmissionInterval)
 			defer t.Stop()


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Going forward, the kubernetes resource manager `name` config is being deprecated and changed to `cluster_name`. This change will change the field used for initialization jobService and resourcePool  from `Name` to `ClusterName` to be consistent with this change.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ