### PR TITLE
fix: delete bindings flake

### DIFF
--- a/master/internal/workspace/postgres_workspace_intg_test.go
+++ b/master/internal/workspace/postgres_workspace_intg_test.go
@@ -329,7 +329,7 @@ func TestDeleteWorkspaceNamespaceBindings(t *testing.T) {
 		&tx)
 	require.NoError(t, err)
 	require.Equal(t, len(expectedMassDeletedBindings), len(deletedBindings))
-	require.EqualValues(t, expectedMassDeletedBindings, deletedBindings)
+	require.ElementsMatch(t, expectedMassDeletedBindings, deletedBindings)
 
 	for _, binding := range expectedBindings {
 		namespace := binding.Namespace


### PR DESCRIPTION
## Ticket
No ticket.



## Description
Fix for a flakey test that checks for correctly deleted workspace-namespace bindings.


## Test Plan
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ