### PR TITLE
fix: historical allocations not showing task allocation workspace

### DIFF
--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -48,7 +48,8 @@ def test_notebook_capture() -> None:
 
         for line in notebook.stdout:
             if re.search("Jupyter Notebook .*is running at", line) is not None:
-                return
+                break
+
     assert task_id is not None
 
     end_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -56,7 +57,11 @@ def test_notebook_capture() -> None:
     r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
     assert r.status_code == requests.codes.ok, r.text
 
-    assert re.search(f"{task_id},NOTEBOOK", r.text) is not None
+    assert re.search(f"{task_id}.*,NOTEBOOK", r.text) is not None
+
+    workspace = clu.utils.get_task_info(sess, "notebook", task_id).get("workspaceName", None)
+    assert workspace is not None
+    assert re.search(f"{workspace},,", r.text) is not None
 
 
 # Create a No_Op Experiment/Tensorboard & Confirm Tensorboard task is captured
@@ -93,3 +98,35 @@ def test_tensorboard_experiment_capture() -> None:
 
     # Confirm Tensorboard task is captured
     assert re.search(f"{tb.task_id}.*,TENSORBOARD", r.text) is not None
+
+    workspace = clu.utils.get_task_info(sess, "tensorboard", tb.task_id).get("workspaceName", None)
+    assert workspace is not None
+    assert re.search(f"{workspace},,", r.text) is not None
+
+
+# Create a command and confirm that the task is captured.
+@pytest.mark.e2e_cpu
+def test_cmd_capture() -> None:
+    sess = api_utils.user_session()
+    start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    task_id = None
+    with cmd.interactive_command(sess, ["cmd", "run", "sleep 10s"]) as sleep_cmd:
+        task_id = sleep_cmd.task_id
+
+        for line in sleep_cmd.stdout:
+            if re.search("Resources for Command .*have started", line) is not None:
+                break
+
+    assert task_id is not None
+
+    end_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sess = api_utils.user_session()
+    r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
+    assert r.status_code == requests.codes.ok, r.text
+
+    assert re.search(f"{task_id}.*,COMMAND", r.text) is not None
+
+    workspace = clu.utils.get_task_info(sess, "command", task_id).get("workspaceName", None)
+    assert workspace is not None
+    assert re.search(f"{workspace},,", r.text) is not None

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -548,6 +548,13 @@ func (m *Master) getResourceAllocations(c echo.Context) error {
 		return err
 	}
 
+	nullIfZero := func(val int) string {
+		if val == 0 {
+			return ""
+		}
+		return strconv.Itoa(val)
+	}
+
 	// Write each entry to the output CSV
 	for rows.Next() {
 		allocationMetadata := new(AllocationMetadata)
@@ -559,7 +566,7 @@ func (m *Master) getResourceAllocations(c echo.Context) error {
 			string(allocationMetadata.TaskType),
 			allocationMetadata.Username,
 			allocationMetadata.WorkspaceName,
-			strconv.Itoa(allocationMetadata.ExperimentID),
+			nullIfZero(allocationMetadata.ExperimentID),
 			strconv.Itoa(allocationMetadata.Slots),
 			formatTimestamp(allocationMetadata.StartTime),
 			formatTimestamp(allocationMetadata.EndTime),

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -459,15 +459,30 @@ func (m *Master) getResourceAllocations(c echo.Context) error {
 		Where("ts.event_type = 'IMAGEPULL'").
 		Group("a.allocation_id")
 
+	taskWorkspaceIDs := db.Bun().NewSelect().
+		ColumnExpr("t.task_id").
+		ColumnExpr("c.generic_command_spec->'Metadata'->>'workspace_id' AS workspace_id").
+		TableExpr("tasks_in_range t").
+		Join("INNER JOIN command_state c ON t.task_id = c.task_id")
+
+	taskWorkspaceNames := db.Bun().NewSelect().
+		ColumnExpr("t.task_id").
+		ColumnExpr("w.name as workspace_name").
+		With("task_wids", taskWorkspaceIDs).
+		TableExpr("task_wids t").
+		Join("INNER JOIN workspaces w ON t.workspace_id::int=w.id")
+
 	// Get experiment info for tasks within time range
 	taskExperimentInfo := db.Bun().NewSelect().
 		ColumnExpr("t.task_id").
 		ColumnExpr("e.id as experiment_id").
-		ColumnExpr("w.name as workspace_name").
+		ColumnExpr("COALESCE(w.name, task_wnames.workspace_name) as workspace_name").
+		With("task_wnames", taskWorkspaceNames).
 		TableExpr("tasks_in_range t").
-		Join("INNER JOIN experiments e ON t.job_id = e.job_id").
-		Join("INNER JOIN projects p ON e.project_id = p.id").
-		Join("INNER JOIN workspaces w ON p.workspace_id = w.id")
+		Join("LEFT JOIN experiments e ON t.job_id = e.job_id").
+		Join("LEFT JOIN projects p ON e.project_id = p.id").
+		Join("LEFT JOIN workspaces w ON p.workspace_id = w.id").
+		Join("LEFT JOIN task_wnames ON task_wnames.task_id=t.task_id")
 
 	// Get task information row-by-row for all tasks in time range
 	rows, err := db.Bun().NewSelect().


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
DET-10323


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Downloading historical allocations resulted in the workspace field being empty for tasks. This is because we queried for experiment workspace, but not task workspace. This PR fixes that issue, and adds test cases to verify the outputted CSV contains the tasks's workspace. This also fixes a broken test (`test_notebook_capture`).


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Make sure e2e_cpu tests pass.

To manually test, run some tasks (notebooks, commands, or tensorboards), then sign in as admin, go to the clusters page, and the historical usage tab. Download the CSV, making sure to select allocations and not workspaces, and verify that the workspace name field is populated for the tasks you ran.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
