### PR TITLE
chore: remove need for explicit singluar podPort tracking

### DIFF
--- a/e2e_tests/tests/cluster/test_proxy.py
+++ b/e2e_tests/tests/cluster/test_proxy.py
@@ -109,7 +109,6 @@ def test_experiment_proxy_simple_zero_slot(exp_port: int, is_tcp: bool) -> None:
 
 
 @pytest.mark.port_registry  # has multiple slots
-@pytest.mark.e2e_multi_k8s
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize(
     "exp_port, is_tcp, max_conc_trials",

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -36,13 +36,10 @@ type gatewayProxyResource struct {
 	serviceSpec     *k8sV1.Service
 	tcpRouteSpec    *alphaGatewayTyped.TCPRoute
 	gatewayListener gatewayTyped.Listener
-	// TODO(gateways) we should be able to remove this and just use PodPort from the tcpRouteSpec.
-	podPort int
 }
 
 func (g gatewayProxyResource) PodPort() int {
-	// return int(*g.tcpRouteSpec.Spec.CommonRouteSpec.ParentRefs[0].Port)
-	return g.podPort
+	return int(g.serviceSpec.Spec.Ports[0].Port)
 }
 
 func (g gatewayProxyResource) GWPort() int {

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -297,7 +297,7 @@ func (j *jobsService) startClientSet() error {
 		j.jobInterfaces[ns] = j.clientSet.BatchV1().Jobs(ns)
 	}
 
-	if exposeConfig := j.internalTaskGWConfig; exposeConfig != nil {
+	if taskGWConfig := j.internalTaskGWConfig; taskGWConfig != nil {
 		// Using the CoreV1 RESTClient for gateway resources will cause "resource not found" errors.
 		alphaGatewayClientSet, err := alphaGateway.NewForConfig(config)
 		if err != nil {
@@ -314,9 +314,9 @@ func (j *jobsService) startClientSet() error {
 			return fmt.Errorf("creating Kubernetes gateway clientSet: %w", err)
 		}
 		gwService, err := newGatewayService(
-			gatewayClientSet.Gateways(exposeConfig.GatewayNamespace),
+			gatewayClientSet.Gateways(taskGWConfig.GatewayNamespace),
 			j.tcpRouteInterfaces,
-			*exposeConfig,
+			*taskGWConfig,
 		)
 		if err != nil {
 			return fmt.Errorf("creating gateway service: %w", err)

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -771,9 +771,7 @@ func (j *jobsService) recreateGatewayProxyResources(
 		if len(service.Spec.Ports) != 1 {
 			return nil, fmt.Errorf("expected service to have one port got %d", len(service.Spec.Ports))
 		}
-
 		resources = append(resources, gatewayProxyResource{
-			podPort:         int(service.Spec.Ports[0].Port),
 			serviceSpec:     service,
 			tcpRouteSpec:    tcpRoute,
 			gatewayListener: createListenerForPod(port),

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -236,7 +236,6 @@ func (j *job) configureProxyResources(t *tasks.TaskSpec) *proxyResourceGenerator
 			gatewayListener := createListenerForPod(gwPort)
 
 			resources = append(resources, gatewayProxyResource{
-				podPort:         proxyPort.Port,
 				serviceSpec:     serviceSpec,
 				tcpRouteSpec:    tcpRouteSpec,
 				gatewayListener: gatewayListener,

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -151,7 +151,6 @@ func TestConfigureProxyResources(t *testing.T) {
 
 	require.Equal(t, []gatewayProxyResource{
 		{
-			podPort:         12345,
 			serviceSpec:     svc,
 			tcpRouteSpec:    tcp,
 			gatewayListener: listener,


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ