### PR TITLE
fix: skip webhook regex matching for exp config

### DIFF
--- a/e2e_tests/tests/cluster/test_webhooks.py
+++ b/e2e_tests/tests/cluster/test_webhooks.py
@@ -89,7 +89,7 @@ def test_log_pattern_send_webhook(should_match: bool) -> None:
 
     regex = r"assert 0 <= self\.metrics_sigma"
     if not should_match:
-        regex = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"
+        regex = r"(.*)cuda(.*)"
 
     webhook_trigger = bindings.v1Trigger(
         triggerType=bindings.v1TriggerType.TASK_LOG,

--- a/master/internal/logpattern/logpattern.go
+++ b/master/internal/logpattern/logpattern.go
@@ -19,7 +19,7 @@ const regexCacheSize = 256
 
 var (
 	defaultSingleton       *LogPatternPolicies
-	expconfigCompiledRegex = regexp.MustCompile("(.*)(\\\"log_policies\\\":)(.*)")
+	ExpconfigCompiledRegex = regexp.MustCompile("(.*)(\\\"log_policies\\\":)(.*)")
 )
 
 // LogPatternPolicies performs log pattern checks.
@@ -70,7 +70,7 @@ func (l *LogPatternPolicies) monitor(ctx context.Context,
 
 			// One of the trial logs prints expconf which has the regex pattern.
 			// We skip monitoring this line.
-			if expconfigCompiledRegex.MatchString(log.Log) {
+			if ExpconfigCompiledRegex.MatchString(log.Log) {
 				continue
 			}
 

--- a/master/internal/logpattern/logpattern.go
+++ b/master/internal/logpattern/logpattern.go
@@ -18,7 +18,8 @@ import (
 const regexCacheSize = 256
 
 var (
-	defaultSingleton       *LogPatternPolicies
+	defaultSingleton *LogPatternPolicies
+	// ExpconfigCompiledRegex is used to identify user submitted config.
 	ExpconfigCompiledRegex = regexp.MustCompile("(.*)(\\\"log_policies\\\":)(.*)")
 )
 

--- a/master/internal/webhooks/postgres_webhook.go
+++ b/master/internal/webhooks/postgres_webhook.go
@@ -18,6 +18,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/determined-ai/determined/master/internal/logpattern"
 
 	"github.com/google/uuid"
 )
@@ -121,6 +122,11 @@ func (l *WebhookManager) scanLogs(ctx context.Context, logs []*model.TaskLog) er
 		}
 
 		for _, cacheItem := range l.regexToTriggers {
+			// One of the trial logs prints expconf which has the regex pattern.
+			// We skip monitoring this line.
+			if logpattern.ExpconfigCompiledRegex.MatchString(log.Log) {
+				continue
+			}
 			if cacheItem.re.MatchString(log.Log) {
 				for _, t := range cacheItem.triggerIDToTrigger {
 					if err := addTaskLogEvent(ctx,

--- a/master/internal/webhooks/postgres_webhook.go
+++ b/master/internal/webhooks/postgres_webhook.go
@@ -14,11 +14,11 @@ import (
 
 	conf "github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/logpattern"
 	"github.com/determined-ai/determined/master/internal/project"
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
-	"github.com/determined-ai/determined/master/internal/logpattern"
 
 	"github.com/google/uuid"
 )


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[MD-435]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Skip webhook log regex match for user submitted config. 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
e2e test should cover it. 


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
