### PR TITLE
chore: longrunning tests to ignore multiRM marked e2e tests

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4740,7 +4740,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not (gpu_required or e2e_multi_k8s)"]
+              mark: ["e2e_gpu and not gpu_required and not e2e_multi_k8s"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]
@@ -4947,7 +4947,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not (gpu_required or e2e_multi_k8s)"]
+              mark: ["e2e_gpu and not gpu_required and not e2e_multi_k8s"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4740,7 +4740,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not gpu_required and not e2e_multi_k8s"]
+              mark: ["e2e_gpu and not gpu_required"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]
@@ -4947,7 +4947,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not gpu_required and not e2e_multi_k8s"]
+              mark: ["e2e_gpu and not gpu_required"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4740,7 +4740,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not gpu_required"]
+              mark: ["e2e_gpu and not (gpu_required or e2e_multi_k8s)"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]
@@ -4947,7 +4947,7 @@ workflows:
           matrix:
             parameters:
               cluster-id-prefix: ["e2e-cpu"]
-              mark: ["e2e_gpu and not gpu_required"]
+              mark: ["e2e_gpu and not (gpu_required or e2e_multi_k8s)"]
               parallelism: [1]
               machine-type: ["n1-standard-8"]
               gpus-per-machine: [0]

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -591,7 +591,6 @@ def test_workspaceid_set() -> None:
         assert cmd.workspaceId == workspace.id
 
 
-@pytest.mark.e2e_gpu
 @pytest.mark.e2e_multi_k8s
 @pytest.mark.e2e_single_k8s
 def test_set_workspace_namespace_bindings(


### PR DESCRIPTION
<!---
chore: longrunning tests to ignore multiRM marked e2e tests
-->
## Ticket
No ticket.



## Description
~End-to-end tests in the long-running workflow use clusters from an isolated GCP project that doesn't have vast visibility, making them difficult to use for multiRM / multi-cluster testing. The shared cluster(s), having better visibility and long-standing setups, are more usable for multiRM testing. Filter out multiRM tests from long-running tests and run any necessary multiRM  end-to-end GKE tests in the shared cluster workflow.~

While the shared cluster workflow is removed from CI, remove the`e2e_gpu` mark from the workspace-namespace binding e2e tests as we use a different mark, `test_e2e_single_k8s`, for the singleRM tests.

## Test Plan
CI passes (particularly, long-running workflow passes)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ