### PR TITLE
feat: det deploy local generates a password for you [DET-10197]

### DIFF
--- a/docs/release-notes/deploy-local-auto-password.rst
+++ b/docs/release-notes/deploy-local-auto-password.rst
@@ -1,8 +1,9 @@
 :orphan:
 
-**Security Fixes**
+Security Fixes
 
--  CLI: If no user accounts have already been created, and neither
-   ``security.initial_user_password`` in master.yaml nor the ``--initial-user-password`` CLI flag is
-   present when running ``det deploy local`` with the ``master-up`` or ``cluster-up`` commands, an
-   initial password will be generated and displayed to the user.
+   -  CLI: When deploying locally using ``det deploy local`` with ``master-up`` or ``cluster-up``
+      commands and no user accounts have been created yet, an initial password will be automatically
+      generated and shown to the user (with the option to change it) if neither
+      ``security.initial_user_password`` in ``master.yaml`` nor the ``--initial-user-password`` CLI
+      flag is present.

--- a/docs/release-notes/deploy-local-auto-password.rst
+++ b/docs/release-notes/deploy-local-auto-password.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+**Security Fixes**
+
+-  CLI: If no user accounts have already been created, and neither
+   ``security.initial_user_password`` in master.yaml nor ``--initial-user-password`` is present when
+   running ``det deploy local`` with the ``master-up`` or ``cluster-up`` commands, an initial
+   password will be generated and displayed to the user.

--- a/docs/release-notes/deploy-local-auto-password.rst
+++ b/docs/release-notes/deploy-local-auto-password.rst
@@ -3,6 +3,6 @@
 **Security Fixes**
 
 -  CLI: If no user accounts have already been created, and neither
-   ``security.initial_user_password`` in master.yaml nor ``--initial-user-password`` is present when
-   running ``det deploy local`` with the ``master-up`` or ``cluster-up`` commands, an initial
-   password will be generated and displayed to the user.
+   ``security.initial_user_password`` in master.yaml nor the ``--initial-user-password`` CLI flag is
+   present when running ``det deploy local`` with the ``master-up`` or ``cluster-up`` commands, an
+   initial password will be generated and displayed to the user.

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -249,6 +249,28 @@ def test_master_up_down() -> None:
 
         containers = client.containers.list(filters={"name": master_name})
         assert len(containers) > 0
+        assert (
+            "The admin and determined users can log in with this password:"
+            not in containers[0].logs()
+        )
+
+    containers = client.containers.list(filters={"name": master_name})
+    assert len(containers) == 0
+
+
+@pytest.mark.det_deploy_local
+def test_master_up_implicit_password() -> None:
+    cluster_name = "test_master_up_implicit_password"
+    master_name = f"{cluster_name}_determined-master_1"
+
+    with resource_manager(Resource.MASTER, master_name):
+        client = docker.from_env()
+
+        containers = client.containers.list(filters={"name": master_name})
+        assert len(containers) > 0
+        assert (
+            "The admin and determined users can log in with this password:" in containers[0].logs()
+        )
 
     containers = client.containers.list(filters={"name": master_name})
     assert len(containers) == 0

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -259,7 +259,7 @@ def test_master_up_down() -> None:
         containers = client.containers.list(filters={"name": master_name})
         assert len(containers) > 0
         assert (
-            "The admin and determined users can log in with this password:"
+            b"The admin and determined users can log in with this password:"
             not in master_up_command.stdout
         )
 
@@ -280,7 +280,7 @@ def test_master_up_implicit_password() -> None:
         containers = client.containers.list(filters={"name": master_name})
         assert len(containers) > 0
         assert (
-            "The admin and determined users can log in with this password:"
+            b"The admin and determined users can log in with this password:"
             in master_up_command.stdout
         )
 

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 import subprocess
 from typing import Dict, Iterator, List, Optional
-from unittest import mock
 
 import docker
 import pytest
@@ -265,10 +264,8 @@ def test_master_up_down() -> None:
 
 
 @pytest.mark.det_deploy_local
-@mock.patch("getpass.getpass")
-def test_master_up_interactive_password(mock_getpass: mock.MagicMock) -> None:
-    mock_getpass.side_effect = lambda *_: "Ya7J42GtY6aXodLp"
-    cluster_name = "test_master_up_interactive_password"
+def test_master_up_without_password() -> None:
+    cluster_name = "test_master_up_without_password"
     master_name = f"{cluster_name}_determined-master_1"
 
     with resource_manager(

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -299,8 +299,6 @@ def test_master_up_interactive_password(
         )
         if expect_generated:
             assert b"A password has been created for you." in master_up_command.stdout
-        else:
-            assert b"A password has been created for you." not in master_up_command.stdout
 
     containers = client.containers.list(filters={"name": master_name})
     assert len(containers) == 0

--- a/e2e_tests/tests/deploy/test_local.py
+++ b/e2e_tests/tests/deploy/test_local.py
@@ -106,7 +106,10 @@ def test_cluster_down() -> None:
     name = "test_cluster_down"
 
     with resource_manager(
-        Resource.CLUSTER, name, {"initial-user-password": conf.USER_PASSWORD}, ["no-gpu"]
+        Resource.CLUSTER,
+        name,
+        {"initial-user-password": conf.USER_PASSWORD},
+        ["no-gpu", "delete-db"],
     ):
         container_name = name + "_determined-master_1"
         client = docker.from_env()
@@ -126,7 +129,7 @@ def test_ee_cluster_up() -> None:
         Resource.CLUSTER,
         name,
         {"initial-user-password": conf.USER_PASSWORD},
-        ["no-gpu", "enterprise-edition"],
+        ["no-gpu", "enterprise-edition", "delete-db"],
     ):
         container_name = name + "_determined-master_1"
         client = docker.from_env()
@@ -148,7 +151,7 @@ def test_custom_etc() -> None:
         Resource.CLUSTER,
         name,
         {"master-config-path": etc_path, "initial-user-password": conf.USER_PASSWORD},
-        ["no-gpu"],
+        ["no-gpu", "delete-db"],
     ):
         sess = mksess("localhost", 8080)
         exp.run_basic_test(
@@ -165,7 +168,10 @@ def test_agent_config_path() -> None:
     cluster_name = "test_agent_config_path"
     master_name = f"{cluster_name}_determined-master_1"
     with resource_manager(
-        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}
+        Resource.MASTER,
+        master_name,
+        {"initial-user-password": conf.USER_PASSWORD},
+        ["delete-db"],
     ):
         # Config makes it unmodified.
         etc_path = str(pathlib.Path(__file__).parent.joinpath("etc/agent.yaml").resolve())
@@ -208,7 +214,7 @@ def test_custom_port() -> None:
         Resource.CLUSTER,
         name,
         {"master-port": str(custom_port), "initial-user-password": conf.USER_PASSWORD},
-        ["no-gpu"],
+        ["no-gpu", "delete-db"],
     ):
         sess = mksess("localhost", custom_port)
         exp.run_basic_test(
@@ -227,7 +233,7 @@ def test_agents_made() -> None:
         Resource.CLUSTER,
         name,
         {"agents": str(num_agents), "initial-user-password": conf.USER_PASSWORD},
-        ["no-gpu"],
+        ["no-gpu", "delete-db"],
     ):
         container_names = [name + f"-agent-{i}" for i in range(0, num_agents)]
         client = docker.from_env()
@@ -243,7 +249,10 @@ def test_master_up_down() -> None:
     master_name = f"{cluster_name}_determined-master_1"
 
     with resource_manager(
-        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}
+        Resource.MASTER,
+        master_name,
+        {"initial-user-password": conf.USER_PASSWORD},
+        ["delete-db"],
     ):
         client = docker.from_env()
 
@@ -263,7 +272,7 @@ def test_master_up_implicit_password() -> None:
     cluster_name = "test_master_up_implicit_password"
     master_name = f"{cluster_name}_determined-master_1"
 
-    with resource_manager(Resource.MASTER, master_name):
+    with resource_manager(Resource.MASTER, master_name, boolean_flags=["delete-db"]):
         client = docker.from_env()
 
         containers = client.containers.list(filters={"name": master_name})
@@ -285,7 +294,7 @@ def test_ee_master_up() -> None:
         Resource.MASTER,
         master_name,
         {"initial-user-password": conf.USER_PASSWORD},
-        ["enterprise-edition"],
+        ["enterprise-edition", "delete-db"],
     ):
         client = docker.from_env()
 
@@ -303,7 +312,7 @@ def test_agent_up_down() -> None:
     master_name = f"{cluster_name}_determined-master_1"
 
     with resource_manager(
-        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}
+        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}, ["delete-db"]
     ):
         with resource_manager(Resource.AGENT, agent_name, {}, ["no-gpu"], [conf.MASTER_IP]):
             client = docker.from_env()
@@ -321,7 +330,7 @@ def test_ee_agent_up() -> None:
     master_name = f"{cluster_name}_determined-master_1"
 
     with resource_manager(
-        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}
+        Resource.MASTER, master_name, {"initial-user-password": conf.USER_PASSWORD}, ["delete-db"]
     ):
         with resource_manager(
             Resource.AGENT, agent_name, {}, ["no-gpu", "enterprise-edition"], [conf.MASTER_IP]

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -2,6 +2,7 @@ import contextlib
 import getpass
 import os
 import pathlib
+import random
 import re
 import secrets
 import socket
@@ -187,9 +188,15 @@ def master_up(
         )
     except ValueError:
         random_password_characters = string.ascii_uppercase + string.ascii_lowercase + string.digits
-        generated_user_password = "".join(
-            [secrets.choice(random_password_characters) for _ in range(16)]
-        )
+        random_password = [
+            secrets.choice(string.ascii_lowercase),
+            secrets.choice(string.ascii_uppercase),
+            secrets.choice(string.digits),
+        ]
+        random_password.extend([secrets.choice(random_password_characters) for _ in range(13)])
+        random.shuffle(random_password)
+        generated_user_password = "".join(random_password)
+
         master_conf["security"]["initial_user_password"] = generated_user_password
         make_temp_conf = True
 

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -325,7 +325,8 @@ def master_up(
                     # terminal, which almost always means we're not going to be able to receive
                     # a password interactively and securely, so should abort quickly rather
                     # than time out.
-                    with warnings.catch_warnings(action="error", category=getpass.GetPassWarning):
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings(action="error", category=getpass.GetPassWarning)
                         prompt = (
                             "Please enter a password for the built-in "
                             + "`determined` and `admin` users: "

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -328,8 +328,6 @@ def master_up(
                 )
 
                 try:
-                    if not sys.stdin.isatty() or sys.stdin.closed:
-                        raise EOFError
                     # getpass raises this warning instead of an exception if it can't find the
                     # terminal, which almost always means we're not going to be able to receive
                     # a password interactively and securely, so should abort quickly rather

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import secrets
 import socket
+import string
 import subprocess
 import sys
 import tempfile
@@ -177,7 +178,10 @@ def master_up(
         master_conf["security"]["initial_user_password"] = initial_user_password
         make_temp_conf = True
     elif master_conf["security"].get("initial_user_password") is None:
-        generated_user_password = secrets.token_urlsafe(16)
+        random_password_characters = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        generated_user_password = "".join(
+            [secrets.choice(random_password_characters) for _ in range(16)]
+        )
         master_conf["security"]["initial_user_password"] = generated_user_password
         make_temp_conf = True
 

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -19,7 +19,7 @@ import docker
 from determined.common import api, constants, util
 from determined.common.api import authentication
 from determined.deploy import errors, healthcheck
-from determined.experimental.client import Determined
+from determined.experimental import client as determined
 
 AGENT_NAME_DEFAULT = f"det-agent-{socket.gethostname()}"
 MASTER_PORT_DEFAULT = 8080
@@ -339,7 +339,7 @@ def master_up(
                     if new_password != new_password_check:
                         raise ValueError("passwords did not match")
 
-                    d = Determined._from_session(sess)
+                    d = determined.Determined._from_session(sess)
                     user = d.get_user_by_name("determined")
                     user.change_password(new_password)
                     user = d.get_user_by_name("admin")

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import pathlib
 import re
+import secrets
 import socket
 import subprocess
 import sys
@@ -13,7 +14,8 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Typ
 import appdirs
 import docker
 
-from determined.common import constants, util
+from determined.common import api, constants, util
+from determined.common.api import authentication
 from determined.deploy import errors, healthcheck
 
 AGENT_NAME_DEFAULT = f"det-agent-{socket.gethostname()}"
@@ -153,9 +155,6 @@ def master_up(
     auto_work_dir: Optional[pathlib.Path],
     enterprise_edition: bool = False,
 ) -> None:
-    # Some cli flags for det deploy local will cause us to write a temporary master.yaml.
-    make_temp_conf = False
-
     if master_name is None:
         master_name = f"{cluster_name}_{MASTER_NAME}"
 
@@ -164,21 +163,22 @@ def master_up(
             master_conf = util.yaml_safe_load(f)
     else:
         master_conf = MASTER_CONF_DEFAULT
-        make_temp_conf = True
 
     if master_conf.get("security") is None:
         master_conf["security"] = {}
 
-    if initial_user_password is not None:
-        master_conf["security"]["initial_user_password"] = initial_user_password
-        make_temp_conf = True
+    used_generated_password = False
+    if not initial_user_password:
+        initial_user_password = secrets.token_urlsafe(16)
+        used_generated_password = True
+
+    master_conf["security"]["initial_user_password"] = initial_user_password
 
     if storage_host_path is not None:
         master_conf["checkpoint_storage"] = {
             "type": "shared_fs",
             "host_path": str(storage_host_path.resolve()),
         }
-        make_temp_conf = True
 
     # Ensure checkpoint storage directory exists.
     storage_info = master_conf.get("checkpoint_storage", {})
@@ -198,16 +198,12 @@ def master_up(
         master_conf["task_container_defaults"].setdefault("bind_mounts", []).append(
             {"host_path": work_dir, "container_path": work_dir}
         )
-        make_temp_conf = True
 
-    if make_temp_conf:
-        fd, temp_path = tempfile.mkstemp(prefix="det-deploy-local-master-config-")
-        with open(fd, "w") as f:
-            util.yaml_safe_dump(master_conf, f)
-        master_config_path = pathlib.Path(temp_path)
+    fd, temp_path = tempfile.mkstemp(prefix="det-deploy-local-master-config-")
+    with open(fd, "w") as f:
+        util.yaml_safe_dump(master_conf, f)
+    master_config_path = pathlib.Path(temp_path)
 
-    # This is always true by now, but mypy needs help.
-    assert master_config_path is not None
     restart_policy = "unless-stopped" if autorestart else "no"
     env = {
         "DET_MASTER_HTTP_PORT": str(port),
@@ -285,6 +281,22 @@ def master_up(
         )
 
         _wait_for_master(f"http://localhost:{port}", cluster_name)
+
+        if used_generated_password:
+            try:
+                session = authentication.login(
+                    f"http://localhost:{port}", "determined", initial_user_password
+                ).with_retry(util.get_max_retries_config())
+                session.get("/api/v1/me")
+                print(
+                    "Determined Master was launched without an initial_user_password set, "
+                    + "so a password has been created for you. The admin and determined users "
+                    + f"can log in with this password:\n\t{initial_user_password}\n"
+                    + "Please change these passwords as soon as possible."
+                )
+            except api.errors.UnauthenticatedException:
+                # There was a non-generated password there already; carry on
+                pass
 
         # Remove all cleanup methods from ExitStack.
         exit_stack.pop_all()

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -321,6 +321,8 @@ def master_up(
                 )
 
                 try:
+                    if not sys.stdin.isatty() or sys.stdin.closed:
+                        raise EOFError
                     # getpass raises this warning instead of an exception if it can't find the
                     # terminal, which almost always means we're not going to be able to receive
                     # a password interactively and securely, so should abort quickly rather

--- a/harness/determined/deploy/local/cluster_utils.py
+++ b/harness/determined/deploy/local/cluster_utils.py
@@ -328,6 +328,8 @@ def master_up(
                 )
 
                 try:
+                    if not sys.stdin.isatty() or sys.stdin.closed:
+                        raise EOFError
                     # getpass raises this warning instead of an exception if it can't find the
                     # terminal, which almost always means we're not going to be able to receive
                     # a password interactively and securely, so should abort quickly rather


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
[DET-10197]

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
BREAKING CHANGE: if an initial user password is not specified, the `det deploy local` command generates one automatically; if that random password is recognized as the correct one for `determined`, it is printed so users can log in with it and change their password. Otherwise, it is assumed that this is a relaunch of a cluster with an existing database.

The proposal for this change was first described here: https://hpe-aiatscale.slack.com/archives/CLCE8D998/p1716571996243779?thread_ts=1716404697.160779&cid=CLCE8D998

### Additional notes
`det deploy aws` and `det deploy gcp` can rely on Terraform state to determine whether a database (or database image) already contains passwords, and prompt interactively if not, and `helm` can run some simple checks during templating. However, `det deploy local` sets up a database in a docker container based on a volume that may or may not be empty, and it's hard to know migration states etc. until master is healthy. Rather than rely on `master` to decide in this case (which has caused problems in the past), this solution guarantees there will always be a password set on cluster creation, with the only major downside being that the admin user is still responsible for changing their password if the deployment logs are somehow exposed long-term.

## Test Plan
I've manually tested and added integration tests, but it is probably worth triple-checking that the following is still true on next release:
- `det deploy local master-up --delete-db` prompts for the user to enter an initial password, displays requirements if the first attempt is blank or weak, and falls back to displaying a generated password if the user can't set this correctly.
- `det deploy local master-up` (with an existing database volume) allows login with whatever passwords were set before and does not print the generated password message
- `det deploy local master-up --delete-db --initial-user-password=$PASSWORD` sets up the provided passwords and does not print the generated password message
- `time det deploy local master-up --det-version='203370a6cdb048aaa579c7406f584bb428e76df4' --master-port=8080 --delete-db --initial-user-password '' &` (runs detached in background) skips prompting for a password due to the detached TTY, and displays the generated password (might need to `fg` the job to see it) in under 2 minutes (should **not** wait ~10 minutes for an overall task timeout)

## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10197]: https://hpe-aiatscale.atlassian.net/browse/DET-10197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ