### PR TITLE
feat: warn users to change their passwords [DET-10216]

### DIFF
--- a/harness/determined/cli/user.py
+++ b/harness/determined/cli/user.py
@@ -80,6 +80,15 @@ def log_in_user(args: argparse.Namespace) -> None:
     except api.errors.UnauthenticatedException:
         raise api.errors.InvalidCredentialsException()
 
+    try:
+        authentication.check_password_complexity(password)
+    except ValueError as e:
+        print(
+            "Warning: your password does not appear to satisfy "
+            + f"recommended complexity requirements:\n{e}\n"
+            + "Please change your password as soon as possible."
+        )
+
     token_store.set_token(sess.username, sess.token)
     token_store.set_active(sess.username)
 

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -236,6 +236,15 @@ def login_with_cache(
             raise api.errors.UnauthenticatedException()
         raise
 
+    try:
+        check_password_complexity(password)
+    except ValueError as e:
+        print(
+            "Warning: your password does not appear to satisfy "
+            + f"recommended complexity requirements:\n{e}\n"
+            + "Please change your password as soon as possible."
+        )
+
     token_store.set_token(user, token)
 
     return sess

--- a/webui/react/src/components/DeterminedAuth.tsx
+++ b/webui/react/src/components/DeterminedAuth.tsx
@@ -14,9 +14,10 @@ import authStore from 'stores/auth';
 import determinedStore from 'stores/determinedInfo';
 import permissionStore from 'stores/permissions';
 import userStore from 'stores/users';
-import handleError, { ErrorType } from 'utils/error';
+import handleError, { ErrorLevel, ErrorType, handleWarning } from 'utils/error';
 import { useObservable } from 'utils/observable';
 import { StorageManager } from 'utils/storage';
+import { isPasswordWeak } from 'utils/user';
 
 import css from './DeterminedAuth.module.scss';
 
@@ -54,7 +55,16 @@ const DeterminedAuth: React.FC<Props> = ({ canceler }: Props) => {
         );
         updateDetApi({ apiKey: `Bearer ${token}` });
         authStore.setAuth({ isAuthenticated: true, token });
+        user.isPasswordWeak = isPasswordWeak(creds.password || '');
         userStore.updateCurrentUser(user);
+        handleWarning({
+          level: ErrorLevel.Warn,
+          publicMessage:
+            'Your current password is either blank or weak according to current security recommendations. Please change your password.',
+          publicSubject: 'Weak Password',
+          silent: false,
+          type: ErrorType.Input,
+        });
         if (rbacEnabled) {
           // Now that we have logged in user, fetch userAssignments and userRoles and place into store.
           permissionStore.fetch(canceler.signal);

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -154,6 +154,7 @@ export const DetailedUser = t.intersection([
   User,
   t.partial({
     agentUserGroup: AgentUserGroup,
+    isPasswordWeak: t.boolean,
     remote: t.boolean,
   }),
   t.type({

--- a/webui/react/src/utils/user.ts
+++ b/webui/react/src/utils/user.ts
@@ -1,3 +1,4 @@
+import { PASSWORD_RULES } from 'constants/passwordRules';
 import { V1Group, V1RoleWithAssignments } from 'services/api-ts-sdk';
 import {
   DetailedUser,
@@ -85,3 +86,16 @@ export const getUserOrGroupWithRoleInfo = (
     .filter((d) => d.userId !== -1);
   return [...groups, ...users];
 };
+
+export function isPasswordWeak(password: string): boolean {
+  let isWeak = false;
+  PASSWORD_RULES.forEach((rule) => {
+    if (rule.min && password.length < rule.min) {
+      isWeak = true;
+    }
+    if (rule.pattern && !RegExp(rule.pattern).test(password)) {
+      isWeak = true;
+    }
+  });
+  return isWeak;
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10216]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
CLI: when supplying a password for `det user login` or for another command that fails login and prompts for a password, a warning is displayed if the provided password fails the complexity check.

WebUI: after successfully logging in, if the password is weak, a warning toast notification is displayed.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Automated testing for these cases is uniquely challenging since end-to-end flows that could result in users with weak passwords have been removed -- and if we could find any, we should patch them out rather than exploit them to generate tests for this.

CLI:
- launch a cluster that has a weak/blank password for a user (may need to start with an older version of determined to allow this)
- authenticate as that user with `det user login`, observe warning message.
- delete or mess up the token that got saved in application cache (e.g. the `"tokens" key in `~/Library/Application\ Support/determined/auth.json` on Darwin-based systems)
- do some other CLI action that requires auth like `det user` [list] which will produce a prompt to re-enter the password
- authenticate again, observe warning message before the action completes successfully

WebUI:
- launch a cluster that has a weak/blank password for a user (may need to start with an older version of determined to allow this)
- authenticate as that user in the Web UI
- observe a warning toast:
![image](https://github.com/determined-ai/determined/assets/159822967/8c904b94-001a-46ba-a4be-7d2aa78274a1)


## Checklist

- [x] Changes have been manually QA'd
- [x] User-facing API changes need the "User-facing API Change" label.
- [x] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10216]: https://hpe-aiatscale.atlassian.net/browse/DET-10216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ