### PR TITLE
fix: historical allocations not appearing

### DIFF
--- a/master/static/srv/update_aggregated_allocation.sql
+++ b/master/static/srv/update_aggregated_allocation.sql
@@ -126,4 +126,4 @@ resource_aggregates (
     FROM
         all_aggs,
         const
-)
+) ON CONFLICT DO NOTHING


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
DET-10311


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Historical allocations weren't showing up sometimes because the data was not present. This can occur when we attempt to calculate the historical allocation for the same date again, violating a constraint and failing the whole transaction. This leads to us repeatedly failing to calculate historical allocation and the data remaining empty. To fix this, we add a clause so that nothing happens when a conflict happens.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
No manual testing required.

Testing this is difficult to reproduce, but if you would like to verify, one way is (on your own devcluster) go to `master/internal/db/postgres_cluster.go` line 99 and add `lastDatePtr=nil`. This forces there to be a key conflict. If devcluster runs successfully, then the PR works.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ