### PR TITLE
chore: allow empty run metadata requests to delete existing metadata

### DIFF
--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -943,10 +943,6 @@ func (a *apiServer) PostRunMetadata(
 		return nil, err
 	}
 
-	if len(req.Metadata.AsMap()) == 0 || req.Metadata.AsMap() == nil {
-		return nil, status.Error(codes.InvalidArgument, "metadata cannot be empty")
-	}
-
 	// Flatten Request Metadata.
 	flatMetadata, err := run.FlattenMetadata(req.Metadata.AsMap())
 	if err != nil {

--- a/master/internal/api_runs_intg_test.go
+++ b/master/internal/api_runs_intg_test.go
@@ -1247,6 +1247,22 @@ func TestPostRunMetadata(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, rawMetadata, metadataResp.Metadata.AsMap())
+
+	// empty metadata
+	metadataResp, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    r.Id,
+		Metadata: &structpb.Struct{},
+	})
+	require.NoError(t, err)
+	require.Empty(t, metadataResp.Metadata.AsMap())
+
+	// nil metadata
+	metadataResp, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    r.Id,
+		Metadata: nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, metadataResp.Metadata.AsMap())
 }
 
 func TestRunMetadata(t *testing.T) {

--- a/master/internal/db/postgres_runs.go
+++ b/master/internal/db/postgres_runs.go
@@ -59,6 +59,11 @@ func UpdateRunMetadata(
 			if err != nil {
 				return fmt.Errorf("deleting run metadata indexes for run(%d): %w", runID, err)
 			}
+
+			// ignore if there is no metadata to insert.
+			if len(flatMetadata) == 0 {
+				return nil
+			}
 			_, err = tx.NewInsert().Model(&flatMetadata).Exec(ctx)
 			if err != nil {
 				return fmt.Errorf("inserting run metadata indexes for run(%d): %w", runID, err)

--- a/master/internal/run/runs.go
+++ b/master/internal/run/runs.go
@@ -30,7 +30,7 @@ func FlattenMetadata(
 	data map[string]any,
 ) (flatMetadata []model.RunMetadataIndex, err error) {
 	if len(data) == 0 {
-		return nil, fmt.Errorf("metadata is empty")
+		return nil, nil
 	}
 	flatMetadata, err = flattenMetadata(data)
 	if err != nil {

--- a/master/internal/run/runs_test.go
+++ b/master/internal/run/runs_test.go
@@ -95,8 +95,6 @@ func TestFlattenMetadataEmpty(t *testing.T) {
 	require.Error(t, err, "metadata is empty")
 }
 
-// TODO(corban): this should actually be adjusted to return an error since we don't want to
-// allow empty post requests to be made to the metadata endpoint.
 func TestFlattenMetadataNil(t *testing.T) {
 	_, err := FlattenMetadata(nil)
 	require.Error(t, err, "metadata is empty")

--- a/master/internal/run/runs_test.go
+++ b/master/internal/run/runs_test.go
@@ -91,13 +91,15 @@ func TestFlattenMetadata(t *testing.T) {
 
 func TestFlattenMetadataEmpty(t *testing.T) {
 	data := map[string]interface{}{}
-	_, err := FlattenMetadata(data)
-	require.Error(t, err, "metadata is empty")
+	flatMetadata, err := FlattenMetadata(data)
+	require.NoError(t, err)
+	require.Empty(t, flatMetadata)
 }
 
 func TestFlattenMetadataNil(t *testing.T) {
-	_, err := FlattenMetadata(nil)
-	require.Error(t, err, "metadata is empty")
+	flatMetadata, err := FlattenMetadata(nil)
+	require.NoError(t, err)
+	require.Empty(t, flatMetadata)
 }
 
 func TestFlattenMetadataNested(t *testing.T) {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
Enables empty an metadata field to be submitted through both the Core API & API endpoints, allowing existing metadata to be deleted internally.

Cleans up an unnecessary todo from `TestFlattenMetadataNil` about returning an error when the provided metadata is empty, this no longer was the decided case since the expectation is to delete existing metadata when the provided metadata is empty.
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
- `TestFlattenMetadataNil`
- `TestFlattenMetadata`
-  `TestPostRunMetadata`
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
