### PR TITLE
fix: add validation to patching project key (ET-305)

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -824,7 +824,17 @@ func (a *apiServer) PatchProject(
 ) (*apiv1.PatchProjectResponse, error) {
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user while updating project")
+		return nil, errors.New("failed to get user while updating project")
+	}
+
+	if req.Project == nil {
+		return nil, errors.New("project in request is nil while updating project")
+	}
+	if req.Project.Key != nil {
+		err = project.ValidateProjectKey(req.Project.Key.Value)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	updatedProject, err := project.UpdateProject(

--- a/master/internal/api_project_intg_test.go
+++ b/master/internal/api_project_intg_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/internal/project"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/random"
 	"github.com/determined-ai/determined/master/pkg/syncx/errgroupx"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/projectv1"
@@ -465,7 +466,7 @@ func TestCreateProjectWithProjectKey(t *testing.T) {
 	require.NoError(t, werr)
 
 	projectName := "test-project" + uuid.New().String()
-	projectKey := uuid.New().String()[:project.MaxProjectKeyLength]
+	projectKey := random.String(project.MaxProjectKeyLength)
 	resp, err := api.PostProject(ctx, &apiv1.PostProjectRequest{
 		Name: projectName, WorkspaceId: wresp.Workspace.Id, Key: &projectKey,
 	})
@@ -487,7 +488,7 @@ func TestCreateProjectWithDuplicateProjectKey(t *testing.T) {
 	require.NoError(t, werr)
 
 	projectName := "test-project" + uuid.New().String()
-	projectKey := uuid.New().String()[:project.MaxProjectKeyLength]
+	projectKey := random.String(project.MaxProjectKeyLength)
 	_, err := api.PostProject(ctx, &apiv1.PostProjectRequest{
 		Name: projectName, WorkspaceId: wresp.Workspace.Id, Key: &projectKey,
 	})
@@ -560,7 +561,7 @@ func TestPatchProject(t *testing.T) {
 
 	newName := uuid.New().String()
 	newDescription := uuid.New().String()
-	newKey := uuid.New().String()[:project.MaxProjectKeyLength]
+	newKey := random.String(project.MaxProjectKeyLength)
 	_, err = api.PatchProject(ctx, &apiv1.PatchProjectRequest{
 		Id: resp.Project.Id,
 		Project: &projectv1.PatchProject{
@@ -625,7 +626,7 @@ func TestPatchProjectWithConcurrent(t *testing.T) {
 	newDescription := "new-description"
 	errgrp := errgroupx.WithContext(ctx)
 	for i := 0; i < 20; i++ {
-		newKey := uuid.New().String()[:project.MaxProjectKeyLength]
+		newKey := random.String(project.MaxProjectKeyLength)
 		errgrp.Go(func(context.Context) error {
 			_, err := api.PatchProject(ctx, &apiv1.PatchProjectRequest{
 				Id: resp.Project.Id,

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -241,7 +241,6 @@ func ValidateProjectKey(key string) error {
 	case len(key) < 1:
 		return errors.New("project key cannot be empty")
 	case !regexp.MustCompile(ProjectKeyRegex).MatchString(key):
-		log.Errorf("project key %s does not match regex %s", key, ProjectKeyRegex)
 		return errors.Errorf(
 			"project key can only contain alphanumeric characters: %s",
 			key,

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -29,7 +29,7 @@ const (
 	// MaxRetries is the maximum number of retries for transaction conflicts.
 	MaxRetries = 5
 	// ProjectKeyRegex is the regex pattern for a project key.
-	ProjectKeyRegex = "^[A-Z0-9]{1,5}$"
+	ProjectKeyRegex = "^[a-zA-Z0-9]{1,5}$"
 )
 
 // getProjectColumns returns a query with the columns for a project, not including experiment

--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -171,8 +171,9 @@ func generateProjectKey(ctx context.Context, tx bun.Tx, projectName string) (str
 	var key string
 	found := true
 	for i := 0; i < MaxRetries && found; i++ {
-		prefixLength := min(len(projectName), MaxProjectKeyPrefixLength)
-		prefix := projectName[:prefixLength]
+		sanitizedName := strings.ToUpper(regexp.MustCompile("[^a-zA-Z0-9]").ReplaceAllString(projectName, ""))
+		prefixLength := min(len(sanitizedName), MaxProjectKeyPrefixLength)
+		prefix := sanitizedName[:prefixLength]
 		suffix := random.String(MaxProjectKeyLength - prefixLength)
 		key = strings.ToUpper(prefix + suffix)
 		err := tx.NewSelect().Model(&model.Project{}).Where("key = ?", key).For("UPDATE").Scan(ctx)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-305
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Adds validation on project keys when making PatchProject requests. 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Automated test pass (`TestPatchProjectWithInvalidProjectKey`)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ