### PR TITLE
chore: handle empty nested structs in run metadata as nil leaf nodes

### DIFF
--- a/master/internal/run/runs.go
+++ b/master/internal/run/runs.go
@@ -91,6 +91,14 @@ func flattenMetadata(data map[string]any) (flatMetadata []model.RunMetadataIndex
 		switch typedVal := entry.value.(type) {
 		// if the value is a map, push each key-value pair onto the stack.
 		case map[string]any:
+			if len(typedVal) == 0 {
+				// if the map is empty, treat it as a leaf node with a nil value.
+				newIndex := model.RunMetadataIndex{
+					FlatKey: entry.prefix + entry.key,
+				}
+				flatMetadata = append(flatMetadata, newIndex)
+				continue
+			}
 			for key, value := range typedVal {
 				newPrefix := entry.prefix + entry.key + "."
 				if newPrefix == "." {
@@ -106,6 +114,14 @@ func flattenMetadata(data map[string]any) (flatMetadata []model.RunMetadataIndex
 			}
 		// if the value is a slice, push each element onto the stack.
 		case []any:
+			if len(typedVal) == 0 {
+				// if the slice is empty, treat it as a leaf node with a nil value.
+				newIndex := model.RunMetadataIndex{
+					FlatKey: entry.prefix + entry.key,
+				}
+				flatMetadata = append(flatMetadata, newIndex)
+				continue
+			}
 			if len(typedVal) > MaxMetadataArrayLength {
 				return nil, fmt.Errorf(
 					"metadata array exceeds maximum length of %d/%d elements",

--- a/master/internal/run/runs_test.go
+++ b/master/internal/run/runs_test.go
@@ -313,3 +313,26 @@ func TestFlattenMetadataNestingTooDeep(t *testing.T) {
 		),
 	)
 }
+
+func TestFlattenMetadataEmptyNestedStructs(t *testing.T) {
+	data := map[string]interface{}{
+		"key1": map[string]interface{}{
+			"key2": map[string]interface{}{},
+			"key3": []any{},
+		},
+	}
+	flattened, err := FlattenMetadata(data)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []model.RunMetadataIndex{
+		{
+			RunID:     0,
+			FlatKey:   "key1.key2",
+			ProjectID: 0,
+		},
+		{
+			RunID:     0,
+			FlatKey:   "key1.key3",
+			ProjectID: 0,
+		},
+	}, flattened)
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-306
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
When submitting metadata with nested structs (maps/lists) that contain no elements, this would previously cause a 500 response. Instead, this changes that behavior to now treat these instances as leaf nodes for indexing with nil values & stores the metadata as expected.

<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
- Automated test `runs_test.go:TestFlattenMetadataEmptyNestedStructs`
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ