### PR TITLE
update perf test

### DIFF
--- a/performance/src/api_performance_tests.ts
+++ b/performance/src/api_performance_tests.ts
@@ -347,10 +347,10 @@ const getloadTests = (
       "search flat runs w/ hparam",
       getRequest(
         `/api/v1/runs?filter=%7B%22filterGroup%22%3A%7B%22children` +
-        `%22%3A%5B%7B%22columnName%22%3A%22hp.global_batch_size%22%2C%22` + 
-        `kind%22%3A%22field%22%2C%22location%22%3A%22LOCATION_TYPE_RUN_HYPERPARAMETERS%22` + 
-        `%2C%22operator%22%3A%22%3C%3D%22%2C%22type%22%3A%22COLUMN_TYPE_NUMBER%22%2C%22value` +
-        `%22%3A60%7D%5D%2C%22conjunction%22%3A%22and%22%2C%22kind` + 
+        `%22%3A%5B%7B%22columnName%22%3A%22hp.global_batch_size%22%2C%22kind` +
+        `%22%3A%22field%22%2C%22location%22%3A%22LOCATION_TYPE_RUN_HYPERPARAMETERS` + 
+        `%22%2C%22operator%22%3A%22%3E%22%2C%22type%22%3A%22COLUMN_TYPE_NUMBER` +
+        `%22%2C%22value%22%3A0.1%7D%5D%2C%22conjunction%22%3A%22and%22%2C%22kind` +
         `%22%3A%22group%22%7D%2C%22showArchived%22%3Afalse%7D`,
       ),
       !!sD?.workspace.projectId,

--- a/performance/src/api_performance_tests.ts
+++ b/performance/src/api_performance_tests.ts
@@ -348,7 +348,7 @@ const getloadTests = (
       getRequest(
         `/api/v1/runs?filter=%7B%22filterGroup%22%3A%7B%22children` +
         `%22%3A%5B%7B%22columnName%22%3A%22hp.global_batch_size%22%2C%22` + 
-        `kind%22%3A%22field%22%2C%22location%22%3A%22LOCATION_TYPE_HYPERPARAMETERS%22` + 
+        `kind%22%3A%22field%22%2C%22location%22%3A%22LOCATION_TYPE_RUN_HYPERPARAMETERS%22` + 
         `%2C%22operator%22%3A%22%3C%3D%22%2C%22type%22%3A%22COLUMN_TYPE_NUMBER%22%2C%22value` +
         `%22%3A60%7D%5D%2C%22conjunction%22%3A%22and%22%2C%22kind` + 
         `%22%3A%22group%22%7D%2C%22showArchived%22%3Afalse%7D`,


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ