### PR TITLE
test: increase timeouts for running experiments on k8s after env split

### DIFF
--- a/e2e_tests/tests/cluster/managed_cluster_k8s.py
+++ b/e2e_tests/tests/cluster/managed_cluster_k8s.py
@@ -17,8 +17,8 @@ class ManagedK8sCluster(abstract_cluster.Cluster):
 
         # Verify we have pulled our image.
         # TODO this won't work if we have multiple nodes.
-        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=0), "TERMINATED", 300)
-        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=1), "TERMINATED", 300)
+        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=0), "TERMINATED", 600)
+        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=1), "TERMINATED", 600)
 
     def kill_master(self) -> None:
         self._scale_master(up=False)

--- a/e2e_tests/tests/cluster/managed_cluster_k8s.py
+++ b/e2e_tests/tests/cluster/managed_cluster_k8s.py
@@ -17,8 +17,18 @@ class ManagedK8sCluster(abstract_cluster.Cluster):
 
         # Verify we have pulled our image.
         # TODO this won't work if we have multiple nodes.
-        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=0), "TERMINATED", 600)
-        utils.wait_for_command_state(sess, utils.run_command(sess, 0, slots=1), "TERMINATED", 600)
+        utils.wait_for_command_state(
+            sess,
+            utils.run_command(sess, 0, slots=0),
+            "TERMINATED",
+            utils.KUBERNETES_EXPERIMENT_TIMEOUT,
+        )
+        utils.wait_for_command_state(
+            sess,
+            utils.run_command(sess, 0, slots=1),
+            "TERMINATED",
+            utils.KUBERNETES_EXPERIMENT_TIMEOUT,
+        )
 
     def kill_master(self) -> None:
         self._scale_master(up=False)

--- a/e2e_tests/tests/cluster/test_agent_disable.py
+++ b/e2e_tests/tests/cluster/test_agent_disable.py
@@ -92,7 +92,10 @@ def test_disable_agent_experiment_resume() -> None:
         ["--config", "max_restarts=0"],
     )
     exp.wait_for_experiment_state(
-        sess, exp_id, bindings.experimentv1State.RUNNING, max_wait_secs=600
+        sess,
+        exp_id,
+        bindings.experimentv1State.RUNNING,
+        max_wait_secs=utils.KUBERNETES_EXPERIMENT_TIMEOUT,
     )
 
     with _disable_agent(admin, agent_id):
@@ -123,7 +126,7 @@ def test_disable_agent_zero_slots() -> None:
 
     command_id = utils.run_zero_slot_command(sess, sleep=180)
     # Wait for it to run.
-    utils.wait_for_command_state(sess, command_id, "RUNNING", 600)
+    utils.wait_for_command_state(sess, command_id, "RUNNING", utils.KUBERNETES_EXPERIMENT_TIMEOUT)
 
     try:
         with _disable_agent(admin, agent_id):
@@ -155,7 +158,10 @@ def test_drain_agent() -> None:
         ["--config", "hyperparameters.training_batch_seconds=0.15"],  # Take 15 seconds.
     )
     exp.wait_for_experiment_state(
-        sess, experiment_id, bindings.experimentv1State.RUNNING, max_wait_secs=600
+        sess,
+        experiment_id,
+        bindings.experimentv1State.RUNNING,
+        max_wait_secs=utils.KUBERNETES_EXPERIMENT_TIMEOUT,
     )
     exp.wait_for_experiment_active_workload(sess, experiment_id)
     exp.wait_for_experiment_workload_progress(sess, experiment_id)

--- a/e2e_tests/tests/cluster/test_agent_disable.py
+++ b/e2e_tests/tests/cluster/test_agent_disable.py
@@ -92,7 +92,7 @@ def test_disable_agent_experiment_resume() -> None:
         ["--config", "max_restarts=0"],
     )
     exp.wait_for_experiment_state(
-        sess, exp_id, bindings.experimentv1State.RUNNING, max_wait_secs=300
+        sess, exp_id, bindings.experimentv1State.RUNNING, max_wait_secs=600
     )
 
     with _disable_agent(admin, agent_id):
@@ -123,7 +123,7 @@ def test_disable_agent_zero_slots() -> None:
 
     command_id = utils.run_zero_slot_command(sess, sleep=180)
     # Wait for it to run.
-    utils.wait_for_command_state(sess, command_id, "RUNNING", 300)
+    utils.wait_for_command_state(sess, command_id, "RUNNING", 600)
 
     try:
         with _disable_agent(admin, agent_id):
@@ -155,7 +155,7 @@ def test_drain_agent() -> None:
         ["--config", "hyperparameters.training_batch_seconds=0.15"],  # Take 15 seconds.
     )
     exp.wait_for_experiment_state(
-        sess, experiment_id, bindings.experimentv1State.RUNNING, max_wait_secs=300
+        sess, experiment_id, bindings.experimentv1State.RUNNING, max_wait_secs=600
     )
     exp.wait_for_experiment_active_workload(sess, experiment_id)
     exp.wait_for_experiment_workload_progress(sess, experiment_id)

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -15,6 +15,8 @@ from tests import command
 from tests import config as conf
 from tests import detproc
 
+KUBERNETES_EXPERIMENT_TIMEOUT = 600
+
 
 class _HTTPServerWithRequest(http.server.HTTPServer):
     def __init__(


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Fix flakey test https://app.circleci.com/pipelines/github/determined-ai/determined/57030/workflows/987af866-5aed-4ff1-825d-1c7dcff5deee/jobs/2681147

Images got a lot larger after framework split so increase timeout.

## Test Plan

ci passes



## Checklist

- [ ] Changes have been manually QA'd
- [ ] User-facing API changes need the "User-facing API Change" label.
- [ ] Release notes should be added as a separate file under `docs/release-notes/`.
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses should be included for new code which was copied and/or modified from any external code.

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ