### PR TITLE
build: INFENG-739: remove hardcoded version from Vite config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -20,8 +20,6 @@ values =
 
 [bumpversion:file:.circleci/real_config.yml]
 
-[bumpversion:file:webui/react/vite.config.mts]
-
 [bumpversion:file:helm/charts/determined/Chart.yaml]
 
 [bumpversion:file:docs/_static/version-switcher/versions.json]

--- a/webui/react/vite.config.mts
+++ b/webui/react/vite.config.mts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import * as child from 'child_process';
 
 import { svgToReact } from '@hpe.com/vite-plugin-svg-to-jsx';
 import react from '@vitejs/plugin-react-swc';
@@ -89,7 +90,7 @@ export default defineConfig(({ mode }) => ({
     'process.env.IS_DEV': JSON.stringify(mode === 'development'),
     'process.env.PUBLIC_URL': JSON.stringify((mode !== 'test' && publicUrl) || ''),
     'process.env.SERVER_ADDRESS': JSON.stringify(process.env.SERVER_ADDRESS),
-    'process.env.VERSION': '"0.32.1-dev0"',
+    'process.env.VERSION': JSON.stringify(process.env.VERSION || child.execSync('git describe --tags --always 2>/dev/null || echo "unknown"').toString().trimEnd()),
   },
   optimizeDeps: {
     include: ['notebook'],


### PR DESCRIPTION
build: INFENG-739: remove hardcoded version from Vite config

## Ticket
INFENG-739

## Description

* Replace the process.env.VERSION variable explicitly defined in vite.config.mts with either the actual VERSION environment variable, if it's set, or the most recent git tag, followed by an optional commit counter and partial unique SHA hash. This shells out to git, and also accounts for the rare but possible case that the config is being used from outside of a git repository. In that situation, the version string is useless anyway, so we return "unknown" from the shell.

* During the release, we will set VERSION ourselves based on the tag, so we don't have to go over the top trying to parse it out here. The local version doesn't matter too much, either, as it's only referenced during development, and, as far as I can tell, is really only used to display the current version to the developer. During the release, we can set VERSION from CircleCI directly, as it already provides the tag if the run was triggered by one.


## Test Plan
1. Make sure you have Determined running locally ([draw the rest of the owl](https://knowyourmeme.com/memes/how-to-draw-an-owl)); [`devcluster`](https://github.com/determined-ai/devcluster) works fine.
1. In the repository somewhere, run `git tag v1.0.0`. This temporarily resolves a `pip` issue I need to fix that causes a `determined>=0.13.11`, namely: the version `make` tries to build doesn't have a proper tag, so it reads as <0.13.11 to pip, and thus fails. Having a tag available will satisfy the requirement. My apologies. It also makes it possible to see a more interesting version string in the UI.
1. In the repository root, run `make clean ; make all` to build Determined locally.
1. `cd` into `./webui/react` and run `npm start`. Run `nvm use` in this directory first if you need to switch Node versions.
1. In the lower left corner of the screen of the web UI that launches in a new tab, you should see `v1.0.0`. If you happened to tag a commit further back than `HEAD`, you would see something like `v1.1.0-2-gca758a773`, which is the tag itself, `v1.0.0`, the number of commits since that tag, `2`, the special prefix indicating a commit hash, `g`, and the unique hash prefix of `HEAD`, `ca758a773`.
1. Run `git tag -d v1.0.0`, kill the running `vite` instance, and re-run `npm start`. You should see just a hash prefix in place of the version this time: `49b0af80a` (just don't rebuild Determined or you'll hit the same `pip` error described before).
1. Finally, stop `vite` again. Run `export VERSION=1.1.2`, or your preferred version string, and re-run `npm start`.
1. The UI should display the version string you've chosen, as it reads from the `VERSION` environment variable.
1. Clean up: run `unset VERSION` wherever you set `VERSION`, and delete any tags you might have missed.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code