### PR TITLE
test: add `ConjunctionContainer` test cases

### DIFF
--- a/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
+++ b/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectValue } from 'hew/Select';
+import UIProvider, { DefaultTheme } from 'hew/Theme';
+
+import ConjunctionContainer from 'components/FilterForm/components/ConjunctionContainer';
+
+import { Conjunction } from './type';
+
+const setup = ({
+  index = 0,
+  conjunction,
+  onClick = vi.fn(),
+}: {
+  index?: number;
+  conjunction: Conjunction;
+  onClick?: (value: SelectValue) => void;
+}) => {
+  const user = userEvent.setup();
+
+  render(
+    <UIProvider theme={DefaultTheme.Light}>
+      <ConjunctionContainer conjunction={conjunction} index={index} onClick={onClick} />
+    </UIProvider>,
+  );
+
+  return { user };
+};
+
+describe('ConjunctionContainer', () => {
+  it('should show Where text when index is 0', () => {
+    setup({ conjunction: Conjunction.Or });
+
+    expect(screen.getByText('Where')).toHaveAttribute('data-test', 'where');
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('should show Select when index is 1', async () => {
+    const { user } = setup({ conjunction: Conjunction.Or, index: 1 });
+
+    const conjunctionSelect = screen.getByRole('combobox');
+    expect(screen.queryByText('Where')).not.toBeInTheDocument();
+    expect(conjunctionSelect).toBeInTheDocument();
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    await user.click(conjunctionSelect);
+    expect(await screen.findByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('should show Conjunction text when index is more than 1', () => {
+    setup({ conjunction: Conjunction.Or, index: 2 });
+
+    expect(screen.queryByText('Where')).not.toBeInTheDocument();
+    expect(screen.queryByText('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText(Conjunction.Or)).toHaveAttribute('data-test', 'conjunctionContinued');
+  });
+});

--- a/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
+++ b/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
@@ -50,7 +50,11 @@ describe('ConjunctionContainer', () => {
     expect(await screen.findByRole('listbox')).toBeInTheDocument();
     expect((await screen.findByRole('listbox')).children[0]).toHaveTextContent(Conjunction.And);
     await user.click((await screen.findAllByText(Conjunction.And))[1]);
-    expect(onClick).toBeCalledTimes(1);
+    expect(onClick).toBeCalledWith(Conjunction.And, {
+      children: Conjunction.And,
+      key: Conjunction.And,
+      value: Conjunction.And,
+    });
   });
 
   it('should show Conjunction text when index is more than 1', () => {

--- a/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
+++ b/webui/react/src/components/FilterForm/components/ConjunctionContainer.test.tsx
@@ -36,15 +36,21 @@ describe('ConjunctionContainer', () => {
   });
 
   it('should show Select when index is 1', async () => {
-    const { user } = setup({ conjunction: Conjunction.Or, index: 1 });
+    const onClick = vi.fn();
+    const { user } = setup({ conjunction: Conjunction.Or, index: 1, onClick });
 
     const conjunctionSelect = screen.getByRole('combobox');
     expect(screen.queryByText('Where')).not.toBeInTheDocument();
     expect(conjunctionSelect).toBeInTheDocument();
+    expect(screen.getByText(Conjunction.Or)).toBeInTheDocument();
+    expect(screen.queryByText(Conjunction.And)).not.toBeInTheDocument();
 
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     await user.click(conjunctionSelect);
     expect(await screen.findByRole('listbox')).toBeInTheDocument();
+    expect((await screen.findByRole('listbox')).children[0]).toHaveTextContent(Conjunction.And);
+    await user.click((await screen.findAllByText(Conjunction.And))[1]);
+    expect(onClick).toBeCalledTimes(1);
   });
 
   it('should show Conjunction text when index is more than 1', () => {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-201]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add `ConjunctionContainer` test cases


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- CI passes
- coverage should be more than 80% (ConjunctionContainer component)

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-201]: https://hpe-aiatscale.atlassian.net/browse/ET-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ