### PR TITLE
fix: persist workspace id/name & experiment id for historic allocations [DET-10378]

### DIFF
--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import io
 import re
+import uuid
 
 import pytest
 import requests
@@ -19,11 +20,30 @@ API_URL = "/resources/allocation/allocations-csv?"
 # Create a No_Op experiment and Check training/validation times
 @pytest.mark.e2e_cpu
 def test_experiment_capture() -> None:
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
+    w1 = bindings.post_PostWorkspace(
+        sess,
+        body=bindings.v1PostWorkspaceRequest(
+            name=f"workspace-{uuid.uuid4().hex[:8]}",
+            agentUserGroup=bindings.v1AgentUserGroup(agentGid=1000, agentGroup="det"),
+        ),
+    ).workspace
+    p1 = bindings.post_PostProject(
+        sess,
+        body=bindings.v1PostProjectRequest(
+            name=f"project-{uuid.uuid4().hex[:8]}",
+            workspaceId=w1.id,
+        ),
+        workspaceId=w1.id,
+    ).project
+
     start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     experiment_id = exp.create_experiment(
-        sess, conf.fixtures_path("no_op/single.yaml"), conf.fixtures_path("no_op")
+        sess,
+        conf.fixtures_path("core_api/whoami.yaml"),
+        conf.fixtures_path("core_api"),
+        ["--project_id", str(p1.id)],
     )
     exp.wait_for_experiment_state(sess, experiment_id, bindings.experimentv1State.COMPLETED)
 
@@ -33,13 +53,57 @@ def test_experiment_capture() -> None:
 
     # Check if an entry exists for experiment that just ran
     reader = csv.DictReader(io.StringIO(r.text))
-    matches = [row for row in reader if row["experiment_id"] == str(experiment_id)]
-    assert len(matches) >= 1, f"could not find any rows for experiment {experiment_id}"
+    rows = [row for row in reader]
+    experiment_matches = [row for row in rows if row["experiment_id"] == str(experiment_id)]
+    assert len(experiment_matches) >= 1, f"could not find any rows for experiment {experiment_id}"
+    workspace_matches = [row for row in rows if row["workspace_name"] == str(w1.name)]
+    assert len(workspace_matches) >= 1, f"could not find any rows for workspace {w1.name}"
+
+    # Move project to new workspace,
+    # and confirm that allocation csv still persists the old workspace id
+    w2 = bindings.post_PostWorkspace(
+        sess,
+        body=bindings.v1PostWorkspaceRequest(
+            name=f"workspace-{uuid.uuid4().hex[:8]}",
+            agentUserGroup=bindings.v1AgentUserGroup(agentGid=1000, agentGroup="det"),
+        ),
+    ).workspace
+    _ = bindings.post_MoveProject(
+        sess,
+        projectId=p1.id,
+        body=bindings.v1MoveProjectRequest(
+            destinationWorkspaceId=w2.id,
+            projectId=p1.id,
+        ),
+    )
+
+    r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
+    assert r.status_code == requests.codes.ok, r.text
+
+    reader = csv.DictReader(io.StringIO(r.text))
+    rows = [row for row in reader]
+    experiment_matches = [row for row in rows if row["experiment_id"] == str(experiment_id)]
+    assert len(experiment_matches) >= 1, f"could not find any rows for experiment {experiment_id}"
+    workspace_matches = [row for row in rows if row["workspace_name"] == str(w1.name)]
+    assert len(workspace_matches) >= 1, f"could not find any rows for workspace {w1.name}"
+
+    # Delete the experiment, and confirm that allocation csv still persists the experiment id
+    bindings.delete_DeleteExperiment(session=sess, experimentId=experiment_id)
+
+    r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
+    assert r.status_code == requests.codes.ok, r.text
+
+    reader = csv.DictReader(io.StringIO(r.text))
+    rows = [row for row in reader]
+    experiment_matches = [row for row in rows if row["experiment_id"] == str(experiment_id)]
+    assert len(experiment_matches) >= 1, f"could not find any rows for experiment {experiment_id}"
+    workspace_matches = [row for row in rows if row["workspace_name"] == str(w1.name)]
+    assert len(workspace_matches) >= 1, f"could not find any rows for workspace {w1.name}"
 
 
 @pytest.mark.e2e_cpu
 def test_notebook_capture() -> None:
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
     start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     task_id = None
@@ -53,7 +117,7 @@ def test_notebook_capture() -> None:
     assert task_id is not None
 
     end_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
     r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
     assert r.status_code == requests.codes.ok, r.text
 
@@ -67,7 +131,7 @@ def test_notebook_capture() -> None:
 # Create a No_Op Experiment/Tensorboard & Confirm Tensorboard task is captured
 @pytest.mark.e2e_cpu
 def test_tensorboard_experiment_capture() -> None:
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
     start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     experiment_id = exp.create_experiment(
@@ -109,7 +173,7 @@ def test_tensorboard_experiment_capture() -> None:
 # Create a command and confirm that the task is captured.
 @pytest.mark.e2e_cpu
 def test_cmd_capture() -> None:
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
     start_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     task_id = None
@@ -123,7 +187,7 @@ def test_cmd_capture() -> None:
     assert task_id is not None
 
     end_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    sess = api_utils.user_session()
+    sess = api_utils.admin_session()
     r = sess.get(f"{API_URL}timestamp_after={start_time}&timestamp_before={end_time}")
     assert r.status_code == requests.codes.ok, r.text
 

--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -96,6 +96,10 @@ def test_experiment_capture() -> None:
     assert r.status_code == requests.codes.ok, r.text
     validate_trial_csv_rows(r.text, experiment_id, w1.name)
 
+    # Clean up test workspaces
+    bindings.delete_DeleteWorkspace(session=sess, id=w1.id)
+    bindings.delete_DeleteWorkspace(session=sess, id=w2.id)
+
 
 @pytest.mark.e2e_cpu
 def test_notebook_capture() -> None:

--- a/e2e_tests/tests/experiment/test_allocation_csv.py
+++ b/e2e_tests/tests/experiment/test_allocation_csv.py
@@ -76,7 +76,7 @@ def test_experiment_capture() -> None:
             agentUserGroup=bindings.v1AgentUserGroup(agentGid=1000, agentGroup="det"),
         ),
     ).workspace
-    _ = bindings.post_MoveProject(
+    bindings.post_MoveProject(
         sess,
         projectId=p1.id,
         body=bindings.v1MoveProjectRequest(

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -145,7 +145,15 @@ func (c *Command) Start(ctx context.Context) error {
 		}
 	}
 
-	err := task.DefaultService.StartAllocation(c.logCtx,
+	err := task.InsertNTSCAllocationWorkspaceRecord(ctx, c.allocationID)
+	if err != nil {
+		return fmt.Errorf(
+			"failure while attempting persist workspace information for NTSC task (%s) allocation: %w",
+			c.taskID,
+			err)
+	}
+
+	err = task.DefaultService.StartAllocation(c.logCtx,
 		sproto.AllocateRequest{
 			AllocationID:        c.allocationID,
 			TaskID:              c.taskID,
@@ -170,11 +178,6 @@ func (c *Command) Start(ctx context.Context) error {
 
 	if err := c.persist(); err != nil {
 		c.syslog.WithError(err).Warnf("command persist failure")
-	}
-
-	err = task.InsertNTSCAllocationWorkspaceRecord(ctx, c.allocationID)
-	if err != nil {
-		return fmt.Errorf("failure while inserting NTSC allocation workspace record: %w", err)
 	}
 	return nil
 }

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -125,6 +125,18 @@ func (c *Command) Start(ctx context.Context) error {
 		if err := c.persistAndEvictContextDirectoryFromMemory(); err != nil {
 			return err
 		}
+		err := task.InsertNTSCAllocationWorkspaceRecord(
+			ctx,
+			c.allocationID,
+			int(c.Metadata.WorkspaceID),
+			c.Base.Workspace,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"failure while attempting to persist workspace information for NTSC task (%s) allocation: %w",
+				c.taskID,
+				err)
+		}
 	}
 
 	priority := c.Config.Resources.Priority
@@ -145,15 +157,7 @@ func (c *Command) Start(ctx context.Context) error {
 		}
 	}
 
-	err := task.InsertNTSCAllocationWorkspaceRecord(ctx, c.allocationID)
-	if err != nil {
-		return fmt.Errorf(
-			"failure while attempting persist workspace information for NTSC task (%s) allocation: %w",
-			c.taskID,
-			err)
-	}
-
-	err = task.DefaultService.StartAllocation(c.logCtx,
+	err := task.DefaultService.StartAllocation(c.logCtx,
 		sproto.AllocateRequest{
 			AllocationID:        c.allocationID,
 			TaskID:              c.taskID,

--- a/master/internal/command/command.go
+++ b/master/internal/command/command.go
@@ -171,6 +171,11 @@ func (c *Command) Start(ctx context.Context) error {
 	if err := c.persist(); err != nil {
 		c.syslog.WithError(err).Warnf("command persist failure")
 	}
+
+	err = task.InsertNTSCAllocationWorkspaceRecord(ctx, c.allocationID)
+	if err != nil {
+		return fmt.Errorf("failure while inserting NTSC allocation workspace record: %w", err)
+	}
 	return nil
 }
 

--- a/master/internal/command/command_intg_test.go
+++ b/master/internal/command/command_intg_test.go
@@ -189,6 +189,8 @@ func CreateMockGenericReq(t *testing.T, pgDB *db.PgDB) *CreateGeneric {
 	cmdSpec.CommandID = uuid.New().String()
 	cmdSpec.Metadata.PrivateKey = &key
 	cmdSpec.Metadata.PublicKey = &key
+	cmdSpec.Metadata.WorkspaceID = model.DefaultWorkspaceID
+	cmdSpec.Base.Workspace = model.DefaultWorkspaceName
 	return &CreateGeneric{Spec: &cmdSpec}
 }
 

--- a/master/internal/task/postgres_allocations.go
+++ b/master/internal/task/postgres_allocations.go
@@ -34,3 +34,67 @@ WHERE allocation_id = ?
 
 	return &allocation, nil
 }
+
+// InsertTrialAllocationWorkspaceRecord inserts a record linking an trial's allocation
+// to a trial to it's respective workspace & experiment.
+func InsertTrialAllocationWorkspaceRecord(
+	ctx context.Context,
+	experimentID int,
+	allocationID model.AllocationID,
+) error {
+	workspaceInfo := model.Workspace{}
+	err := db.Bun().NewSelect().Model(&workspaceInfo).
+		Join("INNER JOIN projects p on workspace.id = p.workspace_id").
+		Join("INNER JOIN experiments e on p.id = e.project_id").
+		Where("e.id = ?", experimentID).Scan(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve workspace information for allocation (%s) associated with experiment %d: %w",
+			allocationID,
+			experimentID,
+			err,
+		)
+	}
+
+	_, err = db.Bun().NewInsert().Model(&model.AllocationWorkspaceRecord{
+		AllocationID:  allocationID,
+		ExperimentID:  experimentID,
+		WorkspaceID:   workspaceInfo.ID,
+		WorkspaceName: workspaceInfo.Name,
+	}).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("inserting allocation workspace record: %w", err)
+	}
+	return nil
+}
+
+// InsertNTSCAllocationWorkspaceRecord inserts a record linking
+// an NTSC tasks' allocation to it's respective workspace.
+func InsertNTSCAllocationWorkspaceRecord(
+	ctx context.Context,
+	allocationID model.AllocationID,
+) error {
+	workspaceInfo := model.Workspace{}
+	err := db.Bun().NewSelect().Model(&workspaceInfo).
+		Join("INNER JOIN command_state c ON (c.generic_command_spec->'Metadata'->>'workspace_id')::int = workspace.id").
+		Join("INNER JOIN tasks t ON c.task_id = t.task_id").
+		Join("INNER JOIN allocations a ON t.task_id = a.task_id").
+		Where("a.allocation_id = ?", allocationID).Scan(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"unable to retrieve workspace information for NTSC allocation (%s): %w",
+			allocationID,
+			err,
+		)
+	}
+
+	_, err = db.Bun().NewInsert().Model(&model.AllocationWorkspaceRecord{
+		AllocationID:  allocationID,
+		WorkspaceID:   workspaceInfo.ID,
+		WorkspaceName: workspaceInfo.Name,
+	}).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("inserting NTSC allocation workspace record: %w", err)
+	}
+	return nil
+}

--- a/master/internal/task/postgres_allocations_intg_test.go
+++ b/master/internal/task/postgres_allocations_intg_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+// +build integration
+
+package task
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/oauth2.v3/utils/uuid"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/etc"
+	"github.com/determined-ai/determined/master/pkg/model"
+)
+
+func TestPersistAllocationWorkspaceInfo(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveTestPostgres(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	type TestCase struct {
+		description string
+		isTrial     bool
+	}
+	testCases := []TestCase{
+		{description: "NTSC Task", isTrial: false},
+		{description: "Trial", isTrial: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			workspaceID, workspaceName := db.RequireMockWorkspaceID(t, pgDB, "")
+
+			// Create dummy allocation & experiment ids.
+			allocID := model.AllocationID(uuid.Must(uuid.NewRandom()).String())
+			expID := 1
+
+			var err error
+			switch tc.isTrial {
+			case true:
+				err = InsertTrialAllocationWorkspaceRecord(
+					ctx,
+					expID,
+					allocID,
+					workspaceName,
+				)
+			case false:
+				err = InsertNTSCAllocationWorkspaceRecord(
+					ctx,
+					allocID,
+					workspaceID,
+					workspaceName,
+				)
+			}
+			require.NoError(t, err)
+
+			// Check if entry in allocation_workspace_info table is correct.
+			var persistedInfo model.AllocationWorkspaceRecord
+			err = db.Bun().NewSelect().
+				Model(&persistedInfo).
+				Where("allocation_id = ?", allocID).
+				Scan(ctx)
+			require.NoError(t, err)
+			require.Equal(t, allocID, persistedInfo.AllocationID)
+			require.Equal(t, workspaceID, persistedInfo.WorkspaceID)
+			require.Equal(t, workspaceName, persistedInfo.WorkspaceName)
+			if tc.isTrial {
+				require.Equal(t, expID, persistedInfo.ExperimentID)
+			}
+		})
+	}
+}
+
+func TestPersistAllocationWorkspaceInfoNonExistentWorkspace(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveTestPostgres(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	// Create dummy allocation & experiment ids.
+	allocID := model.AllocationID(uuid.Must(uuid.NewRandom()).String())
+	nonExistentWorkspaceName := uuid.Must(uuid.NewRandom()).String()
+
+	err := InsertTrialAllocationWorkspaceRecord(
+		ctx,
+		1,
+		allocID,
+		nonExistentWorkspaceName,
+	)
+	require.Error(t, err)
+}

--- a/master/internal/task/postgres_allocations_intg_test.go
+++ b/master/internal/task/postgres_allocations_intg_test.go
@@ -71,6 +71,14 @@ func TestPersistAllocationWorkspaceInfo(t *testing.T) {
 			if tc.isTrial {
 				require.Equal(t, expID, persistedInfo.ExperimentID)
 			}
+
+			// Clean up mock workspaces
+			t.Cleanup(func() {
+				_, err = db.Bun().NewDelete().Table("workspaces").Where("id IN (?)", workspaceID).Exec(ctx)
+				require.NoError(t, err, "error cleaning up workspace")
+				_, err = db.Bun().NewDelete().Table("allocation_workspace_info").Where("workspace_id IN (?)", workspaceID).Exec(ctx)
+			},
+			)
 		})
 	}
 }

--- a/master/internal/task/postgres_allocations_intg_test.go
+++ b/master/internal/task/postgres_allocations_intg_test.go
@@ -46,7 +46,6 @@ func TestPersistAllocationWorkspaceInfo(t *testing.T) {
 					ctx,
 					expID,
 					allocID,
-					workspaceName,
 				)
 			case false:
 				err = InsertNTSCAllocationWorkspaceRecord(
@@ -81,24 +80,4 @@ func TestPersistAllocationWorkspaceInfo(t *testing.T) {
 			)
 		})
 	}
-}
-
-func TestPersistAllocationWorkspaceInfoNonExistentWorkspace(t *testing.T) {
-	ctx := context.Background()
-	require.NoError(t, etc.SetRootPath(db.RootFromDB))
-	pgDB, cleanup := db.MustResolveTestPostgres(t)
-	defer cleanup()
-	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
-
-	// Create dummy allocation & experiment ids.
-	allocID := model.AllocationID(uuid.Must(uuid.NewRandom()).String())
-	nonExistentWorkspaceName := uuid.Must(uuid.NewRandom()).String()
-
-	err := InsertTrialAllocationWorkspaceRecord(
-		ctx,
-		1,
-		allocID,
-		nonExistentWorkspaceName,
-	)
-	require.Error(t, err)
 }

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -472,7 +472,6 @@ func (t *trial) maybeAllocateTask() error {
 		context.Background(),
 		t.experimentID,
 		ar.AllocationID,
-		t.taskSpec.Workspace,
 	)
 	if err != nil {
 		return fmt.Errorf(

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -466,11 +466,20 @@ func (t *trial) maybeAllocateTask() error {
 		Debugf("starting new trial allocation")
 
 	prom.AssociateJobExperiment(t.jobID, strconv.Itoa(t.experimentID), t.config.Labels())
+
 	// persist the allocation workspace/experiment record, in the event of moves or deletions
 	err = task.InsertTrialAllocationWorkspaceRecord(
-		context.Background(), t.experimentID, ar.AllocationID)
+		context.Background(),
+		t.experimentID,
+		ar.AllocationID,
+		t.taskSpec.Workspace,
+	)
 	if err != nil {
-		return fmt.Errorf("failed to persist workspace information for trial (%d) allocation: %w", t.id, err)
+		return fmt.Errorf(
+			"failure while attempting to persist workspace information for trial (%d) allocation: %w",
+			t.id,
+			err,
+		)
 	}
 	err = task.DefaultService.StartAllocation(
 		t.logCtx, ar, t.db, t.rm, specifier,

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -426,6 +426,16 @@ func (t *trial) maybeAllocateTask() error {
 		if err != nil {
 			return err
 		}
+
+		// persist the allocation workspace/experiment record, in the event of moves or deletions
+		err = task.InsertTrialAllocationWorkspaceRecord(
+			context.Background(), t.experimentID, ar.AllocationID)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to insert allocation workspace record when recovering allocation: %w",
+				err,
+			)
+		}
 		t.allocationID = &ar.AllocationID
 		return nil
 	}
@@ -471,6 +481,12 @@ func (t *trial) maybeAllocateTask() error {
 	)
 	if err != nil {
 		return err
+	}
+	// persist the allocation workspace/experiment record, in the event of moves or deletions
+	err = task.InsertTrialAllocationWorkspaceRecord(
+		context.Background(), t.experimentID, ar.AllocationID)
+	if err != nil {
+		return fmt.Errorf("failed to insert allocation workspace record: %w", err)
 	}
 	t.allocationID = &ar.AllocationID
 	return nil

--- a/master/internal/trial_intg_test.go
+++ b/master/internal/trial_intg_test.go
@@ -166,6 +166,7 @@ func setup(t *testing.T) (
 		&tasks.TaskSpec{
 			AgentUserGroup: &model.AgentUserGroup{},
 			SSHRsaSize:     1024,
+			Workspace:      model.DefaultWorkspaceName,
 		},
 		ssh.PrivateAndPublicKeys{},
 		false,

--- a/master/pkg/model/task.go
+++ b/master/pkg/model/task.go
@@ -146,6 +146,16 @@ type Allocation struct {
 	StatusCode   *int32  `db:"status_code" bun:"status_code"`
 }
 
+// AllocationWorkspaceRecord is the model for persisting the workspace and experiment
+// information associated with an allocation.
+type AllocationWorkspaceRecord struct {
+	bun.BaseModel `bun:"table:allocation_workspace_info"`
+	AllocationID  AllocationID `db:"allocation_id" bun:"allocation_id,notnull"`
+	ExperimentID  int          `db:"experiment_id" bun:"experiment_id"`
+	WorkspaceID   int          `db:"workspace_id" bun:"workspace_id,notnull"`
+	WorkspaceName string       `db:"workspace_name" bun:"workspace_name,notnull"`
+}
+
 // AcceleratorData is the model for an allocation accelerator data in the database.
 type AcceleratorData struct {
 	bun.BaseModel `bun:"table:allocation_accelerators"`

--- a/master/pkg/model/workspace.go
+++ b/master/pkg/model/workspace.go
@@ -15,6 +15,8 @@ import (
 const (
 	// DefaultWorkspaceID is a special, always-existing, workspace titled "Uncategorized".
 	DefaultWorkspaceID = 1
+	// DefaultWorkspaceName is the default workspace name, which is always present, and always has ID 1.
+	DefaultWorkspaceName = "Uncategorized"
 	// DefaultProjectID is the default project ID for the default workspace.
 	DefaultProjectID = 1
 )

--- a/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
+++ b/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS allocation_workspace_info (
     allocation_id TEXT PRIMARY KEY REFERENCES allocations (allocation_id),
-    workspace_id SERIAL NOT NULL,
-    workspace_name text NOT NULL,
+    workspace_id SERIAL,
+    workspace_name text,
     experiment_id INT
 );
 

--- a/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
+++ b/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS allocation_workspace_info (
-    allocation_id TEXT PRIMARY KEY REFERENCES allocations (allocation_id),
+    allocation_id TEXT PRIMARY KEY, 
     workspace_id SERIAL,
     workspace_name text,
     experiment_id INT
@@ -30,8 +30,8 @@ allocation_workspace AS (
         projects ON experiments.project_id = projects.id
 )
 -- Populate the new table with existing data based on the previous method of resolving the workspace info & experiment_id
-insert into allocation_workspace_info (allocation_id, workspace_id, workspace_name, experiment_id)
-select
+INSERT INTO allocation_workspace_info (allocation_id, workspace_id, workspace_name, experiment_id)
+SELECT
 	allocation_workspace.allocation_id,
     allocation_workspace.workspace_id,
     workspaces.name,

--- a/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
+++ b/master/static/migrations/20240617155550_add-allocation-workspace-table.tx.up.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS allocation_workspace_info (
+    allocation_id TEXT PRIMARY KEY REFERENCES allocations (allocation_id),
+    workspace_id SERIAL NOT NULL,
+    workspace_name text NOT NULL,
+    experiment_id INT
+);
+
+WITH 
+alloc_experiments AS (
+    SELECT
+        allocations.allocation_id,
+        rtrim(substring(task_id, '\d+?\.'), '.')::int AS experiment_id
+    FROM
+        allocations
+),
+allocation_workspace AS (
+    SELECT
+        allocations.allocation_id,
+        alloc_experiments.experiment_id,
+        COALESCE(projects.workspace_id, (c.generic_command_spec->'Metadata'->>'workspace_id')::int) AS workspace_id
+    FROM
+        allocations
+    LEFT JOIN 
+        command_state c ON allocations.task_id = c.task_id
+    LEFT JOIN
+        alloc_experiments ON allocations.allocation_id = alloc_experiments.allocation_id
+    LEFT JOIN
+        experiments ON alloc_experiments.experiment_id = experiments.id
+    LEFT JOIN
+        projects ON experiments.project_id = projects.id
+)
+-- Populate the new table with existing data based on the previous method of resolving the workspace info & experiment_id
+insert into allocation_workspace_info (allocation_id, workspace_id, workspace_name, experiment_id)
+select
+	allocation_workspace.allocation_id,
+    allocation_workspace.workspace_id,
+    workspaces.name,
+    allocation_workspace.experiment_id
+FROM 
+    allocation_workspace
+    LEFT JOIN
+        workspaces ON allocation_workspace.workspace_id = workspaces.id
+;


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
DET-10378
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Creates `allocation_workspace_information` table, responsible for persisting workspace id/name & experiment id for historic allocation reports. Adds new entries on successful creation of allocation for trials & NTSC tasks.

Backfills table using existing process used to retrieve workspace & experiment information for the historic allocation CSV endpoints.

Modifies logic for historic allocation report to leverage  `allocation_workspace_information` instead of resolving based on current state. 

Modifies existing e2e test to confirm workspace name is consistent when experiments are moved & deleted. 

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- e2e test passes


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ