### PR TITLE
docs: Describe local password sec

### DIFF
--- a/docs/_shared/basic-installation.txt
+++ b/docs/_shared/basic-installation.txt
@@ -2,4 +2,4 @@
 -  Accept the default username of ``determined``.
 -  Click **Sign In**.
 
-After signing in, you'll need to create a :ref:`strong password <strong-password>`.
+After signing in, create a :ref:`strong password <strong-password>`.

--- a/docs/_shared/note-pip-install-determined.txt
+++ b/docs/_shared/note-pip-install-determined.txt
@@ -1,3 +1,5 @@
 .. note::
     
+    When deploying locally, the system prompts you to set a strong password.
+
     The command, ``pip install determined``, installs the ``determined`` library which includes the Determined command-line interface (CLI). 

--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
@@ -86,7 +86,7 @@ CD into the directory and run this command:
 
 Open the Determined WebUI by navigating to the master URL. One way to do this is to navigate to
 ``http://localhost:8080/``, accept the default username of ``determined``, and click **Sign In**.
-After signing in, you'll need to create a :ref:`strong password <strong-password>`.
+After signing in, create a :ref:`strong password <strong-password>`.
 
 .. include:: ../../../_shared/note-local-dtrain-job.txt
 

--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -32,6 +32,16 @@ Ideal for getting started with Determined.
 -  :ref:`install-using-homebrew`
 -  :ref:`install-using-wsl`
 
+.. note::
+
+   Initial password
+
+   When you deploy locally using ``det deploy local`` with ``master-up`` or ``cluster-up`` commands
+   and no user accounts have been created yet, an initial password will be automatically generated
+   and shown to the user (with the option to change it) if neither
+   ``security.initial_user_password`` in ``master.yaml`` nor the ``--initial-user-password`` CLI
+   flag is present.
+
 ******************
  Determined Agent
 ******************

--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -34,9 +34,7 @@ Ideal for getting started with Determined.
 
 .. note::
 
-   Initial password
-
-   When you deploy locally using ``det deploy local`` with ``master-up`` or ``cluster-up`` commands
+   **Initial Password**: When you deploy locally using ``det deploy local`` with ``master-up`` or ``cluster-up`` commands
    and no user accounts have been created yet, an initial password will be automatically generated
    and shown to the user (with the option to change it) if neither
    ``security.initial_user_password`` in ``master.yaml`` nor the ``--initial-user-password`` CLI

--- a/docs/setup-cluster/_index.rst
+++ b/docs/setup-cluster/_index.rst
@@ -34,9 +34,9 @@ Ideal for getting started with Determined.
 
 .. note::
 
-   **Initial Password**: When you deploy locally using ``det deploy local`` with ``master-up`` or ``cluster-up`` commands
-   and no user accounts have been created yet, an initial password will be automatically generated
-   and shown to the user (with the option to change it) if neither
+   **Initial Password**: When you deploy locally using ``det deploy local`` with ``master-up`` or
+   ``cluster-up`` commands and no user accounts have been created yet, an initial password will be
+   automatically generated and shown to the user (with the option to change it) if neither
    ``security.initial_user_password`` in ``master.yaml`` nor the ``--initial-user-password`` CLI
    flag is present.
 

--- a/docs/setup-cluster/on-prem/options/wsl.rst
+++ b/docs/setup-cluster/on-prem/options/wsl.rst
@@ -145,8 +145,8 @@ To open the WebUI from WSL:
 
    explorer.exe http://localhost:8080
 
-The default username for the WebUI is ``determined`` and no password. After signing in, you'll need
-to create a :ref:`strong password <strong-password>`.
+The default username for the WebUI is ``determined`` and no password. After signing in, create a
+:ref:`strong password <strong-password>`.
 
 In the WebUI, go to the ``Cluster`` page. You should now see slots available (either CPU or GPU,
 depending on what hardware is available on the machine).

--- a/docs/tutorials/pachyderm-cat-dog.rst
+++ b/docs/tutorials/pachyderm-cat-dog.rst
@@ -269,8 +269,8 @@ Visit the Determined dashboard to view the progress of your experiment. One way 
 enter the following URL: ``http://localhost:8080/`` in your browser. This is the cluster address for
 your local training environment.
 
-Accept the default username of ``determined``, and click **Sign In**. After signing in, you'll need
-to create a :ref:`strong password <strong-password>`.
+Accept the default username of ``determined``, and click **Sign In**. After signing in, create a
+:ref:`strong password <strong-password>`.
 
 Wait until Determined displays Best Checkpoint before continuing on to the next step. Then, obtain
 the ID of the completed trial, you'll need this to download the checkpoint.

--- a/docs/tutorials/quickstart-mdldev.rst
+++ b/docs/tutorials/quickstart-mdldev.rst
@@ -203,7 +203,7 @@ schedules to run.
 #. Enter the cluster address in the browser address bar to view experiment progress in the WebUI. If
    you installed locally using the ``det deploy local`` command, the URL is
    ``http://localhost:8080/``. Accept the default username of ``determined`` and click **Sign In**.
-   After signing in, you'll need to create a :ref:`strong password <strong-password>`.
+   After signing in, create a :ref:`strong password <strong-password>`.
 
    .. image:: /assets/images/qs01c.png
       :width: 704px


### PR DESCRIPTION
Docs for https://github.com/determined-ai/determined/pull/9518/files


## Test Plan
* Test that the [quick installation](https://docs.determined.ai/latest/get-started/basic.html#step-2-install-determined) steps are reproducible
* Test that messages display as expected and that docs steps match the experience
* Test all local install and password-related messages in the _shared docs directory to see that they match the user experience

## Checklist

- [x] Changes have been manually QA'd
- [ ] 
