### PR TITLE
fix: add missing columns to workspace response [ET-301]

### DIFF
--- a/master/internal/project/postgres_project.go
+++ b/master/internal/project/postgres_project.go
@@ -48,6 +48,8 @@ func getProjectColumns(q *bun.SelectQuery) *bun.SelectQuery {
 		ColumnExpr("(SELECT username FROM users WHERE id = p.user_id) AS username").
 		ColumnExpr("p.user_id").
 		ColumnExpr("p.key").
+		ColumnExpr("w.name as workspace_name").
+		ColumnExpr("p.created_at").
 		Join("INNER JOIN workspaces w ON w.id = p.workspace_id")
 }
 


### PR DESCRIPTION

## Ticket
ET-301



## Description
This adds missing columns to the workspace model query.



## Test Plan
* `getProject` payload should have `workspaceName` and `createdAt` present and correct.
* when viewing a project, the workspace breadcrumb should be present.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ