### PR TITLE
fix: do not modify cached GetAgentsResponse

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -193,7 +193,9 @@ func (k *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentR
 
 // GetAgents implements rm.ResourceManager.
 func (k *ResourceManager) GetAgents() (*apiv1.GetAgentsResponse, error) {
-	return k.jobsService.GetAgents(), nil
+	resp := k.jobsService.GetAgents()
+	// Ensure cached response is not inadvertently modified.
+	return rm.CopyGetAgentsResponse(resp)
 }
 
 // GetAllocationSummaries implements rm.ResourceManager.

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -193,9 +193,7 @@ func (k *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentR
 
 // GetAgents implements rm.ResourceManager.
 func (k *ResourceManager) GetAgents() (*apiv1.GetAgentsResponse, error) {
-	resp := k.jobsService.GetAgents()
-	// Ensure cached response is not inadvertently modified.
-	return rm.CopyGetAgentsResponse(resp)
+	return k.jobsService.GetAgents()
 }
 
 // GetAllocationSummaries implements rm.ResourceManager.

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -170,7 +170,8 @@ func TestGetAgents(t *testing.T) {
 
 	for _, test := range agentsTests {
 		t.Run(test.Name, func(t *testing.T) {
-			agentsResp := test.jobsService.getAgents()
+			agentsResp, err := test.jobsService.getAgents()
+			require.NoError(t, err)
 			require.Equal(t, len(test.wantedAgentIDs), len(agentsResp.Agents))
 			for _, agent := range agentsResp.Agents {
 				_, ok := test.wantedAgentIDs[agent.Id]
@@ -243,7 +244,8 @@ func TestGetAgentsNodeSelectors(t *testing.T) {
 				}},
 			}}
 
-			agentsResp := js.getAgents()
+			agentsResp, err := js.getAgents()
+			require.NoError(t, err)
 			require.Equal(t, len(test.agentsMatched), len(agentsResp.Agents))
 
 			for _, agent := range agentsResp.Agents {
@@ -863,7 +865,7 @@ func TestRMValidateResources(t *testing.T) {
 
 func testROCMGetAgents() {
 	ps := createMockJobsService(createCompNodeMap(), device.ROCM, false)
-	ps.getAgents()
+	ps.getAgents() // nolint
 }
 
 func testROCMGetAgent() {

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -873,7 +873,9 @@ func TestPartialJobsShowQueuedStates(t *testing.T) {
 	require.NoError(t, err)
 
 	var slots int
-	for _, n := range rp.jobsService.GetAgents().Agents {
+	agents, err := rp.jobsService.GetAgents()
+	require.NoError(t, err)
+	for _, n := range agents.Agents {
 		slots += len(n.Slots)
 	}
 
@@ -944,11 +946,12 @@ func TestNodeWorkflows(t *testing.T) {
 	j := newTestJobsService(t)
 	rp := newTestResourcePool(j)
 
-	resp := j.getAgents()
+	resp, err := j.getAgents()
+	require.NoError(t, err)
 	require.Len(t, resp.Agents, 1)
 	nodeID := resp.Agents[0].Id
 
-	_, err := rp.jobsService.DisableAgent(&apiv1.DisableAgentRequest{AgentId: nodeID})
+	_, err = rp.jobsService.DisableAgent(&apiv1.DisableAgentRequest{AgentId: nodeID})
 	defer func() {
 		// Ensure we re-enable the agent, otherwise failures in this test will break others.
 		_, err := rp.jobsService.EnableAgent(&apiv1.EnableAgentRequest{AgentId: nodeID})
@@ -963,7 +966,8 @@ func TestNodeWorkflows(t *testing.T) {
 		j.getAgentsCacheTime = j.getAgentsCacheTime.Add(-time.Hour)
 		j.mu.Unlock()
 
-		resp = j.GetAgents()
+		resp, err := j.GetAgents()
+		require.NoError(t, err)
 		require.Len(t, resp.Agents, 1)
 		return !resp.Agents[0].Enabled
 	}), "GetAgents didn't say %s is disabled, but we just disabled it", nodeID)

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -1,6 +1,8 @@
 package rm
 
 import (
+	"google.golang.org/protobuf/proto"
+
 	"github.com/determined-ai/determined/master/internal/sproto"
 	"github.com/determined-ai/determined/master/pkg/command"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -61,4 +63,18 @@ type ResourcePoolName string
 // String converts a ResourcePoolName to String.
 func (r ResourcePoolName) String() string {
 	return string(r)
+}
+
+// CopyGetAgentsResponse returns a deep copy of GetAgentsResponse struct.
+func CopyGetAgentsResponse(resp *apiv1.GetAgentsResponse) (*apiv1.GetAgentsResponse, error) {
+	respBytes, err := proto.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+	var respCopy apiv1.GetAgentsResponse
+	err = proto.Unmarshal(respBytes, &respCopy)
+	if err != nil {
+		return nil, err
+	}
+	return &respCopy, nil
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[RM-350]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
The Kubernetes resource manager caches the response to a `GetAgents` request. Return a deep copy of the cached response to prevent unintentionally modifying the cached response.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-350]: https://hpe-aiatscale.atlassian.net/browse/RM-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ