### PR TITLE
fix: wrong notebook idleness payload [MD-447]

### DIFF
--- a/docs/release-notes/idle.rst
+++ b/docs/release-notes/idle.rst
@@ -2,4 +2,5 @@
 
 **Bug Fixes**
 
--  Notebooks: Fix a bug where idle notebooks were not terminated as expected.
+-  Notebooks: Fix an issue introduced in 0.30.0 where idle notebooks were not terminated as
+   expected.

--- a/docs/release-notes/idle.rst
+++ b/docs/release-notes/idle.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Notebooks: Fix a bug where idle notebooks where not terminated as expected.

--- a/docs/release-notes/idle.rst
+++ b/docs/release-notes/idle.rst
@@ -2,4 +2,4 @@
 
 **Bug Fixes**
 
--  Notebooks: Fix a bug where idle notebooks where not terminated as expected.
+-  Notebooks: Fix a bug where idle notebooks were not terminated as expected.

--- a/master/static/srv/check_idle.py
+++ b/master/static/srv/check_idle.py
@@ -100,7 +100,7 @@ def main():
             idle = is_idle(notebook_server, token, idle_type)
             sess.put(
                 f"/api/v1/notebooks/{notebook_id}/report_idle",
-                params={"notebook_id": notebook_id, "idle": idle},
+                json={"idle": idle},
             )
         except Exception:
             logging.warning("ignoring error communicating with master", exc_info=True)


### PR DESCRIPTION
## Ticket
MD-447

## Description

Notebooks were not terminated due to idleness because the master would parse the payload as having `idle: false` regardless of what the `check_idle.py` was trying to report. 

I suspect at some point in refactoring the `Sessions` and related code, this `PUT` switched from json payload to body, and master just could not parse out the boolean out of it.

## Test Plan

1. Start a notebook with `det notebook start --config idle_timeout=5m`
2. wait for notebook to open.
3. close the notebook. don't do anything in it, especially do not launch kernels! or, if you do, use a different `notebook_idle_type` value.
4.  wait for 5m
5. notebook should get terminated

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ