### PR TITLE
fix: API requests with single RM and recover from panic during unauthorized autocreate

### DIFF
--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -304,12 +304,16 @@ def create_workspace(args: argparse.Namespace) -> None:
     else:
         render_workspaces([w])
 
-    namespace_bindings = resp.namespaceBindings
-    if not namespace_bindings and set_namespace:
+    if not resp.namespaceBindings and set_namespace:
         print("Failed to set workspace-namespace binding.")
 
-    for cluster_name in resp.namespaceBindings:
-        namespace_binding = resp.namespaceBindings[cluster_name]
+    # Cast namespace_bindings to a Dict (rather than an Optional[Dict]) for lint purposes.
+    namespace_bindings: Dict[str, bindings.v1WorkspaceNamespaceBinding] = cast(
+        Dict[str, bindings.v1WorkspaceNamespaceBinding], resp.namespaceBindings
+    )
+
+    for cluster_name in namespace_bindings:
+        namespace_binding = namespace_bindings[cluster_name]
         print(f"Workspace {w.name} is bound to namespace {namespace_binding.namespace}")
 
 

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, cast
 
 from determined import cli
 from determined.cli import render, user
@@ -267,9 +267,9 @@ def create_workspace(args: argparse.Namespace) -> None:
     agent_user_group = _parse_agent_user_group_args(args)
     checkpoint_storage = _parse_checkpoint_storage_args(args)
 
-    if args.cluster_name and not (
-        args.namespace or args.auto_create_namespace or args.auto_create_namespace_all_clusters
-    ):
+    auto_create_namespace = args.auto_create_namespace or args.auto_create_namespace_all_clusters
+    set_namespace = args.namespace or auto_create_namespace
+    if args.cluster_name and not set_namespace:
         raise api.errors.BadRequestException(
             "must provide --namespace NAMESPACE or --auto-creeate-namespace, or remove "
             + "--cluster-name CLUSTER_NAME and specify --auto-create-namespace-all-clusters"
@@ -288,7 +288,7 @@ def create_workspace(args: argparse.Namespace) -> None:
     # value in the clusterNamespacePairs dictionary. To avoid that, we substitute the argument's
     # value with the empty string if it's null.
     cluster_name = args.cluster_name or ""
-    if args.namespace or args.auto_create_namespace or args.auto_create_namespace_all_clusters:
+    if set_namespace:
         namespace_meta = bindings.v1WorkspaceNamespaceMeta(
             namespace=args.namespace,
             autoCreateNamespace=args.auto_create_namespace,
@@ -303,10 +303,14 @@ def create_workspace(args: argparse.Namespace) -> None:
         render.print_json(w.to_json())
     else:
         render_workspaces([w])
-    if resp.namespaceBindings:
-        for cluster_name in resp.namespaceBindings:
-            namespace_binding = resp.namespaceBindings[cluster_name]
-            print(f"Workspace {w.name} is bound to namespace {namespace_binding.namespace}")
+
+    namespace_bindings = resp.namespaceBindings
+    if not namespace_bindings and set_namespace:
+        print("Failed to set workspace-namespace binding.")
+
+    for cluster_name in resp.namespaceBindings:
+        namespace_binding = resp.namespaceBindings[cluster_name]
+        print(f"Workspace {w.name} is bound to namespace {namespace_binding.namespace}")
 
 
 def describe_workspace(args: argparse.Namespace) -> None:

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -18,13 +18,13 @@ metadata:
      release: {{ .Release.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/status", "pods/log", "configmaps"]
+    resources: ["pods", "pods/status", "pods/log", "configmaps", "namespaces", "resourcequotas"]
     verbs: ["create", "get", "list", "delete"]
   - apiGroups: [""]
     resources: ["services", "resourcequotas"]
     verbs: ["get", "list"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "resourcequotas"]
     verbs: ["watch", "patch"]
   - apiGroups: [""]
     resources: ["events"]

--- a/helm/charts/determined/templates/master-permissions.yaml
+++ b/helm/charts/determined/templates/master-permissions.yaml
@@ -18,7 +18,7 @@ metadata:
      release: {{ .Release.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/status", "pods/log", "configmaps", "namespaces"]
+    resources: ["pods", "pods/status", "pods/log", "configmaps"]
     verbs: ["create", "get", "list", "delete"]
   - apiGroups: [""]
     resources: ["services", "resourcequotas"]

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -145,7 +145,7 @@ func (a *apiServer) validateClusterNamespaceMeta(
 		// but not specified in a given request.
 		if newClusterName != clusterName {
 			namespaceMetaWithAllClusterNames[newClusterName] = &workspacev1.WorkspaceNamespaceMeta{
-				ClusterName:         clusterName,
+				ClusterName:         newClusterName,
 				Namespace:           namespace,
 				AutoCreateNamespace: metadata.AutoCreateNamespace,
 			}

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -209,7 +209,7 @@ func generateNamespaceName(clusterID string, workspace string, wkspID int) strin
 	re := regexp.MustCompile(`[^a-z0-9]([^-a-z0-9]*[^a-z0-9])?`)
 	workspaceStripped := re.ReplaceAllString(workspace, "")
 	workspaceCap := math.Min(float64(len(workspaceStripped)), float64(31))
-	workspacePrefix := workspace[0:int(workspaceCap)]
+	workspacePrefix := workspaceStripped[0:int(workspaceCap)]
 	workspaceID := strconv.Itoa(wkspID)
 	if wkspID > 999999 {
 		workspaceID = workspaceID[0:6]


### PR DESCRIPTION
## Ticket
DET-10385, DET-10386


## Description
This PR fixes the following issues:
- API requests for single RM only work when the cluster name is specified in the request
- Autocreate panic is not handled when attempted with OSS
- Some lint issues after feature branch rebase with main
- Autocreating namespace fails given workspace whose name doesn't match the accepted namespace regex pattern.


## Test Plan
Spin up a single RM kubernetes EE cluster to execute the test plan.
To test API requests for single RM, run the following commands and make sure that they work:
- `det w create ws1 --auto-create-namespace`
- `det w create ws2 && det w bindings set ws2 --namespace default`
- `det w create ws3 --namespace default`
- `det w create ws4 && det w bindings set ws4 --auto-create-namespace`

To test auto-create panic handled gracefully with an intuitive error message:
- Kill your Kubernetes cluster (if it's EE) and spin up an OSS Kubernetes cluster (remove `license.txt` and `public.txt` from your `determined` directory).
- Run `det w create ws10 --auto-create-namespace` and verify that we get an error saying that auto create is an EE-only feature
- Run `det w create ws11 && det w bindings set ws11 --auto-create-namespace` and verify that we get an error saying that auto create is an EE-only feature

To test namespace auto-creation with workspaces whose names don't match the accepted namespace regex pattern, run 
`det w create name,of_workspacE --auto-create-namespace` and verify that a Kubernetes namespace is successfully created
- Run `det w create ANOTHER,name,of_workspacE && det w bindings set ANOTHER,name,of_workspacE --auto-create-namespace` and verify that a Kubernetes namespace is successfully created

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ