### PR TITLE
chore: change linters to handle Go 1.22 loopvar change [RM-353]

### DIFF
--- a/agent/internal/containers/manager.go
+++ b/agent/internal/containers/manager.go
@@ -248,7 +248,6 @@ func (m *Manager) SignalContainer(ctx context.Context, msg aproto.SignalContaine
 func (m *Manager) Detach() {
 	m.mu.RLock()
 	for _, c := range m.containers {
-		c := c
 		m.wg.Go(func(_ context.Context) {
 			c.Detach()
 		})
@@ -261,7 +260,6 @@ func (m *Manager) Detach() {
 func (m *Manager) Close() {
 	m.mu.RLock()
 	for _, c := range m.containers {
-		c := c
 		m.wg.Go(func(_ context.Context) {
 			c.Stop()
 		})

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: "1.20"
+  go: "1.22"
 
   # Timeout for individual linters to complete by.
   timeout: 1m
@@ -90,6 +90,13 @@ linters-settings:
     enable-all-rules: true
     rules:
       # Do not enable these linters.
+      - name: range-val-address # Go language changed.
+        disabled: true
+      - name: range-val-in-closure # Go language changed.
+        disabled: true
+      - name: datarace # Go language changed.
+        disabled: true
+
       - name: function-length # We've internally decided that the char length for lines is 120, not 75.
         disabled: true
       - name: line-length-limit # Already have another linter enabled that takes care of this.
@@ -198,6 +205,8 @@ linters:
     - exhaustive       # We often use switch statements as if statements.
     - protogetter      # Carolina thinks this is overkill.
     - tagalign         # Carolina thinks this is unnecessary.
+    - exportloopref    # Language changed.
+    - intrange         # Buggy, panic with this on Go 1.22.
 
     # Linters that are deprecated / replaced / removed.
     - nosnakecase      # Replaced by revive(var-naming).
@@ -211,4 +220,3 @@ linters:
     - deadcode         # Replaced by unusued.
     - maligned         # Replaced by govet 'fieldalignment'.
     - golint           # Replaced by revive.
-

--- a/master/.golangci.yml
+++ b/master/.golangci.yml
@@ -220,3 +220,4 @@ linters:
     - deadcode         # Replaced by unusued.
     - maligned         # Replaced by govet 'fieldalignment'.
     - golint           # Replaced by revive.
+

--- a/master/internal/api/api_test.go
+++ b/master/internal/api/api_test.go
@@ -22,7 +22,6 @@ func TestPaginate(t *testing.T) {
 	}
 
 	for _, tb := range tables {
-		tb := tb
 		errReporter := func(msg string) {
 			t.Errorf("Failed case: %v - %s", tb, msg)
 		}

--- a/master/internal/api_checkpoint.go
+++ b/master/internal/api_checkpoint.go
@@ -418,7 +418,6 @@ func (a *apiServer) CheckpointsRemoveFiles(
 
 	// Submit checkpoint GC tasks for all checkpoints.
 	for i, expIDcUUIDs := range groupCUUIDsByEIDs {
-		i := i
 		agentUserGroup, err := user.GetAgentUserGroup(ctx, curUser.ID, workspaceIDs[i])
 		if err != nil {
 			return nil, err

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -473,9 +473,7 @@ func (a *apiServer) deleteExperiments(exps []*model.Experiment, userModel *model
 
 	sema := make(chan struct{}, maxConcurrentDeletes)
 	g, _ := errgroup.WithContext(context.Background())
-	for i, e := range exps {
-		i := i
-		exp := e
+	for i, exp := range exps {
 		g.Go(func() error {
 			sema <- struct{}{}
 			defer func() { <-sema }()

--- a/master/internal/checkpoint_gc.go
+++ b/master/internal/checkpoint_gc.go
@@ -50,7 +50,6 @@ func runCheckpointGCForCheckpoints(
 
 	var wg errgroup.Group
 	for _, g := range groups {
-		g := g
 		wg.Go(func() error {
 			taskID := model.TaskID(fmt.Sprintf("%d.%s", expID, uuid.New()))
 			if err := runCheckpointGCTask(

--- a/master/internal/db/postgres_tasks_intg_test.go
+++ b/master/internal/db/postgres_tasks_intg_test.go
@@ -246,12 +246,11 @@ func TestAllocationState(t *testing.T) {
 		}
 		require.NoError(t, AddTask(ctx, task), "failed to add task")
 
-		s := state
 		a := &model.Allocation{
 			TaskID:       tID,
 			AllocationID: model.AllocationID(tID + "allocationID"),
 			ResourcePool: "default",
-			State:        &s,
+			State:        &state,
 		}
 		require.NoError(t, AddAllocation(ctx, a), "failed to add allocation")
 

--- a/master/internal/db/postgres_trial_profiler_metrics.go
+++ b/master/internal/db/postgres_trial_profiler_metrics.go
@@ -227,9 +227,8 @@ func GetTrialProfilerAvailableSeries(
 	}
 	var seriesLabels []*trialv1.TrialProfilerMetricLabels
 	for _, m := range out {
-		for aID, aM := range m.Metrics {
+		for agentID, aM := range m.Metrics {
 			// Top-level keys are always Agent IDs.
-			agentID := aID
 			if metrics, ok := aM.(map[string]interface{}); ok {
 				for k, v := range metrics {
 					// Certain metric groups have additional labels.

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -865,7 +865,6 @@ func (e *internalExperiment) processOperations(
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentTrialOps)
 	for requestID := range updatedTrials {
-		requestID := requestID
 		syslog := e.syslog.WithField("requestID", requestID)
 		t, ok := e.trials[requestID]
 		if !ok {
@@ -958,7 +957,6 @@ func (e *internalExperiment) patchTrialsState(state model.StateWithReason) {
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentTrialOps)
 	for _, t := range e.trials {
-		t := t
 		g.Go(func() error {
 			err := t.PatchState(state)
 			if err != nil {
@@ -1128,7 +1126,6 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	var g errgroup.Group
 	g.SetLimit(maxConcurrentTrialOps)
 	for _, t := range e.trials {
-		t := t
 		g.Go(func() error {
 			t.PatchRP(rp.String())
 			return nil

--- a/master/internal/rbac/rbac_intg_test.go
+++ b/master/internal/rbac/rbac_intg_test.go
@@ -307,8 +307,7 @@ func TestRbac(t *testing.T) {
 			},
 		}
 
-		for _, p := range permissionsToAdd {
-			perm := p
+		for _, perm := range permissionsToAdd {
 			_, err := db.Bun().NewInsert().Model(&perm).TableExpr("permission_assignments").Exec(ctx)
 			require.NoError(t, err, "failure inserting permission assignments in local setup")
 		}
@@ -521,8 +520,7 @@ func TestRbac(t *testing.T) {
 				"role_id":       testRole.ID,
 			},
 		}
-		for _, p := range permissionsToAdd {
-			perm := p
+		for _, perm := range permissionsToAdd {
 			_, err := db.Bun().NewInsert().Model(&perm).TableExpr("permission_assignments").Exec(ctx)
 			require.NoError(t, err, "failure inserting permission assignments in local setup")
 		}

--- a/master/internal/rm/agentrm/agent_state_test.go
+++ b/master/internal/rm/agentrm/agent_state_test.go
@@ -146,7 +146,6 @@ func TestAgentStatePersistence(t *testing.T) {
 	require.Len(t, states, 1)
 	var restored *agentState
 	for _, s := range states {
-		s := s
 		restored = &s
 		break
 	}
@@ -312,7 +311,6 @@ func Test_agentState_checkAgentStartedDevicesMatch(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.state.checkAgentStartedDevicesMatch(tt.agentStarted)
 			if tt.wantErrContains == "" {

--- a/master/internal/rm/agentrm/agents.go
+++ b/master/internal/rm/agentrm/agents.go
@@ -69,7 +69,6 @@ func newAgentService(
 	badAgentIds := []aproto.ID{}
 
 	for agentID, state := range agentStates {
-		state := state
 		agentRef, err := a.createAgent(agentID, state.resourcePoolName, a.opts, &state, func() {
 			_ = a.agents.Delete(agentID)
 		})
@@ -206,7 +205,6 @@ func (a *agents) createAgent(
 	var poolConfig *config.ResourcePoolConfig
 	for _, pc := range a.poolConfigs {
 		// The address of a loop variable is always the same. Use a temporary variable to capture the address.
-		pc := pc
 		if pc.PoolName == resourcePool {
 			poolConfig = &pc
 			break

--- a/master/internal/rm/agentrm/provisioner/aws/aws.go
+++ b/master/internal/rm/agentrm/provisioner/aws/aws.go
@@ -181,8 +181,7 @@ func (c *awsCluster) Launch(instanceNum int) error {
 func (c *awsCluster) Terminate(instanceIDs []string) {
 	ids := make([]*string, 0, len(instanceIDs))
 	for _, id := range instanceIDs {
-		idCopy := id
-		ids = append(ids, &idCopy)
+		ids = append(ids, &id)
 	}
 
 	if c.config.SpotEnabled {

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -746,7 +746,6 @@ func (j *jobsService) recreateGatewayProxyResources(
 	for _, port := range gatewayPorts {
 		var tcpRoute *alphaGatewayTyped.TCPRoute
 		for _, t := range tcpRoutes {
-			t := t
 			if len(t.Spec.ParentRefs) > 0 &&
 				t.Spec.ParentRefs[0].Port != nil &&
 				int(*t.Spec.ParentRefs[0].Port) == port {
@@ -760,7 +759,6 @@ func (j *jobsService) recreateGatewayProxyResources(
 
 		var service *k8sV1.Service
 		for _, s := range services {
-			s := s
 			if s.Name == tcpRoute.Name {
 				service = &s
 				break
@@ -918,7 +916,6 @@ func (j *jobsService) refreshJobState(allocationID model.AllocationID) error {
 		if _, ok := j.namespaceToPoolName[job.Namespace]; !ok {
 			continue
 		}
-		job := job
 		j.jobUpdatedCallback(&job)
 	}
 	return nil
@@ -940,7 +937,6 @@ func (j *jobsService) refreshPodStates(allocationID model.AllocationID) error {
 		if _, ok := j.namespaceToPoolName[pod.Namespace]; !ok {
 			continue
 		}
-		pod := pod
 		j.podStatusCallback(&pod)
 	}
 	return nil

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -126,7 +126,6 @@ func New(
 			maxSlotsPerPod = *poolConfig.TaskContainerDefaults.Kubernetes.MaxSlotsPerPod
 		}
 
-		poolConfig := poolConfig
 		rp := newResourcePool(maxSlotsPerPod, &poolConfig, k.jobsService, k.db)
 		go func() {
 			t := time.NewTicker(podSubmissionInterval)

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -407,7 +407,6 @@ func fanOutRMCall[TReturn any](m *MultiRMRouter, f func(rm.ResourceManager) (TRe
 	res := make([]TReturn, len(m.rms))
 	var eg errgroup.Group
 	for i, rm := range maps.Values(m.rms) {
-		i, rm := i, rm
 		eg.Go(func() error {
 			r, err := f(rm)
 			if err != nil {

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -80,10 +80,9 @@ func TestGetAllocationSummaries(t *testing.T) {
 
 			for _, name := range tt.allocNames {
 				n := name + "0"
-				tmpName := name
 
 				require.NotNil(t, allocs[*model.NewAllocationID(&n)])
-				require.Empty(t, allocs[*model.NewAllocationID(&tmpName)])
+				require.Empty(t, allocs[*model.NewAllocationID(&name)])
 			}
 		})
 	}

--- a/master/internal/rm/rmevents/rmevents_test.go
+++ b/master/internal/rm/rmevents/rmevents_test.go
@@ -25,14 +25,11 @@ func TestRMEvents(t *testing.T) {
 	var mu sync.Mutex
 	results := map[model.AllocationID]map[int][]sproto.ResourcesEvent{}
 	for _, topic := range topics {
-		topic := topic
-
 		mu.Lock()
 		results[topic] = map[int][]sproto.ResourcesEvent{}
 		mu.Unlock()
 
 		for subID := 0; subID < numSubsPerTopic; subID++ {
-			subID := subID
 			sub := Subscribe(topic)
 
 			wg.Add(1)

--- a/master/internal/task/tasklogger/logger_test.go
+++ b/master/internal/task/tasklogger/logger_test.go
@@ -96,7 +96,6 @@ func TestTaskLoggerConcurrent(t *testing.T) {
 
 	var in []*model.TaskLog
 	for i := 0; i < 10000; i++ {
-		i := i
 		in = append(in, &model.TaskLog{ID: &i})
 	}
 

--- a/master/pkg/model/agent_user_group.go
+++ b/master/pkg/model/agent_user_group.go
@@ -67,8 +67,7 @@ func (c *AgentUserGroup) OwnArchive(oldArchive archive.Archive) archive.Archive 
 		return oldArchive
 	}
 	var newArchive archive.Archive
-	for _, item := range oldArchive {
-		newItem := item
+	for _, newItem := range oldArchive {
 		newItem.UserID = c.UID
 		newItem.GroupID = c.GID
 		newArchive = append(newArchive, newItem)

--- a/master/pkg/schemas/expconf/schema_test.go
+++ b/master/pkg/schemas/expconf/schema_test.go
@@ -347,8 +347,7 @@ func RunCasesFile(t *testing.T, path string, displayPath string) {
 	err = json.Unmarshal(jbyts, &cases)
 	assert.NilError(t, err)
 
-	for _, testCase := range cases {
-		tc := testCase
+	for _, tc := range cases {
 		testName := fmt.Sprintf("%v::%v", displayPath, tc.Name)
 		t.Run(testName, func(t *testing.T) {
 			tc.CheckSaneAs(t)

--- a/master/pkg/searcher/grid_test.go
+++ b/master/pkg/searcher/grid_test.go
@@ -17,10 +17,9 @@ import (
 func generateHyperparameters(counts []int) expconf.Hyperparameters {
 	params := make(expconf.Hyperparameters, len(counts))
 	for i, count := range counts {
-		c := count
 		params[strconv.Itoa(i)] = expconf.Hyperparameter{
 			RawDoubleHyperparameter: &expconf.DoubleHyperparameter{
-				RawMinval: -1.0, RawMaxval: 1.0, RawCount: &c,
+				RawMinval: -1.0, RawMaxval: 1.0, RawCount: &count,
 			},
 		}
 	}

--- a/master/pkg/searcher/util_test.go
+++ b/master/pkg/searcher/util_test.go
@@ -250,8 +250,7 @@ func checkValueSimulation(
 }
 
 func runValueSimulationTestCases(t *testing.T, testCases []valueSimulationTestCase) {
-	for _, testCase := range testCases {
-		tc := testCase
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Apply WithDefaults in one place to make tests easyto write.
 			config := schemas.WithDefaults(tc.config)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Go 1.22 had a language change which fixed a common foot gun in Golang. https://go.dev/blog/loopvar-preview

Update our linters to allow you to write code like this 

```
for _, exp := range experiments {
   go func() {
       doSomething(exp)
   }()
}
```

## Test Plan

CI passes
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ