### PR TITLE
docs: Update postgreSQL docs

### DIFF
--- a/docs/setup-cluster/checklists/_index.rst
+++ b/docs/setup-cluster/checklists/_index.rst
@@ -37,8 +37,8 @@ About Offline Installations
  Set Up PostgreSQL
 *******************
 
-Determined uses a PostgreSQL database to store experiment and trial metadata. Choose the
-installation method that best fits your environment and requirements.
+Determined uses a :ref:`PostgreSQL <setup-postgresql>` database to store experiment and trial
+metadata. Choose the installation method that best fits your environment and requirements.
 
 .. note::
 

--- a/docs/setup-cluster/checklists/postgresql-setup-guide.rst
+++ b/docs/setup-cluster/checklists/postgresql-setup-guide.rst
@@ -1,0 +1,29 @@
+.. _postgresql-max-connections-guide:
+
+###################################
+ PostgreSQL Title Maybe Setup Guide
+###################################
+
+When setting up PostgreSQL for your deployment, it's crucial to configure several key parameters to ensure optimal performance. Below are the most important settings to consider:
+
+### max_connections
+
+``max_connections`` is the most important and universal parameter to adjust. If you are using an existing PostgreSQL installation, we recommend confirming that ``max_connections`` is set to at least 96. This setting ensures that your database can handle the number of concurrent connections required for Determined.
+
+### shared_buffers
+
+The ``shared_buffers`` setting determines how much memory PostgreSQL uses for caching data. It is generally recommended to set this to around 25% of your system's total memory. However, you should adjust this based on other workloads running on the same system.
+
+### max_wal_size and min_wal_size
+
+The Write-Ahead Logging (WAL) settings, ``max_wal_size`` and ``min_wal_size``, are more dependent on your specific usage patterns. Increasing these values can help improve performance for larger deployments. For detailed information on configuring these settings, please refer to the [WAL Configuration](https://www.postgresql.org/docs/current/wal-configuration.html) page.
+
+For more detailed information on these and other PostgreSQL configuration parameters, please consult the [PostgreSQL Runtime Configuration](https://www.postgresql.org/docs/current/runtime-config-resource.html) page relevant to the version you are using.
+
+### Summary
+
+1. **max_connections**: Ensure it is set to at least 96.
+2. **shared_buffers**: Set to approximately 25% of total system memory, adjust based on system workloads.
+3. **max_wal_size and min_wal_size**: Adjust according to your usage patterns for improved performance.
+
+Properly configuring these settings will help you achieve optimal performance and reliability with your PostgreSQL deployment.

--- a/docs/setup-cluster/checklists/postgresql-setup-guide.rst
+++ b/docs/setup-cluster/checklists/postgresql-setup-guide.rst
@@ -1,29 +1,44 @@
-.. _postgresql-max-connections-guide:
+.. _postgresql-database-tuning:
 
-###################################
- PostgreSQL Title Maybe Setup Guide
-###################################
+############################
+ PostgreSQL Database Tuning
+############################
 
-When setting up PostgreSQL for your deployment, it's crucial to configure several key parameters to ensure optimal performance. Below are the most important settings to consider:
+When setting up PostgreSQL for your deployment, it's crucial to configure several key parameters to
+ensure optimal performance. Below are the most important settings to consider:
 
 ### max_connections
 
-``max_connections`` is the most important and universal parameter to adjust. If you are using an existing PostgreSQL installation, we recommend confirming that ``max_connections`` is set to at least 96. This setting ensures that your database can handle the number of concurrent connections required for Determined.
+``max_connections`` is the most important and universal parameter to adjust. If you are using an
+existing PostgreSQL installation, we recommend confirming that ``max_connections`` is set to at
+least 96. This setting ensures that your database can handle the number of concurrent connections
+required for Determined.
 
 ### shared_buffers
 
-The ``shared_buffers`` setting determines how much memory PostgreSQL uses for caching data. It is generally recommended to set this to around 25% of your system's total memory. However, you should adjust this based on other workloads running on the same system.
+The ``shared_buffers`` setting determines how much memory PostgreSQL uses for caching data. It is
+generally recommended to set this to around 25% of your system's total memory. However, you should
+adjust this based on other workloads running on the same system.
 
 ### max_wal_size and min_wal_size
 
-The Write-Ahead Logging (WAL) settings, ``max_wal_size`` and ``min_wal_size``, are more dependent on your specific usage patterns. Increasing these values can help improve performance for larger deployments. For detailed information on configuring these settings, please refer to the [WAL Configuration](https://www.postgresql.org/docs/current/wal-configuration.html) page.
+The Write-Ahead Logging (WAL) settings, ``max_wal_size`` and ``min_wal_size``, are more dependent on
+your specific usage patterns. Increasing these values can help improve performance for larger
+deployments. For detailed information on configuring these settings, please refer to the [WAL
+Configuration](https://www.postgresql.org/docs/current/wal-configuration.html) page.
 
-For more detailed information on these and other PostgreSQL configuration parameters, please consult the [PostgreSQL Runtime Configuration](https://www.postgresql.org/docs/current/runtime-config-resource.html) page relevant to the version you are using.
+For more detailed information on these and other PostgreSQL configuration parameters, please consult
+the [PostgreSQL Runtime
+Configuration](https://www.postgresql.org/docs/current/runtime-config-resource.html) page relevant
+to the version you are using.
 
 ### Summary
 
-1. **max_connections**: Ensure it is set to at least 96.
-2. **shared_buffers**: Set to approximately 25% of total system memory, adjust based on system workloads.
-3. **max_wal_size and min_wal_size**: Adjust according to your usage patterns for improved performance.
+#. **max_connections**: Ensure it is set to at least 96.
+#. **shared_buffers**: Set to approximately 25% of total system memory, adjust based on system
+   workloads.
+#. **max_wal_size and min_wal_size**: Adjust according to your usage patterns for improved
+   performance.
 
-Properly configuring these settings will help you achieve optimal performance and reliability with your PostgreSQL deployment.
+Properly configuring these settings will help you achieve optimal performance and reliability with
+your PostgreSQL deployment.

--- a/docs/setup-cluster/checklists/postgresql-setup-guide.rst
+++ b/docs/setup-cluster/checklists/postgresql-setup-guide.rst
@@ -7,38 +7,41 @@
 When setting up PostgreSQL for your deployment, it's crucial to configure several key parameters to
 ensure optimal performance. Below are the most important settings to consider:
 
-### max_connections
+#. **max_connections**: Ensure ``max_connections`` is set to at least 96.
+#. **shared_buffers**: Set ``shared_buffers`` to approximately 25% of total system memory, adjust
+   based on system workloads.
+#. **max_wal_size and min_wal_size**: Adjust ``max_wal_size`` and ``min_wal_size`` according to your
+   usage patterns for improved performance.
+
+For more details, visit the relevant section below.
+
+*****************
+ max_connections
+*****************
 
 ``max_connections`` is the most important and universal parameter to adjust. If you are using an
 existing PostgreSQL installation, we recommend confirming that ``max_connections`` is set to at
 least 96. This setting ensures that your database can handle the number of concurrent connections
 required for Determined.
 
-### shared_buffers
+****************
+ shared_buffers
+****************
 
 The ``shared_buffers`` setting determines how much memory PostgreSQL uses for caching data. It is
 generally recommended to set this to around 25% of your system's total memory. However, you should
 adjust this based on other workloads running on the same system.
 
-### max_wal_size and min_wal_size
+*******************************
+ max_wal_size and min_wal_size
+*******************************
 
 The Write-Ahead Logging (WAL) settings, ``max_wal_size`` and ``min_wal_size``, are more dependent on
 your specific usage patterns. Increasing these values can help improve performance for larger
-deployments. For detailed information on configuring these settings, please refer to the [WAL
-Configuration](https://www.postgresql.org/docs/current/wal-configuration.html) page.
-
-For more detailed information on these and other PostgreSQL configuration parameters, please consult
-the [PostgreSQL Runtime
-Configuration](https://www.postgresql.org/docs/current/runtime-config-resource.html) page relevant
-to the version you are using.
-
-### Summary
-
-#. **max_connections**: Ensure it is set to at least 96.
-#. **shared_buffers**: Set to approximately 25% of total system memory, adjust based on system
-   workloads.
-#. **max_wal_size and min_wal_size**: Adjust according to your usage patterns for improved
-   performance.
+deployments. For detailed information on configuring these settings, please refer to the `WAL
+Configuration <https://www.postgresql.org/docs/current/wal-configuration.html>`__ page or the
+`PostgreSQL Runtime Configuration
+<https://www.postgresql.org/docs/current/runtime-config-resource.html>`__ page.
 
 Properly configuring these settings will help you achieve optimal performance and reliability with
 your PostgreSQL deployment.

--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -9,7 +9,8 @@ Determined uses a PostgreSQL database to store experiment and trial metadata.
 .. note::
 
    If you are using an existing PostgreSQL installation, we recommend confirming that
-   ``max_connections`` is at least 96, which is sufficient for Determined.
+   ``max_connections`` is at least 96, which is sufficient for Determined. See: :ref:`Max
+   Connections <postgresql-max-connections-guide>`.
 
 .. _install-postgres-docker:
 

--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -10,7 +10,7 @@ Determined uses a PostgreSQL database to store experiment and trial metadata.
 
    If you are using an existing PostgreSQL installation, we recommend confirming that
    ``max_connections`` is at least 96, which is sufficient for Determined. See: :ref:`Max
-   Connections <postgresql-max-connections-guide>`.
+   Connections <postgresql-database-tuning>`.
 
 .. _install-postgres-docker:
 


### PR DESCRIPTION
## Description

audience: admin
purpose: users often miss important information including the recommended configuration for max_connections and other settings for bigger deployments

since this links from the "advanced installation" guide it is appropriate to move the content to its own page