### PR TITLE
docs: Improve postgreSQL setup

### DIFF
--- a/docs/setup-cluster/checklists/_index.rst
+++ b/docs/setup-cluster/checklists/_index.rst
@@ -37,8 +37,8 @@ About Offline Installations
  Set Up PostgreSQL
 *******************
 
-Determined uses a PostgreSQL database to store experiment and trial metadata. Choose the
-installation method that best fits your environment and requirements.
+Determined uses a :ref:`PostgreSQL <setup-postgresql>` database to store experiment and trial
+metadata. Choose the installation method that best fits your environment and requirements.
 
 .. note::
 

--- a/docs/setup-cluster/checklists/postgresql-setup-guide.rst
+++ b/docs/setup-cluster/checklists/postgresql-setup-guide.rst
@@ -19,9 +19,9 @@ For more details, visit the relevant section below.
  max_connections
 *****************
 
-``max_connections`` is the most important and universal parameter to adjust. We recommend confirming that ``max_connections`` is set to at
-least 96. This setting ensures that your database can handle the number of concurrent connections
-required for Determined.
+``max_connections`` is the most important and universal parameter to adjust. We recommend confirming
+that ``max_connections`` is set to at least 96. This setting ensures that your database can handle
+the number of concurrent connections required for Determined.
 
 ****************
  shared_buffers

--- a/docs/setup-cluster/checklists/postgresql-setup-guide.rst
+++ b/docs/setup-cluster/checklists/postgresql-setup-guide.rst
@@ -1,0 +1,46 @@
+.. _postgresql-database-tuning:
+
+############################
+ PostgreSQL Database Tuning
+############################
+
+When setting up PostgreSQL for your deployment, it's crucial to configure several key parameters to
+ensure optimal performance. Below are the most important settings to consider:
+
+#. **max_connections**: Ensure ``max_connections`` is set to at least 96.
+#. **shared_buffers**: Set ``shared_buffers`` to approximately 25% of total system memory, adjust
+   based on system workloads.
+#. **max_wal_size and min_wal_size**: Adjust ``max_wal_size`` and ``min_wal_size`` according to your
+   usage patterns for improved performance.
+
+For more details, visit the relevant section below.
+
+*****************
+ max_connections
+*****************
+
+``max_connections`` is the most important and universal parameter to adjust. We recommend confirming that ``max_connections`` is set to at
+least 96. This setting ensures that your database can handle the number of concurrent connections
+required for Determined.
+
+****************
+ shared_buffers
+****************
+
+The ``shared_buffers`` setting determines how much memory PostgreSQL uses for caching data. It is
+generally recommended to set this to around 25% of your system's total memory. However, you should
+adjust this based on other workloads running on the same system.
+
+*******************************
+ max_wal_size and min_wal_size
+*******************************
+
+The Write-Ahead Logging (WAL) settings, ``max_wal_size`` and ``min_wal_size``, are more dependent on
+your specific usage patterns. Increasing these values can help improve performance for larger
+deployments. For detailed information on configuring these settings, please refer to the `WAL
+Configuration <https://www.postgresql.org/docs/current/wal-configuration.html>`__ page or the
+`PostgreSQL Runtime Configuration
+<https://www.postgresql.org/docs/current/runtime-config-resource.html>`__ page.
+
+Properly configuring these settings will help you achieve optimal performance and reliability with
+your PostgreSQL deployment.

--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -9,7 +9,8 @@ Determined uses a PostgreSQL database to store experiment and trial metadata.
 .. note::
 
    If you are using an existing PostgreSQL installation, we recommend confirming that
-   ``max_connections`` is at least 96, which is sufficient for Determined.
+   ``max_connections`` is at least 96, which is sufficient for Determined. See: :ref:`Max
+   Connections <postgresql-database-tuning>`.
 
 .. _install-postgres-docker:
 


### PR DESCRIPTION
replaces: #9586

audience: admin
purpose: users often miss important information including the recommended configuration for max_connections and other settings for bigger deployments

since this links from the "advanced installation" guide it is appropriate to move the content to its own page

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ