### PR TITLE
fix: lint issue from flake8-comprehensions 3.15.0

### DIFF
--- a/e2e_tests/tests/experiment/test_metrics.py
+++ b/e2e_tests/tests/experiment/test_metrics.py
@@ -311,7 +311,7 @@ def test_trial_time_series(group: str) -> None:
     metric_names = ["lossx"]
 
     trial_metrics = bindings.v1TrialMetrics(
-        metrics=bindings.v1Metrics(avgMetrics={name: 3.3 for name in metric_names}),
+        metrics=bindings.v1Metrics(avgMetrics=dict.fromkeys(metric_names, 3.3)),
         stepsCompleted=10,
         trialId=trial_id,
         trialRunId=0,

--- a/harness/determined/common/api/_rbac.py
+++ b/harness/determined/common/api/_rbac.py
@@ -39,7 +39,7 @@ def create_group_assignment_request(
 
 
 def usernames_to_user_ids(session: api.Session, usernames: List[str]) -> List[int]:
-    usernames_to_ids: Dict[str, Optional[int]] = {u: None for u in usernames}
+    usernames_to_ids: Dict[str, Optional[int]] = dict.fromkeys(usernames, None)
     users = bindings.get_GetUsers(session).users or []
     for user in users:
         if user.username in usernames_to_ids:


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
`flake8-comprehensions` was updated from 3.14.0 to 3.15.0 over the weekend. Some of the code couldn't pass lint check.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ