### PR TITLE
fix: upload non-conflicting files for sharded checkpointing [MD-298]

### DIFF
--- a/harness/determined/common/storage/base.py
+++ b/harness/determined/common/storage/base.py
@@ -80,7 +80,9 @@ class StorageManager(metaclass=abc.ABCMeta):
         return pathlib.Path(storage_dir)
 
     @abc.abstractmethod
-    def post_store_path(self, src: Union[str, os.PathLike], dst: str) -> None:
+    def post_store_path(
+        self, src: Union[str, os.PathLike], dst: str, paths: Optional[Set[str]] = None
+    ) -> None:
         """
         Subclasses typically push to persistent storage if necessary, then delete the src directory,
         if necessary.

--- a/harness/determined/common/storage/cloud.py
+++ b/harness/determined/common/storage/cloud.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
 import pathlib
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional, Set, Union
 
 from determined import util
 from determined.common import storage
@@ -22,12 +22,14 @@ class CloudStorageManager(storage.StorageManager):
         finally:
             util.rmtree_nfs_safe(dst, ignore_errors=True)
 
-    def post_store_path(self, src: Union[str, os.PathLike], dst: str) -> None:
+    def post_store_path(
+        self, src: Union[str, os.PathLike], dst: str, paths: Optional[Set[str]] = None
+    ) -> None:
         """
         post_store_path uploads the checkpoint to cloud storage and deletes the original files.
         """
         try:
-            self.upload(src, dst)
+            self.upload(src, dst, paths)
         finally:
             util.rmtree_nfs_safe(src, ignore_errors=True)
 

--- a/harness/determined/common/storage/shared.py
+++ b/harness/determined/common/storage/shared.py
@@ -5,7 +5,7 @@ import os
 import pathlib
 import shutil
 import urllib
-from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Union
 
 from determined import errors, util
 from determined.common import check, storage
@@ -171,7 +171,9 @@ class SharedFSStorageManager(storage.StorageManager):
         )
         return cls(base_path)
 
-    def post_store_path(self, src: Union[str, os.PathLike], dst: str) -> None:
+    def post_store_path(
+        self, src: Union[str, os.PathLike], dst: str, paths: Optional[Set[str]] = None
+    ) -> None:
         """
         Nothing to clean up after writing directly to shared_fs.
         """

--- a/harness/tests/core/test_checkpoint.py
+++ b/harness/tests/core/test_checkpoint.py
@@ -39,7 +39,7 @@ def make_mock_storage_manager(
         path.mkdir(exist_ok=True)
         return pathlib.Path(path)
 
-    mock_list_dir = dict([(f, i) for i, f in enumerate(dir_files)])
+    mock_list_dir = {f: i for i, f in enumerate(dir_files)}
 
     storage_manager = mock.MagicMock()
     storage_manager.store_path = mock.MagicMock(side_effect=store_path)
@@ -303,13 +303,13 @@ def test_checkpoint_upload(sharded: bool, tmp_path: pathlib.Path) -> None:
             return upload_paths
 
     assert len(upload_ckpt) == 2
-    assert sorted(list(upload_ckpt[0])) == sorted(ckpt_files[0] + all_workers_files)
+    assert sorted(upload_ckpt[0]) == sorted(ckpt_files[0] + all_workers_files)
 
     if sharded:
         # In the sharded case, expect each worker to upload unique files. Files that conflict across
         # workers should only be uploaded by the chief worker.
-        assert sorted(list(upload_ckpt[1])) == sorted(ckpt_files[1])
-        assert len(upload_ckpt[0].intersection(ckpt_files[1])) == 0
+        assert sorted(upload_ckpt[1]) == sorted(ckpt_files[1])
+        assert len(set(upload_ckpt[0]).intersection(ckpt_files[1])) == 0
     else:
         # Only the chief worker should upload files in the non-sharded case.
         assert len(list(upload_ckpt[1])) == 0


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

make sharded checkpoint uploads with `store_path` check for file conflicts across workers before upload.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ