### PR TITLE
fix: display runs count in ProjectCard (ET-314)

### DIFF
--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -52,7 +52,9 @@ describe('ProjectCard', () => {
 
   it('should display experiments count', () => {
     setup();
-    expect(screen.getByText(projectMock.numExperiments?.toString() ?? 'Count undefined')).toBeInTheDocument();
+    expect(
+      screen.getByText(projectMock.numExperiments?.toString() ?? 'Count undefined'),
+    ).toBeInTheDocument();
   });
 
   it('should display archived label', () => {

--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -30,9 +30,7 @@ const setup = () => {
   render(
     <UIProvider theme={DefaultTheme.Light}>
       <ThemeProvider>
-        <ProjectCard
-          project={projectMock}
-        />
+        <ProjectCard project={projectMock} />
       </ThemeProvider>
     </UIProvider>,
   );

--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -52,7 +52,7 @@ describe('ProjectCard', () => {
 
   it('should display experiments count', () => {
     setup();
-    expect(screen.getByText(projectMock.numExperiments?.toString() ?? '')).toBeInTheDocument();
+    expect(screen.getByText(projectMock.numExperiments?.toString() ?? 'Count undefined')).toBeInTheDocument();
   });
 
   it('should display archived label', () => {

--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UIProvider, { DefaultTheme } from 'hew/Theme';
+
+import { handlePath } from 'routes/utils';
+import { Project } from 'types';
+
+import ProjectCard from './ProjectCard';
+import { ThemeProvider } from './ThemeProvider';
+
+const projectMock: Project = {
+  archived: false,
+  description: '',
+  id: 1849,
+  immutable: false,
+  lastExperimentStartedAt: '2024-06-03T19:33:38.731220Z',
+  name: 'test',
+  notes: [],
+  numActiveExperiments: 1,
+  numExperiments: 16,
+  state: 'UNSPECIFIED',
+  userId: 1354,
+  workspaceId: 1684,
+  workspaceName: '',
+};
+
+const user = userEvent.setup();
+
+const setup = () => {
+  render(
+    <UIProvider theme={DefaultTheme.Light}>
+      <ThemeProvider>
+        <ProjectCard
+          project={projectMock}
+        />
+      </ThemeProvider>
+    </UIProvider>,
+  );
+};
+
+vi.mock('routes/utils', () => ({
+  handlePath: vi.fn(),
+  paths: {
+    projectDetails: () => 'testPath',
+  },
+  serverAddress: () => 'http://localhost',
+}));
+
+describe('ProjectCard', () => {
+  it('should display project name', () => {
+    setup();
+    expect(screen.getByText(projectMock.name)).toBeInTheDocument();
+  });
+
+  it('should display experiments count', () => {
+    setup();
+    expect(screen.getByText(projectMock.numExperiments?.toString() ?? '')).toBeInTheDocument();
+  });
+
+  it('should display archived label', () => {
+    setup();
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
+    projectMock.archived = true;
+    setup();
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+  });
+
+  it('should navigate to details page on click', async () => {
+    setup();
+    await user.click(screen.getByTestId(`card-${projectMock.name}`));
+    const click = vi.mocked(handlePath).mock.calls[0];
+    expect(click[0]).toMatchObject({ type: 'click' });
+    expect(click[1]).toMatchObject({
+      path: 'testPath',
+    });
+  });
+});

--- a/webui/react/src/components/ProjectCard.tsx
+++ b/webui/react/src/components/ProjectCard.tsx
@@ -10,10 +10,12 @@ import { isUndefined } from 'lodash';
 import React from 'react';
 
 import TimeAgo from 'components/TimeAgo';
+import useFeature from 'hooks/useFeature';
 import { handlePath, paths } from 'routes/utils';
 import { Project } from 'types';
 import { nearestCardinalNumber } from 'utils/number';
 import { AnyMouseEvent } from 'utils/routes';
+import { pluralizer } from 'utils/string';
 
 import { useProjectActionMenu } from './ProjectActionDropdown';
 import css from './ProjectCard.module.scss';
@@ -35,6 +37,8 @@ const ProjectCard: React.FC<Props> = ({
   showWorkspace,
   workspaceArchived,
 }: Props) => {
+  const f_flat_runs = useFeature().isOn('flat_runs');
+
   const { contextHolders, menu, onClick } = useProjectActionMenu({
     onDelete: onRemove,
     onEdit,
@@ -77,13 +81,19 @@ const ProjectCard: React.FC<Props> = ({
           </Row>
           <Row justifyContent="space-between" width="fill">
             <div className={css.footerContainer}>
-              {!isUndefined(project.numExperiments) && (
+              {f_flat_runs && !isUndefined(project.numRuns) && (
                 <div className={css.experiments}>
                   <Tooltip
-                    content={
-                      `${project.numExperiments?.toLocaleString()}` +
-                      ` experiment${project.numExperiments === 1 ? '' : 's'}`
-                    }>
+                    content={`${project.numRuns?.toLocaleString()} ${pluralizer(project.numRuns, 'run')}`}>
+                    <Icon name="experiment" size="small" title="Number of runs" />
+                    <span>{nearestCardinalNumber(project.numRuns)}</span>
+                  </Tooltip>
+                </div>
+              )}
+              {!f_flat_runs && !isUndefined(project.numExperiments) && (
+                <div className={css.experiments}>
+                  <Tooltip
+                    content={`${project.numExperiments?.toLocaleString()} ${pluralizer(project.numExperiments, 'experiment')}`}>
                     <Icon name="experiment" size="small" title="Number of experiments" />
                     <span>{nearestCardinalNumber(project.numExperiments)}</span>
                   </Tooltip>

--- a/webui/react/src/types.ts
+++ b/webui/react/src/types.ts
@@ -1104,6 +1104,7 @@ export const Project = t.intersection([
     lastExperimentStartedAt: t.string,
     numActiveExperiments: t.number,
     numExperiments: t.number,
+    numRuns: t.number,
     workspaceName: t.string,
   }),
 ]);


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
ET-314


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
ProjectCard should display runs count instead of experiments count when Flat Runs feature flag is on.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
With Flat Runs feature flag on 
- ProjectCards on dashboard should display number of runs, and the tooltip should say "runs" on hover
- Same on Workspace Details pages
With Flat Runs feature flag on, they should still show experiments.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ