### PR TITLE
fix: resolve indefinitely queued (STOPPING_COMPLETED) trials

### DIFF
--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -85,12 +85,12 @@ def test_master_agent_restart_reattach_recover_experiment(
         # Start an experiment
         exp_id = exp.create_experiment(
             sess,
-            conf.fixtures_path("core_api/sleep.yaml"),
-            conf.fixtures_path("core_api"),
+            conf.fixtures_path("no_op/single-medium-train-step.yaml"),
+            conf.fixtures_path("no_op"),
             None,
         )
 
-        exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
+        #exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
 
         # Kill the agent & master
         restartable_managed_cluster.kill_agent()

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -90,8 +90,6 @@ def test_master_agent_restart_reattach_recover_experiment(
             None,
         )
 
-        # exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
-
         # Kill the agent & master
         restartable_managed_cluster.kill_agent()
         restartable_managed_cluster.kill_master()

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -90,7 +90,7 @@ def test_master_agent_restart_reattach_recover_experiment(
             None,
         )
 
-        #exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
+        # exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
 
         # Kill the agent & master
         restartable_managed_cluster.kill_agent()

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -747,17 +747,16 @@ func (t *trial) transition(s model.StateWithReason) error {
 				InformationalReason: s.InformationalReason,
 			})
 		default:
-			if action, ok := map[model.State]task.AllocationSignal{
-				model.StoppingCompletedState: task.TerminateAllocation,
-				model.StoppingCanceledState:  task.TerminateAllocation,
-				model.StoppingKilledState:    task.KillAllocation,
-				model.StoppingErrorState:     task.KillAllocation,
-			}[t.state]; ok {
-				t.syslog.Infof("decided to %s trial", action)
-				err := task.DefaultService.Signal(*t.allocationID, action, s.InformationalReason)
-				if err != nil {
-					t.syslog.WithError(err).Warnf("could not %s allocation during stop", action)
-				}
+			// For StoppingKilled and StoppingErrorState, default to KillAllocation.
+			action := task.KillAllocation
+
+			if (t.state == model.StoppingCompletedState) || (t.state == model.StoppingCanceledState) {
+				action = task.TerminateAllocation
+			}
+
+			t.syslog.Infof("decided to %s trial", action)
+			if err := task.DefaultService.Signal(*t.allocationID, action, s.InformationalReason); err != nil {
+				t.syslog.WithError(err).Warnf("could not %s allocation during stop", action)
 			}
 		}
 	case model.TerminalStates[t.state]:

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -748,9 +748,10 @@ func (t *trial) transition(s model.StateWithReason) error {
 			})
 		default:
 			if action, ok := map[model.State]task.AllocationSignal{
-				model.StoppingCanceledState: task.TerminateAllocation,
-				model.StoppingKilledState:   task.KillAllocation,
-				model.StoppingErrorState:    task.KillAllocation,
+				model.StoppingCompletedState: task.TerminateAllocation,
+				model.StoppingCanceledState:  task.TerminateAllocation,
+				model.StoppingKilledState:    task.KillAllocation,
+				model.StoppingErrorState:     task.KillAllocation,
 			}[t.state]; ok {
 				t.syslog.Infof("decided to %s trial", action)
 				err := task.DefaultService.Signal(*t.allocationID, action, s.InformationalReason)

--- a/master/internal/trial_intg_test.go
+++ b/master/internal/trial_intg_test.go
@@ -135,6 +135,7 @@ func setup(t *testing.T) (
 		"StartAllocation", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return(nil)
+	as.On("Signal", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	a, _, _ := setupAPITest(t, nil)
 	j := &model.Job{JobID: model.NewJobID(), JobType: model.JobTypeExperiment}

--- a/master/internal/trial_intg_test.go
+++ b/master/internal/trial_intg_test.go
@@ -44,8 +44,6 @@ func TestTrial(t *testing.T) {
 		Complete: false,
 		Closed:   true,
 	}))
-	require.True(t, alloc.AssertExpectations(t))
-	require.NotNil(t, tr.allocationID)
 
 	// Running stage.
 	require.NoError(t, tr.PatchSearcherState(experiment.TrialSearcherState{
@@ -57,6 +55,8 @@ func TestTrial(t *testing.T) {
 		Complete: true,
 		Closed:   true,
 	}))
+	require.True(t, alloc.AssertExpectations(t))
+	require.NotNil(t, tr.allocationID)
 
 	dbTrial, err := internaldb.TrialByID(context.TODO(), tr.id)
 	require.NoError(t, err)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
RM-368



## Description
When a cluster restarts, it restarts running trials. For large experiments with several trials (like a hyperparameter experiment), some of these restored trails end up in STOPPING_COMPLETED indefinitely versus COMPLETED state. Fix this bug.

I was able to reproduce this on AWS by killing the agent service, stopping the master service, and then restarting them both. WIth my fix, the experiments naturally resolved themselves.



## Test Plan
See new e2e test. No additional testing needed.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ