### PR TITLE
feat: switch default rsa_key_size to 2048.

### DIFF
--- a/docs/release-notes/rsa-2048.rst
+++ b/docs/release-notes/rsa-2048.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+**Improvements**
+
+-  Shells: Change default RSA key size to 2048 bits.

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -107,7 +107,7 @@ func DefaultConfig() *Config {
 				Group: "root",
 			},
 			SSH: SSHConfig{
-				RsaKeySize: 1024,
+				RsaKeySize: 2048,
 			},
 			AuthZ: *DefaultAuthZConfig(),
 		},


### PR DESCRIPTION
## Description

It seems minimum recommended RSA key size on RHEL are 2048: https://access.redhat.com/articles/3642912
similar problem came up in the past for an openshift customer: https://hpe-aiatscale.atlassian.net/browse/DET-5983

I have a suspicion we're seeing it again for a fedora user: https://determined-community.slack.com/archives/CV3MTNZ6U/p1720179622244169

we elected not to do it in the past over performance concerns: https://github.com/determined-ai/determined/pull/2966#issuecomment-921397606
but now we `GenerateKey` once per experiment, not per trial.

This'll slow down new experiment and shell creation by ~150 ms because the key generation takes longer.

## Test Plan

1. `det shell start` on a cluster with the default settings
2. Verify the bit strength is 2048: `openssl rsa -text -in /run/determined/ssh/id_rsa | head -n1`

## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ