### PR TITLE
fix: allocation csv: gpu_hours -> slot_hours, add resource_pool [DET-10408]

### DIFF
--- a/docs/manage/historical-cluster-usage-data.rst
+++ b/docs/manage/historical-cluster-usage-data.rst
@@ -6,7 +6,7 @@
 
 Determined provides insights into the usage of your cluster, measured in compute hours allocated.
 Note that this is based on allocation, not resource utilization. For example, if a user has 1 GPU
-allocated but uses only 20% of it, we still report one GPU hour.
+allocated but uses only 20% of it, we still report one slot-hour.
 
 .. warning::
 
@@ -23,11 +23,11 @@ allocated but uses only 20% of it, we still report one GPU hour.
 
 .. note::
 
-   When using the export to CSV functionality, ``gpu_hours`` reflects only the GPU hours used during
-   the export time window. This means that allocations overlapping the export window have their GPU
-   hours calculated only for the time within the window. As a result, allocations not starting and
-   ending within the export window may appear to have incorrect GPU hours when calculated manually
-   from their start and end times.
+   When using the export to CSV functionality, ``slot_hours`` reflects only the slot hours used
+   during the export time window. This means that allocations overlapping the export window have
+   their slot-hours calculated only for the time within the window. As a result, allocations not
+   starting and ending within the export window may appear to have incorrect slot-hours when
+   calculated manually from their start and end times.
 
 *********************
  WebUI Visualization

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -1179,7 +1179,7 @@ multiple GPUs is done using data parallelism. Configuring ``slots_per_trial`` to
 
 For historical reasons, this field usually passes config validation steps, but has no practical
 effect when present in experiment config. Use :ref:`slots_per_trial
-<_exp-config-resources-slots-per-trial>` instead.
+<exp-config-resources-slots-per-trial>` instead.
 
 ``max_slots``
 =============

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -1168,6 +1168,12 @@ specifying a value greater than 1 means that multiple GPUs will be used in paral
 multiple GPUs is done using data parallelism. Configuring ``slots_per_trial`` to be greater than
 ``max_slots`` is not sensible and will result in an error.
 
+.. note::
+
+   Using ``slots_per_trial`` to enable data parallel training for PyTorch can alter the behavior of
+   certain models, as described in the `PyTorch documentation
+   <https://pytorch.org/docs/stable/generated/torch.nn.DataParallel.html#torch.nn.DataParallel>`__.
+
 ``slots``
 =========
 

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -1168,11 +1168,12 @@ specifying a value greater than 1 means that multiple GPUs will be used in paral
 multiple GPUs is done using data parallelism. Configuring ``slots_per_trial`` to be greater than
 ``max_slots`` is not sensible and will result in an error.
 
-.. note::
+``slots``
+=========
 
-   Using ``slots_per_trial`` to enable data parallel training for PyTorch can alter the behavior of
-   certain models, as described in the `PyTorch documentation
-   <https://pytorch.org/docs/stable/generated/torch.nn.DataParallel.html#torch.nn.DataParallel>`__.
+For historical reasons, this field usually passes config validation steps, but has no practical
+effect when present in experiment config. Use :ref:`slots_per_trial
+<_exp-config-resources-slots-per-trial>` instead.
 
 ``max_slots``
 =============

--- a/docs/release-notes/relabel-allocation-csv.rst
+++ b/docs/release-notes/relabel-allocation-csv.rst
@@ -2,6 +2,6 @@
 
 **Breaking Changes**
 
--  Tasks: The :ref:`historical usage <_historical-cluster-usage-data>` CSV header row for slot-hours
+-  Tasks: The :ref:`historical usage <historical-cluster-usage-data>` CSV header row for slot-hours
    is now named ``slot_hours`` as it may also track allocation time for resource pools without GPUs.
    Also, this CSV now has an additional column providing the ``resource_pool`` for each allocation.

--- a/docs/release-notes/relabel-allocation-csv.rst
+++ b/docs/release-notes/relabel-allocation-csv.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Breaking Changes**
+
+-  Tasks: The :ref:`historical usage <_historical-cluster-usage-data>` CSV header row for slot-hours
+   is now named ``slot_hours`` as it may also track allocation time for resource pools without GPUs.
+   Also, this CSV now has an additional column providing the ``resource_pool`` for each allocation.


### PR DESCRIPTION
Waiting on acceptance or response to https://hpe-aiatscale.atlassian.net/browse/DET-10408?focusedCommentId=32936

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10408]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Renames the `gpu_hours` column in the allocation report CSV to `slot_hours` as this is a more accurate description. Adds a `resource_pool` column to help users identify what slot type(s) these slot-hours apply to.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Run any number of experiments >0 on a cluster that has at least one slot configured.
On cluster historical usage tab, make sure the end date is current, and click Download CSV.
<img width="1480" alt="image" src="https://github.com/determined-ai/determined/assets/159822967/57879359-1317-4593-8e7f-07256972a046">
Choose to group by Allocations and download the CSV
<img width="351" alt="image" src="https://github.com/determined-ai/determined/assets/159822967/475fb14a-6688-4742-b343-18a64821a263">
Observe `slot_hours` and `resource_pool` columns are present in the download
<img width="734" alt="image" src="https://github.com/determined-ai/determined/assets/159822967/8bb642f6-56fc-44f6-bdf4-3ea0603c33bd">



## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10408]: https://hpe-aiatscale.atlassian.net/browse/DET-10408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ