### PR TITLE
fix: user IDs instead of user session IDs for notebook sessions [MD-453]

### DIFF
--- a/master/internal/api_notebook.go
+++ b/master/internal/api_notebook.go
@@ -360,7 +360,7 @@ func (a *apiServer) LaunchNotebook(
 	// Launch a Notebook.
 	genericCmd, err := command.DefaultCmdService.LaunchNotebookCommand(
 		launchReq,
-		session)
+		user)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/command/command_intg_test.go
+++ b/master/internal/command/command_intg_test.go
@@ -83,18 +83,18 @@ func TestNotebookManagerLifecycle(t *testing.T) {
 
 	// Verify Notebooks return valid tokens.
 	for _, resp := range resp2.Notebooks {
-		re := regexp.MustCompile("^/proxy/(.*)/\\?token=(.*)")
+		re := regexp.MustCompile(`^/proxy/(.*)/\?token=(.*)`)
 		addrMatches := re.FindStringSubmatch(resp.ServiceAddress)
 		require.Len(t, addrMatches, 3)
 
-		taskId, token := addrMatches[1], addrMatches[2]
+		taskID, token := addrMatches[1], addrMatches[2]
 		require.NotEmpty(t, token)
-		require.NotEmpty(t, taskId)
+		require.NotEmpty(t, taskID)
 
 		usr, notebookSession, err := user.GetService().UserAndNotebookSessionFromToken(token)
 		require.NoError(t, err)
 		require.Equal(t, resp.UserId, int32(usr.ID))
-		require.Equal(t, taskId, string(notebookSession.TaskID))
+		require.Equal(t, taskID, string(notebookSession.TaskID))
 	}
 
 	// Kill 1 Notebook.

--- a/master/internal/command/command_service.go
+++ b/master/internal/command/command_service.go
@@ -133,7 +133,7 @@ func (cs *CommandService) LaunchGenericCommand(
 // LaunchNotebookCommand creates notebook commands and persists them to the database.
 func (cs *CommandService) LaunchNotebookCommand(
 	req *CreateGeneric,
-	session *model.UserSession,
+	user *model.User,
 ) (*Command, error) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
@@ -149,7 +149,7 @@ func (cs *CommandService) LaunchNotebookCommand(
 		"task-type": model.TaskTypeNotebook,
 	}
 
-	token, err := db.GenerateNotebookSessionToken(session.ID, taskID)
+	token, err := db.GenerateNotebookSessionToken(user.ID, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (cs *CommandService) LaunchNotebookCommand(
 		return nil, err
 	}
 
-	if err := db.StartNotebookSession(context.TODO(), session.ID, taskID, &token); err != nil {
+	if err := db.StartNotebookSession(context.TODO(), user.ID, taskID); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/db/postgres_notebook_sessions.go
+++ b/master/internal/db/postgres_notebook_sessions.go
@@ -12,14 +12,12 @@ import (
 // StartNotebookSession persists a new notebook session row into the database.
 func StartNotebookSession(
 	ctx context.Context,
-	userSessionID model.SessionID,
+	userID model.UserID,
 	taskID model.TaskID,
-	token *string,
 ) error {
 	notebookSession := &model.NotebookSession{
-		UserSessionID: userSessionID,
-		TaskID:        taskID,
-		Token:         token,
+		UserID: userID,
+		TaskID: taskID,
 	}
 
 	if _, err := Bun().NewInsert().Model(notebookSession).
@@ -32,12 +30,12 @@ func StartNotebookSession(
 
 // GenerateNotebookSessionToken generates a token for a notebook session.
 func GenerateNotebookSessionToken(
-	userSessionID model.SessionID,
+	userID model.UserID,
 	taskID model.TaskID,
 ) (string, error) {
 	notebookSession := &model.NotebookSession{
-		UserSessionID: userSessionID,
-		TaskID:        taskID,
+		UserID: userID,
+		TaskID: taskID,
 	}
 
 	v2 := paseto.NewV2()

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -423,7 +423,7 @@ func BySessionID(ctx context.Context, sessionID model.SessionID) (*model.User, e
 		Join("JOIN user_sessions ON user_sessions.user_id = users.id").
 		Where("user_sessions.id = ?", sessionID).Scan(ctx, &user)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error fetching session (%d)", sessionID)
 	}
 	return &user, nil
 }

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -413,3 +413,17 @@ func ByUsername(ctx context.Context, username string) (*model.User, error) {
 		return &user, nil
 	}
 }
+
+// BySessionID looks up a user by session ID in the database.
+func BySessionID(ctx context.Context, sessionID model.SessionID) (*model.User, error) {
+	var user model.User
+	err := db.Bun().NewSelect().
+		Table("users").
+		ColumnExpr("users.*").
+		Join("JOIN user_sessions ON user_sessions.user_id = users.id").
+		Where("user_sessions.id = ?", sessionID).Scan(ctx, &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}

--- a/master/pkg/model/notebook_session.go
+++ b/master/pkg/model/notebook_session.go
@@ -7,8 +7,9 @@ type NotebookSession struct {
 	bun.BaseModel `bun:"table:notebook_sessions"`
 	ID            SessionID `db:"id" bun:"id,pk,autoincrement" json:"id"`
 	TaskID        TaskID    `db:"task_id" bun:"task_id" json:"task_id"`
-	UserSessionID SessionID `db:"user_session_id" bun:"user_session_id" json:"user_session_id"`
-	Token         *string   `db:"token" bun:"token" json:"token"`
+	// SessionID is only used for notebooks launched before UserID column was added.
+	SessionID *SessionID `bun:"-" json:"user_session_id"`
+	UserID    UserID     `db:"user_id" bun:"user_id" json:"user_id"`
 }
 
 // NotebookSessionEnvVar is the environment variable name for notebook task tokens.

--- a/master/pkg/tasks/task_command.go
+++ b/master/pkg/tasks/task_command.go
@@ -60,8 +60,7 @@ type GenericCommandSpec struct {
 	WatchProxyIdleTimeout  bool
 	WatchRunnerIdleTimeout bool
 
-	TaskType             model.TaskType
-	NotebookSessionToken string
+	TaskType model.TaskType
 }
 
 // ToTaskSpec generates a TaskSpec.

--- a/master/static/migrations/20240709125620_notebook-sessions-by-user.tx.up.sql
+++ b/master/static/migrations/20240709125620_notebook-sessions-by-user.tx.up.sql
@@ -1,0 +1,21 @@
+/*
+   Changes the `notebook_sessions` table to associate with user IDs instead of user session IDs.
+*/
+
+-- Add a new user_id column.
+ALTER TABLE notebook_sessions ADD COLUMN user_id int REFERENCES users(id) NULL;
+
+-- Migrate existing rows.
+UPDATE notebook_sessions ns
+SET user_id = us.user_id
+FROM user_sessions us
+WHERE ns.user_session_id = us.id;
+
+-- Add not null constraint.
+ALTER TABLE notebook_sessions ALTER COLUMN user_id SET NOT NULL;
+
+-- Drop previous column.
+ALTER TABLE notebook_sessions DROP COLUMN user_session_id;
+
+-- Drop unused token column.
+ALTER TABLE notebook_sessions DROP COLUMN token;


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

[MD-453]

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

SaaS / managed deployments do not persist user sessions into the user_sessions table which prevents notebook tokens from being generated. Instead of hacking around different codepaths for managed vs unmanaged deployments, this fix changes notebook sessions to associate with users instead of user sessions, since we always persist users.

Also removes some unnecessary fields.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Make sure notebooks can start successfully. On the task list page and task dropdown, clicking "Connect" should open a modal that displays a URL with a token. 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[MD-453]: https://hpe-aiatscale.atlassian.net/browse/MD-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ