### PR TITLE
chore: Deprecate model hub

### DIFF
--- a/docs/model-hub-library/_index.rst
+++ b/docs/model-hub-library/_index.rst
@@ -2,6 +2,12 @@
  Model Hub Library
 ###################
 
+.. important::
+
+   **Deprecation Notice**: The Model Hub library is now deprecated. Users of ``MMDetTrial`` and
+   ``BaseTransformerTrial`` should switch to either the :ref:`Core API <api-core-ug>` or the
+   :ref:`PyTorch Trainer <pytorch_trainer_ug>` for integrations with ``mmcv`` and ``huggingface``.
+
 .. meta::
    :description: The Model Hub Library page contains info about Transformers and MMDetection where you can access the benefits of using Determined.
 

--- a/docs/release-notes/model-hub-deprecation.rst
+++ b/docs/release-notes/model-hub-deprecation.rst
@@ -3,8 +3,5 @@
 **Deprecation**
 
 -  API: The ``model_hub`` library is now deprecated. Users of MMDetTrial and BaseTransformerTrial
-   should switch to :ref:`CoreAPI
-   <https://docs.determined.ai/latest/model-dev-guide/api-guides/apis-howto/api-core-ug-basic.html#get-started-with-core-api>`
-   or :ref:`TrainerAPI
-   <https://docs.determined.ai/latest/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.html#pytorch-trainer>`
+   should switch to :ref:`Core API <api-core-ug>` or the :ref:`PyTorch Trainer <pytorch_trainer_ug>`
    for integrations with ``mmcv`` and ``huggingface``.

--- a/docs/release-notes/model-hub-deprecation.rst
+++ b/docs/release-notes/model-hub-deprecation.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+**Deprecation**
+
+-  API: The ``model_hub`` library is now deprecated. Users of MMDetTrial and BaseTransformerTrial
+   should switch to :ref:`CoreAPI
+   <https://docs.determined.ai/latest/model-dev-guide/api-guides/apis-howto/api-core-ug-basic.html#get-started-with-core-api>`
+   or :ref:`TrainerAPI
+   <https://docs.determined.ai/latest/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.html#pytorch-trainer>`
+   for integrations with ``mmcv`` and ``huggingface``.

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
+import warnings
 
 import datasets as hf_datasets
 import torch
@@ -212,6 +213,8 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
     """
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
+        warnings.warn("BaseTransformerTrial is deprecated and will be removed in the next release."
+                      "Users of huggingface can refer to the TrainerAPI examples we have provided.")
         self.context = context
         # A subclass of BaseTransformerTrial may have already set hparams and data_config
         # attributes so we only reset them if they do not exist.

--- a/model_hub/model_hub/huggingface/_trial.py
+++ b/model_hub/model_hub/huggingface/_trial.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
 import warnings
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import datasets as hf_datasets
 import torch
@@ -213,8 +213,11 @@ class BaseTransformerTrial(det_torch.PyTorchTrial):
     """
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
-        warnings.warn("BaseTransformerTrial is deprecated and will be removed in the next release."
-                      "Users of huggingface can refer to the TrainerAPI examples we have provided.")
+        warnings.warn(
+            "BaseTransformerTrial is deprecated and will be removed in the next release."
+            "Users of huggingface can refer to the TrainerAPI examples we have provided.",
+            stacklevel=2,
+        )
         self.context = context
         # A subclass of BaseTransformerTrial may have already set hparams and data_config
         # attributes so we only reset them if they do not exist.

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -22,8 +22,8 @@ limitations under the License.
 
 import logging
 import os
-from typing import Any, Dict, List
 import warnings
+from typing import Any, Dict, List
 
 import mmcv
 import mmcv.parallel
@@ -55,8 +55,11 @@ class MMDetTrial(det_torch.PyTorchTrial):
     """
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
-        warnings.warn("MMDetTrial is deprecated and will be removed in the next release."
-                      "Users of mmcv can implement training workloads with CoreAPI.")
+        warnings.warn(
+            "MMDetTrial is deprecated and will be removed in the next release."
+            "Users of mmcv can implement training workloads with CoreAPI.",
+            stacklevel=2,
+        )
         self.context = context
         self.hparams = utils.AttrDict(context.get_hparams())
         self.data_config = utils.AttrDict(context.get_data_config())

--- a/model_hub/model_hub/mmdetection/_trial.py
+++ b/model_hub/model_hub/mmdetection/_trial.py
@@ -23,6 +23,7 @@ limitations under the License.
 import logging
 import os
 from typing import Any, Dict, List
+import warnings
 
 import mmcv
 import mmcv.parallel
@@ -54,6 +55,8 @@ class MMDetTrial(det_torch.PyTorchTrial):
     """
 
     def __init__(self, context: det_torch.PyTorchTrialContext) -> None:
+        warnings.warn("MMDetTrial is deprecated and will be removed in the next release."
+                      "Users of mmcv can implement training workloads with CoreAPI.")
         self.context = context
         self.hparams = utils.AttrDict(context.get_hparams())
         self.data_config = utils.AttrDict(context.get_data_config())


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
https://hpe-aiatscale.atlassian.net/browse/MD-32

## Docs
#9666 

## Description
Officially deprecate Model Hub with removal planned in the next release.



## Test Plan
None



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ