### PR TITLE
docs: Link to cluster info

### DIFF
--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -128,6 +128,8 @@ whatever configuration is needed for loading data for use by the experiment's mo
 example, if your experiment loads data from Amazon S3, the ``data`` field might contain the S3
 bucket name, object prefix, and AWS authentication credentials.
 
+See also: :ref:`det API Reference <det-reference>` > ``user_data`` property.
+
 ``workspace``
 =============
 


### PR DESCRIPTION
How to access user data

Problem: it isn't clear what the interface is to access the values from inside the model code. 

Users can call their own arbitrary user_data from the Experiment Configuration file. This would be things like data sources and containers or even credentials (which are obscurable). To do this, the user uses `data` (not `metadata.data`) in the Experiment configuration yaml file. Which is documented [here](https://docs.determined.ai/latest/reference/experiment-config-reference.html#data). However, it is not clear how Determined accesses the values of this user data from inside the model code.

Solution:
Help users understand that the way to access the data:
https://docs.determined.ai/latest/reference/experiment-config-reference.html#data ... 

is here
https://docs.determined.ai/latest/reference/training/api-det-reference.html#determined.ClusterInfo.user_data

**another way**
another way is just the xpath, for example, under the "username" section we could have task_container_defaults.registry_auth.username

there are 3 ways to retrieve data config and one way to get all of it:

From DET_EXPERIMENT_CONFIG env var like:
`expconf = os.environ.get("DET_EXPERIMENT_CONFIG")`
- You can then json.loads(expconf) and handle it like json

From context
- `data_config = train_context.get_data_config()`

From cluster_info
- `data = det.get_cluster_info().user_data`
