### PR TITLE
chore: send alerts can wait forever and fail for broken workflows

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4144,7 +4144,11 @@ workflows:
   send-alerts:
     <<: *do-not-run-on-manual-trigger
     jobs:
-      - send-job-level-alerts
+      - send-job-level-alerts:
+          filters:
+            branches:
+              only:
+                - main
 
   test-go:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4144,11 +4144,7 @@ workflows:
   send-alerts:
     <<: *do-not-run-on-manual-trigger
     jobs:
-      - send-job-level-alerts:
-          filters:
-            branches:
-              only:
-                - main
+      - send-job-level-alerts
 
   test-go:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/scripts/job_level_alerts.py
+++ b/.circleci/scripts/job_level_alerts.py
@@ -10,6 +10,9 @@ workflows_to_skip = {
     # Skip test-e2e-longrunning for testing on feature branches since it won't complete on them.
     "test-e2e-longrunning",
     "send-alerts",
+    # Skip nightly tests as a temporary measure to bring this ci check back.
+    # https://hpe-aiatscale.slack.com/archives/C04C9JXB1C2/p1720448458815989
+    "nightly",
 }
 
 

--- a/.circleci/scripts/job_level_alerts.py
+++ b/.circleci/scripts/job_level_alerts.py
@@ -11,9 +11,6 @@ workflows_to_skip = {
     # Skip test-e2e-longrunning for testing on feature branches since it won't complete on them.
     "test-e2e-longrunning",
     "send-alerts",
-    # Skip nightly tests as a temporary measure to bring this ci check back.
-    # https://hpe-aiatscale.slack.com/archives/C04C9JXB1C2/p1720448458815989
-    "nightly",
 }
 
 

--- a/.circleci/scripts/job_level_alerts.py
+++ b/.circleci/scripts/job_level_alerts.py
@@ -71,9 +71,7 @@ def main() -> None:
     while failure_count < 20:
         try:
             print("Checking circleci API for jobs")
-            still_workflows_in_progress = send_alerts_for_failed_jobs(
-                sent_alerts, timeout_minutes=10
-            )
+            still_workflows_in_progress = send_alerts_for_failed_jobs(sent_alerts)
             if not still_workflows_in_progress:
                 print("all workflows complete, ending")
                 return

--- a/.circleci/scripts/job_level_alerts.py
+++ b/.circleci/scripts/job_level_alerts.py
@@ -71,7 +71,9 @@ def main() -> None:
     while failure_count < 20:
         try:
             print("Checking circleci API for jobs")
-            still_workflows_in_progress = send_alerts_for_failed_jobs(sent_alerts)
+            still_workflows_in_progress = send_alerts_for_failed_jobs(
+                sent_alerts, timeout_minutes=10
+            )
             if not still_workflows_in_progress:
                 print("all workflows complete, ending")
                 return


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

https://hpe-aiatscale.atlassian.net/browse/RM-372

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

adding a condition to skip over workflows that have elapsed their timeout instead of reporting them as active.
make sure send alerts does not:


### why

send-alert job:
1. takes too long 5hrs in these cases
2. does not fail if another ci job takes long

this job has been staying active for 5hours
https://app.circleci.com/pipelines/github/determined-ai/determined/57843/workflows/1a75f6bf-77b2-45e5-8155-9f2f5dcc96c4/jobs/2742238

testing the timeout https://app.circleci.com/pipelines/github/determined-ai/determined/58023/workflows/53afd482-abd0-403a-9346-0de85400e533/jobs/2756232

context https://hpe-aiatscale.slack.com/archives/C04C9JXB1C2/p1720448458815989

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ