### PR TITLE
chore: hide the docker password in cloudformation stacks

### DIFF
--- a/harness/determined/deploy/aws/templates/efs.yaml
+++ b/harness/determined/deploy/aws/templates/efs.yaml
@@ -97,6 +97,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/fsx.yaml
+++ b/harness/determined/deploy/aws/templates/fsx.yaml
@@ -97,6 +97,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/govcloud.yaml
+++ b/harness/determined/deploy/aws/templates/govcloud.yaml
@@ -63,6 +63,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/lore.yaml
+++ b/harness/determined/deploy/aws/templates/lore.yaml
@@ -97,6 +97,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/secure.yaml
+++ b/harness/determined/deploy/aws/templates/secure.yaml
@@ -118,6 +118,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/simple-rds.yaml
+++ b/harness/determined/deploy/aws/templates/simple-rds.yaml
@@ -89,6 +89,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String

--- a/harness/determined/deploy/aws/templates/simple.yaml
+++ b/harness/determined/deploy/aws/templates/simple.yaml
@@ -89,6 +89,7 @@ Parameters:
     Type: String
     Description: Docker password to pull images that need authentication
     Default: ""
+    NoEcho: true
 
   Version:
     Type: String


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
If you investigate the Cloudformation stacks on AWS, the `DockerPass` field is in plain text. This hides it by doing the same thing we are doing for `DBPassword`


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Not needed to be tested in release party.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ