### PR TITLE
feat:  allow resource quota input field to be visible at all times

### DIFF
--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -241,23 +241,21 @@ const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }
                           onChange={() => form.setFieldValue(['resourceQuotas', name], undefined)}
                         />
                       </Form.Item>
-                      {(workspaceId !== undefined ||
-                        (watchBindings?.[name]?.['autoCreateNamespace'] ?? false)) && (
-                        <Form.Item
-                          label="Resource Quota"
-                          name={['resourceQuotas', name]}
-                          rules={[
-                            {
-                              message: 'Resource Quota has to be greater or equal to 0',
-                              min: 0,
-                              type: 'number',
-                            },
-                          ]}>
-                          <InputNumber
-                            disabled={!(watchBindings?.[name]?.['autoCreateNamespace'] ?? false)}
-                          />
-                        </Form.Item>
-                      )}
+                      <Form.Item
+                        label="Resource Quota"
+                        name={['resourceQuotas', name]}
+                        rules={[
+                          {
+                            message: 'Resource Quota has to be greater or equal to 0',
+                            min: 0,
+                            type: 'number',
+                          },
+                        ]}>
+                        <InputNumber
+                          disabled={!(watchBindings?.[name]?.['autoCreateNamespace'] ?? false)}
+                          min={0}
+                        />
+                      </Form.Item>
                     </>
                   )}
                 </Fragment>


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
The resource quota input field is now visible even if the auto-create namespace toggle is off, but it is greyed out. Also added a min of 0 to the resource quota counter


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Verify that the resource quota input field is visible and greyed out when autocreate toggle is off and editable when autocreate toggle is on.
- Verify that the counter for resource quota does not go below 0


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ