### PR TITLE
feat: Add resources allocation-csv to det cli [DFR-519]

### DIFF
--- a/harness/determined/cli/resources.py
+++ b/harness/determined/cli/resources.py
@@ -12,6 +12,13 @@ def print_response(r: requests.Response) -> None:
         sys.stdout.buffer.write(chunk)
 
 
+def csv(args: argparse.Namespace) -> None:
+    sess = cli.setup_session(args)
+    params = {"timestamp_after": args.timestamp_after, "timestamp_before": args.timestamp_before}
+    path = "resources/allocation/allocations-csv"
+    print_response(sess.get(path, params=params))
+
+
 def raw(args: argparse.Namespace) -> None:
     sess = cli.setup_session(args)
     params = {"timestamp_after": args.timestamp_after, "timestamp_before": args.timestamp_before}
@@ -40,6 +47,15 @@ args_description: cli.ArgsDescription = [
         None,
         "query historical resource allocation",
         [
+            cli.Cmd(
+                "all|ocations",
+                csv,
+                "get a detailed csv of resource allocation at an allocation level",
+                [
+                    cli.Arg("timestamp_after"),
+                    cli.Arg("timestamp_before"),
+                ],
+            ),
             cli.Cmd(
                 "raw",
                 raw,


### PR DESCRIPTION
## PR TITLE (Commit Body)
feat: Add resources allocation-csv to det cli [DFR-519]

## Ticket
[DFR-519]


## Description
Add feature to det cli to allow query of resources allocation-csv endpoint.


## Test Plan
run `det res all 2024-07-12T00:00:00 2030-01-01T00:00:00` and see that you get output.

## Checklist

- [Y] Changes have been manually QA'd
- [N] New features have been approved by the corresponding PM
- [N/A] User-facing API changes have the "User-facing API Change" label
- [N] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [N/A] Licenses have been included for new code which was copied and/or modified from any external code


[DFR-519]: https://hpe-aiatscale.atlassian.net/browse/DFR-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DFR-519]: https://hpe-aiatscale.atlassian.net/browse/DFR-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ