### PR TITLE
docs: Update historical csv release note

### DIFF
--- a/docs/release-notes/relabel-allocation-csv.rst
+++ b/docs/release-notes/relabel-allocation-csv.rst
@@ -2,6 +2,7 @@
 
 **Breaking Changes**
 
--  Tasks: The :ref:`historical usage <historical-cluster-usage-data>` CSV header row for slot-hours
-   is now named ``slot_hours`` as it may also track allocation time for resource pools without GPUs.
-   Also, this CSV now has an additional column providing the ``resource_pool`` for each allocation.
+-  Tasks: The :ref:`historical usage <historical-cluster-usage-data>` CSV file has been updated. The
+   header row for slot-hours is now named ``slot_hours`` instead of ``gpu_hours`` to accurately
+   reflect the allocation time for resource pools including those without GPUs. In addition, a new
+   column, ``resource_pool``, has been added to provide the resource pool for each allocation.


### PR DESCRIPTION
Readability, usability, and to let users know the name of the column before it was renamed