### PR TITLE
build: INFENG-744: remove VERSION file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,8 +16,6 @@ values =
 	-rc
 	-final
 
-[bumpversion:file:VERSION]
-
 [bumpversion:file:.circleci/real_config.yml]
 
 [bumpversion:file:helm/charts/determined/Chart.yaml]

--- a/.devcontainer/server.sh
+++ b/.devcontainer/server.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-VERSION=$(cat VERSION)
+VERSION=$(./version.sh)
 GO_LDFLAGS="-X github.com/determined-ai/determined/master/version.Version=${VERSION}"
 
 nodemon --watch './**/*' -e go --signal SIGTERM --exec \

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: set VERSION env var
         shell: bash
-        run: echo "VERSION=$(< ./VERSION )" >> $GITHUB_ENV
+        run: echo "VERSION=$(./version.sh)" >> $GITHUB_ENV
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export VERSION := $(shell ./version.sh)
+
 .PHONY: all
 all:
 	$(MAKE) get-deps

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build
 SHELL := bash
 
-export VERSION:=$(shell cat ../VERSION)
+export VERSION:=$(shell ../version.sh)
 export GO111MODULE := on
 export DOCKER_REPO ?= determinedai
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-export VERSION := $(shell cat ../VERSION)
+export VERSION := $(shell ../version.sh)
 .DEFAULT_GOAL := build
 
 SPHINXOPTS    = -W

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,6 @@ See the documentation: http://www.sphinx-doc.org/en/master/config
 
 import json
 import os
-import pathlib
 import sys
 import time
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,16 @@ project = "Determined"
 html_title = "Determined AI Documentation"
 copyright = time.strftime("%Y, Determined AI")
 author = "ai-open-source@hpe.com"
-version = pathlib.Path(__file__).parents[1].joinpath("VERSION").read_text().strip()
+
+# Read the application version string from the VERSION environment
+# variable. Previously, this was read from a static VERSION file at the root of
+# the repository. Now, we read it from an environment variable set by a
+# Makefile, generated from version.sh in the repository root.
+version = os.environ.get("VERSION")
+if version is None:
+    print("Please ensure VERSION environment variable is set.")
+    os.exit(1)
+
 release = version
 language = "en"
 

--- a/docs/deploy/Makefile
+++ b/docs/deploy/Makefile
@@ -1,4 +1,4 @@
-export TF_VAR_det_version := $(shell cat ../../VERSION)
+export TF_VAR_det_version := $(shell ../../version.sh)
 export DET_VARIANT ?= OSS
 export TF_VAR_det_variant := ${DET_VARIANT}
 export TF_CLI_ARGS_init :=  "-backend-config=backend_${DET_VARIANT}.conf"

--- a/docs/deploy/scrape.py
+++ b/docs/deploy/scrape.py
@@ -292,10 +292,16 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Pick the correct version.
-    HERE = pathlib.Path(__file__).parent
-    with (HERE / ".." / ".." / "VERSION").open() as f:
-        version = f.read().strip()
+    # Read the application version string from the VERSION environment
+    # variable. Previously, this was read from a static VERSION file at the root
+    # of the repository. Now, we read it from an environment variable set by a
+    # Makefile, generated from version.sh in the repository root.
+    version = os.environ.get("VERSION")
+
+    if version is None:
+        print("Please ensure VERSION environment variable is set.")
+        exit(1)
+
     if "-dev" in version:
         # Dev builds search against a special dev index that is update with every push to master.
         version = "dev"

--- a/docs/deploy/upload.py
+++ b/docs/deploy/upload.py
@@ -24,12 +24,6 @@ if __name__ == "__main__":
         help="whether the upload should go under the short-lived /previews path",
     )
     parser.add_argument(
-        "--version-file",
-        type=str,
-        default=HERE / ".." / ".." / "VERSION",
-        help="file containing version string for local docs build",
-    )
-    parser.add_argument(
         "--bucket-id",
         type=str,
         default="determined-ai-docs",
@@ -67,9 +61,16 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # check version file to determine upload path
-    with args.version_file.open() as f:
-        version = f.read().strip()
+    # Read the application version string from the VERSION environment
+    # variable to determine upload path. Previously, this was read
+    # from a static VERSION file at the root of the repository. Now,
+    # we read it from an environment variable set by a Makefile,
+    # generated from version.sh in the repository root.
+    version = os.environ.get("VERSION")
+
+    if version is None:
+        print("Please ensure VERSION environment variable is set.")
+        os.exit(1)
 
     # ya know, jic
     if version == "latest":

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -2,6 +2,8 @@ TEST_RESULTS_DIR=/tmp/test-results
 py_bindings_dest=determined/common/api/bindings.py
 cuda_available=$(shell python -c "import torch; print(torch.cuda.is_available())") \
 
+export VERSION:=$(shell ../version.sh)
+
 .PHONY: build
 build:
 	PYTHONWARNINGS=ignore:Normalizing:UserWarning:setuptools.dist \

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=64", "wheel", "setuptools_scm>=8"]
+# requires = ["setuptools>=64", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -71,6 +72,8 @@ exclude = '(_gen.py|determined/_swagger/client/*)'
 # [tool.setuptools_scm]
 # # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
 # root = "../"
+# version_scheme = "version:git_version_scheme"
+# local_scheme = "version:git_local_version"
 
 [tool.setuptools]
 include-package-data = true

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-# requires = ["setuptools>=64", "wheel", "setuptools_scm>=8"]
 requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -68,12 +67,6 @@ Documentation = "https://docs.determined.ai/"
 [tool.black]
 line-length = 100
 exclude = '(_gen.py|determined/_swagger/client/*)'
-
-# [tool.setuptools_scm]
-# # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
-# root = "../"
-# version_scheme = "version:git_version_scheme"
-# local_scheme = "version:git_local_version"
 
 [tool.setuptools]
 include-package-data = true

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -68,9 +68,9 @@ Documentation = "https://docs.determined.ai/"
 line-length = 100
 exclude = '(_gen.py|determined/_swagger/client/*)'
 
-[tool.setuptools_scm]
-# Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
-root = "../"
+# [tool.setuptools_scm]
+# # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
+# root = "../"
 
 [tool.setuptools]
 include-package-data = true

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -72,9 +72,6 @@ exclude = '(_gen.py|determined/_swagger/client/*)'
 # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
 root = "../"
 
-local_scheme = "no-local-version"
-git_describe_command = "git describe --tags --always"
-
 [tool.setuptools]
 include-package-data = true
 

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -72,6 +72,9 @@ exclude = '(_gen.py|determined/_swagger/client/*)'
 # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
 root = "../"
 
+local_scheme = "no-local-version"
+git_describe_command = "git describe --tags --always"
+
 [tool.setuptools]
 include-package-data = true
 

--- a/harness/pyproject.toml
+++ b/harness/pyproject.toml
@@ -72,9 +72,6 @@ exclude = '(_gen.py|determined/_swagger/client/*)'
 # Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
 root = "../"
 
-# Don't add the extra commit hash. PyPI complains, and it's also just noisy.
-local_scheme = "no-local-version"
-
 [tool.setuptools]
 include-package-data = true
 

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -4,10 +4,25 @@ def readme():
     with open("../README.md", "r") as fd:
         return fd.read()
 
+def version():
+    # VERSION should be set by the harness Makefile, obtained from running
+    # version.sh at the repository root. This means either the build has to be
+    # done via make, or VERSION has to be explicitly set to run python -m build
+    # directly. Given the intended use cases, though, this should be fine. It's
+    # also more consistent, as it doesn't rely on duplicating version-finding
+    # behavior in Python, which has the possibility of drifting if we update one
+    # version discovery script but not the other.
+    version = os.environ.get("VERSION")
+    if version is None:
+        raise Exception("VERSION environment variable must be set.")
+
+    return version
+
 setuptools.setup(
     # We can't seem to use pyproject.toml to include the Determined README
     # relative to pyproject.toml. But that's okay, because we can still keep
     # setup.py for this.
     long_description=readme(),
     long_description_content_type="text/markdown",
+    version=version()
 )

--- a/harness/setup.py
+++ b/harness/setup.py
@@ -1,3 +1,4 @@
+import os
 import setuptools
 
 def readme():

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -1,4 +1,4 @@
-export VERSION:=$(shell cat ../VERSION)
+export VERSION:=$(shell ../version.sh)
 
 build/stamp: $(shell find charts -type f)
 	mkdir -p build

--- a/master/Makefile
+++ b/master/Makefile
@@ -8,7 +8,8 @@ STREAM_TS_CLIENT = ../webui/react/src/services/stream/wire.ts
 MOCK_INPUTS = ./internal/sproto/task.go ./internal/db/database.go ./internal/command/authz_iface.go ../go.mod ../go.sum ./internal/rm/resource_manager_iface.go ./internal/task/allocation_service_iface.go
 GORELEASER = goreleaser
 
-export VERSION := $(shell cat ../VERSION)
+export VERSION := $(shell ../version.sh)
+
 export GO111MODULE := on
 export DOCKER_REPO ?= determinedai
 

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := $(shell ../version.sh)
+export VERSION := $(shell ../version.sh)
 SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 
 ARTIFACTS_DIR := /tmp/artifacts

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := $(shell cat ../VERSION)
+VERSION := $(shell ../version.sh)
 SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 
 ARTIFACTS_DIR := /tmp/artifacts

--- a/model_hub/pyproject.toml
+++ b/model_hub/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=64", "wheel", "setuptools_scm>=8"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,13 +28,6 @@ Documentation = "https://docs.determined.ai/"
 
 [tool.black]
 line-length = 100
-
-[tool.setuptools_scm]
-# Path relative_to pyproject.toml. Necessary for correct git metadata parsing.
-root = "../"
-
-# Don't add the extra commit hash. PyPI complains, and it's also just noisy.
-local_scheme = "no-local-version"
 
 [tool.setuptools]
 include-package-data = true

--- a/model_hub/setup.py
+++ b/model_hub/setup.py
@@ -1,0 +1,20 @@
+import os
+import setuptools
+
+def version():
+    # VERSION should be set by the harness Makefile, obtained from running
+    # version.sh at the repository root. This means either the build has to be
+    # done via make, or VERSION has to be explicitly set to run python -m build
+    # directly. Given the intended use cases, though, this should be fine. It's
+    # also more consistent, as it doesn't rely on duplicating version-finding
+    # behavior in Python, which has the possibility of drifting if we update one
+    # version discovery script but not the other.
+    version = os.environ.get("VERSION")
+    if version is None:
+        raise Exception("VERSION environment variable must be set.")
+
+    return version
+
+setuptools.setup(
+    version=version()
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ devcluster>=1,<2
 coverage
 sqlfluff==2.1.4
 setuptools==70.0.0
-setuptools-scm==8.1.0
 # typeshed
 types-certifi
 types-chardet

--- a/version.sh
+++ b/version.sh
@@ -1,16 +1,73 @@
 #!/bin/bash
 
-# Safety first.
-# -e: exit at first non-zero error code
-# -x: print commands as we execute them
-# -o pipefail: exit if one part of a pipe fails
-set -exo pipefail
+# This script dynamically determines an appropriate version string for the
+# currently checked-out commit. As tag versions will typically be provided by CI
+# for releases, this script is primarily to support local builds that work as
+# one would expect.
+#
+# Consider the following git DAG representing a hypothetical Determined git
+# tree:
+#
+#                  I---J (feat-behind-latest-tag)
+#                /
+#...A---B---C---D---E---F---M---N---O
+#    \                   \
+#     G---H (1.1.x)       K---L (1.2.x)
+#         |                   |
+#       1.1.0               1.2.0
+#
+# The newest version is 1.2.0, as tagged on the release branch 1.2.x, at L. The
+# previous version is 1.1.0, on release branch 1.1.x, at H. Our feature branch
+# is feat-behind-latest-tag, with HEAD at J. The goal is to output the nearest
+# tag on the release branch behind wherever we are. At first, I tried to finagle
+# git-rev-list to make this happen, but I was unable to get a working
+# solution. So instead, I used a combination of git-describe and git-tag.
+#
+# git-describe will give us a tag if we're currently on a release branch, or any
+# branch with tags, which is unlikely, but possible. If we're on a feature
+# branch, which is much more likely, we need to use git-tag and git-merge-base
+# to work backward: we find the merge-base of HEAD and main, then search for all
+# tags that don't contain that commit (i.e. all tags created before that
+# commit). From there, we just sort and filter the tag list, and grab the top
+# element, which is the most recent, previous tag.
+#
+# So, in our diagram, if run from B, C, D, E, F, I, J, or K, the script will return
+# 1.1.0. If run from L, M, N, or O, it will return 1.2.0. And so on.
+
+set -x
 
 # If VERSION is unset or the empty string, ""
 if [ -z ${VERSION} ]; then
-	# Grab version from git.
-	echo -n "$(git describe --tags --always 2>/dev/null)" | sed -e 's/-/./g' | sed -e 's/v//g'
+    # Check if this branch has any tags (typically, only release branches will
+    # have tags).
+    MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+    SHA=$(git rev-parse --short HEAD)
+
+    # No tag on current branch.
+    if [ -z ${MAYBE_TAG} ]; then
+        # Use git to find the merge base between the current branch and main,
+        # and then find the closest tag behind that, using --no-contains. Then,
+        # use grep to remove some special cases, namely: old Determined version
+        # tags beginning with 'v', and all tags that end in '-ee'. Then, use
+        # head to grab the first one, since the list is sorted in descending
+        # order, handling -rc tags correctly courtesy of
+        # versionsort.suffix. Finally, use sed to remove the 'v' prefix to get
+        # the bare version string.
+        MAYBE_TAG=$(git \
+                        -c versionsort.suffix='-rc' \
+                        tag \
+                        --sort='-v:refname:short' \
+                        --format='%(refname:short)' \
+                        --no-contains=$(git merge-base HEAD main) | \
+                    grep -E -v 'v0.12|-ee' | \
+                    head -n 1 | \
+                    sed -e 's/v//g'
+                  )
+    fi
+
+    # Munge the tag into the form we want.
+    echo -n "${MAYBE_TAG}-${SHA}"
 else
-	# Use existing VERSION.
-	echo -n "${VERSION}"
+    # Use existing VERSION, which is much easier.
+    echo -n "${VERSION}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -8,6 +8,8 @@
 # Consider the following git DAG representing a hypothetical Determined git
 # tree:
 #
+#                     HEAD
+#                      |
 #                  I---J (feat-behind-latest-tag)
 #                /
 #...A---B---C---D---E---F---M---N---O

--- a/version.sh
+++ b/version.sh
@@ -65,9 +65,13 @@ if [ -z ${VERSION} ]; then
                   )
     fi
 
-    # Munge the tag into the form we want.
+    # Munge the tag into the form we want. Note: we always append a SHA hash,
+    # even if we're on the commit with the tag. This is partially because I feel
+    # like it will be more consistent and result in fewer surprises, but also it
+    # might help indicate that this is a local version.
     echo -n "${MAYBE_TAG}-${SHA}"
 else
-    # Use existing VERSION, which is much easier.
+    # Use existing VERSION, which is much easier. This should be the default
+    # case for CI, as VERSION will already be set.
     echo -n "${VERSION}"
 fi

--- a/version.sh
+++ b/version.sh
@@ -12,7 +12,7 @@
 #                      |
 #                  I---J (feat-behind-latest-tag)
 #                /
-#...A---B---C---D---E---F---M---N---O
+#...A---B---C---D---E---F---M---N---O - main
 #    \                   \
 #     G---H (1.1.x)       K---L (1.2.x)
 #         |                   |

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Safety first.
+# -e: exit at first non-zero error code
+# -x: print commands as we execute them
+# -o pipefail: exit if one part of a pipe fails
+set -exo pipefail
+
+# If VERSION is unset or the empty string, ""
+if [ -z ${VERSION} ]; then
+	# Grab version from git.
+	echo -n "$(git describe --tags --always 2>/dev/null)" | sed -e 's/-/./g' | sed -e 's/v//g'
+else
+	# Use existing VERSION.
+	echo -n "${VERSION}"
+fi

--- a/version.sh
+++ b/version.sh
@@ -12,7 +12,7 @@
 #                      |
 #                  I---J (feat-behind-latest-tag)
 #                /
-#...A---B---C---D---E---F---M---N---O - main
+#...A---B---C---D---E---F---M---N---O (main)
 #    \                   \
 #     G---H (1.1.x)       K---L (1.2.x)
 #         |                   |


### PR DESCRIPTION
## Ticket
INFENG-744

## Description

* Remove dependency on static `VERSION` file and replace it with a bash
  script, version.sh, that either fetches the version from git tags,
  usually used for local builds, or returns an existing environment
  variable, mainly used in CI.

* The script uses a few different git tools to find the most recent
  previous tag for a given commit, a combination of git-describe,
  git-tag, and git-merge-base. Additional implementation details are
  available in the comments in that file. The resulting version, though,
  is `<prev-tag>+<HEAD-short-SHA>`. This ensures that certain Python
  dependency constraints are able to be satisfied when building
  Determined locally. Otherwise, if `VERSION` is already set, as will be
  the case in CI, the script simply returns that instead.

* Replace existing `cat`s of the `VERSION` file with invocations of this
  shell script; specifically, in the following files:

  - `.devcontainer/server.sh`
  - `.github/workflows/lint-python.yml`
  - `agent/Makefile`
  - `docs/Makefile`
  - `docs/deploy/Makefile`
  - `helm/Makefile`
  - `master/Makefile`
  - `model_hub/Makefile`

* Invoke version.sh in the Python Determined module Makefile:
  `harness/Makefile`. This was necessary to replace my previous attempt at
  fetching version string information from git using a Pythom setuptools
  plugin called setuptools_scm. Although that library works and is quite
  handy, and I sincerely thank Ronny Pfannschmidt and all other
  contributors for their work, configuring it was non-trivial, at times,
  and it was becoming difficult to cleanly get it to do what I wanted. I
  also decided that it makes more sense to have a single, canonical
  version string (not unlike the `VERSION` file itself) that we use for as
  many things as possible, notwithstanding certain potential
  incongruences between how different systems parse version strings.
  
  Now, instead of using `setuptools_scm`, we read the environment variable
  in `harness/setup.py`, and pass that to setuptools as a dynamic
  version. This also helps ensure that there aren't multiple ways to
  fetch a canonical version, which could become out of sync if we aren't
  careful. It does, however, mean that you need to use the Makefile to
  build the determined module; if you want to invoke `python -m build`
  directly, you'll have to set `VERSION` yourself. This is unlikely. If
  VERSION is unset, setup.py will raise an exception.

* Remove the `--version-file` flag from `docs/deploy/upload.py`. I don't
  think it's even used, but it's certainly unnecessary now.

* Replace reading the `VERSION` file in `docs/deploy/upload.py` with
  fetching the `VERSION` environment variable, which should be set by the
  docs makefile. I've done the same thing in `docs/conf.py`.

* Although I've described what version.sh does, the diff will show some
  minor tweaks, like editing comments and moving some tag-munging
  commands around. I've also removed `set -x`, because I forgot that
  executing the script locally, even in a subshell, will set shell
  options globally, and apply after the script exits. This is
  undesirable. There are ways to mitigate this, but it's not a pressing
  issue.

* Remove `VERSION` file from `.bumpversion.cfg`.

## Test Plan
This one is challenging. There will be various different areas to check, so I'll try to group them together in a way that makes sense.

### Build

Most of the changes, mercifully, are part of the build process. To do that, simply run `make` from the root of the repository (you may need to `cd` into `webui/react/` and `nvm use` if you don't currently have the appropriate NodeJS interpreter sourced). If everything builds successfully, that's a good sign!

You'll want to check the built version of Python artifact in `harness/dist`. From `HEAD` on this branch, the artifact should be called `determined-0.32.1+b00f6d03a-py3-none-any.whl` (this is because this particular branch is based off of INFENG-382-release-redesign, which is fairly behind `main`, at this point).

Also, check the artifact in `model_hub/dist`; it should be `model_hub-0.32.1+b00f6d03a-py3-none-any.whl`.

### `version.sh`

There are various scenarios to check for the `version.sh` script. The easiest is to make sure it outputs an existing `VERSION` variable properly. Run:

```
export VERSION=v1.4.0
./version.sh
```

If the script outputs `1.4.0`, then that's correct.

Testing the various git tree situations takes more work; referring to the diagram in the comments of `version.sh` might be helpful. You'll want to test the behavior of `version.sh` in the following scenarios, where `HEAD` is pointing to the following:

- `main`
- `INFENG-744-remove-version-file` (should be exercised by the build, but it never hurts)
- A release branch, like `1.1.x`, with `HEAD` pointing to the tip of the branch that also has a tag.
- A release branch, like `1.1.x`, with a deatched `HEAD` pointing to a release branch commit before the newest tag on that branch.
- A feature branch that is branched off of `main` between two tags (i.e. after `0.34.0` and whatever new, fake tag you make for testing, like `v1.1.0`).

The goal is to make sure that `version.sh` outputs an appropriate version for any possible commit, as it should be possible to build Determined from any revision without getting an incorrect local version.

Note: the script will always output the version string **without the leading v**. So if you're on, say, tag `v1.1.0`, the script should output `1.1.0-SHA`, where `SHA` is the shortest unique hash of `HEAD`. This helps ensure uniqueness, spares us the messiness of attempting to count commits across branches, and indicates that this is a local build.

### Docs

1. `cd` into `docs/site/html`.
1. Run `python -m http.server 8080` (or similar available port).
1. Navigate to `localhost:8080` in your browser.
1. In the upper left corner, where the version picker usually is, you should see the current version string displayed.

### devcontainer

[Draw the rest of the owl](https://knowyourmeme.com/memes/how-to-draw-an-owl) territory here, but you'll want to make sure VSCode devcontainer functionality works. It should, given the diff and the fact that the script works everywhere else, but it still needs to be tested.

### helm

I'm making a note here, because although `helm/Makefile` has changed, updating Helm chart version bumping was not part of this ticket, so you don't have to worry about testing it for now.

### master and agent

After the build, verify that the `ldflags` for the master and agent binaries contain the correct version:

1. `cd` into `master/build`.
1. Run `go version -m determined-master | grep "0\.32\.1"`.
1. You should one line, beginning with: `build   -ldflags="-X github.com/determined-ai/determined/master/version.Version=0.32.1+b00f6d03a`.

Repeat the steps under `agent/build`, and you should see a similar line for the agent binary.

### `.github/workflows/lint-python.yml`

This GitHub action is currently disabled. We might actually be able to remove this entirely, but I have no idea when it was disabled, or why. So you can just spot-check the YAML, but don't worry about testing the actual action.

### `docs/deploy/Makefile`

This one might be difficult to test, but you should be able to run `make plan` if you have the correct AWS credentials set.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code