### PR TITLE
chore: raise exception in HF trainer for mismatched train units [MD-456]

### DIFF
--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -264,16 +264,16 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
     def _check_searcher_compatibility(self, args: transformers.TrainingArguments) -> None:
         if self.searcher_unit == "batches":
             if args.max_steps == -1:
-                self._check_config_mismatch("epochs", args.num_train_epochs)
+                self._raise_config_mismatch("epochs", args.num_train_epochs)
             elif args.max_steps != self.searcher_max_length:
-                self._check_config_mismatch("batches", args.max_steps)
+                self._raise_config_mismatch("batches", args.max_steps)
         elif self.searcher_unit == "epochs":
             if args.max_steps != -1:
-                self._check_config_mismatch("batches", args.max_steps)
+                self._raise_config_mismatch("batches", args.max_steps)
             elif args.num_train_epochs != self.searcher_max_length:
-                self._check_config_mismatch("epochs", args.num_train_epochs)
+                self._raise_config_mismatch("epochs", args.num_train_epochs)
 
-    def _check_config_mismatch(
+    def _raise_config_mismatch(
         self,
         trainer_units: str,
         trainer_len: float,

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -264,21 +264,21 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
     def _check_searcher_compatibility(self, args: transformers.TrainingArguments) -> None:
         if self.searcher_unit == "batches":
             if args.max_steps == -1:
-                self._log_config_mismatch("epochs", args.num_train_epochs)
+                self._check_config_mismatch("epochs", args.num_train_epochs)
             elif args.max_steps != self.searcher_max_length:
-                self._log_config_mismatch("batches", args.max_steps)
+                self._check_config_mismatch("batches", args.max_steps)
         elif self.searcher_unit == "epochs":
             if args.max_steps != -1:
-                self._log_config_mismatch("batches", args.max_steps)
+                self._check_config_mismatch("batches", args.max_steps)
             elif args.num_train_epochs != self.searcher_max_length:
-                self._log_config_mismatch("epochs", args.num_train_epochs)
+                self._check_config_mismatch("epochs", args.num_train_epochs)
 
-    def _log_config_mismatch(
+    def _check_config_mismatch(
         self,
         trainer_units: str,
         trainer_len: float,
     ) -> None:
-        logger.warning(
+        logger.error(
             f"Searcher configuration does not match HF Trainer configuration. "
             f"Searcher uses {self.searcher_unit}={self.searcher_max_length}, "
             f"while HF Trainer uses {trainer_units}={trainer_len}. "
@@ -286,6 +286,10 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
             f"Make sure to match the units between HF Trainer and Searcher: "
             f"use (--num_train_epochs and searcher.max_length.epochs) OR "
             f"(--max_steps and searcher.max_length.batches)."
+        )
+        raise ValueError(
+            f"HF trainer units {trainer_units}={trainer_len} do not match searcher config "
+            f"{self.searcher_unit}={self.searcher_max_length}"
         )
 
 

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -278,18 +278,12 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
         trainer_units: str,
         trainer_len: float,
     ) -> None:
-        logger.error(
-            f"Searcher configuration does not match HF Trainer configuration. "
-            f"Searcher uses {self.searcher_unit}={self.searcher_max_length}, "
-            f"while HF Trainer uses {trainer_units}={trainer_len}. "
-            f"Continuing this run may cause Searcher not to behave correctly. "
-            f"Make sure to match the units between HF Trainer and Searcher: "
-            f"use (--num_train_epochs and searcher.max_length.epochs) OR "
-            f"(--max_steps and searcher.max_length.batches)."
-        )
         raise ValueError(
-            f"HF trainer units {trainer_units}={trainer_len} do not match searcher config "
-            f"{self.searcher_unit}={self.searcher_max_length}"
+            f"HF trainer units {trainer_units}={trainer_len} MUST match searcher config "
+            f"{self.searcher_unit}={self.searcher_max_length}. "
+            f"Modify either --num_train_epochs for the training script or "
+            f"searcher.max_length.epochs in the experiment config so they are the same value "
+            f"(--max_steps and searcher.max_length.batches if using batches)."
         )
 
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

raise an exception to exit training if searcher units do not match units passed into HF trainer. 

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

in `examples/hf_trainer_api/hf_language_modeling/const.yaml` change searcher.max_length.batches to 101, submit the experiment and make sure it errors out


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ