### PR TITLE
chore: add `determined_master_scheme` for K8s multirm

### DIFF
--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -153,8 +153,10 @@ the same as the “cluster name” for a given cluster.
    default Determined deployment, all that's necessary is to upgrade the Helm deployment with that
    value as the master IP for the additional clusters.
 
-   If the external Kubernetes cluster is going to connect to the Determined master through a gateway
-   ``resource_manager.determined_master_scheme`` should be set to ``https``.
+   If an additional resource manager needs to connect to the Determined master through a gateway
+   requiring TLS, ``resource_manager.determined_master_scheme`` should be set to ``https``. If
+   ``resource_manager.determined_master_scheme`` is not set ``determined_master_ip`` will assume
+   ``https`` if the master is terminating TLS and ``http`` otherwise.
 
 *******
  WebUI

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -153,6 +153,9 @@ the same as the “cluster name” for a given cluster.
    default Determined deployment, all that's necessary is to upgrade the Helm deployment with that
    value as the master IP for the additional clusters.
 
+   If the external Kubernetes cluster is going to connect to the Determined master through a gateway
+   ``resource_manager.determined_master_scheme`` should be set to ``https``.
+
 *******
  WebUI
 *******

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -168,8 +168,10 @@ type KubernetesResourceManagerConfig struct {
 	// deprecated, no longer in use.
 	Fluent         FluentConfig `json:"fluent"`
 	KubeconfigPath string       `json:"kubeconfig_path"`
-	DetMasterIP    string       `json:"determined_master_ip,omitempty"`
-	DetMasterPort  int32        `json:"determined_master_port,omitempty"`
+
+	DetMasterScheme string `json:"determined_master_scheme,omitempty"`
+	DetMasterIP     string `json:"determined_master_ip,omitempty"`
+	DetMasterPort   int32  `json:"determined_master_port,omitempty"`
 
 	DefaultAuxResourcePool     string `json:"default_aux_resource_pool"`
 	DefaultComputeResourcePool string `json:"default_compute_resource_pool"`

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -82,6 +82,7 @@ type job struct {
 	clusterID       string
 	masterIP        string
 	masterPort      int32
+	masterScheme    string
 	masterTLSConfig model.TLSClientConfig
 	jobName         string
 	configMapName   string
@@ -134,6 +135,7 @@ func newJob(
 	namespace string,
 	masterIP string,
 	masterPort int32,
+	masterScheme string,
 	masterTLSConfig model.TLSClientConfig,
 	podInterface typedV1.PodInterface,
 	configMapInterface typedV1.ConfigMapInterface,
@@ -156,6 +158,7 @@ func newJob(
 		namespace:             namespace,
 		masterIP:              masterIP,
 		masterPort:            masterPort,
+		masterScheme:          masterScheme,
 		masterTLSConfig:       masterTLSConfig,
 		numPods:               msg.numPods,
 		slotsPerPod:           msg.slots,

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -96,6 +96,7 @@ type jobsService struct {
 	masterTLSConfig       model.TLSClientConfig
 	detMasterIP           string
 	detMasterPort         int32
+	detMasterScheme       string
 	kubeconfigPath        string
 
 	internalTaskGWConfig *config.InternalTaskGatewayConfig
@@ -146,6 +147,7 @@ func newJobsService(
 	taskContainerDefaults *model.TaskContainerDefaultsConfig,
 	detMasterIP string,
 	detMasterPort int32,
+	detMasterScheme string,
 	kubeconfigPath string,
 	jobSchedulingStateCb jobSchedulingStateCallback,
 	internalTaskGWConfig *config.InternalTaskGatewayConfig,
@@ -157,6 +159,7 @@ func newJobsService(
 		namespaceToPoolName:               namespaceToPoolName,
 		masterServiceName:                 masterServiceName,
 		masterTLSConfig:                   masterTLSConfig,
+		detMasterScheme:                   detMasterScheme,
 		scheduler:                         scheduler,
 		jobNameToJobHandler:               make(map[string]*job),
 		jobNameToResourcePool:             make(map[string]string),
@@ -560,6 +563,7 @@ func (j *jobsService) startJob(msg startJob) error {
 		msg.namespace,
 		j.detMasterIP,
 		j.detMasterPort,
+		j.detMasterScheme,
 		j.masterTLSConfig,
 		j.podInterfaces[msg.namespace],
 		j.configMapInterfaces[msg.namespace],
@@ -806,6 +810,7 @@ func (j *jobsService) recreateJobHandler(
 		job.Namespace,
 		j.detMasterIP,
 		j.detMasterPort,
+		j.detMasterScheme,
 		j.masterTLSConfig,
 		j.podInterfaces[job.Namespace],
 		j.configMapInterfaces[job.Namespace],

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -107,6 +107,7 @@ func New(
 		k.taskContainerDefaults,
 		k.config.DetMasterIP,
 		k.config.DetMasterPort,
+		k.config.DetMasterScheme,
 		k.config.KubeconfigPath,
 		k.jobSchedulingStateCallback,
 		k.config.InternalTaskGateway,

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -1279,6 +1279,7 @@ func newTestJobsService(t *testing.T) *jobsService {
 		&model.TaskContainerDefaultsConfig{},
 		"localhost",
 		8080,
+		"",
 		"~/.kube/config",
 		nil,
 		nil,

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -112,6 +112,14 @@ func (j *job) configureEnvVars(
 	if j.masterTLSConfig.Enabled {
 		masterScheme = "https"
 	}
+
+	// For multi rm support add an override to our defaulting logic because it is possible the
+	// external cluster connects to master through a gateway with TLS
+	// while the other does not use TLS.
+	if j.masterScheme != "" {
+		masterScheme = j.masterScheme
+	}
+
 	envVarsMap["DET_CLUSTER_ID"] = j.clusterID
 	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s://%s:%d", masterScheme, j.masterIP, j.masterPort)
 	envVarsMap["DET_MASTER_HOST"] = j.masterIP


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Add a ```determined_master_scheme``` to help this case

https://hpe-aiatscale.slack.com/archives/C06K1CD0DMW/p1721244178479199?thread_ts=1721243514.575999&cid=C06K1CD0DMW

The idea is defaulting based off the TLS config is not right in the multirm case because the within cluster likely won't use TLS while the external cluster might connect to master through a gateway.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ