### PR TITLE
fix: default value in filter form

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
@@ -512,7 +512,7 @@ describe('FilterFormStore', () => {
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
         let field = getField(filterFormStore);
-        expect(field).toMatchObject({ operator: Operator.Contains });
+        expect(field).toMatchObject({ operator: Operator.Eq });
         filterFormStore.setFieldOperator(field.id, Operator.GreaterEq);
         field = getField(filterFormStore);
         expect(field).toMatchObject({ operator: Operator.GreaterEq });

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -34,12 +34,12 @@ const getInitGroup = (): FormGroup => ({
 });
 
 export const getInitField = (): FormField => ({
-  columnName: '',
+  columnName: 'id',
   id: uuidv4(),
   kind: FormKind.Field,
   location: V1LocationType.EXPERIMENT,
-  operator: AvailableOperators[V1ColumnType.TEXT][0],
-  type: V1ColumnType.TEXT,
+  operator: AvailableOperators[V1ColumnType.NUMBER][0],
+  type: V1ColumnType.NUMBER,
   value: null,
 });
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-600]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
#9509 removed the default columnName.
the filter form UI has been broken, so fixed it. Used `id` because thats the common column among the new experiment table, flat run table, search table. 

### Before

<img width="725" alt="image" src="https://github.com/user-attachments/assets/06f91cfd-ecf8-4054-8272-f9f8a30dfccc">

### After

<img width="721" alt="image" src="https://github.com/user-attachments/assets/54dcccf1-a561-40e9-9e93-05e7487757df">


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- open the filter form and clear it and see the default value is set


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-600]: https://hpe-aiatscale.atlassian.net/browse/ET-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ