### PR TITLE
fix: fixed getKubernetesResourceManager error in webui and default ns validation

### DIFF
--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -110,9 +110,11 @@ func New(
 		return nil, err
 	}
 
-	err = k.jobsService.VerifyNamespaceExists(k.config.DefaultNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("error verifying default namespace existence for cluster '%s': %w", k.config.Name, err)
+	if len(k.config.DefaultNamespace) > 0 {
+		err = k.jobsService.VerifyNamespaceExists(k.config.DefaultNamespace)
+		if err != nil {
+			return nil, fmt.Errorf("error verifying default namespace existence for cluster '%s': %w", k.config.Name, err)
+		}
 	}
 
 	for _, poolConfig := range k.poolsConfig {

--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -60,6 +60,10 @@ const isNonK8RMError = (e: unknown): boolean => {
   return e instanceof DetError && e.sourceErr instanceof Response && e.sourceErr['status'] === 404;
 };
 
+const isNotAuthorizedErr = (e: unknown): boolean => {
+  return e instanceof DetError && e.sourceErr instanceof Response && e.sourceErr['status'] === 403;
+};
+
 const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }: Props = {}) => {
   const idPrefix = useId();
   const {
@@ -78,12 +82,14 @@ const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }
       const response = await getKubernetesResourceManagers(undefined, { signal: canceller.signal });
       return response.names;
     } catch (e) {
-      handleError(e, {
-        level: ErrorLevel.Error,
-        publicMessage: 'Failed to fetch Resource Managers.',
-        silent: false,
-        type: ErrorType.Server,
-      });
+      if (!isNotAuthorizedErr(e)) {
+        handleError(e, {
+          level: ErrorLevel.Error,
+          publicMessage: 'Failed to fetch Resource Managers.',
+          silent: false,
+          type: ErrorType.Server,
+        });
+      }
       return NotLoaded;
     }
   }, []);


### PR DESCRIPTION
… validation

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
DET-10418
DET-10432

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Fixed the error toasts from the KubernetesRM endpoint that appear for non-cluster admins and fixed the failing build when a default namespace isn't supplied in the additional RM config and default to the default ns


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
1. Open devcluster.yaml in tools/k8s. Comment out the default_namespace field under resource_manager.
2. spin up a minikube devcluster using.
3. Make sure that master builds without an error.
4. login with non-admin account.
5. Go to workspaces page and make sure there aren't getKubernetesResourceManager errors showing up.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ