### PR TITLE
fix: require full object for debounced settings updates

### DIFF
--- a/webui/react/src/hooks/useDebouncedSettings.ts
+++ b/webui/react/src/hooks/useDebouncedSettings.ts
@@ -21,13 +21,13 @@ import { eagerSubscribe } from 'utils/observable';
  *
  * - handles the hand-off between local and server state (that is, server state
  *   wins until the initial load, at which point local state wins)
- * - provides local state and a partial update function which debounces sending
+ * - provides local state and an update function which debounces sending
  *   state to the store/server
  */
 export function useDebouncedSettings<T extends t.HasProps | t.ExactC<t.HasProps>>(
   type: T,
   path: string,
-): [Loadable<t.TypeOf<T> | null>, (p: Partial<t.TypeOf<T>>) => void] {
+): [Loadable<t.TypeOf<T> | null>, (p: t.TypeOf<T>) => void] {
   const settingsObs = useMemo(() => userSettings.get(type, path), [type, path]);
   const [localState, updateLocalState] = useState<Loadable<T | null>>(NotLoaded);
 
@@ -47,12 +47,12 @@ export function useDebouncedSettings<T extends t.HasProps | t.ExactC<t.HasProps>
   );
 
   const updateSettings = useCallback(
-    (partial: Partial<T>) => {
+    (partial: T) => {
       // don't send settings to server if they haven't loaded yet
       settingsObs.get().forEach(() => {
         updateLocalState((localStateLoadable) => {
           return localStateLoadable.flatMap((ls) => {
-            const newState = ls && { ...ls, ...partial };
+            const newState = { ...ls, ...partial };
             if (isEqual(newState, ls)) {
               return localStateLoadable;
             }


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-622


## Description
This fixes an issue where debounced settings slices would not update when the settings path did not previously exist. The update function for the debounced slice took a partial version of the slice and spread it out with the final version of the slice. Because malformed settings objects return null, we guarded against further issues by returning the same if an update was made. However, unset settings also return null. To get around this, we now require fully formed settings slices in the debounced settings update function.




## Test Plan
* reset your user settings
* visit the new experiment list
* when dragging a column header edge, the column width should update.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
