### PR TITLE
fix: add autocreate as true to db when user inputs autocreated ns manually

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -881,6 +881,10 @@ func (a *apiServer) setWorkspaceNamespaceBindings(ctx context.Context,
 			namespace = *metadata.Namespace
 		}
 
+		if namespace == *autoCreatedNamespace {
+			metadata.AutoCreateNamespace = true
+		}
+
 		// Since workspace-namespace bindings for the default namespace of a given cluster are not
 		// automatically saved in the database, maintain constistency by not saving default
 		// namespace bindings to the db if a user tries to set them.


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Auto-created namespaces were not being recorded as autocreated in the db when the user inputted them manually. Fixed the issue.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
1. spin up a k8 cluster on minikube with EE.
2. Try to create a workspace with the autocreate toggle on.
3. Open the edit workspace modal and copy the name of the auto created namespace.
4. turn the toggle off for the autocreate ns and input default as the ns and save.
5. open the edit workspace modal and paste the autocreated ns name and save.
6. open the edit workspace modal and verify that the autocreated toggle is on.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ