### PR TITLE
fix: Remove experiments immediately after deleting by filtering out deleting experiments

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2570,6 +2570,7 @@ func (a *apiServer) SearchExperiments(
 		Model(&experiments).
 		ModelTableExpr("experiments as e").
 		Column("e.best_trial_id").
+		Where("e.state != ?", model.DeletingState).
 		Apply(getExperimentColumns)
 
 	curUser, _, err := grpcutil.GetUser(ctx)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1243,7 +1243,6 @@ func TestSearchExperimentsMalformed(t *testing.T) {
 func TestSearchExperimentsNoDeleting(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
 	_, projectIDInt := createProjectAndWorkspace(ctx, t, api)
-	projectID := int32(projectIDInt)
 
 	exp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
 
@@ -1259,13 +1258,13 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 		JobID:     model.JobID(uuid.New().String()),
 		State:     model.DeletingState,
 		OwnerID:   &curUser.ID,
-		ProjectID: projectID,
+		ProjectID: projectIDInt,
 		StartTime: time.Now(),
 		Config:    activeConfig.AsLegacy(),
 	}
 	require.NoError(t, api.m.db.AddExperiment(exp, []byte{10, 11, 12}, activeConfig))
 
-	resp, err = api.SearchExperiments(ctx, req)
+	resp, err := api.SearchExperiments(ctx, req)
 	require.NoError(t, err)
 	// Deleting experiment should not be in the response
 	require.Len(t, resp.Experiments, 1)

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1244,7 +1244,7 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 	api, curUser, ctx := setupAPITest(t, nil)
 	_, projectIDInt := createProjectAndWorkspace(ctx, t, api)
 
-	exp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
+	shownExp := createTestExpWithProjectID(t, api, curUser, projectIDInt)
 
 	// Add deleting experiment
 	experimentConfig := expconf.ExperimentConfig{
@@ -1254,7 +1254,7 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 
 	activeConfig := schemas.WithDefaults(schemas.Merge(minExpConfig, experimentConfig))
 
-	exp = &model.Experiment{
+	hiddenExp := &model.Experiment{
 		JobID:     model.JobID(uuid.New().String()),
 		State:     model.DeletingState,
 		OwnerID:   &curUser.ID,
@@ -1262,7 +1262,7 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 		StartTime: time.Now(),
 		Config:    activeConfig.AsLegacy(),
 	}
-	require.NoError(t, api.m.db.AddExperiment(exp, []byte{10, 11, 12}, activeConfig))
+	require.NoError(t, api.m.db.AddExperiment(hiddenExp, []byte{10, 11, 12}, activeConfig))
 
 	projectID := int32(projectIDInt)
 
@@ -1277,7 +1277,7 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 	// Deleting experiment should not be in the response
 	require.Len(t, resp.Experiments, 1)
 	require.Nil(t, resp.Experiments[0].BestTrial)
-	require.Equal(t, int32(exp.ID), resp.Experiments[0].Experiment.Id)
+	require.Equal(t, int32(shownExp.ID), resp.Experiments[0].Experiment.Id)
 }
 
 // Test that endpoints don't puke when running against old experiments.

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1264,6 +1264,14 @@ func TestSearchExperimentsNoDeleting(t *testing.T) {
 	}
 	require.NoError(t, api.m.db.AddExperiment(exp, []byte{10, 11, 12}, activeConfig))
 
+	projectID := int32(projectIDInt)
+
+	// Empty response causes no errors.
+	req := &apiv1.SearchExperimentsRequest{
+		ProjectId: &projectID,
+		Sort:      ptrs.Ptr("id=asc"),
+	}
+
 	resp, err := api.SearchExperiments(ctx, req)
 	require.NoError(t, err)
 	// Deleting experiment should not be in the response


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
ET-86


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Experiments/Searches in "deleting" state appear in tables. This causes confusing behaviour where a deleted experiment gets removed then re-appers in the table until it gets deleted.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
With Flat Run Flag On:

1. Go to Searches tab in run table
2. Select one or multiple searches
3. Delete them and confirm that the search is removed

With Flat Run Flag Off:

1. Go to Experiments table
2. Select one or multiple experiments
3. Delete them and confirm that the experiment is removed

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ