### PR TITLE
docs: use postgres 14 in code snippets.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ the Determined master host:
 docker run -it --rm \
   --network determined \
   -e PGPASSWORD=my-postgres-password \
-  postgres:10 psql -h determined-db -U postgres -d determined
+  postgres:14 psql -h determined-db -U postgres -d determined
 ```
 
 ### Get profiling information

--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -22,11 +22,11 @@ Determined uses a PostgreSQL database to store experiment and trial metadata.
    GPUs, ensure that the :ref:`NVIDIA Container Toolkit <validate-nvidia-container-toolkit>` on each
    one is working as expected.
 
-#. Pull the official Docker image for PostgreSQL. We recommend using the version listed below.
+#. Pull the official Docker image for PostgreSQL. PostgreSQL version 10 and later is supported.
 
    .. code::
 
-      docker pull postgres:10
+      docker pull postgres:14
 
    This image is not provided by Determined AI; visit `its Docker Hub page
    <https://hub.docker.com/_/postgres>`_ for more information.
@@ -54,7 +54,7 @@ Determined uses a PostgreSQL database to store experiment and trial metadata.
           -v determined_db:/var/lib/postgresql/data \
           -e POSTGRES_DB=determined \
           -e POSTGRES_PASSWORD=<Database password> \
-          postgres:10
+          postgres:14
 
    If the master will connect to PostgreSQL via Docker networking, exposing port 5432 via the ``-p``
    argument isn't necessary; however, you may still want to expose it for administrative or

--- a/docs/setup-cluster/on-prem/options/docker.rst
+++ b/docs/setup-cluster/on-prem/options/docker.rst
@@ -14,11 +14,11 @@ This user guide provides step-by-step instructions for installing Determined usi
    GPUs, ensure that the :ref:`NVIDIA Container Toolkit <validate-nvidia-container-toolkit>` on each
    one is working as expected.
 
-#. Pull the official Docker image for PostgreSQL. We recommend using the version listed below.
+#. Pull the official Docker image for PostgreSQL. PostgreSQL version 10 and later is supported.
 
    .. code::
 
-      docker pull postgres:10
+      docker pull postgres:14
 
    This image is not provided by Determined AI; please see `its Docker Hub page
    <https://hub.docker.com/_/postgres>`_ for more information.
@@ -51,7 +51,7 @@ Run the following command to start the PostgreSQL container:
        -v determined_db:/var/lib/postgresql/data \
        -e POSTGRES_DB=determined \
        -e POSTGRES_PASSWORD=<DB password> \
-       postgres:10
+       postgres:14
 
 In order to expose the port only on the master machine's loopback network interface, pass ``-p
 127.0.0.1:5432:5432`` instead of ``-p 5432:5432``. If you choose to run in host networking mode,

--- a/docs/setup-cluster/on-prem/options/linux-packages.rst
+++ b/docs/setup-cluster/on-prem/options/linux-packages.rst
@@ -34,11 +34,11 @@ Docker container or your Linux distribution's package and service.
 Run PostgreSQL in Docker
 ------------------------
 
-#. Pull the official Docker image for PostgreSQL. We recommend using version 10 or greater.
+#. Pull the official Docker image for PostgreSQL. PostgreSQL version 10 and later is supported.
 
    .. code::
 
-      docker pull postgres:10
+      docker pull postgres:14
 
    This image is not provided by Determined AI; please see `its Docker Hub page
    <https://hub.docker.com/_/postgres>`_ for more information.
@@ -55,7 +55,7 @@ Run PostgreSQL in Docker
           -v determined_db:/var/lib/postgresql/data \
           -e POSTGRES_DB=determined \
           -e POSTGRES_PASSWORD=<Database password> \
-          postgres:10
+          postgres:14
 
    If the master will connect to PostgreSQL via Docker networking, exposing port 5432 via the ``-p``
    argument isn't necessary; however, you may still want to expose it for administrative or
@@ -65,7 +65,7 @@ Run PostgreSQL in Docker
 Install PostgreSQL using ``apt`` or ``yum``
 -------------------------------------------
 
-#. Install PostgreSQL 10 or greater.
+#. Install PostgreSQL. Version 10 and later is supported.
 
    **Debian Distributions**
 
@@ -73,13 +73,13 @@ Install PostgreSQL using ``apt`` or ``yum``
 
    .. code::
 
-      sudo apt install postgresql-10
+      sudo apt install postgresql
 
    **Enterprise Linux Distributions**
 
    On Enterprise Linux distributions, you'll need to configure the PostgreSQL yum repository as
    described in the `Enterprise Linux documentation
-   <https://www.postgresql.org/download/linux/redhat>`_. Then, install version 10:
+   <https://www.postgresql.org/download/linux/redhat>`_. Then, install ``postgresql-server``:
 
    .. code::
 


### PR DESCRIPTION
## Description

Update docs to use postgreql 14 instead of 10. Also explicitly state that any version later than 10 is supported.

## Test Plan
N/A

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ