### PR TITLE
fix: don't ignore failed exps

### DIFF
--- a/docs/release-notes/experiments-failed-status.rst
+++ b/docs/release-notes/experiments-failed-status.rst
@@ -2,5 +2,5 @@
 
 **Bug Fixes**
 
--  Experiments: Report an experiment's status as FAILED if there is failed behavior while
-   experiments are shutting down, but have not gracefully completed.
+-  Experiments: Report an experiment's status as FAILED if any failure occurs during the shutdown
+   process, before the experiment has completed gracefully.

--- a/docs/release-notes/experiments-failed-status.rst
+++ b/docs/release-notes/experiments-failed-status.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Bug Fixes**
+
+-  Experiments: Report an experiment's status as FAILED if there is failed behavior while
+   experiments are shutting down, but have not gracefully completed.

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -397,7 +397,10 @@ def test_master_restart_stopping_container_gone(
     restartable_managed_cluster.restart_master()
     restartable_managed_cluster.restart_agent(wait_for_amnesia=False)
 
-    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
+    # exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
+    # If this passes then something weird is going on
+    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.CANCELED)
+
     trials = exp.experiment_trials(sess, exp_id)
     assert len(trials) == 1
     assert trials[0].trial.state == bindings.trialv1State.ERROR

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -397,9 +397,7 @@ def test_master_restart_stopping_container_gone(
     restartable_managed_cluster.restart_master()
     restartable_managed_cluster.restart_agent(wait_for_amnesia=False)
 
-    # exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
-    # If this passes then something weird is going on
-    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.CANCELED)
+    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
 
     trials = exp.experiment_trials(sess, exp_id)
     assert len(trials) == 1

--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -397,8 +397,7 @@ def test_master_restart_stopping_container_gone(
     restartable_managed_cluster.restart_master()
     restartable_managed_cluster.restart_agent(wait_for_amnesia=False)
 
-    # TODO(RM-70) make this state be an error.
-    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.CANCELED)
+    exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
     trials = exp.experiment_trials(sess, exp_id)
     assert len(trials) == 1
     assert trials[0].trial.state == bindings.trialv1State.ERROR

--- a/e2e_tests/tests/experiment/test_core.py
+++ b/e2e_tests/tests/experiment/test_core.py
@@ -368,17 +368,14 @@ def test_max_concurrent_trials(name: str, searcher_cfg: str) -> None:
         # Give the experiment time to refill max_concurrent_trials.
         trials = exp.wait_for_at_least_n_trials(sess, experiment_id, 2)
 
-        # The experiment handling the cancel message and waiting for it to be cancelled slyly
-        # (hackishly) allows us to synchronize with the experiment state after after canceling
-        # the first two trials.
-        exp.cancel_single(sess, experiment_id)
+        # Pause the experiment to count the trials.
+        exp.pause_experiment(sess, experiment_id)
 
         # Make sure that there were never more than 2 total trials created.
         trials = exp.wait_for_at_least_n_trials(sess, experiment_id, 2)
         assert len(trials) == 2, trials
-
     finally:
-        exp.kill_single(sess, experiment_id)
+        exp.kill_experiments(sess, [experiment_id], -1)
 
 
 @pytest.mark.e2e_cpu

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -762,7 +762,7 @@ func (e *internalExperiment) processOperations(
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
 	// type Shutdown failures.
-	if _, ok := model.StoppingStates[e.State]; ok {
+	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
 		return
 	}
 

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -762,9 +762,9 @@ func (e *internalExperiment) processOperations(
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
 	// type Shutdown.
-	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
-		return
-	}
+	//	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
+	//		return
+	//	}
 
 	if err != nil {
 		e.syslog.Error(err)

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -761,10 +761,10 @@ func (e *internalExperiment) processOperations(
 	ops []searcher.Operation, err error,
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
-	// type Shutdown.
-	//	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
-	//		return
-	//	}
+	// type Shutdown failures.
+	if _, ok := model.StoppingStates[e.State]; ok {
+		return
+	}
 
 	if err != nil {
 		e.syslog.Error(err)
@@ -1140,7 +1140,7 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 
 func onlySearcherShutdownOperations(ops []searcher.Operation) bool {
 	for _, operation := range ops {
-		if _, ok := operation.(searcher.Shutdown); !ok {
+		if op, ok := operation.(searcher.Shutdown); !ok && !op.Cancel {
 			return false
 		}
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -762,7 +762,7 @@ func (e *internalExperiment) processOperations(
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
 	// type Shutdown failures.
-	if _, ok := model.StoppingStates[e.State]; ok && notASearcherShutdown(ops) {
+	if _, ok := model.StoppingStates[e.State]; ok && !allSearcherShutdowns(ops) {
 		return
 	}
 
@@ -1138,11 +1138,11 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	return nil
 }
 
-func notASearcherShutdown(ops []searcher.Operation) bool {
+func allSearcherShutdowns(ops []searcher.Operation) bool {
 	for _, operation := range ops {
-		if _, ok := operation.(searcher.Shutdown); !ok {
-			return true
+		if _, ok := operation.(searcher.Shutdown); ok {
+			return false
 		}
 	}
-	return false
+	return true
 }

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -762,8 +762,7 @@ func (e *internalExperiment) processOperations(
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
 	// type Shutdown failures.
-
-	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
+	if _, ok := model.StoppingStates[e.State]; ok && notASearcherShutdown(ops) {
 		return
 	}
 
@@ -1139,7 +1138,7 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	return nil
 }
 
-func onlySearcherShutdownOperations(ops []searcher.Operation) bool {
+func notASearcherShutdown(ops []searcher.Operation) bool {
 	for _, operation := range ops {
 		if _, ok := operation.(searcher.Shutdown); !ok {
 			return true

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -1140,7 +1140,7 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 
 func allSearcherShutdowns(ops []searcher.Operation) bool {
 	for _, operation := range ops {
-		if _, ok := operation.(searcher.Shutdown); ok {
+		if _, ok := operation.(searcher.Shutdown); !ok {
 			return false
 		}
 	}

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -760,9 +760,12 @@ func (e *internalExperiment) handleContinueExperiment(reqID model.RequestID) (*i
 func (e *internalExperiment) processOperations(
 	ops []searcher.Operation, err error,
 ) {
-	if _, ok := model.StoppingStates[e.State]; ok {
+	// Only continue for experiments in stopping states if the searcher operations are all
+	// type Shutdown.
+	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
 		return
 	}
+
 	if err != nil {
 		e.syslog.Error(err)
 		e.updateState(model.StateWithReason{
@@ -832,7 +835,6 @@ func (e *internalExperiment) processOperations(
 			if err := e.searcher.SetCustomSearcherProgress(op.Progress); err != nil {
 				e.syslog.WithError(err).Error("failed to set searcher progress")
 			}
-
 		case searcher.Close:
 			state := e.TrialSearcherState[op.RequestID]
 			state.Closed = true
@@ -1134,4 +1136,13 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 	_ = g.Wait() // Errors handled in g.Go.
 
 	return nil
+}
+
+func onlySearcherShutdownOperations(ops []searcher.Operation) bool {
+	for _, operation := range ops {
+		if _, ok := operation.(searcher.Shutdown); !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -762,6 +762,7 @@ func (e *internalExperiment) processOperations(
 ) {
 	// Only continue for experiments in stopping states if the searcher operations are all
 	// type Shutdown failures.
+
 	if _, ok := model.StoppingStates[e.State]; ok && onlySearcherShutdownOperations(ops) {
 		return
 	}
@@ -1140,9 +1141,9 @@ func (e *internalExperiment) setRP(resourcePool string) error {
 
 func onlySearcherShutdownOperations(ops []searcher.Operation) bool {
 	for _, operation := range ops {
-		if op, ok := operation.(searcher.Shutdown); !ok && !op.Cancel {
-			return false
+		if _, ok := operation.(searcher.Shutdown); !ok {
+			return true
 		}
 	}
-	return true
+	return false
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
fix: cancelled/completed experiments do not ignore failed trials or shutdowns.
-->
## Ticket
RM-70



## Description
If a searcher completes but the experiment fails in shutdown, the experiment should end in failure. Thus, if an experiment is cancelled, a trial failure should trump the CANCELLED state = the experiment should be marked as FAILED.



## Test Plan
See new e2e test, and edited e2e tests. No manual testing needed.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ