### PR TITLE
chore: unit tests for set resource quota perms

### DIFF
--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -1065,7 +1065,6 @@ func (a *apiServer) SetResourceQuotas(ctx context.Context,
 				"is an Enterprise-Edition feature")
 		}
 	}()
-	license.RequireLicense("set resource quota")
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {

--- a/master/internal/workspace/authz_basic_impl.go
+++ b/master/internal/workspace/authz_basic_impl.go
@@ -173,7 +173,7 @@ func (a *WorkspaceAuthZBasic) CanSetResourceQuotas(ctx context.Context, curUser 
 	workspace *workspacev1.Workspace,
 ) error {
 	if !curUser.Admin {
-		return fmt.Errorf("only admins may set workspace bindings")
+		return fmt.Errorf("only admins may set resource quotas")
 	}
 	return nil
 }


### PR DESCRIPTION

## Ticket
DET-10421



## Description
Unit tests for set resource quota permissions as ClusterAdmin for RBAC and as Deterimed Admin for OSS.



## Test Plan
CI Passes.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ