### PR TITLE
fix: disallow slots in exp config [MD-454]

### DIFF
--- a/e2e_tests/tests/cluster/test_proxy.py
+++ b/e2e_tests/tests/cluster/test_proxy.py
@@ -194,7 +194,7 @@ def test_experiment_proxy_ray_tunnel() -> None:
         sess,
         str(exp_path / "ray_launcher.yaml"),
         str(exp_path),
-        ["--config", "max_restarts=0", "--config", "resources.slots=1"],
+        ["--config", "max_restarts=0"],
     )
     try:
         exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.RUNNING)
@@ -276,8 +276,6 @@ def test_experiment_proxy_ray_publish() -> None:
             str(exp_path),
             "--config",
             "max_restarts=0",
-            "--config",
-            "resources.slots=1",
             "-f",
             "-p",
             "8265",

--- a/e2e_tests/tests/cluster/test_resource_manager.py
+++ b/e2e_tests/tests/cluster/test_resource_manager.py
@@ -37,7 +37,7 @@ def test_allocation_resources_incremental_release() -> None:
         ) as config_file:
             # Launch an experiment that has one resource (docker container) that exits immediately.
             config_obj = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
-            config_obj["resources"] = {**config_obj.get("resources", {}), **{"slots": 2}}
+            config_obj["resources"] = {**config_obj.get("resources", {}), **{"slots_per_trial": 2}}
             config_obj["hyperparameters"] = {
                 **config_obj.get("hyperparameters", {}),
                 **{"non_chief_exit_immediately": True},

--- a/e2e_tests/tests/cluster/test_resource_manager.py
+++ b/e2e_tests/tests/cluster/test_resource_manager.py
@@ -37,7 +37,6 @@ def test_allocation_resources_incremental_release() -> None:
         ) as config_file:
             # Launch an experiment that has one resource (docker container) that exits immediately.
             config_obj = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
-            config_obj["resources"] = {**config_obj.get("resources", {})}
             config_obj["hyperparameters"] = {
                 **config_obj.get("hyperparameters", {}),
                 **{"non_chief_exit_immediately": True},

--- a/e2e_tests/tests/cluster/test_resource_manager.py
+++ b/e2e_tests/tests/cluster/test_resource_manager.py
@@ -37,7 +37,7 @@ def test_allocation_resources_incremental_release() -> None:
         ) as config_file:
             # Launch an experiment that has one resource (docker container) that exits immediately.
             config_obj = conf.load_config(conf.fixtures_path("no_op/single.yaml"))
-            config_obj["resources"] = {**config_obj.get("resources", {}), **{"slots_per_trial": 2}}
+            config_obj["resources"] = {**config_obj.get("resources", {})}
             config_obj["hyperparameters"] = {
                 **config_obj.get("hyperparameters", {}),
                 **{"non_chief_exit_immediately": True},

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -271,6 +271,9 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
+	if config.RawResources.Slots() != nil {
+		return nil, nil, config, nil, nil, fmt.Errorf("<config>.resources: additionalProperties \"slots\" not allowed")
+	}
 
 	// Apply the template that the user specified.
 	if req.Template != nil {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -271,7 +271,7 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
-	if config.RawResources.Slots() != nil {
+	if config.RawResources != nil && config.RawResources.Slots() != nil {
 		return nil, nil, config, nil, nil, fmt.Errorf("<config>.resources: additionalProperties \"slots\" not allowed")
 	}
 

--- a/master/pkg/model/experiment_config.go
+++ b/master/pkg/model/experiment_config.go
@@ -80,8 +80,8 @@ func (d *DeviceConfig) UnmarshalJSON(data []byte) error {
 	return errors.Wrap(json.Unmarshal(data, DefaultParser(d)), "failed to parse device")
 }
 
-// ResourcesConfig configures resource usage for an experiment, command, notebook, tensorboard
-// or generic task.
+// ResourcesConfig configures resource usage for a command, notebook, tensorboard,
+// generic task, or old experiment(new experiment uses ResourcesConfigV0).
 type ResourcesConfig struct {
 	Slots int `json:"slots"`
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
MD-454


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
`Slots` is not a valid key in the experiment config. It's required in `ResourcesConfigV0` for [compatibility with older resource config](https://github.com/determined-ai/determined/blob/main/master/pkg/model/compat.go#L28-L46). 

I also reviewed other fields in [interactive job configuration](https://docs.determined.ai/latest/reference/job-config-reference.html#command-notebook-configuration)(NTSC). `Slots` is the only field that in the interactive job configuration and shares the same struct with experiment, but it is not valid for use in the experiment config.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ