### PR TITLE
fix: debounce searches column width settings

### DIFF
--- a/webui/react/src/components/Searches/Searches.settings.ts
+++ b/webui/react/src/components/Searches/Searches.settings.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import { pick } from 'lodash';
 
 import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 
@@ -21,23 +22,25 @@ export const DEFAULT_SELECTION: t.TypeOf<typeof RegularSelectionType> = {
   type: 'ONLY_IN',
 };
 
-// have to intersect with an empty object bc of settings store type issue
-export const ProjectSettings = t.intersection([
-  t.type({}),
-  t.partial({
-    columns: t.array(t.string),
-    columnWidths: t.record(t.string, t.number),
-    compare: t.boolean,
-    filterset: t.string, // save FilterFormSet as string
-    heatmapOn: t.boolean,
-    heatmapSkipped: t.array(t.string),
-    pageLimit: t.number,
-    pinnedColumnsCount: t.number,
-    selection: SelectionType,
-    sortString: t.string,
-  }),
-]);
+export const ProjectSettings = t.partial({
+  columns: t.array(t.string),
+  columnWidths: t.record(t.string, t.number),
+  compare: t.boolean,
+  filterset: t.string, // save FilterFormSet as string
+  heatmapOn: t.boolean,
+  heatmapSkipped: t.array(t.string),
+  pageLimit: t.number,
+  pinnedColumnsCount: t.number,
+  selection: SelectionType,
+  sortString: t.string,
+});
 export type ProjectSettings = t.TypeOf<typeof ProjectSettings>;
+
+/**
+ * Slice of ProjectSettings that concerns column widths -- this is extracted to
+ * allow updates to it to be debounced.
+ */
+export const ColumnWidthsSlice = t.exact(t.partial(pick(ProjectSettings.props, ['columnWidths'])));
 
 export const ProjectUrlSettings = t.partial({
   compare: t.boolean,

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -51,6 +51,7 @@ import { DataGridGlobalSettings, settingsConfigGlobal } from 'components/Options
 import TableActionBar from 'components/TableActionBar';
 import useUI from 'components/ThemeProvider';
 import { useAsync } from 'hooks/useAsync';
+import { useDebouncedSettings } from 'hooks/useDebouncedSettings';
 import { useGlasbey } from 'hooks/useGlasbey';
 import useMobile from 'hooks/useMobile';
 import usePolling from 'hooks/usePolling';
@@ -82,6 +83,7 @@ import { pluralizer } from 'utils/string';
 import { getColumnDefs, searcherMetricsValColumn } from './columns';
 import css from './Searches.module.scss';
 import {
+  ColumnWidthsSlice,
   DEFAULT_SELECTION,
   defaultProjectSettings,
   ProjectSettings,
@@ -145,12 +147,13 @@ const Searches: React.FC<Props> = ({ project }) => {
     (p: Partial<ProjectSettings>) => userSettings.setPartial(ProjectSettings, settingsPath, p),
     [settingsPath],
   );
+  const [columnWidths, setColumnWidths] = useDebouncedSettings(ColumnWidthsSlice, settingsPath);
   const settings = useMemo(
     () =>
-      projectSettings
-        .map((s) => ({ ...defaultProjectSettings, ...s }))
+      Loadable.all([projectSettings, columnWidths])
+        .map(([s, cw]) => ({ ...defaultProjectSettings, ...s, ...cw }))
         .getOrElse(defaultProjectSettings),
-    [projectSettings],
+    [projectSettings, columnWidths],
   );
 
   const { params, updateParams } = useTypedParams(ProjectUrlSettings, {});
@@ -540,16 +543,18 @@ const Searches: React.FC<Props> = ({ project }) => {
           acc[col] = DEFAULT_COLUMN_WIDTH;
           return acc;
         }, {});
-      updateSettings({
-        columns: newColumnsOrder,
+      setColumnWidths({
         columnWidths: {
           ...settings.columnWidths,
           ...newColumnWidths,
         },
+      });
+      updateSettings({
+        columns: newColumnsOrder,
         pinnedColumnsCount: isUndefined(pinnedCount) ? settings.pinnedColumnsCount : pinnedCount,
       });
     },
-    [updateSettings, settings.pinnedColumnsCount, settings.columnWidths],
+    [setColumnWidths, updateSettings, settings.pinnedColumnsCount, settings.columnWidths],
   );
 
   const handleRowHeightChange = useCallback(
@@ -586,14 +591,14 @@ const Searches: React.FC<Props> = ({ project }) => {
 
   const handleColumnWidthChange = useCallback(
     (columnId: string, width: number) => {
-      updateSettings({
+      setColumnWidths({
         columnWidths: {
           ...settings.columnWidths,
           [columnId]: width,
         },
       });
     },
-    [updateSettings, settings.columnWidths],
+    [setColumnWidths, settings.columnWidths],
   );
 
   const columnsIfLoaded = useMemo(

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -8,6 +8,7 @@ import {
   defaultNumberColumn,
   defaultSelectionColumn,
   defaultTextColumn,
+  MIN_COLUMN_WIDTH,
   MULTISELECT,
 } from 'hew/DataGrid/columns';
 import DataGrid, {
@@ -594,7 +595,7 @@ const Searches: React.FC<Props> = ({ project }) => {
       setColumnWidths({
         columnWidths: {
           ...settings.columnWidths,
-          [columnId]: width,
+          [columnId]: Math.max(MIN_COLUMN_WIDTH, width),
         },
       });
     },


### PR DESCRIPTION

## Ticket
ET-641



## Description
This debounces the column width settings for the searches pages.




## Test Plan

1. Open your browsers devtools and navigate to the network tab.
2. navigate the page to a project search list.
3. change the sort order either by using the column header menu or the dropdown menu. Note that there should be one POST request to settings per change.
4. change the width of any column. Only one POST request should be made when the column width is done moving.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ