### PR TITLE
chore: add auto-create namespace & set resource quota test cases for workspace_namespace bindings

### DIFF
--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -737,7 +737,7 @@ def test_set_workspace_namespace_bindings(
                 "--cluster-name",
                 conf.DEFAULT_RM_CLUSTER_NAME,
                 "--auto-create-namespace",
-                "--set_resource_quota-quota",
+                "--resource-quota",
                 "1",
             ],
         )
@@ -753,7 +753,7 @@ def test_set_workspace_namespace_bindings(
                 "create",
                 w_name,
                 "--auto-create-namespace",
-                "--set_resource_quota-quota",
+                "--resource-quota",
                 "1",
             ],
         )
@@ -763,7 +763,7 @@ def test_set_workspace_namespace_bindings(
     w_name = uuid.uuid4().hex[:8]
     detproc.check_error(
         sess,
-        ["det", "w", "create", w_name, "--set_resource_quota-quota", "1"],
+        ["det", "w", "create", w_name, "--resource-quota", "1"],
         "cannot set resource quota on a namespace that was not auto-created by Determined.",
     )
 

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -724,6 +724,30 @@ def test_set_workspace_namespace_bindings(
     output = detproc.check_output(sess, set_binding_cmd + ["--namespace", namespace])
     assert bound_to_namespace in output
 
+    # Auto-Create namespace
+    if is_multirm_cluster:
+        w_name = uuid.uuid4().hex[:8]
+        output = detproc.check_output(
+            sess,
+            [
+                "det",
+                "w",
+                "create",
+                w_name,
+                "--cluster-name",
+                conf.DEFAULT_RM_CLUSTER_NAME,
+                "--auto-create-namespace",
+            ],
+        )
+        assert bound_to_namespace in output
+    else:
+        w_name = uuid.uuid4().hex[:8]
+        output = detproc.check_output(
+            sess,
+            ["det", "w", "create", w_name, "--auto-create-namespace"],
+        )
+        assert bound_to_namespace in output
+
 
 @pytest.mark.e2e_gpu
 @pytest.mark.e2e_multi_k8s

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -1,6 +1,7 @@
 import contextlib
 import http
 import os
+import re
 import tempfile
 import uuid
 from typing import Generator, List, Optional, Tuple
@@ -742,6 +743,21 @@ def test_set_workspace_namespace_bindings(
             ],
         )
         assert bound_to_namespace in output
+
+        output = detproc.check_output(
+            sess,
+            [
+                "det",
+                "w",
+                "resource-quota",
+                "set",
+                w_name,
+                "5",
+                "--cluster-name",
+                conf.DEFAULT_RM_CLUSTER_NAME,
+            ],
+        )
+        assert re.search(r"Resource quota .* is set on workspace", output)
     # SingleRM: No cluster name, no namespace name, auto-create namespace & resource quota.
     else:
         w_name = uuid.uuid4().hex[:8]
@@ -758,6 +774,19 @@ def test_set_workspace_namespace_bindings(
             ],
         )
         assert bound_to_namespace in output
+
+        output = detproc.check_output(
+            sess,
+            [
+                "det",
+                "w",
+                "resource-quota",
+                "set",
+                w_name,
+                "5",
+            ],
+        )
+        assert re.search(r"Resource quota .* is set on workspace", output)
 
     # MultiRM & SingleRM: fail to set resource quota on a workspace without a namespace binding.
     w_name = uuid.uuid4().hex[:8]

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -737,8 +737,8 @@ def test_set_workspace_namespace_bindings(
                 "--cluster-name",
                 conf.DEFAULT_RM_CLUSTER_NAME,
                 "--auto-create-namespace",
-                "--resource-quota",
-                "cpu=1,memory=1G",
+                "--set_resource_quota-quota",
+                "1",
             ],
         )
         assert bound_to_namespace in output
@@ -753,30 +753,18 @@ def test_set_workspace_namespace_bindings(
                 "create",
                 w_name,
                 "--auto-create-namespace",
-                "--resource-quota",
-                "cpu=1,memory=1G",
+                "--set_resource_quota-quota",
+                "1",
             ],
         )
         assert bound_to_namespace in output
 
-    # MultiRM & SingleRM: fail to set resource quota, if namespace is not created by determined.
+    # MultiRM & SingleRM: fail to set resource quota on a workspace without a namespace binding.
     w_name = uuid.uuid4().hex[:8]
     detproc.check_error(
         sess,
-        [
-            "det",
-            "w",
-            "bindings",
-            "set",
-            w_name,
-            "--cluster-name",
-            conf.DEFAULT_RM_CLUSTER_NAME,
-            "--namespace",
-            namespace,
-            "--resource-quota",
-            "cpu=1,memory=1G",
-        ],
-        "error setting resource quota",
+        ["det", "w", "create", w_name, "--set_resource_quota-quota", "1"],
+        "cannot set resource quota on a namespace that was not auto-created by Determined.",
     )
 
 

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -669,6 +669,12 @@ def test_set_workspace_namespace_bindings(
         )
         assert bound_to_namespace in output
 
+        detproc.check_error(
+            sess,
+            ["det", "w", "resource-quota", "set", w_name, "5"],
+            "cannot set quota on a workspace that is not bound to an auto-created namespace",
+        )
+
     # MultiRM: Valid cluster name, no namespace name.
     if is_multirm_cluster:
         w_name = uuid.uuid4().hex[:8]
@@ -758,6 +764,13 @@ def test_set_workspace_namespace_bindings(
             ],
         )
         assert re.search(r"Resource quota .* is set on workspace", output)
+
+        detproc.check_error(
+            sess,
+            ["det", "w", "resource-quota", "set", w_name, "-5"],
+            "must be greater than or equal to 0",
+        )
+
     # SingleRM: No cluster name, no namespace name, auto-create namespace & resource quota.
     else:
         w_name = uuid.uuid4().hex[:8]

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -814,8 +814,17 @@ def test_set_workspace_namespace_bindings(
     w_name = uuid.uuid4().hex[:8]
     detproc.check_error(
         sess,
-        ["det", "w", "create", w_name, "--resource-quota", "1"],
-        "cannot set resource quota on a namespace that was not auto-created by Determined.",
+        [
+            "det",
+            "w",
+            "create",
+            w_name,
+            "--resource-quota",
+            "1",
+            "--cluster-name",
+            conf.DEFAULT_RM_CLUSTER_NAME,
+        ],
+        "Failed to create workspace: must provide --namespace NAMESPACE or --auto-create-namespace",
     )
 
 

--- a/e2e_tests/tests/cluster/test_workspace_org.py
+++ b/e2e_tests/tests/cluster/test_workspace_org.py
@@ -767,7 +767,16 @@ def test_set_workspace_namespace_bindings(
 
         detproc.check_error(
             sess,
-            ["det", "w", "resource-quota", "set", w_name, "-5"],
+            [
+                "det",
+                "w",
+                "resource-quota",
+                "set",
+                w_name,
+                "-5",
+                "--cluster-name",
+                conf.DEFAULT_RM_CLUSTER_NAME,
+            ],
             "must be greater than or equal to 0",
         )
 

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -173,7 +173,7 @@ def set_workspace_namespace_binding(args: argparse.Namespace) -> None:
         args.namespace or args.auto_create_namespace or args.auto_create_namespace_all_clusters
     ):
         raise api.errors.BadRequestException(
-            "must provide --namespace NAMESPACE or --auto-creeate-namespace, or remove "
+            "must provide --namespace NAMESPACE or --auto-create-namespace, or remove "
             + "--cluster-name CLUSTER_NAME and specify --auto-create-namespace-all-clusters"
         )
 

--- a/harness/determined/cli/workspace.py
+++ b/harness/determined/cli/workspace.py
@@ -271,7 +271,7 @@ def create_workspace(args: argparse.Namespace) -> None:
     set_namespace = args.namespace or auto_create_namespace
     if args.cluster_name and not set_namespace:
         raise api.errors.BadRequestException(
-            "must provide --namespace NAMESPACE or --auto-creeate-namespace, or remove "
+            "must provide --namespace NAMESPACE or --auto-create-namespace, or remove "
             + "--cluster-name CLUSTER_NAME and specify --auto-create-namespace-all-clusters"
         )
 

--- a/master/internal/api_workspace.go
+++ b/master/internal/api_workspace.go
@@ -886,7 +886,7 @@ func (a *apiServer) setWorkspaceNamespaceBindings(ctx context.Context,
 		}
 
 		// Since workspace-namespace bindings for the default namespace of a given cluster are not
-		// automatically saved in the database, maintain constistency by not saving default
+		// automatically saved in the database, maintain consistency by not saving default
 		// namespace bindings to the db if a user tries to set them.
 		defaultNamespace, err := a.m.rm.DefaultNamespace(clusterName)
 		if err != nil {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
DET-10423
DET-10425


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add additional test cases for auto-creating namespaces & setting resource quotas when creating a workspace in a cluster using multi/single K8s resource managers.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- N/A (ensure these tests pass)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ