### PR TITLE
chore: default flat runs to on

### DIFF
--- a/docs/release-notes/run-centric-ux.rst
+++ b/docs/release-notes/run-centric-ux.rst
@@ -2,23 +2,19 @@
 
 **New Features**
 
--  WebUI: Turn on new run-centric search view
+- WebUI: In the Experimental features, Flat Runs View is now "on" by default in the :ref:`WebUI
+<web-ui-if>`. Users can still toggle this feature "off".
 
-   -  This replaces the existing experiment search and multi-trial experiment views with views that
-      allow comparison between arbitrary trials.
+- This update improves the ability to compare model performance between different trials, based on user feedback that most Determined users run single-trial experiments.
 
-   -  We recieved user feedback indicating that users of Determined run primarily single-trial
-      experiments, and the preexisting views made comparing model performance between different
-      trials difficult.
 
-   -  We are renaming experiments to searches and trials to runs to make the difference between the
-      two easier to understand.
+- "Experiments" is now renamed to "searches" and "trials" is now renamed to "runs" for better clarity.
 
-   -  The experiment list is now the run list, which shows all trials from experiments in the
-      project. It should function similar to the previous new experiment list.
+- The "experiment list" is renamed the "run list", showing all trials from experiments in the
+      project. It functions similarly to the previous new experiment list.
 
    -  Multi-trial experiments can be viewed in the new searches view, which allows for sorting,
-      filtering and navigation of the multi-trial experiments in the project.
+      filtering and navigating multi-trial experiments.
 
-   -  When viewing a multi-trial experiment, we now show a list of trials in the experiment to allow
-      for sorting, filtering and arbitrary comparison.
+- When viewing a multi-trial experiment, a list of trials is displayed, allowing
+      for sorting, filtering and arbitrary comparison between trials.

--- a/docs/release-notes/run-centric-ux.rst
+++ b/docs/release-notes/run-centric-ux.rst
@@ -2,19 +2,15 @@
 
 **New Features**
 
-- WebUI: In the Experimental features, Flat Runs View is now "on" by default in the :ref:`WebUI
-<web-ui-if>`. Users can still toggle this feature "off".
-
-- This update improves the ability to compare model performance between different trials, based on user feedback that most Determined users run single-trial experiments.
-
-
-- "Experiments" is now renamed to "searches" and "trials" is now renamed to "runs" for better clarity.
-
-- The "experiment list" is renamed the "run list", showing all trials from experiments in the
-      project. It functions similarly to the previous new experiment list.
-
-   -  Multi-trial experiments can be viewed in the new searches view, which allows for sorting,
-      filtering and navigating multi-trial experiments.
-
-- When viewing a multi-trial experiment, a list of trials is displayed, allowing
-      for sorting, filtering and arbitrary comparison between trials.
+-  WebUI: In the Experimental features, Flat Runs View is now "on" by default in the :ref:`WebUI
+   <web-ui-if>`\. Users can still toggle this feature "off".
+-  This update improves the ability to compare model performance between different trials, based on
+   user feedback that most Determined users run single-trial experiments.
+-  "Experiments" is now renamed to "searches" and "trials" is now renamed to "runs" for better
+   clarity.
+-  The "experiment list" is renamed the "run list", showing all trials from experiments in the
+   project. It functions similarly to the previous new experiment list.
+-  Multi-trial experiments can be viewed in the new searches view, which allows for sorting,
+   filtering and navigating multi-trial experiments.
+-  When viewing a multi-trial experiment, a list of trials is displayed, allowing for sorting,
+   filtering and arbitrary comparison between trials.

--- a/docs/release-notes/run-centric-ux.rst
+++ b/docs/release-notes/run-centric-ux.rst
@@ -1,0 +1,24 @@
+:orphan:
+
+**New Features**
+
+-  WebUI: Turn on new run-centric search view
+
+   -  This replaces the existing experiment search and multi-trial experiment views with views that
+      allow comparison between arbitrary trials.
+
+   -  We recieved user feedback indicating that users of Determined run primarily single-trial
+      experiments, and the preexisting views made comparing model performance between different
+      trials difficult.
+
+   -  We are renaming experiments to searches and trials to runs to make the difference between the
+      two easier to understand.
+
+   -  The experiment list is now the run list, which shows all trials from experiments in the
+      project. It should function similar to the previous new experiment list.
+
+   -  Multi-trial experiments can be viewed in the new searches view, which allows for sorting,
+      filtering and navigation of the multi-trial experiments in the project.
+
+   -  When viewing a multi-trial experiment, we now show a list of trials in the experiment to allow
+      for sorting, filtering and arbitrary comparison.

--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -53,7 +53,7 @@ describe('ProjectCard', () => {
   it('should display experiments count', () => {
     setup();
     expect(
-      screen.getByText(projectMock.numExperiments?.toString() ?? 'Count undefined'),
+      screen.getByText(projectMock.numRuns?.toString() ?? 'Count undefined'),
     ).toBeInTheDocument();
   });
 

--- a/webui/react/src/components/ProjectCard.test.tsx
+++ b/webui/react/src/components/ProjectCard.test.tsx
@@ -18,6 +18,7 @@ const projectMock: Project = {
   notes: [],
   numActiveExperiments: 1,
   numExperiments: 16,
+  numRuns: 16,
   state: 'UNSPECIFIED',
   userId: 1354,
   workspaceId: 1684,

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -40,6 +40,17 @@ export const test = baseTest.extend<CustomFixtures, CustomWorkerFixtures>({
         username: newAdmin.user!.username,
       },
     });
+    await apiAuth.apiContext?.post('/api/v1/users/setting', {
+      data: {
+        settings: [
+          {
+            key: 'flat_runs',
+            storagePath: 'global-features',
+            value: 'false',
+          },
+        ],
+      },
+    });
     await use(apiAuth);
   },
 

--- a/webui/react/src/e2e/fixtures/global-fixtures.ts
+++ b/webui/react/src/e2e/fixtures/global-fixtures.ts
@@ -79,6 +79,17 @@ export const test = baseTest.extend<CustomFixtures, CustomWorkerFixtures>({
     async ({ playwright, browser }, use) => {
       const backgroundApiAuth = new ApiAuthFixture(playwright.request, browser, apiUrl());
       await backgroundApiAuth.loginApi();
+      await backgroundApiAuth.apiContext?.post('/api/v1/users/setting', {
+        data: {
+          settings: [
+            {
+              key: 'flat_runs',
+              storagePath: 'global-features',
+              value: 'false',
+            },
+          ],
+        },
+      });
       await use(backgroundApiAuth);
       await backgroundApiAuth.dispose();
     },

--- a/webui/react/src/hooks/useFeature.ts
+++ b/webui/react/src/hooks/useFeature.ts
@@ -29,7 +29,7 @@ export const FEATURES: Record<ValidFeature, FeatureDescription> = {
     friendlyName: 'New Experiment List',
   },
   flat_runs: {
-    defaultValue: false,
+    defaultValue: true,
     description:
       'Presents all runs in a project in a single view, rather than grouped into experiments',
     friendlyName: 'Flat Runs View',

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.test.tsx
@@ -31,6 +31,16 @@ vi.mock('react-router-dom', async (importOriginal) => ({
   useParams: vi.fn(),
 }));
 
+vi.mock('hooks/useFeature', () => {
+  return {
+    default: () => ({
+      isOn() {
+        return false;
+      },
+    }),
+  };
+});
+
 vi.mock('services/api', () => ({
   getExperimentDetails: vi.fn(),
   getExpTrials: vi.fn(),


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-636



## Description
This defaults the flat runs view to on while also adding release notes



## Test Plan
* clear your settings
* go to the uncategorized project page
* you should see the flat runs view



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ