### PR TITLE
chore: lengthen abbreviation to avoid ambiguity

### DIFF
--- a/harness/determined/cli/resources.py
+++ b/harness/determined/cli/resources.py
@@ -48,7 +48,7 @@ args_description: cli.ArgsDescription = [
         "query historical resource allocation",
         [
             cli.Cmd(
-                "all|ocations",
+                "alloc|ations",
                 csv,
                 "get a detailed csv of resource allocation at an allocation level",
                 [


### PR DESCRIPTION
## Description

First time using the `det resources` CLI and I think the help text could be improved. One quick thing to squeeze in before release is a new command that gets abbreviated as "all", which I think could be confusing as it's not like an option to return all allocations, which is kinda how it reads.

## Test Plan

Going to install and manually verify

## Checklist

- [ NOT YET! ] Changes have been manually QA'd
- [ Y ] New features have been approved by the corresponding PM
- [ N ] User-facing API changes have the "User-facing API Change" label
- [ N/A ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ N/A ] Licenses have been included for new code which was copied and/or modified from any external code