### PR TITLE
fix: load trial data for single run searches in search view

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.tsx
@@ -120,7 +120,7 @@ const ExperimentSingleTrialTabs: React.FC<Props> = ({
       // make sure the experiment is in terminal state before the request is made.
       const isTerminalExp = terminalRunStates.has(experiment.state);
       const expTrials = await getExpTrials(
-        { id: experiment.id, limit: 2 },
+        { id: experiment.id, limit: 1 },
         { signal: canceler.signal },
       );
       const firstTrial = expTrials.trials[0];

--- a/webui/react/src/pages/SearchDetails.tsx
+++ b/webui/react/src/pages/SearchDetails.tsx
@@ -1,6 +1,6 @@
 import Pivot, { PivotProps } from 'hew/Pivot';
 import Notes from 'hew/RichTextEditor';
-import { Loadable } from 'hew/utils/loadable';
+import { Loadable, NotLoaded } from 'hew/utils/loadable';
 import { string } from 'io-ts';
 import _ from 'lodash';
 import { useObservable } from 'micro-observables';
@@ -9,14 +9,16 @@ import { unstable_useBlocker, useLocation, useNavigate, useParams } from 'react-
 
 import Page, { BreadCrumbRoute } from 'components/Page';
 import { terminalRunStates } from 'constants/states';
+import { useAsync } from 'hooks/useAsync';
 import usePermissions from 'hooks/usePermissions';
 import usePolling from 'hooks/usePolling';
 import { SettingsConfig, useSettings } from 'hooks/useSettings';
 import { paths } from 'routes/utils';
-import { getExperimentDetails, patchExperiment } from 'services/api';
+import { getExperimentDetails, getExpTrials, patchExperiment } from 'services/api';
 import workspaceStore from 'stores/workspaces';
-import { ExperimentBase, Note, ValueOf, Workspace } from 'types';
+import { ExperimentBase, Note, TrialItem, ValueOf, Workspace } from 'types';
 import handleError, { ErrorLevel, ErrorType } from 'utils/error';
+import { isSingleTrialExperiment } from 'utils/experiment';
 import { isAborted, isNotFound } from 'utils/service';
 
 import ExperimentCodeViewer from './ExperimentDetails/ExperimentCodeViewer';
@@ -119,6 +121,32 @@ const SearchDetails: React.FC = () => {
       if (!pageError && !isAborted(e)) setPageError(e as Error);
     }
   }, [pageError, searchId]);
+
+  const singleTrialData = useAsync<TrialItem | undefined>(
+    async (canceler) => {
+      if (!experiment || !isSingleTrialExperiment(experiment)) {
+        return NotLoaded;
+      }
+      try {
+        const trialsResponse = await getExpTrials(
+          { id: experiment.id, limit: 2 },
+          { signal: canceler.signal },
+        );
+        return trialsResponse.trials[0];
+      } catch (e) {
+        if (!canceler.signal.aborted) {
+          handleError(e, {
+            level: ErrorLevel.Error,
+            publicMessage: 'Failed to fetch run information for search',
+            silent: false,
+            type: ErrorType.Server,
+          });
+        }
+      }
+      return NotLoaded;
+    },
+    [experiment],
+  );
 
   const handleNotesUpdate = useCallback(
     async (notes: Note) => {
@@ -237,6 +265,7 @@ const SearchDetails: React.FC = () => {
           <ExperimentDetailsHeader
             experiment={experiment}
             fetchExperimentDetails={fetchExperimentDetails}
+            trial={singleTrialData.getOrElse(undefined)}
           />
         )
       }


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-647



## Description
This loads trial data for single run searches in the search view. this prevents issues with the continue trial where the trial information was missing in the experiment config.

## Test Plan
when visiting the search page of a single-run search, both options on the "Continue Run" menu button should open a modal.

## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ