### PR TITLE
Revert "chore: add configurable posix claims fields to master config [RM-398]"

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -119,17 +119,6 @@ stringData:
       {{- if .Values.oidc.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.oidc.displayNameAttributeName }}
       {{- end }}
-      {{- if .Values.oidc.agentUidAttributeName }}
-      agent_uid_attribute_name: {{ .Values.oidc.agentUidAttributeName }}
-      {{- end }}
-      {{- if .Values.oidc.agentGidAttributeName }}
-      agent_gid_attribute_name: {{ .Values.oidc.agentGidAttributeName }}
-      {{- end }}
-      {{- if .Values.oidc.agentUserNameAttributeName }}
-      agent_user_name_attribute_name: {{ .Values.oidc.agentUserNameAttributeName }}
-      {{- end }}
-      {{- if .Values.oidc.agentGroupNameAttributeName }}
-      agent_group_name_attribute_name: {{ .Values.oidc.agentGroupNameAttributeName }}
       {{- if .Values.oidc.alwaysRedirect }}
       always_redirect: {{ .Values.oidc.alwaysRedirect }}
       {{- end }}
@@ -163,17 +152,6 @@ stringData:
       {{- if .Values.saml.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.saml.displayNameAttributeName }}
       {{- end }}
-      {{- if .Values.saml.agentUidAttributeName }}
-      agent_uid_attribute_name: {{ .Values.saml.agentUidAttributeName }}
-      {{- end }}
-      {{- if .Values.saml.agentGidAttributeName }}
-      agent_gid_attribute_name: {{ .Values.saml.agentGidAttributeName }}
-      {{- end }}
-      {{- if .Values.saml.agentUserNameAttributeName }}
-      agent_user_name_attribute_name: {{ .Values.saml.agentUserNameAttributeName }}
-      {{- end }}
-      {{- if .Values.saml.agentGroupNameAttributeName }}
-      agent_group_name_attribute_name: {{ .Values.saml.agentGroupNameAttributeName }}
       {{- if .Values.saml.alwaysRedirect }}
       always_redirect: {{ .Values.saml.alwaysRedirect }}
       {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -124,10 +124,6 @@ useNodePortForMaster: false
 #   autoProvisionUsers:
 #   groupsAttributeName:
 #   displayNameAttributeName:
-#   agentUidAttributeName:
-#   agentGidAttributeName:
-#   agentUserNameAttributeName:
-#   agentGroupNameAttributeName:
 #   alwaysRedirect:
 
 # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
@@ -153,10 +149,6 @@ useNodePortForMaster: false
 #   autoProvisionUsers:
 #   groupsAttributeName:
 #   displayNameAttributeName:
-#   agentUidAttributeName:
-#   agentGidAttributeName:
-#   agentUserNameAttributeName:
-#   agentGroupNameAttributeName:
 #   alwaysRedirect:
 
 # db sets the configurations for the database.

--- a/master/internal/config/oidc_config.go
+++ b/master/internal/config/oidc_config.go
@@ -17,10 +17,6 @@ type OIDCConfig struct {
 	AutoProvisionUsers          bool   `json:"auto_provision_users"`
 	GroupsAttributeName         string `json:"groups_attribute_name"`
 	DisplayNameAttributeName    string `json:"display_name_attribute_name"`
-	AgentUIDAttributeName       int    `json:"agent_uid_attribute_name"`
-	AgentGIDAttributeName       int    `json:"agent_gid_attribute_name"`
-	AgentUserNameAttributeName  string `json:"agent_user_name_attribute_name"`
-	AgentGroupNameAttributeName string `json:"agent_group_name_attribute_name"`
 	AlwaysRedirect              bool   `json:"always_redirect"`
 }
 

--- a/master/internal/config/saml_config.go
+++ b/master/internal/config/saml_config.go
@@ -8,20 +8,16 @@ import (
 
 // SAMLConfig describes config for SAML.
 type SAMLConfig struct {
-	Enabled                     bool   `json:"enabled"`
-	Provider                    string `json:"provider"`
-	IDPRecipientURL             string `json:"idp_recipient_url"`
-	IDPSSOURL                   string `json:"idp_sso_url"`
-	IDPSSODescriptorURL         string `json:"idp_sso_descriptor_url"`
-	IDPMetadataURL              string `json:"idp_metadata_url"`
-	AutoProvisionUsers          bool   `json:"auto_provision_users"`
-	GroupsAttributeName         string `json:"groups_attribute_name"`
-	DisplayNameAttributeName    string `json:"display_name_attribute_name"`
-	AgentUIDAttributeName       int    `json:"agent_uid_attribute_name"`
-	AgentGIDAttributeName       int    `json:"agent_gid_attribute_name"`
-	AgentUserNameAttributeName  string `json:"agent_user_name_attribute_name"`
-	AgentGroupNameAttributeName string `json:"agent_group_name_attribute_name"`
-	AlwaysRedirect              bool   `json:"always_redirect"`
+	Enabled                  bool   `json:"enabled"`
+	Provider                 string `json:"provider"`
+	IDPRecipientURL          string `json:"idp_recipient_url"`
+	IDPSSOURL                string `json:"idp_sso_url"`
+	IDPSSODescriptorURL      string `json:"idp_sso_descriptor_url"`
+	IDPMetadataURL           string `json:"idp_metadata_url"`
+	AutoProvisionUsers       bool   `json:"auto_provision_users"`
+	GroupsAttributeName      string `json:"groups_attribute_name"`
+	DisplayNameAttributeName string `json:"display_name_attribute_name"`
+	AlwaysRedirect           bool   `json:"always_redirect"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -45,26 +45,18 @@ type Service struct {
 
 // userConfig represents the user defined configurations for SAML integration.
 type userConfig struct {
-	autoProvisionUsers          bool
-	groupsAttributeName         string
-	displayNameAttributeName    string
-	agentUIDAttributeName       int
-	agentGIDAttributeName       int
-	agentUserNameAttributeName  string
-	agentGroupNameAttributeName string
+	autoProvisionUsers       bool
+	groupsAttributeName      string
+	displayNameAttributeName string
 }
 
 // New constructs a new SAML service that is capable of sending SAML requests and consuming
 // responses.
 func New(db *db.PgDB, c config.SAMLConfig) (*Service, error) {
 	uc := userConfig{
-		autoProvisionUsers:          c.AutoProvisionUsers,
-		groupsAttributeName:         c.GroupsAttributeName,
-		displayNameAttributeName:    c.DisplayNameAttributeName,
-		agentUIDAttributeName:       c.AgentUIDAttributeName,
-		agentGIDAttributeName:       c.AgentGIDAttributeName,
-		agentUserNameAttributeName:  c.AgentUserNameAttributeName,
-		agentGroupNameAttributeName: c.AgentGroupNameAttributeName,
+		autoProvisionUsers:       c.AutoProvisionUsers,
+		groupsAttributeName:      c.GroupsAttributeName,
+		displayNameAttributeName: c.DisplayNameAttributeName,
 	}
 
 	key, cert, err := proxy.GenSignedCert()


### PR DESCRIPTION
Reverts determined-ai/determined#9690

I think this branch caused ci failures that were masked by other failures. Reverting to investigate.