### PR TITLE
feat: Auto-Populate POSIX Information on sign in using SSO [CM-399]

### DIFF
--- a/docs/manage/users-remote.rst
+++ b/docs/manage/users-remote.rst
@@ -94,10 +94,10 @@ relevant field, e.g. ``agent_uid_attribute_name: "custom_uid_attribute_name"``.
 
 .. note::
 
-Once this feature is enabled and an agent UID/GID is set for a user, the UID/GID can only be reset
-manually. In order to have have the UID or GID revert back to using the
-security.default_task.uid(gid), an admin needs to manually remove the agent UID/GID settings for
-that user.
+   Once this feature is enabled and an agent UID/GID is set for a user, the UID/GID can only be
+   reset manually. In order to have have the UID or GID revert back to using the
+   security.default_task.uid(gid), an admin needs to manually remove the agent UID/GID settings for
+   that user.
 
 Set the Groups Claim Name Option
 ================================

--- a/docs/manage/users-remote.rst
+++ b/docs/manage/users-remote.rst
@@ -89,14 +89,16 @@ enable user auto-provisioning and the remote management of any information attac
 Determined sets the username of the user to the IdP email address. You cannot set the username
 independently.
 
-Custom claims can be recognized and automatically linked by configuring the attribute name with the
-relevant field, e.g. ``agent_uid_attribute_name: "custom_uid_attribute_name"``.
+To automatically link custom claims, you can configure the attribute name with the relevant field.
+For example:
+
+``agent_uid_attribute_name: "custom_uid_attribute_name"``
 
 .. note::
 
-   Once this feature is enabled and an agent UID/GID is set for a user, the UID/GID can only be
-   reset manually. In order to have have the UID or GID revert back to using the
-   security.default_task.uid(gid), an admin needs to manually remove the agent UID/GID settings for
+   Once this feature is enabled and an agent UID/GID is assigned to a user, it can only be reset
+   manually. To revert the UID or GID back to the default value specified by
+   ``security.default_task.uid(gid)``, an admin must manually remove the agent UID/GID settings for
    that user.
 
 Set the Groups Claim Name Option

--- a/docs/manage/users-remote.rst
+++ b/docs/manage/users-remote.rst
@@ -90,7 +90,7 @@ Determined sets the username of the user to the IdP email address. You cannot se
 independently.
 
 Custom claims can be recognized and automatically linked by configuring the attribute name with the
-relevant field, e.g. `agent_uid_attribute_name: "custom_uid_attribute_name"`.
+relevant field, e.g. ``agent_uid_attribute_name: "custom_uid_attribute_name"``.
 
 .. note::
 

--- a/docs/manage/users-remote.rst
+++ b/docs/manage/users-remote.rst
@@ -52,6 +52,10 @@ enable user auto-provisioning and the remote management of any information attac
              auto_provision_users: true
              always_redirect: true
              display_name_attribute_name: "XYZ"
+             agent_uid_attribute_name: "user_id_key"
+             agent_gid_attribute_name: "group_id_key"
+             agent_user_name_attribute_name: "agent_user_key"
+             agent_group_name_attribute_name: "agent_group_key"
 
    .. tab::
 
@@ -77,9 +81,23 @@ enable user auto-provisioning and the remote management of any information attac
              idp_metadata_path: "https://myorg.okta.com/app/.../sso/saml/metadata"
              auto_provision_users: true
              always_redirect: true
+             agent_uid_attribute_name: "user_id_key"
+             agent_gid_attribute_name: "group_id_key"
+             agent_user_name_attribute_name: "agent_user_key"
+             agent_group_name_attribute_name: "agent_group_key"
 
 Determined sets the username of the user to the IdP email address. You cannot set the username
 independently.
+
+Custom claims can be recognized and automatically linked by configuring the attribute name with the
+relevant field, e.g. `agent_uid_attribute_name: "custom_uid_attribute_name"`.
+
+.. note::
+
+Once this feature is enabled and an agent UID/GID is set for a user, the UID/GID can only be reset
+manually. In order to have have the UID or GID revert back to using the
+security.default_task.uid(gid), an admin needs to manually remove the agent UID/GID settings for
+that user.
 
 Set the Groups Claim Name Option
 ================================

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1766,7 +1766,7 @@ used for :ref:`remote user <remote-users>` management.
           scim_authentication_attribute: "string"
           auto_provision_users: true
           groups_attribute_name: "XYZ"
-          display_name_attribute_name: "string"
+          display_name_attribute_name: "XYZ"
           agent_uid_attribute_name: "string"
           agent_gid_attribute_name: "string"
           agent_user_name_attribute_name: "string"

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1741,6 +1741,8 @@ The username for HTTP basic authentication (only allowed with ``type: basic``).
 
 The password for HTTP basic authentication (only allowed with ``type: basic``).
 
+.. _master-config-oidc:
+
 **********
  ``oidc``
 **********
@@ -1764,7 +1766,11 @@ used for :ref:`remote user <remote-users>` management.
           scim_authentication_attribute: "string"
           auto_provision_users: true
           groups_attribute_name: "XYZ"
-          display_name_attribute_name: "XYZ"
+          display_name_attribute_name: "string"
+          agent_uid_attribute_name: "string"
+          agent_gid_attribute_name: "string"
+          agent_user_name_attribute_name: "string"
+          agent_group_name_attribute_name: "string"
           always_redirect: true
           exclude_groups_scope: false
 
@@ -1836,6 +1842,30 @@ The name of the attribute passed in through the claim that specifies group membe
 The name of the attribute passed in through the claim from the OIDC provider used to set the user's
 display name in Determined.
 
+``agent_uid_attribute_name``
+============================
+
+The name of the attribute passed in through the claim from the OIDC provider used to set a unique
+numeric ID for user.
+
+``agent_gid_attribute_name``
+============================
+
+The name of the attribute passed in through the claim from the OIDC provider used to set a unique
+numeric ID for group.
+
+``agent_user_name_attribute_name``
+==================================
+
+The name of the attribute passed in through the claim from the OIDC provider used to set a unique
+name for user.
+
+``agent_group_name_attribute_name``
+===================================
+
+The name of the attribute passed in through the claim from the OIDC provider used to set a unique
+name for group.
+
 ``always_redirect``
 ===================
 
@@ -1850,6 +1880,8 @@ and returned to the requested page after authentication.
 Specifies if the groups scope should be excluded for this OIDC provider. For most OIDC providers
 such as Okta, this should be false (or blank) if you'd like to provision group memberships. But for
 some providers such as Azure, that do not support groups scope, this should be set to true.
+
+.. _master-config-saml:
 
 **********
  ``saml``
@@ -1872,7 +1904,11 @@ For example:
           auto_provision_users: true
           groups_attribute_name: "groups"
           display_name_attribute_name: "disp_name"
-         always_redirect: true
+          agent_uid_attribute_name: "user_id_name"
+          agent_gid_attribute_name: "group_id_name"
+          agent_user_name_attribute_name: "agent_user_name"
+          agent_group_name_attribute_name: "agent_group_name"
+          always_redirect: true
 
 ``enabled``
 ===========
@@ -1921,6 +1957,30 @@ The claim name that specifies group memberships in SAML.
 ===============================
 
 The claim name from the SAML provider used to set the user's display name in Determined.
+
+``agent_uid_attribute_name``
+============================
+
+The name of the attribute passed in through the claim from the SAML provider used to set a unique
+numeric ID for user.
+
+``agent_gid_attribute_name``
+============================
+
+The name of the attribute passed in through the claim from the SAML provider used to set a unique
+numeric ID for group.
+
+``agent_user_name_attribute_name``
+==================================
+
+The name of the attribute passed in through the claim from the SAML provider used to set a unique
+name for user.
+
+``agent_group_name_attribute_name``
+===================================
+
+The name of the attribute passed in through the claim from the SAML provider used to set a unique
+name for group.
 
 ``always_redirect``
 ===================

--- a/docs/release-notes/auto-populate-posix.rst
+++ b/docs/release-notes/auto-populate-posix.rst
@@ -2,8 +2,8 @@
 
 **New Features**
 
--  Master Configuration: Master Configuration accepts POSIX claims `agent_uid_attribute_name`,
-   `agent_gid_attribute_name`, `agent_user_name_attribute_name`, or
-   `agent_group_name_attribute_name`. Please visit :ref:`oidc master configuration
-   <_master-config-oidc>` or :ref:`saml master configuration <_master-config-saml>` for details. If
-   any of the fields are configured, they will be used and synced to the database.
+-  Master Configuration: Add support for POSIX claims in the master configuration. It now accepts
+   `agent_uid_attribute_name`, `agent_gid_attribute_name`, `agent_user_name_attribute_name`, or
+   `agent_group_name_attribute_name`. Refer to the :ref:OIDC master configuration
+   <master-config-oidc> or :ref:SAML master configuration <master-config-saml> for details. If any
+   of these fields are configured, they will be used and synced to the database.

--- a/docs/release-notes/auto-populate-posix.rst
+++ b/docs/release-notes/auto-populate-posix.rst
@@ -2,5 +2,8 @@
 
 **New Features**
 
-- Master Configuration: Master Configuration accepts POSIX claims `agent_uid_attribute_name`, `agent_gid_attribute_name`, `agent_user_name_attribute_name`, or `agent_group_name_attribute_name`. Please visit :ref:`oidc master configuration <_master-config-oidc>` or :ref:`saml master configuration <_master-config-saml>` for details. If any of the fields are configured, they will be used and synced to the database.
-. 
+-  Master Configuration: Master Configuration accepts POSIX claims `agent_uid_attribute_name`,
+   `agent_gid_attribute_name`, `agent_user_name_attribute_name`, or
+   `agent_group_name_attribute_name`. Please visit :ref:`oidc master configuration
+   <_master-config-oidc>` or :ref:`saml master configuration <_master-config-saml>` for details. If
+   any of the fields are configured, they will be used and synced to the database.

--- a/docs/release-notes/auto-populate-posix.rst
+++ b/docs/release-notes/auto-populate-posix.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+- Master Configuration: Master Configuration accepts POSIX claims `agent_uid_attribute_name`, `agent_gid_attribute_name`, `agent_user_name_attribute_name`, or `agent_group_name_attribute_name`. Please visit :ref:`oidc master configuration <_master-config-oidc>` or :ref:`saml master configuration <_master-config-saml>` for details. If any of the fields are configured, they will be used and synced to the database.
+. 

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -119,6 +119,17 @@ stringData:
       {{- if .Values.oidc.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.oidc.displayNameAttributeName }}
       {{- end }}
+      {{- if .Values.oidc.agentUidAttributeName }}
+      agent_uid_attribute_name: {{ .Values.oidc.agentUidAttributeName }}
+      {{- end }}
+      {{- if .Values.oidc.agentGidAttributeName }}
+      agent_gid_attribute_name: {{ .Values.oidc.agentGidAttributeName }}
+      {{- end }}
+      {{- if .Values.oidc.agentUserNameAttributeName }}
+      agent_user_name_attribute_name: {{ .Values.oidc.agentUserNameAttributeName }}
+      {{- end }}
+      {{- if .Values.oidc.agentGroupNameAttributeName }}
+      agent_group_name_attribute_name: {{ .Values.oidc.agentGroupNameAttributeName }}
       {{- if .Values.oidc.alwaysRedirect }}
       always_redirect: {{ .Values.oidc.alwaysRedirect }}
       {{- end }}
@@ -155,6 +166,17 @@ stringData:
       {{- if .Values.saml.displayNameAttributeName }}
       display_name_attribute_name: {{ .Values.saml.displayNameAttributeName }}
       {{- end }}
+      {{- if .Values.saml.agentUidAttributeName }}
+      agent_uid_attribute_name: {{ .Values.saml.agentUidAttributeName }}
+      {{- end }}
+      {{- if .Values.saml.agentGidAttributeName }}
+      agent_gid_attribute_name: {{ .Values.saml.agentGidAttributeName }}
+      {{- end }}
+      {{- if .Values.saml.agentUserNameAttributeName }}
+      agent_user_name_attribute_name: {{ .Values.saml.agentUserNameAttributeName }}
+      {{- end }}
+      {{- if .Values.saml.agentGroupNameAttributeName }}
+      agent_group_name_attribute_name: {{ .Values.saml.agentGroupNameAttributeName }}
       {{- if .Values.saml.alwaysRedirect }}
       always_redirect: {{ .Values.saml.alwaysRedirect }}
       {{- end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -124,6 +124,10 @@ useNodePortForMaster: false
 #   autoProvisionUsers:
 #   groupsAttributeName:
 #   displayNameAttributeName:
+#   agentUidAttributeName:
+#   agentGidAttributeName:
+#   agentUserNameAttributeName:
+#   agentGroupNameAttributeName:
 #   alwaysRedirect:
 #   excludeGroupsScope:
 
@@ -150,6 +154,10 @@ useNodePortForMaster: false
 #   autoProvisionUsers:
 #   groupsAttributeName:
 #   displayNameAttributeName:
+#   agentUidAttributeName:
+#   agentGidAttributeName:
+#   agentUserNameAttributeName:
+#   agentGroupNameAttributeName:
 #   alwaysRedirect:
 
 # db sets the configurations for the database.

--- a/master/internal/config/oidc_config.go
+++ b/master/internal/config/oidc_config.go
@@ -17,6 +17,10 @@ type OIDCConfig struct {
 	AutoProvisionUsers          bool   `json:"auto_provision_users"`
 	GroupsAttributeName         string `json:"groups_attribute_name"`
 	DisplayNameAttributeName    string `json:"display_name_attribute_name"`
+	AgentUIDAttributeName       string `json:"agent_uid_attribute_name"`
+	AgentGIDAttributeName       string `json:"agent_gid_attribute_name"`
+	AgentUserNameAttributeName  string `json:"agent_user_name_attribute_name"`
+	AgentGroupNameAttributeName string `json:"agent_group_name_attribute_name"`
 	AlwaysRedirect              bool   `json:"always_redirect"`
 	ExcludeGroupsScope          bool   `json:"exclude_groups_scope"`
 }

--- a/master/internal/config/saml_config.go
+++ b/master/internal/config/saml_config.go
@@ -8,16 +8,20 @@ import (
 
 // SAMLConfig describes config for SAML.
 type SAMLConfig struct {
-	Enabled                  bool   `json:"enabled"`
-	Provider                 string `json:"provider"`
-	IDPRecipientURL          string `json:"idp_recipient_url"`
-	IDPSSOURL                string `json:"idp_sso_url"`
-	IDPSSODescriptorURL      string `json:"idp_sso_descriptor_url"`
-	IDPMetadataURL           string `json:"idp_metadata_url"`
-	AutoProvisionUsers       bool   `json:"auto_provision_users"`
-	GroupsAttributeName      string `json:"groups_attribute_name"`
-	DisplayNameAttributeName string `json:"display_name_attribute_name"`
-	AlwaysRedirect           bool   `json:"always_redirect"`
+	Enabled                     bool   `json:"enabled"`
+	Provider                    string `json:"provider"`
+	IDPRecipientURL             string `json:"idp_recipient_url"`
+	IDPSSOURL                   string `json:"idp_sso_url"`
+	IDPSSODescriptorURL         string `json:"idp_sso_descriptor_url"`
+	IDPMetadataURL              string `json:"idp_metadata_url"`
+	AutoProvisionUsers          bool   `json:"auto_provision_users"`
+	GroupsAttributeName         string `json:"groups_attribute_name"`
+	DisplayNameAttributeName    string `json:"display_name_attribute_name"`
+	AgentUIDAttributeName       string `json:"agent_uid_attribute_name"`
+	AgentGIDAttributeName       string `json:"agent_gid_attribute_name"`
+	AgentUserNameAttributeName  string `json:"agent_user_name_attribute_name"`
+	AgentGroupNameAttributeName string `json:"agent_group_name_attribute_name"`
+	AlwaysRedirect              bool   `json:"always_redirect"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/plugin/oidc/service.go
+++ b/master/internal/plugin/oidc/service.go
@@ -56,6 +56,8 @@ type IDTokenClaims struct {
 	AgentGID            int      `json:"agent_gid"`
 	AgentUserName       string   `json:"agent_user_name"`
 	AgentGroupName      string   `json:"agent_group_name"`
+	AgentUIDSet         bool     `json:"agent_uid_set"`
+	AgentGIDSet         bool     `json:"agent_gid_set"`
 	Groups              []string `json:"groups"`
 }
 
@@ -252,6 +254,7 @@ func (s *Service) toIDTokenClaim(userInfo *oidc.UserInfo) (*IDTokenClaims, error
 			return nil, fmt.Errorf("user info agentUID value was not a valid number")
 		}
 		c.AgentUID = int(math.Round(agentUID))
+		c.AgentUIDSet = true
 	}
 	if cs[s.config.AgentGIDAttributeName] != nil {
 		agentGID, ok := cs[s.config.AgentGIDAttributeName].(float64)
@@ -259,6 +262,7 @@ func (s *Service) toIDTokenClaim(userInfo *oidc.UserInfo) (*IDTokenClaims, error
 			return nil, fmt.Errorf("user info agentGID value was not a valid number")
 		}
 		c.AgentGID = int(math.Round(agentGID))
+		c.AgentGIDSet = true
 	}
 	if cs[s.config.AgentUserNameAttributeName] != nil {
 		agentUserName, ok := cs[s.config.AgentUserNameAttributeName].(string)
@@ -317,10 +321,10 @@ func mergeUserGroups(sessionData *IDTokenClaims, dbData *model.AgentUserGroup) *
 		Group: dbData.Group,
 	}
 
-	if sessionData.AgentUID != 0 {
+	if sessionData.AgentUIDSet {
 		result.UID = sessionData.AgentUID
 	}
-	if sessionData.AgentGID != 0 {
+	if sessionData.AgentGIDSet {
 		result.GID = sessionData.AgentGID
 	}
 	if sessionData.AgentUserName != "" {

--- a/master/internal/plugin/oidc/service.go
+++ b/master/internal/plugin/oidc/service.go
@@ -124,7 +124,6 @@ func (s *Service) callback(c echo.Context) error {
 		return fmt.Errorf("failed to get user info from oidc provider: %w", err)
 	}
 
-	// kristine - we populate claims here, I think
 	claims, err := s.toIDTokenClaim(userInfo)
 	if err != nil {
 		return err
@@ -333,9 +332,10 @@ func mergeUserGroups(sessionData *IDTokenClaims, dbData *model.AgentUserGroup) *
 	return &result
 }
 
-// kristine - TODO update syncUser
 // syncUser syncs the mutable user fields parsed from the claim, only if there are non-null changes.
-func (s *Service) syncUser(ctx context.Context, u *model.User, claims *IDTokenClaims, ug *model.AgentUserGroup) (*model.User, error) {
+func (s *Service) syncUser(ctx context.Context, u *model.User, claims *IDTokenClaims,
+	ug *model.AgentUserGroup,
+) (*model.User, error) {
 	ugUpdate := mergeUserGroups(claims, ug)
 	if ugUpdate.UID == ug.UID && ugUpdate.GID == ug.GID && ugUpdate.User == ug.User && ugUpdate.Group == ug.Group {
 		// nothing in user group uto update

--- a/master/internal/plugin/oidc/service.go
+++ b/master/internal/plugin/oidc/service.go
@@ -51,6 +51,10 @@ type Service struct {
 type IDTokenClaims struct {
 	AuthenticationClaim string   `json:"authentication_claim"`
 	DisplayName         string   `json:"display_name"`
+	AgentUID            int      `json:"agent_uid"`
+	AgentGID            int      `json:"agent_gid"`
+	AgentUserName       string   `json:"agent_user_name"`
+	AgentGroupName      string   `json:"agent_group_name"`
 	Groups              []string `json:"groups"`
 }
 
@@ -120,6 +124,7 @@ func (s *Service) callback(c echo.Context) error {
 		return fmt.Errorf("failed to get user info from oidc provider: %w", err)
 	}
 
+	// kristine - we populate claims here, I think
 	claims, err := s.toIDTokenClaim(userInfo)
 	if err != nil {
 		return err
@@ -146,7 +151,11 @@ func (s *Service) callback(c echo.Context) error {
 			"user exists but was not created with the --remote option")
 	}
 
-	u, err = s.syncUser(ctx, u, claims)
+	ug, err := user.GetAgentUserGroup(ctx, u.ID, 0)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "unable to look up user group")
+	}
+	u, err = s.syncUser(ctx, u, claims, ug)
 	if err != nil {
 		return err
 	}
@@ -237,6 +246,34 @@ func (s *Service) toIDTokenClaim(userInfo *oidc.UserInfo) (*IDTokenClaims, error
 		}
 		c.DisplayName = displayName
 	}
+	if cs[s.config.AgentUIDAttributeName] != nil {
+		agentUID, ok := cs[s.config.AgentUIDAttributeName].(int)
+		if !ok {
+			return nil, fmt.Errorf("user info agentUID value was not an integer")
+		}
+		c.AgentUID = agentUID
+	}
+	if cs[s.config.AgentGIDAttributeName] != nil {
+		agentGID, ok := cs[s.config.AgentGIDAttributeName].(int)
+		if !ok {
+			return nil, fmt.Errorf("user info agentGID value was not an integer")
+		}
+		c.AgentUID = agentGID
+	}
+	if cs[s.config.AgentUserNameAttributeName] != nil {
+		agentUserName, ok := cs[s.config.AgentUserNameAttributeName].(string)
+		if !ok {
+			return nil, fmt.Errorf("user info agentUserName value was not a string")
+		}
+		c.AgentUserName = agentUserName
+	}
+	if cs[s.config.AgentGroupNameAttributeName] != nil {
+		agentGroupName, ok := cs[s.config.AgentGroupNameAttributeName].(string)
+		if !ok {
+			return nil, fmt.Errorf("user info agentUserName value was not a string")
+		}
+		c.AgentGroupName = agentGroupName
+	}
 	if cs[s.config.GroupsAttributeName] != nil {
 		gs, ok := cs[s.config.GroupsAttributeName].([]interface{})
 		if !ok {
@@ -272,8 +309,39 @@ func (s *Service) lookupUser(ctx context.Context, claimValue string) (*model.Use
 	return u, err
 }
 
+func mergeUserGroups(sessionData *IDTokenClaims, dbData *model.AgentUserGroup) *model.AgentUserGroup {
+	result := model.AgentUserGroup{
+		UID:   dbData.UID,
+		GID:   dbData.GID,
+		User:  dbData.User,
+		Group: dbData.Group,
+	}
+
+	if sessionData.AgentUID != 0 {
+		result.UID = sessionData.AgentUID
+	}
+	if sessionData.AgentGID != 0 {
+		result.GID = sessionData.AgentGID
+	}
+	if sessionData.AgentUserName != "" {
+		result.User = sessionData.AgentUserName
+	}
+	if sessionData.AgentGroupName != "" {
+		result.Group = sessionData.AgentGroupName
+	}
+
+	return &result
+}
+
+// kristine - TODO update syncUser
 // syncUser syncs the mutable user fields parsed from the claim, only if there are non-null changes.
-func (s *Service) syncUser(ctx context.Context, u *model.User, claims *IDTokenClaims) (*model.User, error) {
+func (s *Service) syncUser(ctx context.Context, u *model.User, claims *IDTokenClaims, ug *model.AgentUserGroup) (*model.User, error) {
+	ugUpdate := mergeUserGroups(claims, ug)
+	if ugUpdate.UID == ug.UID && ugUpdate.GID == ug.GID && ugUpdate.User == ug.User && ugUpdate.Group == ug.Group {
+		// nothing in user group uto update
+		ugUpdate = nil
+	}
+
 	if err := db.Bun().RunInTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(ctx context.Context, tx bun.Tx) error {
 			// If the config is set to auto-provision users, sync the display name.
@@ -284,7 +352,7 @@ func (s *Service) syncUser(ctx context.Context, u *model.User, claims *IDTokenCl
 							ID:          u.ID,
 							Username:    claims.AuthenticationClaim,
 							DisplayName: null.NewString(claims.DisplayName, true),
-						}, []string{"display_name"}, nil)
+						}, []string{"display_name"}, ugUpdate)
 					if err != nil {
 						return fmt.Errorf("error setting display name of %q: %s", u.Username, err)
 					}

--- a/master/internal/plugin/oidc/service_intg_test.go
+++ b/master/internal/plugin/oidc/service_intg_test.go
@@ -174,7 +174,6 @@ func TestFailToExtractClaims(t *testing.T) {
 	require.Nil(t, claims)
 }
 
-// kristine - config needs to have our fields that we're testing
 func mockService(t *testing.T, url string) *Service {
 	clientID := "123456"
 	clientSecret := "abcdefgh"

--- a/master/internal/plugin/oidc/service_intg_test.go
+++ b/master/internal/plugin/oidc/service_intg_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -52,18 +53,23 @@ func TestOIDCWorkflow(t *testing.T) {
 
 	ctx := context.Background()
 
+	user1 := uuid.NewString()
+	user2 := uuid.NewString()
 	cases := []struct {
 		name            string
 		userName        string
+		uid             int
+		gid             int
+		groupName       string
 		groups          []string
 		createDuplicate bool
 	}{
-		{"user-provisioned", uuid.NewString(), []string{"abc"}, false},
-		{"user-exists", uuid.NewString(), []string{"abc"}, true},
+		{"user-provisioned", user1, 12, 15, user1 + "group", []string{"abc"}, false},
+		{"user-exists", user2, 22, 25, user2 + "group", []string{"abc"}, true},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			svr := newHTTPTestServer(t, tt.userName+"@hpe.com", "1234567", tt.userName, tt.groups)
+			svr := newHTTPTestServer(t, tt.userName+"@hpe.com", "1234567", tt.userName, tt.uid, tt.gid, tt.userName, tt.groups)
 			defer svr.Close()
 
 			// Add a fake user to the db with the same email but DIFFERENT display name.
@@ -100,7 +106,10 @@ func TestOIDCWorkflow(t *testing.T) {
 
 			require.True(t, u.Remote)
 
-			u, err = s.syncUser(ctx, u, claims)
+			ug, err := user.GetAgentUserGroup(ctx, u.ID, 0)
+			require.NoError(t, err)
+
+			u, err = s.syncUser(ctx, u, claims, ug)
 			require.NoError(t, err)
 
 			require.True(t, u.Active)
@@ -108,6 +117,15 @@ func TestOIDCWorkflow(t *testing.T) {
 			// Now check that all user fields match the response.
 			require.Equal(t, tt.userName, u.DisplayName.String)
 			require.Equal(t, tt.userName+"@hpe.com", u.Username)
+
+			ug, err = user.GetAgentUserGroup(ctx, u.ID, 0)
+			require.NoError(t, err)
+
+			// Check that user group fields match response.
+			require.Equal(t, tt.uid, ug.UID)
+			require.Equal(t, tt.gid, ug.GID)
+			require.Equal(t, tt.userName, ug.User)
+			require.Equal(t, tt.groupName, ug.Group)
 
 			actualGroups := []string{}
 			err = db.Bun().NewSelect().TableExpr("user_group_membership AS ug").ColumnExpr("g.group_name").
@@ -124,7 +142,7 @@ func TestOIDCWorkflow(t *testing.T) {
 }
 
 func TestFailOauthToken(t *testing.T) {
-	svr := newHTTPTestServer(t, "", "", "", []string{})
+	svr := newHTTPTestServer(t, "", "", "", 0, 0, "", []string{})
 	defer svr.Close()
 
 	s := mockService(t, svr.URL)
@@ -136,7 +154,7 @@ func TestFailOauthToken(t *testing.T) {
 }
 
 func TestFailToExtractClaims(t *testing.T) {
-	svr := newHTTPTestServer(t, "", "1234567", "", []string{})
+	svr := newHTTPTestServer(t, "", "1234567", "", 0, 0, "", []string{})
 	defer svr.Close()
 
 	s := mockService(t, svr.URL)
@@ -156,6 +174,7 @@ func TestFailToExtractClaims(t *testing.T) {
 	require.Nil(t, claims)
 }
 
+// kristine - config needs to have our fields that we're testing
 func mockService(t *testing.T, url string) *Service {
 	clientID := "123456"
 	clientSecret := "abcdefgh"
@@ -176,6 +195,10 @@ func mockService(t *testing.T, url string) *Service {
 			AutoProvisionUsers:          true,           // Hard-coding these variables
 			GroupsAttributeName:         "groups",       // for testing purposes,
 			DisplayNameAttributeName:    "display_name", // but they can be customized.
+			AgentUIDAttributeName:       "uid",
+			AgentGIDAttributeName:       "gid",
+			AgentUserNameAttributeName:  "user",
+			AgentGroupNameAttributeName: "group",
 		},
 		provider: p,
 		oauth2Config: oauth2.Config{
@@ -208,13 +231,13 @@ func mockContext(url string) echo.Context {
 }
 
 func newHTTPTestServer(t *testing.T, email string, accessToken string,
-	dispName string, groups []string,
+	dispName string, uid int, gid int, username string, groups []string,
 ) *httptest.Server {
 	var svr *httptest.Server
 	svr = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(echo.HeaderContentType, "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(writeResponse(t, svr.URL, email, accessToken, dispName, groups))
+		_, err := w.Write(writeResponse(t, svr.URL, email, accessToken, dispName, uid, gid, username, groups))
 		require.NoError(t, err)
 	}))
 
@@ -222,7 +245,7 @@ func newHTTPTestServer(t *testing.T, email string, accessToken string,
 }
 
 func writeResponse(t *testing.T, url string, email string, accessToken string,
-	dispName string, groups []string,
+	dispName string, uid int, gid int, username string, groups []string,
 ) []byte {
 	groupResponse := map[string][]string{
 		"groups": groups,
@@ -246,6 +269,19 @@ func writeResponse(t *testing.T, url string, email string, accessToken string,
 
 	if dispName != "" {
 		strResponse["display_name"] = dispName
+	}
+
+	if uid != 0 {
+		strResponse["uid"] = strconv.Itoa(uid)
+	}
+
+	if gid != 0 {
+		strResponse["gid"] = strconv.Itoa(gid)
+	}
+
+	if username != "" {
+		strResponse["user"] = username
+		strResponse["group"] = username + "group"
 	}
 
 	b, err := json.Marshal(strResponse)

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -281,7 +281,7 @@ func getAttributeValues(r *saml.Assertion, name string) []string {
 	return values
 }
 
-func mergeUserGroups(sessionData userAttributes, dbData *model.AgentUserGroup) *model.AgentUserGroup {
+func mergeUserGroups(sessionData *userAttributes, dbData *model.AgentUserGroup) *model.AgentUserGroup {
 	result := model.AgentUserGroup{
 		UID:   dbData.UID,
 		GID:   dbData.GID,
@@ -307,7 +307,7 @@ func mergeUserGroups(sessionData userAttributes, dbData *model.AgentUserGroup) *
 
 // syncUser syncs the mutable user fields parsed from the claim, only if there are non-null changes.
 func (s *Service) syncUser(ctx context.Context, u *model.User, uAttr *userAttributes, ug *model.AgentUserGroup) (*model.User, error) {
-	ugUpdate := mergeUserGroups(*uAttr, ug)
+	ugUpdate := mergeUserGroups(uAttr, ug)
 	if ugUpdate.UID == ug.UID && ugUpdate.GID == ug.GID && ugUpdate.User == ug.User && ugUpdate.Group == ug.Group {
 		// nothing in user group uto update
 		ugUpdate = nil

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -185,6 +185,12 @@ func (s *Service) consumeAssertion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error syncing user")
 	}
 
+	logrus.Error(" ****** printing user posix info")
+	logrus.Errorf("uid: %s, %d\n", s.userConfig.agentUIDAttributeName, userAttr.agentUID)
+	logrus.Errorf("gid: %s, %d\n", s.userConfig.agentGIDAttributeName, userAttr.agentGID)
+	logrus.Errorf("user: %s, %s\n", s.userConfig.agentUserNameAttributeName, userAttr.agentUserName)
+	logrus.Errorf("group: %s, %s\n", s.userConfig.agentGroupNameAttributeName, userAttr.agentGroupName)
+
 	logrus.WithFields(logrus.Fields{
 		"userName": userAttr.userName,
 		"userId":   u.ID,
@@ -318,7 +324,8 @@ func (s *Service) syncUser(ctx context.Context, u *model.User, uAttr *userAttrib
 		func(ctx context.Context, tx bun.Tx) error {
 			// If the config is set to auto-provision users, sync the display name.
 			if s.userConfig.autoProvisionUsers {
-				if uAttr.displayName != "" && uAttr.displayName != u.DisplayName.String {
+				updateDisplayName := uAttr.displayName != "" && uAttr.displayName != u.DisplayName.String
+				if updateDisplayName || ugUpdate != nil {
 					err := user.Update(ctx,
 						&model.User{
 							ID:          u.ID,

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -232,12 +232,12 @@ func (s *Service) toUserAttributes(response *saml.Assertion) *userAttributes {
 		return nil
 	}
 
-	strAgentUID := getSAMLAttribute(response, string(s.userConfig.agentUIDAttributeName))
+	strAgentUID := getSAMLAttribute(response, s.userConfig.agentUIDAttributeName)
 	tempAgentUID, err := strconv.Atoi(strAgentUID)
 	if err != nil {
 		logrus.WithError(err).WithField("agentUID", strAgentUID).Error("unable to convert to integer")
 	}
-	strAgentGID := getSAMLAttribute(response, string(s.userConfig.agentGIDAttributeName))
+	strAgentGID := getSAMLAttribute(response, s.userConfig.agentGIDAttributeName)
 	tempAgentGID, err := strconv.Atoi(strAgentGID)
 	if err != nil {
 		logrus.WithError(err).WithField("agentGID", strAgentGID).Error("unable to convert to integer")
@@ -306,7 +306,9 @@ func mergeUserGroups(sessionData *userAttributes, dbData *model.AgentUserGroup) 
 }
 
 // syncUser syncs the mutable user fields parsed from the claim, only if there are non-null changes.
-func (s *Service) syncUser(ctx context.Context, u *model.User, uAttr *userAttributes, ug *model.AgentUserGroup) (*model.User, error) {
+func (s *Service) syncUser(ctx context.Context, u *model.User, uAttr *userAttributes,
+	ug *model.AgentUserGroup,
+) (*model.User, error) {
 	ugUpdate := mergeUserGroups(uAttr, ug)
 	if ugUpdate.UID == ug.UID && ugUpdate.GID == ug.GID && ugUpdate.User == ug.User && ugUpdate.Group == ug.Group {
 		// nothing in user group uto update

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -239,13 +239,11 @@ func (s *Service) toUserAttributes(response *saml.Assertion) (*userAttributes, e
 	strAgentUID := getSAMLAttribute(response, s.userConfig.agentUIDAttributeName)
 	tempAgentUID, err := strconv.Atoi(strAgentUID)
 	if err != nil && strAgentUID != "" {
-		//logrus.WithError(err).WithField("agentUID", strAgentUID).Error("unable to convert to integer")
 		return nil, fmt.Errorf("SAML attribute identifier agentUID is not an integer: %s", strAgentUID)
 	}
 	strAgentGID := getSAMLAttribute(response, s.userConfig.agentGIDAttributeName)
 	tempAgentGID, err := strconv.Atoi(strAgentGID)
 	if err != nil && strAgentGID != "" {
-		//logrus.WithError(err).WithField("agentGID", strAgentGID).Error("unable to convert to integer")
 		return nil, fmt.Errorf("SAML attribute identifier agentGID is not an integer: %s", strAgentGID)
 	}
 

--- a/master/internal/plugin/saml/service.go
+++ b/master/internal/plugin/saml/service.go
@@ -59,9 +59,13 @@ type userConfig struct {
 // responses.
 func New(db *db.PgDB, c config.SAMLConfig) (*Service, error) {
 	uc := userConfig{
-		autoProvisionUsers:       c.AutoProvisionUsers,
-		groupsAttributeName:      c.GroupsAttributeName,
-		displayNameAttributeName: c.DisplayNameAttributeName,
+		autoProvisionUsers:          c.AutoProvisionUsers,
+		groupsAttributeName:         c.GroupsAttributeName,
+		displayNameAttributeName:    c.DisplayNameAttributeName,
+		agentUIDAttributeName:       c.AgentUIDAttributeName,
+		agentGIDAttributeName:       c.AgentGIDAttributeName,
+		agentUserNameAttributeName:  c.AgentUserNameAttributeName,
+		agentGroupNameAttributeName: c.AgentGroupNameAttributeName,
 	}
 
 	key, cert, err := proxy.GenSignedCert()
@@ -185,12 +189,6 @@ func (s *Service) consumeAssertion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error syncing user")
 	}
 
-	logrus.Error(" ****** printing user posix info")
-	logrus.Errorf("uid: %s, %d\n", s.userConfig.agentUIDAttributeName, userAttr.agentUID)
-	logrus.Errorf("gid: %s, %d\n", s.userConfig.agentGIDAttributeName, userAttr.agentGID)
-	logrus.Errorf("user: %s, %s\n", s.userConfig.agentUserNameAttributeName, userAttr.agentUserName)
-	logrus.Errorf("group: %s, %s\n", s.userConfig.agentGroupNameAttributeName, userAttr.agentGroupName)
-
 	logrus.WithFields(logrus.Fields{
 		"userName": userAttr.userName,
 		"userId":   u.ID,
@@ -240,12 +238,12 @@ func (s *Service) toUserAttributes(response *saml.Assertion) *userAttributes {
 
 	strAgentUID := getSAMLAttribute(response, s.userConfig.agentUIDAttributeName)
 	tempAgentUID, err := strconv.Atoi(strAgentUID)
-	if err != nil {
+	if err != nil && strAgentUID != "" {
 		logrus.WithError(err).WithField("agentUID", strAgentUID).Error("unable to convert to integer")
 	}
 	strAgentGID := getSAMLAttribute(response, s.userConfig.agentGIDAttributeName)
 	tempAgentGID, err := strconv.Atoi(strAgentGID)
-	if err != nil {
+	if err != nil && strAgentGID != "" {
 		logrus.WithError(err).WithField("agentGID", strAgentGID).Error("unable to convert to integer")
 	}
 

--- a/master/internal/plugin/saml/service_intg_test.go
+++ b/master/internal/plugin/saml/service_intg_test.go
@@ -98,14 +98,15 @@ func TestSAMLWorkflowUserNotProvisioned(t *testing.T) {
 	gid := 37
 	resp := getUserResponse(username, username+"123", uid, gid, username+"group", []string{"abc", "bcd"})
 
-	userAttr := s.toUserAttributes(resp.Assertion)
+	userAttr, err := s.toUserAttributes(resp.Assertion)
+	require.NoError(t, err)
 	require.Equal(t, username, userAttr.userName)
 	require.Equal(t, uid, userAttr.agentUID)
 	require.Equal(t, gid, userAttr.agentGID)
 	require.Equal(t, username, userAttr.agentUserName)
 	require.Equal(t, username+"group", userAttr.agentGroupName)
 
-	_, err := user.ByUsername(ctx, userAttr.userName)
+	_, err = user.ByUsername(ctx, userAttr.userName)
 	log.Print(err)
 	require.ErrorContains(t, err, "not found")
 }
@@ -204,10 +205,11 @@ func addAttribute(response saml.Response, name, value string) {
 func processResponseUnprovisioned(ctx context.Context, t *testing.T,
 	response *saml.Assertion, username string, dispName string, uid int, gid int, groupname string, s *Service,
 ) *model.User {
-	userAttr := s.toUserAttributes(response)
+	userAttr, err := s.toUserAttributes(response)
+	require.NoError(t, err)
 	require.Equal(t, username, userAttr.userName)
 
-	_, err := user.ByUsername(ctx, userAttr.userName)
+	_, err = user.ByUsername(ctx, userAttr.userName)
 	log.Print(err)
 	require.True(t, errors.Is(err, db.ErrNotFound), true)
 	u, err := s.provisionUser(ctx, userAttr.userName, userAttr.groups)
@@ -233,7 +235,8 @@ func processResponseUnprovisioned(ctx context.Context, t *testing.T,
 func processResponseProvisioned(ctx context.Context, t *testing.T,
 	response *saml.Assertion, username string, dispName string, uid int, gid int, groupname string, s *Service,
 ) *model.User {
-	userAttr := s.toUserAttributes(response)
+	userAttr, err := s.toUserAttributes(response)
+	require.NoError(t, err)
 	require.Equal(t, username, userAttr.userName)
 
 	u, err := user.ByUsername(ctx, userAttr.userName)

--- a/master/internal/plugin/saml/service_intg_test.go
+++ b/master/internal/plugin/saml/service_intg_test.go
@@ -160,7 +160,9 @@ func mockService(autoProvision bool) *Service {
 	return service
 }
 
-func getUserResponse(username string, dispName string, uid int, gid int, groupname string, groups []string) saml.Response {
+func getUserResponse(username string, dispName string, uid int, gid int, groupname string,
+	groups []string,
+) saml.Response {
 	resp := saml.Response{
 		XMLName:      xml.Name{},
 		IssueInstant: time.Time{},

--- a/master/internal/user/postgres_agentusergroup.go
+++ b/master/internal/user/postgres_agentusergroup.go
@@ -58,7 +58,9 @@ func GetAgentUserGroup(
 ) (*model.AgentUserGroup, error) {
 	workspaceAug, err := getAgentUserGroupFromWorkspaceID(ctx, workspaceID)
 	if err == sql.ErrNoRows {
-		logrus.WithError(err).Warnf("no agent user group results from workspaceID=%d", workspaceID)
+		if workspaceID != 0 {
+			logrus.WithError(err).Warnf("no agent user group results from workspaceID=%d", workspaceID)
+		}
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to get agent user group from experiment: %w", err)
 	}

--- a/master/internal/user/postgres_agentusergroup.go
+++ b/master/internal/user/postgres_agentusergroup.go
@@ -57,7 +57,6 @@ func GetAgentUserGroup(
 	workspaceID int,
 ) (*model.AgentUserGroup, error) {
 	workspaceAug, err := getAgentUserGroupFromWorkspaceID(ctx, workspaceID)
-	fmt.Printf("workspaceID=%d, workspaceAug=%v\n", workspaceID, workspaceAug)
 	if err == sql.ErrNoRows {
 		logrus.WithError(err).Warnf("no agent user group results from workspaceID=%d", workspaceID)
 	} else if err != nil {

--- a/master/internal/user/postgres_agentusergroup.go
+++ b/master/internal/user/postgres_agentusergroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/determined-ai/determined/master/internal/config"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -56,7 +57,10 @@ func GetAgentUserGroup(
 	workspaceID int,
 ) (*model.AgentUserGroup, error) {
 	workspaceAug, err := getAgentUserGroupFromWorkspaceID(ctx, workspaceID)
-	if err != nil {
+	fmt.Printf("workspaceID=%d, workspaceAug=%v\n", workspaceID, workspaceAug)
+	if err == sql.ErrNoRows {
+		logrus.WithError(err).Warnf("no agent user group results from workspaceID=%d", workspaceID)
+	} else if err != nil {
 		return nil, fmt.Errorf("failed to get agent user group from experiment: %w", err)
 	}
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-399]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
When the a determined master is configured to expected the POSIX claims in SSO login & they are provided in the claim, then we will populate the relevant fields for the user:

	AgentUID   null.Int    `db:"agent_uid" json:"agent_uid"`
	AgentGID   null.Int    `db:"agent_gid" json:"agent_gid"`
	AgentUser  null.String `db:"agent_user" json:"agent_user"`
	AgentGroup null.String `db:"agent_group" json:"agent_group"`

Also re-adds new fields to master configuration (original done here https://github.com/determined-ai/determined/pull/9690/files). The original PR was reverted because of CI errors. 

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Test using an Okta application.

### OIDC
Recommended application: `carolina-oidc-test`, https://dev-2564556-admin.okta.com/admin/app/oidc_client/instance/0oacxxzecx7a9l5O85d7/#tab-general 

- add your user to the test application, filling in the fields `posix_uid` (int), `posix_gid` (int), `agent_user_name` (string) and `agent_group_name` (string)
- in your master config, add the following fields to an `oidc` section:
```
oidc:
  agent_uid_attribute_name: posix_uid
  agent_gid_attribute_name: posix_gid
  agent_user_name_attribute_name: agent_user_name
  agent_group_name_attribute_name: agent_group_name
  always_redirect: true
```
- start devcluster, and log in using Okta
- inspect the database and ensure that it is updated, e.g. `SELECT * FROM agent_user_groups;` and look at columns `uid`, `gid`, `user_` and `group_`

**You can also try different combinations! A user should be able to specify any, none, or all of the new parameters.**

### SAML
Recommended application: `Determined SAML CI`, https://dev-2564556-admin.okta.com/admin/app/dev-2564556_determinedsamlci_1/instance/0oaganmj6zxHC3A575d7/#tab-assignments

- add your user to the test application, the fields will be filled out automatically
- in your master config, add the following fields to an `saml` section:
```
saml:
  agent_uid_attribute_name: posix_uid
  agent_gid_attribute_name: posix_gid
  agent_user_name_attribute_name: agent_user_name
  agent_group_name_attribute_name: agent_group_name
  always_redirect: true
```
- start devcluster, and log in using Okta
- inspect the database and ensure that it is updated, e.g.
```
determined=# select * from agent_user_groups;
 id | user_id |  user_   | uid |  group_  | gid 
----+---------+----------+-----+----------+-----
  2 |       3 | Kristine |   4 | Kunapuli |   5
```

`user_` will be your first name and `group_` will be your last name.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CM-399]: https://hpe-aiatscale.atlassian.net/browse/CM-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ