### PR TITLE
chore: deprecate kubernetes priority w/ preemption scheduler

### DIFF
--- a/docs/get-started/architecture/introduction.rst
+++ b/docs/get-started/architecture/introduction.rst
@@ -677,8 +677,7 @@ a higher priority (e.g. a priority 50 task will run before a priority 40 task).
 Priority Scheduling with Preemption
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Determined has deprecated a priority scheduler that extends the Kubernetes scheduler to support
-preemption with backfilling as of version 0.36.0.
+This extension to the Kubernetes scheduler has been deprecated and removed as of version 0.36.0.
 
 .. _concept-trial:
 

--- a/docs/get-started/architecture/introduction.rst
+++ b/docs/get-started/architecture/introduction.rst
@@ -677,51 +677,8 @@ a higher priority (e.g. a priority 50 task will run before a priority 40 task).
 Priority Scheduling with Preemption
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Determined also makes available a priority scheduler that extends the Kubernetes scheduler to
-support preemption with backfilling. This plugin will preempt existing pods if higher priority pods
-are submitted. If there is still space in the cluster, backfilling will attempt to fill the nodes by
-scheduling lower priority jobs. Additionally, if there are leftover slots on partially-filled nodes,
-the scheduler will attempt to assign single-slot tasks until the space is filled. This packing
-behavior only occurs with single-slot tasks.
-
-This plugin is also in beta and is not enabled by default. To enable it, edit ``values.yaml`` in the
-Determined Helm chart to set the ``defaultScheduler`` field to ``preemption``. Autoscaling is not
-supported and Determined can only automatically set labels for GPU experiments.
-
-Determined provides a default priority class, ``determined-medium-priority`` that has a priority of
-``50`` and is used for all tasks. If users want to set a different priority level for an experiment,
-they may either specify a priority in the ``resources`` field of the experiment config or create a
-priorityClass and specify it in the ``pod_spec`` of the config. If both are specified, the specified
-priorityClass will take precedence over the priority field. In Kubernetes, a higher priority value
-means a higher priority (e.g. a priority 50 task will run before a priority 40 task).
-
-Additionally, if using a cluster with tainted nodes or labels, users must specify the tolerations or
-node selectors in the ``pod_spec``. It is recommended that you use both tolerations and node
-selectors to better constrain where your experiments can run, especially on clusters that contain
-multiple GPU types.
-
-Below is an example that illustrates how to set priorities, tolerations, and node selectors.
-
-.. code:: yaml
-
-   resources:
-      priority: 42 # priorityClass, if set, takes precedence over this value
-   environment:
-      pod_spec:
-         apiVersion: v1
-         kind: Pod
-         spec:
-            priorityClassName: determined-medium-priority # don't set if using priority value
-            nodeSelector:
-               key: value
-            tolerations:
-            -  key: "key1"
-               operator: "Equal"
-               value: "value"
-               effect: "NoSchedule"
-
-The Kubernetes priority scheduler can be used with the Determined job queue feature, which allows
-more insight into scheduling decisions.
+Determined has deprecated a priority scheduler that extends the Kubernetes scheduler to support
+preemption with backfilling as of version 0.36.0.
 
 .. _concept-trial:
 

--- a/docs/get-started/architecture/introduction.rst
+++ b/docs/get-started/architecture/introduction.rst
@@ -677,7 +677,7 @@ a higher priority (e.g. a priority 50 task will run before a priority 40 task).
 Priority Scheduling with Preemption
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This extension to the Kubernetes scheduler has been deprecated and removed as of version 0.36.0.
+This extension to the Kubernetes scheduler was deprecated and removed as of version 0.36.0.
 
 .. _concept-trial:
 

--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -255,9 +255,8 @@
 
 -  ``defaultScheduler``: Configures the default scheduler that Determined will use. Currently
    supports the ``coscheduler`` option, which enables the `lightweight coscheduling plugin
-   <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__, and
-   the ``preemption`` option, which enables a priority-based preemption scheduler. Unless specified
-   as ``coscheduler``, Determined will use the default Kubernetes scheduler.
+   <https://github.com/kubernetes-sigs/scheduler-plugins/tree/release-1.18/pkg/coscheduling>`__.
+   Unless specified as ``coscheduler``, Determined will use the default Kubernetes scheduler.
 
 -  ``resourcePools``: This section contains the names of the resource pools and their linked
    namespaces. Maps to the ``resource_pools`` section from the :ref:`master configuration

--- a/docs/release-notes/deprecate-k8s-preemption-scheduler.rst
+++ b/docs/release-notes/deprecate-k8s-preemption-scheduler.rst
@@ -3,4 +3,5 @@
 **Deprecations**
 
 -  Kubernetes Scheduling: Support for the priority with preemption scheduler for Kubernetes Resource Managers
-      was deprecated in 0.35.0 and is now removed.
+      was deprecated in 0.35.0 and is now removed. Users should transition to the default scheduler.
+      Visit :ref:`Kubernetes Default Scheduler <kubernetes-default-scheduler>` for details.

--- a/docs/release-notes/deprecate-k8s-preemption-scheduler.rst
+++ b/docs/release-notes/deprecate-k8s-preemption-scheduler.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Deprecations**
+
+-  Kubernetes Scheduling: Support for the priority with preemption scheduler for Kubernetes Resource Managers
+      was deprecated in 0.35.0 and is now removed.

--- a/helm/charts/determined/templates/NOTES.txt
+++ b/helm/charts/determined/templates/NOTES.txt
@@ -37,8 +37,7 @@ format X.Y.Z (e.g., 0.13.6).
 {{ end -}}
 
 {{- if .Values.defaultScheduler }}
-      {{- $schedulerType := .Values.defaultScheduler | trim}}
-      {{- if not (or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption"))}}
+      {{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 WARNING: defaultScheduler has been set to an unsupported value. The cluster default scheduler will be set to the Kubernetes scheduler.
       {{ end }}
 {{ end -}}

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -187,9 +187,8 @@ stringData:
       max_slots_per_pod: {{ required "A valid Values.maxSlotsPerPod entry is required!" .Values.maxSlotsPerPod }}
       master_service_name: determined-master-service-{{ .Release.Name }}
       {{- if .Values.defaultScheduler}}
-      {{- $schedulerType := .Values.defaultScheduler | trim}}
-      {{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
-      default_scheduler: {{ $schedulerType }}
+      {{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
+      default_scheduler: "coscheduler"
       {{- end }}
       {{- end }}
       {{- if (ne (default "gpu" .Values.slotType) "gpu") }}

--- a/helm/charts/determined/templates/scheduler-config.yaml
+++ b/helm/charts/determined/templates/scheduler-config.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.defaultScheduler}}
-{{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+{{- if eq (.Values.defaultScheduler | trim ) "coscheduler"}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,18 +12,13 @@ data:
     leaderElection:
       leaderElect: false
     profiles:
-    - schedulerName: {{ $schedulerType }}
+    - schedulerName: {{ .Values.defaultScheduler }}
       plugins:
         queueSort:
           enabled:
             - name: Coscheduling
           disabled:
             - name: "*"
-        {{- if eq $schedulerType "preemption"}}
-        preFilter:
-          enabled:
-            - name: Coscheduling
-        {{- end }}
         permit:
           enabled:
             - name: Coscheduling

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.defaultScheduler}}
 {{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
-apiVersion: apps/v1
+{{- if (eq $schedulerType "coscheduler") }}apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -31,11 +30,7 @@ spec:
         - --scheduler-name=coscheduler
         - --config=/etc/config/config.yaml
         name: {{ $schedulerType }}
-        {{- if eq $schedulerType "preemption"}}
-        image: "{{ .Values.defaultImages.kubeSchedulerPreemption }}"
-        {{- else }}
         image: "{{ .Values.defaultImages.kubeScheduler }}"
-        {{- end}}
         imagePullPolicy: "Always"
         livenessProbe:
           httpGet:

--- a/helm/charts/determined/templates/scheduler-deployment.yaml
+++ b/helm/charts/determined/templates/scheduler-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.defaultScheduler}}
 {{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if (eq $schedulerType "coscheduler") }}apiVersion: apps/v1
+{{- if (eq $schedulerType "coscheduler") }}
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/helm/charts/determined/templates/scheduler-permissions.yaml
+++ b/helm/charts/determined/templates/scheduler-permissions.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.defaultScheduler}}
 {{- $schedulerType := .Values.defaultScheduler | trim}}
-{{- if or (eq $schedulerType "coscheduler") (eq $schedulerType "preemption")}}
+{{- if (eq $schedulerType "coscheduler") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -347,9 +347,8 @@ telemetry:
       # certificate: <certificate contents>
 
 ## Configure the default Determined scheduler
-## Currently supports "coscheduler" for gang scheduling and "preemption" for priority based
-## scheduling with preemption
-# defaultScheduler: preemption
+## Currently supports "coscheduler" for gang scheduling.
+# defaultScheduler: coscheduler
 
 ## Configure the resource pools in the Determined cluster.
 resourcePools:

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -26,10 +26,6 @@ defaultImages:
   # default Kube Scheduler image
   kubeScheduler: "k8s.gcr.io/scheduler-plugins/kube-scheduler:v0.18.9"
 
-  # Kube Scheduler used when the K8s default scheduler is set to preemption
-  # when, defaultScheduler: preemption
-  kubeSchedulerPreemption: "determinedai/kube-scheduler:0.17.0"
-
   # default images for CPU and GPU environments
   cpuImage: "determinedai/pytorch-ngc-dev:5432424"
   gpuImage: "determinedai/pytorch-ngc-dev:5432424"

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -350,7 +350,7 @@ func (c *Config) Resolve() error {
 				return err
 			}
 			if r.ResourceManager.KubernetesRM.DefaultScheduler == preemptionScheduler {
-				log.Info("pqriority with preemption scheduler has been deprecated as of 0.36.0, and this field will be ignored")
+				log.Info("priority with preemption scheduler has been deprecated as of 0.36.0, and this field will be ignored")
 				return fmt.Errorf("scheduler not available")
 			}
 		}

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -39,6 +39,7 @@ var (
 const (
 	KubernetesDefaultPriority = 50
 	sslModeDisable            = "disable"
+	preemptionScheduler       = "preemption"
 )
 
 type (
@@ -348,8 +349,8 @@ func (c *Config) Resolve() error {
 			if err != nil {
 				return err
 			}
-			if r.ResourceManager.KubernetesRM.DefaultScheduler == PriorityScheduling {
-				log.Info("Priority Scheduler has been deprecated as of 0.36.0, and this field will be ignored.")
+			if r.ResourceManager.KubernetesRM.DefaultScheduler == preemptionScheduler {
+				log.Info("pqriority with preemption scheduler has been deprecated as of 0.36.0, and this field will be ignored")
 				return fmt.Errorf("scheduler not available")
 			}
 		}
@@ -420,8 +421,8 @@ func (c *Config) Deprecations() (errs []error) {
 			if len(rm.KubernetesRM.Name) > 0 {
 				errs = append(errs, fmt.Errorf(nameDeprecatedWarning, rm.KubernetesRM.ClusterName))
 			}
-			if rm.KubernetesRM.DefaultScheduler == "priority" {
-				errs = append(errs, fmt.Errorf("the priority scheduler for Kubernetes is deprecated, "+
+			if rm.KubernetesRM.DefaultScheduler == preemptionScheduler {
+				errs = append(errs, fmt.Errorf("the priority with preemption scheduler for Kubernetes is deprecated, "+
 					"and this field will be ignored"))
 			}
 		case rm.DispatcherRM != nil:

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -349,7 +349,7 @@ func (c *Config) Resolve() error {
 				return err
 			}
 			if r.ResourceManager.KubernetesRM.DefaultScheduler == PriorityScheduling {
-				log.Info("Priority Scheduler has been removed, and this field will be ignored.")
+				log.Info("Priority Scheduler has been deprecated as of 0.36.0, and this field will be ignored.")
 				return fmt.Errorf("scheduler not available")
 			}
 		}

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -862,7 +862,7 @@ resource_manager:
 resource_manager:
   type: kubernetes
   max_slots_per_pod: 1
-  default_scheduler: priority
+  default_scheduler: preemption
 `
 
 	type result struct {

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -843,17 +843,6 @@ resource_manager:
 			rpName:            "",
 			preemptionEnabled: false,
 		},
-		{
-			name: "k8 with preemption plugin",
-			configRaw: `
-resource_manager:
-  type: kubernetes
-  default_scheduler: preemption
-  max_slots_per_pod: 54
-`,
-			rpName:            "default",
-			preemptionEnabled: true,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -863,81 +852,42 @@ resource_manager:
 	}
 }
 
-func TestMultiRMPreemptionAndPriority(t *testing.T) {
-	prio1 := 3
-	prio2 := 30
+func TestKubernetesRMSchedulerDeprecation(t *testing.T) {
+	noScheduler := dbConfig + `
+resource_manager:
+  type: kubernetes
+  max_slots_per_pod: 1
+`
+	priorityScheduler := dbConfig + `
+resource_manager:
+  type: kubernetes
+  max_slots_per_pod: 1
+  default_scheduler: priority
+`
 
-	cfg := DefaultConfig()
-	cfg.ResourceConfig = ResourceConfig{
-		RootManagerInternal: &ResourceManagerConfig{AgentRM: &AgentResourceManagerConfig{
-			Name: DefaultClusterName, Scheduler: &SchedulerConfig{
-				Priority: &PrioritySchedulerConfig{
-					Preemption:      false,
-					DefaultPriority: &prio1,
-				},
-			},
-		}},
-		RootPoolsInternal: []ResourcePoolConfig{{
-			PoolName: "default123",
-			Scheduler: &SchedulerConfig{Priority: &PrioritySchedulerConfig{
-				Preemption:      true,
-				DefaultPriority: &prio2,
-			}},
-		}},
-		AdditionalResourceManagersInternal: []*ResourceManagerWithPoolsConfig{
-			{ResourceManager: &ResourceManagerConfig{KubernetesRM: &KubernetesResourceManagerConfig{
-				Name:             "test",
-				DefaultScheduler: "not-preemption-scheduler",
-			}}, ResourcePools: []ResourcePoolConfig{{
-				PoolName: "default234",
-				Scheduler: &SchedulerConfig{Priority: &PrioritySchedulerConfig{
-					Preemption:      true,
-					DefaultPriority: &prio1,
-				}},
-			}}},
-			// nil preemption case
-			{
-				ResourceManager: &ResourceManagerConfig{KubernetesRM: &KubernetesResourceManagerConfig{
-					Name: "nil-rm", DefaultScheduler: "not-preemption-scheduler",
-				}},
-				ResourcePools: []ResourcePoolConfig{{PoolName: "nil-rp"}},
-			},
-		},
+	type result struct {
+		scheduler string
+		allowed   bool
+	}
+	tests := map[string]result{
+		noScheduler:       {"", true},
+		priorityScheduler: {"priority", false},
 	}
 
-	SetMasterConfig(cfg)
-
-	// 'default123' RP exists under 'default' RM, so the preemption will
-	// be 'True' & priority to prio2, like the RP.
-	status := ReadRMPreemptionStatus("default123")
-	require.True(t, status)
-
-	priority := ReadPriority("default123", model.CommandConfig{})
-	require.Equal(t, prio2, priority)
-
-	// 'test1' RP doesn't exist under any RM so the preemption and
-	// priority will default.
-	status = ReadRMPreemptionStatus("test1")
-	require.False(t, status)
-
-	priority = ReadPriority("test1", model.CommandConfig{})
-	require.Equal(t, DefaultSchedulingPriority, priority)
-
-	// 'default234' RP exists under 'test' RM, so the preemption
-	// & priority will default to the RP's.
-	status = ReadRMPreemptionStatus("default234")
-	require.True(t, status)
-
-	priority = ReadPriority("default234", model.CommandConfig{})
-	require.Equal(t, prio1, priority)
-
-	// 'nil-rp' RP exists under 'nil-rm' RM, so the preemption
-	// & priority default to the RMs.
-	status = ReadRMPreemptionStatus("nil-rp")
-	require.False(t, status)
-
-	priority = ReadPriority("nil-rp", model.CommandConfig{})
-	require.Equal(t, KubernetesDefaultPriority, priority)
+	for config, expected := range tests {
+		unmarshaled := Config{}
+		err := yaml.Unmarshal([]byte(config), &unmarshaled, yaml.DisallowUnknownFields)
+		require.NoError(t, err)
+		if expected.allowed {
+			require.NoError(t, unmarshaled.Resolve())
+		} else {
+			require.Error(t, unmarshaled.Resolve())
+		}
+		rm := unmarshaled.ResourceManagers()
+		require.Len(t, rm, 1)
+		// In both cases, since we don't define a valid RM, expect something empty
+		require.Equal(t, expected.scheduler, rm[0].ResourceManager.KubernetesRM.DefaultScheduler)
+	}
 }
 
 func TestPickVariation(t *testing.T) {

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -871,7 +871,7 @@ resource_manager:
 	}
 	tests := map[string]result{
 		noScheduler:       {"", true},
-		priorityScheduler: {"priority", false},
+		priorityScheduler: {"preemption", false},
 	}
 
 	for config, expected := range tests {

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -268,11 +268,6 @@ var defaultKubernetesResourceManagerConfig = KubernetesResourceManagerConfig{
 	SlotType: device.CUDA, // default to CUDA-backed slots.
 }
 
-// GetPreemption returns whether the RM is set to preempt.
-func (k *KubernetesResourceManagerConfig) GetPreemption() bool {
-	return k.DefaultScheduler == PreemptionScheduler
-}
-
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (k *KubernetesResourceManagerConfig) UnmarshalJSON(data []byte) error {
 	*k = defaultKubernetesResourceManagerConfig
@@ -314,10 +309,19 @@ func (k KubernetesResourceManagerConfig) Validate() []error {
 			k.SlotResourceRequests.CPU, float32(0), "slot_resource_requests.cpu must be > 0")
 	}
 
+	var checkRMScheduler error
+	if k.DefaultScheduler == PriorityScheduling {
+		checkRMScheduler = fmt.Errorf("the ``priority`` scheduler was deprecated, please " +
+			"use the default Kubernetes scheduler or coscheduler")
+	} else if k.DefaultScheduler != "" && k.DefaultScheduler != "coscheduler" {
+		checkRMScheduler = fmt.Errorf("only blank or ``coscheduler`` values allowed for Kubernetes scheduler")
+	}
+
 	return []error{
 		checkSlotType,
 		checkCPUResource,
 		check.NotEmpty(k.ClusterName, "cluster_name is required"),
+		checkRMScheduler,
 	}
 }
 
@@ -332,8 +336,3 @@ type FluentConfig struct {
 	UID   int    `json:"uid"`
 	GID   int    `json:"gid"`
 }
-
-// PreemptionScheduler is the name of the preemption scheduler for k8.
-// HACK(Brad): Here because circular imports; Kubernetes probably needs its own
-// configuration package.
-const PreemptionScheduler = "preemption"

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -623,7 +623,6 @@ func (k *ResourceManager) createResourcePoolSummary(
 	const na = "n/a"
 
 	poolType := resourcepoolv1.ResourcePoolType_RESOURCE_POOL_TYPE_K8S
-	preemptible := k.config.GetPreemption()
 	location := na
 	imageID := ""
 	instanceType := na
@@ -638,7 +637,7 @@ func (k *ResourceManager) createResourcePoolSummary(
 		SlotType:                     k.config.SlotType.Proto(),
 		DefaultAuxPool:               k.config.DefaultAuxResourcePool == poolName,
 		DefaultComputePool:           k.config.DefaultComputeResourcePool == poolName,
-		Preemptible:                  preemptible,
+		Preemptible:                  false,
 		SlotsPerAgent:                int32(slotsPerAgent),
 		AuxContainerCapacityPerAgent: int32(pool.MaxAuxContainersPerAgent),
 		SchedulerType:                schedulerType,

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -12,8 +12,6 @@ import (
 
 	batchV1 "k8s.io/api/batch/v1"
 
-	"github.com/determined-ai/determined/master/internal/config"
-
 	"github.com/docker/docker/api/types/mount"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -337,7 +335,7 @@ func (j *job) modifyPodSpec(
 			)
 		}
 		newPod.Spec.PriorityClassName = "determined-system-priority"
-	} else if scheduler == coscheduler || scheduler == config.PreemptionScheduler {
+	} else if scheduler == coscheduler {
 		if newPod.Spec.SchedulerName == "" {
 			newPod.Spec.SchedulerName = scheduler
 		}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
chore: deprecate kubernetes priority w/ preemption scheduler
-->


## Ticket
CM-385


## Description
Deprecate the Kubernetes priority with preemption scheduler. Remove references to the helm chart & invalidate master configuration input `defaultScheduler: preemption`. Set the `preemption` value for all kubernetes resource managers to false (since now no scheduler has preemption enabled).

## Test Plan
No testing needed, but manual testing shows that defining `defaultScheduler: preemption` in the yaml chart will be overwritten by a blank default value to the master configuration. Also, trying to define `defaultScheduler: preemption` in a devcluster yaml's master configuration won't be recognized as valid.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code
