### PR TITLE
fix: extract searcher metric from experiment payload

### DIFF
--- a/webui/react/src/services/decoder.ts
+++ b/webui/react/src/services/decoder.ts
@@ -528,6 +528,7 @@ export function mapV1Experiment(
     projectId: data.projectId,
     projectName: data.projectName,
     resourcePool: data.resourcePool || '',
+    searcherMetric: data.searcherMetric,
     searcherMetricValue: data.bestTrialSearcherMetric,
     searcherType: data.searcherType,
     startTime: data.startTime as unknown as string,


### PR DESCRIPTION
## Ticket
ET-655



## Description
This fixes an issue where the searcher metric wasn't decoded from the experiment api payload.



## Test Plan
on the searches table, add the "searcher metric" column to the view. It should be populated.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ