### PR TITLE
feat: make groups scope optional to support azure with OIDC

### DIFF
--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -122,6 +122,9 @@ stringData:
       {{- if .Values.oidc.alwaysRedirect }}
       always_redirect: {{ .Values.oidc.alwaysRedirect }}
       {{- end }}
+      {{- if .Values.oidc.isGroupsSupported }}
+      is_groups_supported: {{ .Values.oidc.isGroupsSupported }}
+      {{- end }}
     {{- end }}
 
     {{- if .Values.scim }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -125,6 +125,7 @@ useNodePortForMaster: false
 #   groupsAttributeName:
 #   displayNameAttributeName:
 #   alwaysRedirect:
+#   isGroupsSupported:
 
 # scim (EE-only) enables System for Cross-domain Identity Management (SCIM) integration, which is
 # only available if enterpriseEdition is true. It allows administrators to easily and securely

--- a/master/internal/config/oidc_config.go
+++ b/master/internal/config/oidc_config.go
@@ -18,6 +18,7 @@ type OIDCConfig struct {
 	GroupsAttributeName         string `json:"groups_attribute_name"`
 	DisplayNameAttributeName    string `json:"display_name_attribute_name"`
 	AlwaysRedirect              bool   `json:"always_redirect"`
+	IsGroupsSupported           bool   `json:"is_groups_supported"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/plugin/oidc/service.go
+++ b/master/internal/plugin/oidc/service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -80,7 +81,11 @@ func New(db *db.PgDB, config config.OIDCConfig, pachEnabled bool) (*Service, err
 		return nil, fmt.Errorf("client secret has not been set")
 	}
 
-	scope := []string{oidc.ScopeOpenID, "profile", "email", "groups"}
+	scope := []string{oidc.ScopeOpenID, "profile", "email"}
+	log.Print("config.IsGroupsSupported ", config.IsGroupsSupported)
+	if config.IsGroupsSupported {
+		scope = append(scope, "groups")
+	}
 	if pachEnabled {
 		scope = append(scope, "audience:server:client_id:pachd")
 	}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
