### PR TITLE
fix: Add loading indicator when creating HP search

### DIFF
--- a/webui/react/src/components/HyperparameterSearchModal.tsx
+++ b/webui/react/src/components/HyperparameterSearchModal.tsx
@@ -108,6 +108,7 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
   const [form] = Form.useForm();
   const [currentPage, setCurrentPage] = useState(0);
   const [validationError, setValidationError] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const formValues = Form.useWatch([], form);
   const f_flat_runs = useFeature().isOn('flat_runs');
 
@@ -217,6 +218,7 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
     const newConfig = yaml.dump(baseConfig);
 
     try {
+      setIsSubmitting(true);
       const { experiment: newExperiment, warnings } = await createExperiment(
         {
           activate: true,
@@ -253,6 +255,8 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
 
       // We throw an error to prevent the modal from closing.
       throw new DetError(errorMessage, { publicMessage: errorMessage, silent: true });
+    } finally {
+      setIsSubmitting(false);
     }
   }, [entityCopy, experiment.configRaw, experiment.id, experiment.projectId, form, currentHPs]);
 
@@ -626,7 +630,11 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
         <div className={css.spacer} />
         <Row>
           <Button onClick={handleCancel}>Cancel</Button>
-          <Button disabled={validationError} type="primary" onClick={handleOk}>
+          <Button
+            disabled={validationError}
+            loading={isSubmitting}
+            type="primary"
+            onClick={handleOk}>
             {currentPage === 0
               ? 'Select Hyperparameters'
               : `Run ${capitalize(entityCopy.experiment)}`}
@@ -634,7 +642,7 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
         </Row>
       </>
     );
-  }, [currentPage, entityCopy, handleBack, handleCancel, handleOk, validationError]);
+  }, [currentPage, entityCopy, handleBack, handleCancel, handleOk, validationError, isSubmitting]);
 
   return (
     <Modal footer={footer} title="Hyperparameter Search">

--- a/webui/react/src/components/HyperparameterSearchModal.tsx
+++ b/webui/react/src/components/HyperparameterSearchModal.tsx
@@ -137,6 +137,7 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
   );
 
   const submitExperiment = useCallback(async () => {
+    if (isSubmitting) return;
     const fields: Record<string, Primitive | HyperparameterRowValues> = form.getFieldsValue(true);
 
     // Deep cloning parent experiment's config
@@ -258,7 +259,15 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
     } finally {
       setIsSubmitting(false);
     }
-  }, [entityCopy, experiment.configRaw, experiment.id, experiment.projectId, form, currentHPs]);
+  }, [
+    entityCopy,
+    experiment.configRaw,
+    experiment.id,
+    experiment.projectId,
+    form,
+    currentHPs,
+    isSubmitting,
+  ]);
 
   const handleOk = useCallback(() => {
     if (currentPage === 0) {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[MD-472]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Sometime the API can take a while to finish, adding a loading indicator to the HP search modal so the page does not seem freeze.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
When creating an experiment using HP search, after submission, the button would become loading. 


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MD-472]: https://hpe-aiatscale.atlassian.net/browse/MD-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ