### PR TITLE
chore: add Cluster Name title and change helm value

### DIFF
--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -363,7 +363,7 @@ resourcePools:
 #   - resource_manager:
 #       type: kubernetes
 #       max_slots_per_pod: 1
-#       name: carolina-multirm-1
+#       cluster_name: carolina-multirm-1
 #       default_namespace: default
 #       kubeconfig_secret_name: additionalrm
 #       kubeconfig_secret_value: config

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -363,7 +363,7 @@ resourcePools:
 #   - resource_manager:
 #       type: kubernetes
 #       max_slots_per_pod: 1
-#       cluster_name: carolina-multirm-1
+#       cluster_name: additional-cluster
 #       default_namespace: default
 #       kubeconfig_secret_name: additionalrm
 #       kubeconfig_secret_value: config

--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -198,7 +198,7 @@ const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }
             <>
               {resourceManagers.map((name) => (
                 <Fragment key={name}>
-                  <Form.Item label={name} name={['bindings', name, 'namespace']}>
+                  <Form.Item label={'Cluster Name: ' + name} name={['bindings', name, 'namespace']}>
                     <Input
                       disabled={watchBindings?.[name]?.['autoCreateNamespace'] ?? false}
                       maxLength={63}

--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -198,7 +198,7 @@ const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }
             <>
               {resourceManagers.map((name) => (
                 <Fragment key={name}>
-                  <Form.Item label={'Cluster Name: ' + name} name={['bindings', name, 'namespace']}>
+                  <Form.Item label={`Cluster Name: ${name}`} name={['bindings', name, 'namespace']}>
                     <Input
                       disabled={watchBindings?.[name]?.['autoCreateNamespace'] ?? false}
                       maxLength={63}


### PR DESCRIPTION
## Ticket


## Description
- Add "Cluster Name" title as shown below
-  change helm chart `additional_resource_managers[i].name` to `additional_resource_managers[i].cluster_name`

Before (No title)
![NoClusterNameTitle](https://github.com/user-attachments/assets/978ba5bb-660e-48e7-98fe-88ec15dec1c0)


After (with title)
 
<img width="681" alt="WithClusterNameTitle" src="https://github.com/user-attachments/assets/78e8ac70-503b-4787-9b31-ed415459048a">



## Test Plan
CI Passes.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ