### PR TITLE
fix: prevent extra initial calls to search endpoints

### DIFF
--- a/webui/react/src/components/ComparisonView.tsx
+++ b/webui/react/src/components/ComparisonView.tsx
@@ -58,27 +58,31 @@ const ComparisonView: React.FC<Props> = ({
   const [isSelectionLimitReached, setIsSelectionLimitReached] = useState(false);
 
   const loadableSelectedExperiments = useAsync(async () => {
-    if (experimentSelection) {
-      try {
-        const filterFormSet = INIT_FORMSET;
-        const filter = getExperimentIdsFilter(filterFormSet, experimentSelection);
-        const response = await searchExperiments({
-          filter: JSON.stringify(filter),
-          limit: SELECTION_LIMIT,
-        });
-        if (response?.pagination?.total && response?.pagination?.total > SELECTION_LIMIT) {
-          setIsSelectionLimitReached(true);
-        } else {
-          setIsSelectionLimitReached(false);
-        }
-        return response.experiments;
-      } catch (e) {
-        handleError(e, { publicSubject: 'Unable to fetch experiments for comparison' });
-        return NotLoaded;
-      }
+    if (
+      !open ||
+      !experimentSelection ||
+      (experimentSelection.type === 'ONLY_IN' && experimentSelection.selections.length === 0)
+    ) {
+      return NotLoaded;
     }
-    return NotLoaded;
-  }, [experimentSelection]);
+    try {
+      const filterFormSet = INIT_FORMSET;
+      const filter = getExperimentIdsFilter(filterFormSet, experimentSelection);
+      const response = await searchExperiments({
+        filter: JSON.stringify(filter),
+        limit: SELECTION_LIMIT,
+      });
+      if (response?.pagination?.total && response?.pagination?.total > SELECTION_LIMIT) {
+        setIsSelectionLimitReached(true);
+      } else {
+        setIsSelectionLimitReached(false);
+      }
+      return response.experiments;
+    } catch (e) {
+      handleError(e, { publicSubject: 'Unable to fetch experiments for comparison' });
+      return NotLoaded;
+    }
+  }, [experimentSelection, open]);
 
   const selectedExperiments: ExperimentWithTrial[] | undefined = Loadable.getOrElse(
     undefined,
@@ -86,27 +90,31 @@ const ComparisonView: React.FC<Props> = ({
   );
 
   const loadableSelectedRuns = useAsync(async () => {
-    if (runSelection) {
-      const filterFormSet = INIT_FORMSET;
-      try {
-        const filter = getRunIdsFilter(filterFormSet, runSelection);
-        const response = await searchRuns({
-          filter: JSON.stringify(filter),
-          limit: SELECTION_LIMIT,
-        });
-        if (response?.pagination?.total && response?.pagination?.total > SELECTION_LIMIT) {
-          setIsSelectionLimitReached(true);
-        } else {
-          setIsSelectionLimitReached(false);
-        }
-        return response.runs;
-      } catch (e) {
-        handleError(e, { publicSubject: 'Unable to fetch runs for comparison' });
-        return NotLoaded;
-      }
+    if (
+      !open ||
+      !runSelection ||
+      (runSelection.type === 'ONLY_IN' && runSelection.selections.length === 0)
+    ) {
+      return NotLoaded;
     }
-    return NotLoaded;
-  }, [runSelection]);
+    const filterFormSet = INIT_FORMSET;
+    try {
+      const filter = getRunIdsFilter(filterFormSet, runSelection);
+      const response = await searchRuns({
+        filter: JSON.stringify(filter),
+        limit: SELECTION_LIMIT,
+      });
+      if (response?.pagination?.total && response?.pagination?.total > SELECTION_LIMIT) {
+        setIsSelectionLimitReached(true);
+      } else {
+        setIsSelectionLimitReached(false);
+      }
+      return response.runs;
+    } catch (e) {
+      handleError(e, { publicSubject: 'Unable to fetch runs for comparison' });
+      return NotLoaded;
+    }
+  }, [open, runSelection]);
 
   const selectedRuns: FlatRun[] | undefined = Loadable.getOrElse(undefined, loadableSelectedRuns);
 

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -172,12 +172,14 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const { settings: globalSettings, updateSettings: updateGlobalSettings } =
     useSettings<DataGridGlobalSettings>(settingsConfigGlobal);
-  const [sorts, setSorts] = useState<Sort[]>(() => {
-    if (!isLoadingSettings) {
-      return parseSortString(settings.sortString);
-    }
-    return [EMPTY_SORT];
-  });
+
+  const sorts = useMemo(() => {
+    return (
+      projectSettings
+        .map((s) => s?.sortString && parseSortString(s?.sortString))
+        .getOrElse(undefined) || [EMPTY_SORT]
+    );
+  }, [projectSettings]);
   const sortString = useMemo(() => makeSortString(sorts.filter(validSort.is)), [sorts]);
   const [experiments, setExperiments] = useState<Loadable<ExperimentWithTrial>[]>(
     INITIAL_LOADING_EXPERIMENTS,
@@ -304,7 +306,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
 
   const handleSortChange = useCallback(
     (sorts: Sort[]) => {
-      setSorts(sorts);
       const newSortString = makeSortString(sorts.filter(validSort.is));
       if (newSortString !== sortString) {
         resetPagination();
@@ -313,12 +314,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     },
     [resetPagination, sortString, updateSettings],
   );
-
-  useEffect(() => {
-    if (!isLoadingSettings && settings.sortString) {
-      setSorts(parseSortString(settings.sortString));
-    }
-  }, [isLoadingSettings, settings.sortString]);
 
   useEffect(() => {
     return eagerSubscribe(projectSettingsObs, (ps, prevPs) => {


### PR DESCRIPTION

## Ticket
ET-677



## Description
this fixes an issue where the new table experience tables would call their search endpoints multiple times on mount, possibly causing server load issues. This happened due to two root causes:

1) the comparison view would call the search endpoint for user selections even when the comparison view was closed and the user had selected no experiments or runs. we now bail on the request if the comparison view is closed or the selection is empty. This may impact the user because now the comparison view will update on open instead of in the background, but I think this is a fair tradeoff.

2) the sort state updated as an effect of loading the settings, so the polling function would initially fire when the settings loaded, then again when the sort state updated. We now derive the sort state directly from the sort string instead.




## Test Plan
* with developer tools open to the network tab, visit a project's run list
* in the request list, every call to the runs endpoint should be 5 seconds apart
* when opening the comparison view, another call should be made
* Repeat the above for the searches view as well as the New Experiment List page



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
