### PR TITLE
fix: don't filter single runs in the comparison view

### DIFF
--- a/webui/react/src/components/FilterForm/components/type.ts
+++ b/webui/react/src/components/FilterForm/components/type.ts
@@ -25,9 +25,9 @@ export type FilterFormSet = {
   showArchived: boolean;
 };
 
-type FormFieldWithoutId = Omit<FormField, 'id'>;
+export type FormFieldWithoutId = Omit<FormField, 'id'>;
 
-type FormGroupWithoutId = {
+export type FormGroupWithoutId = {
   readonly kind: typeof FormKind.Group;
   conjunction: Conjunction;
   children: (FormGroupWithoutId | FormFieldWithoutId)[];

--- a/webui/react/src/components/RunFilterInterstitialModalComponent.test.tsx
+++ b/webui/react/src/components/RunFilterInterstitialModalComponent.test.tsx
@@ -109,14 +109,23 @@ describe('RunFilterInterstitialModalComponent', () => {
     expect(filterFormSetString).toBeDefined();
     const filterFormSet = JSON.parse(filterFormSetString || '');
 
-    // TODO: is there a better way to test this expectation?
+    // TODO: is there a better way to test these expectations?
     expect(filterFormSet.showArchived).toBeTruthy();
-    const [filterGroup, idFilterGroup] = filterFormSet.filterGroup.children?.[0].children || [];
-    expect(filterGroup).toEqual(expectedFilterGroup);
+    const [, , idFilter] = filterFormSet.filterGroup.children;
+    for (const child of expectedFilterGroup.children) {
+      expect(filterFormSet.filterGroup.children).toContainEqual(child);
+    }
 
-    const idFilters = idFilterGroup.children;
-    expect(idFilters.every((f: FormField) => f.operator === '!=')).toBeTruthy();
-    expect(idFilters.map((f: FormField) => f.value)).toEqual(expectedExclusions);
+    for (const exclusion of expectedExclusions) {
+      expect(idFilter?.children[0].children).toContainEqual({
+        columnName: 'id',
+        kind: 'field',
+        location: 'LOCATION_TYPE_RUN',
+        operator: '!=',
+        type: 'COLUMN_TYPE_NUMBER',
+        value: exclusion,
+      });
+    }
   });
 
   it('calls server with filter describing visual selection', () => {
@@ -139,7 +148,7 @@ describe('RunFilterInterstitialModalComponent', () => {
     const filterFormSet = JSON.parse(filterFormSetString || '');
 
     expect(filterFormSet.showArchived).toBe(false);
-    const idFilters = filterFormSet.filterGroup.children?.[0].children || [];
+    const idFilters = filterFormSet.filterGroup.children || [];
     expect(idFilters.every((f: FormField) => f.operator === '=')).toBe(true);
     expect(idFilters.map((f: FormField) => f.value)).toEqual(expectedSelection);
   });

--- a/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
+++ b/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
@@ -10,6 +10,7 @@ import { useAsync } from 'hooks/useAsync';
 import { searchRuns } from 'services/api';
 import { SelectionType } from 'types';
 import { DetError } from 'utils/error';
+import { combine } from 'utils/filterFormSet';
 import { getIdsFilter } from 'utils/flatRun';
 import mergeAbortControllers from 'utils/mergeAbortControllers';
 import { observable } from 'utils/observable';
@@ -77,7 +78,18 @@ export const RunFilterInterstitialModalComponent = forwardRef<ControlledModalRef
       async (canceler) => {
         if (!isOpen) return NotLoaded;
         const mergedCanceler = mergeAbortControllers(canceler, closeController.current);
-        const filter = getIdsFilter(filterFormSet, selection);
+        const filter: FilterFormSetWithoutId = {
+          ...filterFormSet,
+          filterGroup: combine(getIdsFilter(filterFormSet, selection).filterGroup, 'and', {
+            columnName: 'searcherType',
+            kind: 'field',
+            location: 'LOCATION_TYPE_RUN',
+            operator: '!=',
+            type: 'COLUMN_TYPE_TEXT',
+            value: 'single',
+          }),
+        };
+
         try {
           const results = await searchRuns(
             {

--- a/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
+++ b/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
@@ -78,17 +78,21 @@ export const RunFilterInterstitialModalComponent = forwardRef<ControlledModalRef
       async (canceler) => {
         if (!isOpen) return NotLoaded;
         const mergedCanceler = mergeAbortControllers(canceler, closeController.current);
-        const filter: FilterFormSetWithoutId = {
-          ...filterFormSet,
-          filterGroup: combine(getIdsFilter(filterFormSet, selection).filterGroup, 'and', {
-            columnName: 'searcherType',
-            kind: 'field',
-            location: 'LOCATION_TYPE_RUN',
-            operator: '!=',
-            type: 'COLUMN_TYPE_TEXT',
-            value: 'single',
-          }),
-        };
+        const filterWithSingleFilter = combine(filterFormSet.filterGroup, 'and', {
+          columnName: 'searcherType',
+          kind: 'field',
+          location: 'LOCATION_TYPE_RUN',
+          operator: '!=',
+          type: 'COLUMN_TYPE_TEXT',
+          value: 'single',
+        });
+        const filter: FilterFormSetWithoutId = getIdsFilter(
+          {
+            ...filterFormSet,
+            filterGroup: filterWithSingleFilter,
+          },
+          selection,
+        );
 
         try {
           const results = await searchRuns(

--- a/webui/react/src/utils/filterFormSet.ts
+++ b/webui/react/src/utils/filterFormSet.ts
@@ -1,0 +1,28 @@
+import {
+  Conjunction,
+  FormFieldWithoutId,
+  FormGroupWithoutId,
+} from 'components/FilterForm/components/type';
+
+/**
+ * build a new filter group given an existing one and a child. will add the child
+ * as a child of the current formGroup if the conjunction matches, otherwise
+ * will create a new wrapper group having both as children
+ */
+export const combine = (
+  filterGroup: FormGroupWithoutId,
+  conjunction: Conjunction,
+  child: FormGroupWithoutId | FormFieldWithoutId,
+): FormGroupWithoutId => {
+  if (filterGroup.conjunction === conjunction) {
+    return {
+      ...filterGroup,
+      children: [...filterGroup.children, child],
+    };
+  }
+  return {
+    children: [filterGroup, child],
+    conjunction,
+    kind: 'group',
+  };
+};


### PR DESCRIPTION

## Ticket
ET-679


## Description
This fixes an issue where single search runs were being filtered out of
the comparison view in runs view. We were erroneously applying a filter
to the search results.



## Test Plan
* in the search runs view, open the comparison view and switch to the details tab
* filter the search results such that only runs of single searches are in the view
* add rows to the selection
* trials selected should appear in the details tab as the user updates the selection



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ