### PR TITLE
ci: label `make slurmcluster` instances for cloud spend [CM-405]

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -311,7 +311,7 @@ commands:
   install-codecov:
     steps:
       - run: pip install codecov
-      
+
   upload-junit-datadog:
     parameters:
       service:
@@ -627,7 +627,7 @@ commands:
         default: true
     steps:
       - when:
-          condition: 
+          condition:
             and:
               - equal: [<<parameters.master-host>>,'localhost']
               - <<parameters.wait-for-master>>
@@ -656,7 +656,7 @@ commands:
                     DD_HOST_TAGS="$host_tags" \
                     DD_SERVICE="determined-pytest-<<parameters.mark>>" \
                     bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
-                    
+
                     # config files for the agent have an expected file structure
                     sudo mkdir -p /etc/datadog-agent/conf.d/determined-master.d/
                     sudo chmod a+rw /etc/datadog-agent/datadog.yaml
@@ -766,7 +766,7 @@ commands:
                   if [ "$AIS_DD_ENABLE_MONITORING" == "true" ]; then
                     sudo systemctl stop datadog-agent || true
                   fi
-            
+
 
   run-det-deploy-tests:
     parameters:
@@ -2429,7 +2429,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-cpu
-          env: ci-cpu 
+          env: ci-cpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2456,7 +2456,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-gpu
-          env: ci-gpu 
+          env: ci-gpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2483,7 +2483,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-pytorch2-gpu
-          env: ci-gpu 
+          env: ci-gpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2509,7 +2509,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-pytorch2-cpu
-          env: ci-cpu 
+          env: ci-cpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2536,7 +2536,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-gpu-parallel
-          env: ci-gpu 
+          env: ci-gpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2563,7 +2563,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-gpu-deepseed
-          env: ci-gpu 
+          env: ci-gpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2589,7 +2589,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-harness-tf2
-          env: ci-cpu 
+          env: ci-cpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2617,7 +2617,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-storage
-          env: ci-cpu 
+          env: ci-cpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2648,7 +2648,7 @@ jobs:
       - run: codecov -v -t $CODECOV_TOKEN -F harness
       - upload-junit-datadog:
           service: test-unit-model-hub
-          env: ci-cpu 
+          env: ci-cpu
       - persist_to_workspace:
           root: .
           paths:
@@ -2837,7 +2837,9 @@ jobs:
             sudo apt-get update
             sudo apt-get install gettext
             sudo apt-get install iproute2
-            yes yes | PATH=$HOME/.local/bin:$PATH make slurmcluster FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>>" TF_LOCK=false | tee output.log
+            yes yes | PATH=$HOME/.local/bin:$PATH make slurmcluster \
+              FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\"determined_ci\", gh_team=\"machine-user\"}'" \
+              TF_LOCK=false | tee output.log
           background: true
 
       - run:
@@ -3123,7 +3125,7 @@ jobs:
                 }
               }
             EOF
-            
+
       - run-e2e-tests:
           mark: <<parameters.mark>>
           master-host: localhost

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2838,7 +2838,7 @@ jobs:
             sudo apt-get install gettext
             sudo apt-get install iproute2
             yes yes | PATH=$HOME/.local/bin:$PATH make slurmcluster \
-              FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\"determined_ci\", gh_team=\"machine-user\"}'" \
+              FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\\\"determined_ci\\\", gh_team=\\\"machine-user\\\"}'" \
               TF_LOCK=false | tee output.log
           background: true
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2839,7 +2839,7 @@ jobs:
             sudo apt-get install iproute2
             yes yes | PATH=$HOME/.local/bin:$PATH make slurmcluster \
               FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\\\"determined_ci\\\", gh_team=\\\"machine-user\\\"}'" \
-              TF_LOCK=false | tee output.log
+              TF_LOCK=false || circleci-agent step halt | tee output.log
           background: true
 
       - run:

--- a/tools/slurm/scripts/slurmcluster.sh
+++ b/tools/slurm/scripts/slurmcluster.sh
@@ -38,6 +38,10 @@ while [[ $# -gt 0 ]]; do
             MACHINE_TYPE=$2
             shift 2
             ;;
+        -l)
+            # This is processed already by generate-tfvars.sh
+            shift 2
+            ;;
         -g)
             # This is processed already by generate-tfvars.sh
             GPUS=$2

--- a/tools/slurm/terraform/main.tf
+++ b/tools/slurm/terraform/main.tf
@@ -54,11 +54,14 @@ resource "google_compute_instance" "vm_instance" {
     ssh-keys = "${var.ssh_user}:${file(var.ssh_key_pub)}"
   }
 
+  labels = var.vm_labels
+
   machine_type = var.machine_type
 
   boot_disk {
     initialize_params {
       image = var.boot_disk
+      labels = var.vm_labels
     }
   }
 
@@ -89,7 +92,7 @@ resource "google_compute_instance" "vm_instance" {
     on_host_maintenance = "TERMINATE"
   }
 
-  
+
 
   metadata_startup_script = templatefile("${path.module}/scripts/startup-script.sh", { WORKLOAD_MANAGER = var.workload_manager })
 }

--- a/tools/slurm/terraform/scripts/generate-tfvars.sh
+++ b/tools/slurm/terraform/scripts/generate-tfvars.sh
@@ -11,6 +11,8 @@ MACHINE_TYPE=
 GPU_TYPE=
 # Number of GPUs
 GPU_COUNT=
+# Instance labels
+LABELS=
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -76,6 +78,13 @@ while [[ $# -gt 0 ]]; do
                 shift
             fi
             ;;
+        -l)
+            shift
+            if [[ -n $1 && $1 != -* ]]; then
+                LABELS="$1"
+                shift
+            fi
+            ;;
         *)
             echo "Invalid option: $1. Skipping..." >&2
             shift
@@ -118,4 +127,7 @@ if [[ -n $GPU_TYPE ]]; then
     echo "   count: $GPU_COUNT"
     echo "}"
     echo "allow_stopping_for_update        = true"
+fi
+if [[ -n $LABELS ]]; then
+    echo "vm_labels = $LABELS"
 fi

--- a/tools/slurm/terraform/variables.tf
+++ b/tools/slurm/terraform/variables.tf
@@ -69,3 +69,8 @@ variable "allow_stopping_for_update" {
 variable "boot_disk" {
   type    = string
 }
+
+variable "vm_labels" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
CM-405


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
1. Add a flag for `make slurmcluster` pipeline to set labels on the VM it creates and its disk
2. Use them in the CI

Also I've discovered that `make slurmcluster` job will stay pending when a background task to create a cluster failed, so I've fixed that. The job should now fail right away if that happens.

Also I went to war with trailing whitespace in the circle config.

## Test Plan

<img width="680" alt="Screen Shot 2024-08-02 at 17 05 56" src="https://github.com/user-attachments/assets/370ffaa4-1f7c-4952-a9d3-cc0b0a6efc41">


Do the VMs spawned by CI have that label?

Test run: https://app.circleci.com/pipelines/github/determined-ai/determined/59112/workflows/bd2dfd65-498c-46be-a01f-908aefa48a05/jobs/2836426

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ