### PR TITLE
chore: initial k8s rocm support [CM-367]

### DIFF
--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -155,6 +155,12 @@
    distributed experiments will launch with 4 GPUs per pod (with two pods on 8-GPU nodes).
    (*Required*)
 
+-  ``slotType``: Specifies the type of the slot that Determined will deploy. Valid options are
+   ``cpu`` for CPU training, ``gpu`` or ``cuda`` for Nvidia GPUs, and ``rocm`` for AMD GPUs.
+   Defaults to ``gpu``.
+
+   The ``rocm`` slot type is an experimental feature.
+
 -  ``masterCpuRequest``: The CPU requirements for the Determined master.
 
 -  ``masterMemRequest``: The memory requirements for the Determined master.

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -403,13 +403,20 @@ resource pool ``max_slots_per_pod``.
 ``slot_type``
 -------------
 
-Resource type used for compute tasks. Defaults to ``cuda``.
+Resource type used for compute tasks. Valid options are ``gpu``, ``cuda``, ``cpu``, or ``rocm``.
+Defaults to ``cuda``.
 
 ``slot_type: cuda``
 ^^^^^^^^^^^^^^^^^^^
 
    One NVIDIA GPU will be requested per compute slot. Prior to Determined 0.17.6, this option was
    called ``gpu``.
+
+``slot_type: rocm``
+^^^^^^^^^^^^^^^^^^^
+
+   One AMD GPU will be requested per compute slot. The ``rocm`` slot type is an experimental
+   feature.
 
 ``slot_type: cpu``
 ^^^^^^^^^^^^^^^^^^

--- a/docs/release-notes/rocm-k8s-gpu.rst
+++ b/docs/release-notes/rocm-k8s-gpu.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+-  Kubernetes: Experimental support for AMD ROCM GPUs is now available for Kubernetes. To use set
+   ``slotType=rocm``. See :ref:`helm-config-reference` for more details.

--- a/docs/release-notes/rocm-k8s-gpu.rst
+++ b/docs/release-notes/rocm-k8s-gpu.rst
@@ -3,4 +3,4 @@
 **New Features**
 
 -  Kubernetes: Experimental support for AMD ROCM GPUs is now available for Kubernetes. To use set
-   ``slotType=rocm``. See :ref:`helm-config-reference` for more details.
+   ``slotType=rocm``. Visit :ref:`helm-config-reference` for more details.

--- a/master/internal/config/resource_config_test.go
+++ b/master/internal/config/resource_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/determined-ai/determined/master/pkg/aproto"
 	"github.com/determined-ai/determined/master/pkg/check"
+	"github.com/determined-ai/determined/master/pkg/device"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 )
@@ -271,15 +272,6 @@ additional_resource_managers:
 			"least one resource pool\n\terror found at root: for additional_resource_managers, " +
 			"you must specify at least one resource pool"},
 
-		{"k8s rocm config", `
-resource_manager:
-  type: kubernetes
-  max_slots_per_pod: 1
-  name: a
-  cluster_name: a
-  slot_type: rocm`, nil, "Check Failed! 1 errors found:\n\terror found at root.ResourceConfig." +
-			"RootManagerInternal.KubernetesRM: rocm slot_type is not supported yet on k8s"},
-
 		{"k8s negative cpu", `
 resource_manager:
   type: kubernetes
@@ -385,6 +377,33 @@ resource_manager:
 						DefaultAuxResourcePool:     "default",
 						DefaultComputeResourcePool: "default",
 						Scheduler:                  DefaultSchedulerConfig(),
+					},
+				},
+				RootPoolsInternal: []ResourcePoolConfig{
+					{
+						PoolName:                 "default",
+						MaxAuxContainersPerAgent: 100,
+						MaxCPUContainersPerAgent: -1,
+						AgentReconnectWait:       model.Duration(aproto.AgentReconnectWait),
+					},
+				},
+			},
+		}},
+
+		{"k8s rocm config", `
+resource_manager:
+  type: kubernetes
+  slot_type: rocm
+  max_slots_per_pod: 3
+`, Config{
+			ResourceConfig: ResourceConfig{
+				RootManagerInternal: &ResourceManagerConfig{
+					KubernetesRM: &KubernetesResourceManagerConfig{
+						Name:                       DefaultRMName,
+						DefaultAuxResourcePool:     "default",
+						DefaultComputeResourcePool: "default",
+						SlotType:                   device.ROCM,
+						MaxSlotsPerPod:             ptrs.Ptr(3),
 					},
 				},
 				RootPoolsInternal: []ResourcePoolConfig{

--- a/master/internal/config/resource_config_test.go
+++ b/master/internal/config/resource_config_test.go
@@ -399,7 +399,7 @@ resource_manager:
 			ResourceConfig: ResourceConfig{
 				RootManagerInternal: &ResourceManagerConfig{
 					KubernetesRM: &KubernetesResourceManagerConfig{
-						Name:                       DefaultRMName,
+						ClusterName:                DefaultClusterName,
 						DefaultAuxResourcePool:     "default",
 						DefaultComputeResourcePool: "default",
 						SlotType:                   device.ROCM,

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -301,11 +301,9 @@ func (k *KubernetesResourceManagerConfig) UnmarshalJSON(data []byte) error {
 func (k KubernetesResourceManagerConfig) Validate() []error {
 	var checkSlotType error
 	switch k.SlotType {
-	case device.CPU, device.CUDA:
-	case device.ROCM:
-		checkSlotType = errors.Errorf("rocm slot_type is not supported yet on k8s")
+	case device.CPU, device.CUDA, device.ROCM:
 	default:
-		checkSlotType = errors.Errorf("slot_type must be either cuda or cpu")
+		checkSlotType = errors.Errorf("slot_type must be cuda, cpu, or rocm")
 	}
 
 	var checkCPUResource error

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -66,6 +66,13 @@ const (
 
 	resourceTypeNvidia = "nvidia.com/gpu"
 	resourceTypeAMD    = "amd.com/gpu"
+
+	defaultNamespace = "default"
+	// ReleaseNamespaceEnvVar is the name of the environment variable within a pod running the
+	// master service containing the namespace in which determined was deployed.
+	ReleaseNamespaceEnvVar = "DET_RELEASE_NAMESPACE"
+	// ResourceTypeNvidia describes the GPU resource type.
+	ResourceTypeNvidia = "nvidia.com/gpu"
 )
 
 var cacheSyncs []cache.InformerSynced
@@ -2060,11 +2067,12 @@ func (j *jobsService) getNonDetSlots(deviceType device.Type) (map[string][]strin
 		}
 		reqs := int64(0)
 		for _, c := range pod.Spec.Containers {
-			if deviceType == device.CPU {
+			switch deviceType {
+			case device.CPU:
 				reqs += j.getCPUReqs(c)
-			} else if deviceType == device.CUDA {
+			case device.CUDA:
 				reqs += c.Resources.Requests.Name(resourceTypeNvidia, resource.DecimalSI).Value()
-			} else if deviceType == device.ROCM {
+			case device.ROCM:
 				reqs += c.Resources.Requests.Name(resourceTypeAMD, resource.DecimalSI).Value()
 			}
 		}

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -65,12 +65,7 @@ const (
 	kubernetesJobNameLabel = "batch.kubernetes.io/job-name"
 
 	resourceTypeNvidia = "nvidia.com/gpu"
-	defaultNamespace   = "default"
-	// ReleaseNamespaceEnvVar is the name of the environment variable within a pod running the
-	// master service containing the namespace in which determined was deployed.
-	ReleaseNamespaceEnvVar = "DET_RELEASE_NAMESPACE"
-	// ResourceTypeNvidia describes the GPU resource type.
-	ResourceTypeNvidia = "nvidia.com/gpu"
+	resourceTypeAMD    = "amd.com/gpu"
 )
 
 var cacheSyncs []cache.InformerSynced
@@ -1759,6 +1754,10 @@ func (j *jobsService) summarize() (map[string]model.AgentSummary, error) {
 	return j.summarizeCache.summary, j.summarizeCache.err
 }
 
+func isSlotTypeGPU(slotType device.Type) bool {
+	return slotType == device.CUDA || slotType == device.ROCM
+}
+
 // Get the mapping of many-to-many relationship between nodes and resource pools.
 func (j *jobsService) getNodeResourcePoolMapping(nodeSummaries map[string]model.AgentSummary) (
 	map[string][]*k8sV1.Node, map[string][]string,
@@ -1767,11 +1766,18 @@ func (j *jobsService) getNodeResourcePoolMapping(nodeSummaries map[string]model.
 
 	// Nvidia automatically taints nodes, so we should tolerate that when users don't customize
 	// their resource pool config.
-	defaultTolerations := []k8sV1.Toleration{{
-		Key:      resourceTypeNvidia,
-		Value:    "present",
-		Operator: k8sV1.TolerationOpEqual,
-	}}
+	defaultTolerations := []k8sV1.Toleration{
+		{
+			Key:      resourceTypeNvidia,
+			Value:    "present",
+			Operator: k8sV1.TolerationOpEqual,
+		},
+		{
+			Key:      resourceTypeAMD,
+			Value:    "present",
+			Operator: k8sV1.TolerationOpEqual,
+		},
+	}
 	cpuTolerations, gpuTolerations := extractTolerations(j.baseContainerDefaults)
 	poolsToNodes := make(map[string][]*k8sV1.Node)
 	nodesToPools := make(map[string][]string)
@@ -1788,7 +1794,7 @@ func (j *jobsService) getNodeResourcePoolMapping(nodeSummaries map[string]model.
 			// isn't defined.
 			if len(j.resourcePoolConfigs) <= 1 &&
 				(tcd == nil || (tcd.CPUPodSpec == nil && tcd.GPUPodSpec == nil)) {
-				if slotType == device.CUDA {
+				if isSlotTypeGPU(slotType) {
 					//nolint:gocritic
 					poolTolerations = append(defaultTolerations, gpuTolerations...)
 				} else if slotType == device.CPU {
@@ -1797,7 +1803,7 @@ func (j *jobsService) getNodeResourcePoolMapping(nodeSummaries map[string]model.
 				}
 			} else if tcd != nil {
 				// Decide which poolTolerations to use based on slot device type
-				if slotType == device.CUDA && tcd.GPUPodSpec != nil {
+				if isSlotTypeGPU(slotType) && tcd.GPUPodSpec != nil {
 					//nolint:gocritic
 					poolTolerations = append(tcd.GPUPodSpec.Spec.Tolerations, gpuTolerations...)
 					selectors, affinities = extractNodeSelectors(tcd.GPUPodSpec)
@@ -1920,7 +1926,9 @@ func (j *jobsService) summarizeClusterByNodes() map[string]model.AgentSummary {
 			numSlots = int64(float32(milliCPUs) / (1000. * j.slotResourceRequests.CPU))
 			deviceType = device.CPU
 		case device.ROCM:
-			panic("ROCm is not supported on k8s yet")
+			resources := node.Status.Allocatable[resourceTypeAMD]
+			deviceType = device.ROCM
+			numSlots = resources.Value()
 		case device.CUDA:
 			fallthrough
 		default:
@@ -2056,6 +2064,8 @@ func (j *jobsService) getNonDetSlots(deviceType device.Type) (map[string][]strin
 				reqs += j.getCPUReqs(c)
 			} else if deviceType == device.CUDA {
 				reqs += c.Resources.Requests.Name(resourceTypeNvidia, resource.DecimalSI).Value()
+			} else if deviceType == device.ROCM {
+				reqs += c.Resources.Requests.Name(resourceTypeAMD, resource.DecimalSI).Value()
 			}
 		}
 		if reqs > 0 {
@@ -2093,6 +2103,9 @@ func numSlots(slots model.SlotsSummary) int {
 
 	if slotCountsByType[device.CUDA] > 0 {
 		return slotCountsByType[device.CUDA]
+	}
+	if slotCountsByType[device.ROCM] > 0 {
+		return slotCountsByType[device.ROCM]
 	}
 
 	return slotCountsByType[device.CPU]
@@ -2482,18 +2495,24 @@ func extractNodeSelectors(pod *k8sV1.Pod) (selectors, affinities *k8sV1.NodeSele
 }
 
 func extractSlotInfo(node model.AgentSummary) (numSlots int, devType device.Type) {
-	var gpuSlots, cpuSlots int
+	var cudaSlots, rocmSlots, cpuSlots int
 
 	for _, slot := range node.Slots {
-		if slot.Device.Type == device.CPU {
+		switch slot.Device.Type {
+		case device.CPU:
 			cpuSlots++
-		} else if slot.Device.Type == device.CUDA {
-			gpuSlots++
+		case device.CUDA:
+			cudaSlots++
+		case device.ROCM:
+			rocmSlots++
 		}
 	}
 
-	if gpuSlots > 0 {
-		return gpuSlots, device.CUDA
+	if cudaSlots > 0 {
+		return cudaSlots, device.CUDA
+	}
+	if rocmSlots > 0 {
+		return rocmSlots, device.ROCM
 	}
 
 	return cpuSlots, device.CPU

--- a/master/internal/rm/kubernetesrm/jobs_test.go
+++ b/master/internal/rm/kubernetesrm/jobs_test.go
@@ -615,3 +615,47 @@ current-context: minikube
 kind: Config
 preferences: {}
 `
+
+func TestExtractSlotInfo(t *testing.T) {
+	for _, deviceType := range []device.Type{device.CPU, device.CUDA, device.ROCM} {
+		t.Run(string(deviceType), func(t *testing.T) {
+			n := model.AgentSummary{
+				Slots: model.SlotsSummary{
+					"a": model.SlotSummary{
+						Device: device.Device{
+							Type: deviceType,
+						},
+					},
+					"b": model.SlotSummary{
+						Device: device.Device{
+							Type: deviceType,
+						},
+					},
+				},
+			}
+			numSlots, actualDeviceType := extractSlotInfo(n)
+			require.Equal(t, 2, numSlots)
+			require.Equal(t, deviceType, actualDeviceType)
+		})
+	}
+}
+
+func TestNumSlots(t *testing.T) {
+	for _, deviceType := range []device.Type{device.CPU, device.CUDA, device.ROCM} {
+		t.Run(string(deviceType), func(t *testing.T) {
+			s := model.SlotsSummary{
+				"a": model.SlotSummary{
+					Device: device.Device{
+						Type: deviceType,
+					},
+				},
+				"b": model.SlotSummary{
+					Device: device.Device{
+						Type: deviceType,
+					},
+				},
+			}
+			require.Equal(t, 2, numSlots(s))
+		})
+	}
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description

Adds initial experimental support for amd gpus on k8s.


## Test Plan

Unit tests cover this change

Also manually verified on amd hardware. Automated e2e tests were deemed not in scope due to hardware availability issues

blocked on https://github.com/determined-ai/environments/pull/275. We just need the environment images to land in the same release as this. Some additional docs will be added in the environments pr detailing what our rocm environment does and does not support. 

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ