### PR TITLE
fix: prevent multiple calls to time-series on compare view select

### DIFF
--- a/webui/react/src/components/CompareHyperparameters.test.mock.tsx
+++ b/webui/react/src/components/CompareHyperparameters.test.mock.tsx
@@ -108,20 +108,6 @@ export const METRIC_DATA: RunMetricData = {
     },
   ],
   scale: 'linear',
-  selectedMetrics: [
-    {
-      group: 'training',
-      name: 'loss',
-    },
-    {
-      group: 'validation',
-      name: 'accuracy',
-    },
-    {
-      group: 'validation',
-      name: 'validation_loss',
-    },
-  ],
   setScale: (): Scale => {
     return Scale.Linear;
   },

--- a/webui/react/src/components/CompareMetrics.tsx
+++ b/webui/react/src/components/CompareMetrics.tsx
@@ -1,6 +1,5 @@
 import { ChartGrid, ChartsProps } from 'hew/LineChart';
 import { Loadable, Loaded, NotLoaded } from 'hew/utils/loadable';
-import _ from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import MetricBadgeTag from 'components/MetricBadgeTag';
@@ -116,7 +115,7 @@ const CompareMetrics: React.FC<Props> = ({
   );
 
   const chartsProps: Loadable<ChartsProps> = useMemo(() => {
-    const { metricHasData, metrics, isLoaded, selectedMetrics } = metricData;
+    const { metricHasData, metrics, isLoaded } = metricData;
     const { chartProps, chartedMetrics } = selectedRuns
       ? calculateRunsChartProps(metricData, selectedRuns, xAxis, colorMap)
       : calculateExperimentChartProps(metricData, selectedExperiments, trials, xAxis, colorMap);
@@ -134,11 +133,7 @@ const CompareMetrics: React.FC<Props> = ({
     if (!isLoaded) {
       // When trial metrics hasn't loaded metric names or individual trial metrics.
       return NotLoaded;
-    } else if (!chartDataIsLoaded || !_.isEqual(selectedMetrics, metrics)) {
-      // In some cases the selectedMetrics returned may not be up to date
-      // with the metrics selected by the user. In this case we want to
-      // show a loading state until the metrics match.
-
+    } else if (!chartDataIsLoaded) {
       // returns the chartProps with a NotLoaded series which enables
       // the ChartGrid to show a spinner for the loading charts.
       return Loaded(chartProps.map((chartProps) => ({ ...chartProps, series: NotLoaded })));

--- a/webui/react/src/components/ComparisonView.test.mock.tsx
+++ b/webui/react/src/components/ComparisonView.test.mock.tsx
@@ -57,20 +57,6 @@ export const METRIC_DATA: RunMetricData = {
     },
   ],
   scale: 'linear',
-  selectedMetrics: [
-    {
-      group: 'training',
-      name: 'loss',
-    },
-    {
-      group: 'validation',
-      name: 'accuracy',
-    },
-    {
-      group: 'validation',
-      name: 'validation_loss',
-    },
-  ],
   setScale: (): Scale => {
     return Scale.Linear;
   },


### PR DESCRIPTION
## Ticket
ET-677



## Description
This fixes an issue where the page could appear slower than it should on load due to too much blocking traffic. We make three requests to build the comparison view for runs, searches and experiments:

1) request to get search/run information of selected runs/search ids

2) request to get metric names from selected runs/searches

3) request to get timeseries data given selected run ids and metric names.

we were attempting to make these requests simultaneously when the each request is dependent on information in the previous request. We also used `usePrevious` hooks as dependencies of `useCallback` hooks, which meant that we would erroneously update the callback reference when the previous value update was picked up on subsequent renders.

this pr fixes these issues by not rendering the comparison view tabs until the request for the records in the selection has completed, then not loading the time series data until the metric names request has started to return information. We also clean up some places where effects were called due to usePrevious and the overall data flow which should prevent issues with out of date data appearing.



## Test Plan
* Visit the runs page with the developer tools open to the network tab
* ensure some runs are selected
* when opening the comparison view, there should be one request made to `metric-names` and one request made to `time-series`
* when updating the selection, there should be one request made to `metric-names` and one request made to `time-series`. the comparison view should briefly show the loading state before showing the full data state.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ