### PR TITLE
chore: make bindings more reusable

### DIFF
--- a/bindings/Makefile
+++ b/bindings/Makefile
@@ -12,10 +12,10 @@ force-gen:
 	touch $(SWAGGER_SPEC)
 
 $(py_bindings_dest): $(SWAGGER_SPEC) swagger_parser.py $(py_generator)
-	python $(py_generator) --output $(py_bindings_dest)
+	python $(py_generator) --input $(SWAGGER_SPEC) --output $@
 
 $(ts_bindings_dest): $(SWAGGER_SPEC) swagger_parser.py $(ts_generator) $(wildcard static_ts_files/*)
-	python $(ts_generator) --output $@
+	python $(ts_generator) --input $(SWAGGER_SPEC) --output $@
 
 .PHONY: build/python
 build/python: $(py_bindings_dest)

--- a/bindings/generate_bindings_py.py
+++ b/bindings/generate_bindings_py.py
@@ -4,8 +4,6 @@ import typing
 import swagger_parser
 from typing_extensions import assert_never
 
-SWAGGER = "proto/build/swagger/determined/api/v1/api.swagger.json"
-SWAGGER = os.path.join(os.path.dirname(__file__), "..", SWAGGER)
 TAB = "    "
 
 Code = str
@@ -205,10 +203,9 @@ def gen_function(func: swagger_parser.Function) -> Code:
     out = [f"def {func.operation_name_sc()}("]
 
     # Function parameters.
-    out += ['    session: "api.BaseSession",']
+    out += ['    session: "RequestHandler",']
     if func.params:
         out += ["    *,"]
-
 
     required = sorted((k, v) for k, v in func.params.items() if v.required)
     optional = sorted((k, v) for k, v in func.params.items() if not v.required)
@@ -442,9 +439,6 @@ from urllib import parse
 
 import requests
 
-if typing.TYPE_CHECKING:
-    from determined.common import api
-
 # flake8: noqa
 Json = typing.Any
 
@@ -453,6 +447,20 @@ Json = typing.Any
 class Unset:
     pass
 
+
+class RequestHandler(typing.Protocol):
+    def _do_request(
+        self,
+        method: str,
+        path: str,
+        params: typing.Optional[typing.Dict[str, typing.Any]],
+        json: typing.Any,
+        data: typing.Optional[str],
+        headers: typing.Optional[typing.Dict[str, typing.Any]],
+        timeout: typing.Optional[int],
+        stream: bool,
+    ) -> requests.Response:
+        raise NotImplementedError
 
 _unset = Unset()
 
@@ -543,7 +551,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--input", "-i", action="store", default=SWAGGER, help="input swagger file")
+    parser.add_argument("--input", "-i", action="store", required=True, help="input swagger file")
     parser.add_argument("--output", "-o", action="store", required=True, help="output file")
     args = parser.parse_args()
 

--- a/bindings/generate_bindings_ts.py
+++ b/bindings/generate_bindings_ts.py
@@ -8,8 +8,6 @@ import swagger_parser
 from typing_extensions import Literal, assert_never
 
 DIRNAME = os.path.dirname(__file__)
-SWAGGER = "proto/build/swagger/determined/api/v1/api.swagger.json"
-SWAGGER = os.path.join(DIRNAME, "..", SWAGGER)
 STATIC_FOLDER = os.path.join(DIRNAME, "static_ts_files")
 
 Code = str
@@ -597,7 +595,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--input", "-i", action="store", default=SWAGGER, help="input swagger file")
+    parser.add_argument("--input", "-i", action="store", required=True, help="input swagger file")
     parser.add_argument("--output", "-o", action="store", required=True, help="output folder")
     args = parser.parse_args()
 

--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -8,9 +8,6 @@ from urllib import parse
 
 import requests
 
-if typing.TYPE_CHECKING:
-    from determined.common import api
-
 # flake8: noqa
 Json = typing.Any
 
@@ -19,6 +16,20 @@ Json = typing.Any
 class Unset:
     pass
 
+
+class RequestHandler(typing.Protocol):
+    def _do_request(
+        self,
+        method: str,
+        path: str,
+        params: typing.Optional[typing.Dict[str, typing.Any]],
+        json: typing.Any,
+        data: typing.Optional[str],
+        headers: typing.Optional[typing.Dict[str, typing.Any]],
+        timeout: typing.Optional[int],
+        stream: bool,
+    ) -> requests.Response:
+        raise NotImplementedError
 
 _unset = Unset()
 
@@ -17223,7 +17234,7 @@ class v1WorkspaceState(DetEnum):
     DELETED = "WORKSPACE_STATE_DELETED"
 
 def post_AckAllocationPreemptionSignal(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1AckAllocationPreemptionSignalRequest",
@@ -17253,7 +17264,7 @@ def post_AckAllocationPreemptionSignal(
     raise APIHttpError("post_AckAllocationPreemptionSignal", _resp)
 
 def post_ActivateExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -17277,7 +17288,7 @@ def post_ActivateExperiment(
     raise APIHttpError("post_ActivateExperiment", _resp)
 
 def post_ActivateExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ActivateExperimentsRequest",
     projectId: int,
@@ -17302,7 +17313,7 @@ def post_ActivateExperiments(
     raise APIHttpError("post_ActivateExperiments", _resp)
 
 def post_AddProjectNote(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1Note",
     projectId: int,
@@ -17328,7 +17339,7 @@ def post_AddProjectNote(
     raise APIHttpError("post_AddProjectNote", _resp)
 
 def post_AllocationAllGather(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1AllocationAllGatherRequest",
@@ -17356,7 +17367,7 @@ def post_AllocationAllGather(
     raise APIHttpError("post_AllocationAllGather", _resp)
 
 def post_AllocationPendingPreemptionSignal(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1AllocationPendingPreemptionSignalRequest",
@@ -17386,7 +17397,7 @@ def post_AllocationPendingPreemptionSignal(
     raise APIHttpError("post_AllocationPendingPreemptionSignal", _resp)
 
 def get_AllocationPreemptionSignal(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     timeoutSeconds: "typing.Optional[int]" = None,
@@ -17419,7 +17430,7 @@ def get_AllocationPreemptionSignal(
     raise APIHttpError("get_AllocationPreemptionSignal", _resp)
 
 def post_AllocationReady(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1AllocationReadyRequest",
@@ -17446,7 +17457,7 @@ def post_AllocationReady(
     raise APIHttpError("post_AllocationReady", _resp)
 
 def get_AllocationRendezvousInfo(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     resourcesId: str,
@@ -17478,7 +17489,7 @@ def get_AllocationRendezvousInfo(
     raise APIHttpError("get_AllocationRendezvousInfo", _resp)
 
 def post_AllocationWaiting(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1AllocationWaitingRequest",
@@ -17505,7 +17516,7 @@ def post_AllocationWaiting(
     raise APIHttpError("post_AllocationWaiting", _resp)
 
 def post_ArchiveExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -17529,7 +17540,7 @@ def post_ArchiveExperiment(
     raise APIHttpError("post_ArchiveExperiment", _resp)
 
 def post_ArchiveExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ArchiveExperimentsRequest",
     projectId: int,
@@ -17554,7 +17565,7 @@ def post_ArchiveExperiments(
     raise APIHttpError("post_ArchiveExperiments", _resp)
 
 def post_ArchiveModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
 ) -> None:
@@ -17580,7 +17591,7 @@ def post_ArchiveModel(
     raise APIHttpError("post_ArchiveModel", _resp)
 
 def post_ArchiveProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -17604,7 +17615,7 @@ def post_ArchiveProject(
     raise APIHttpError("post_ArchiveProject", _resp)
 
 def post_ArchiveRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ArchiveRunsRequest",
 ) -> "v1ArchiveRunsResponse":
@@ -17625,7 +17636,7 @@ def post_ArchiveRuns(
     raise APIHttpError("post_ArchiveRuns", _resp)
 
 def post_ArchiveWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -17649,7 +17660,7 @@ def post_ArchiveWorkspace(
     raise APIHttpError("post_ArchiveWorkspace", _resp)
 
 def patch_AssignMultipleGroups(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1AssignMultipleGroupsRequest",
 ) -> None:
@@ -17670,7 +17681,7 @@ def patch_AssignMultipleGroups(
     raise APIHttpError("patch_AssignMultipleGroups", _resp)
 
 def post_AssignRoles(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1AssignRolesRequest",
 ) -> None:
@@ -17691,7 +17702,7 @@ def post_AssignRoles(
     raise APIHttpError("post_AssignRoles", _resp)
 
 def post_BindRPToWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1BindRPToWorkspaceRequest",
     resourcePoolName: str,
@@ -17718,7 +17729,7 @@ def post_BindRPToWorkspace(
     raise APIHttpError("post_BindRPToWorkspace", _resp)
 
 def post_BulkAutoCreateWorkspaceNamespaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1BulkAutoCreateWorkspaceNamespaceBindingsRequest",
 ) -> None:
@@ -17739,7 +17750,7 @@ def post_BulkAutoCreateWorkspaceNamespaceBindings(
     raise APIHttpError("post_BulkAutoCreateWorkspaceNamespaceBindings", _resp)
 
 def post_CancelExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -17763,7 +17774,7 @@ def post_CancelExperiment(
     raise APIHttpError("post_CancelExperiment", _resp)
 
 def post_CancelExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CancelExperimentsRequest",
     projectId: int,
@@ -17788,7 +17799,7 @@ def post_CancelExperiments(
     raise APIHttpError("post_CancelExperiments", _resp)
 
 def post_CheckpointsRemoveFiles(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CheckpointsRemoveFilesRequest",
 ) -> None:
@@ -17809,7 +17820,7 @@ def post_CheckpointsRemoveFiles(
     raise APIHttpError("post_CheckpointsRemoveFiles", _resp)
 
 def post_CleanupLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1CleanupLogsResponse":
     """Cleanup task logs according to the retention policy."""
     _params = None
@@ -17828,7 +17839,7 @@ def post_CleanupLogs(
     raise APIHttpError("post_CleanupLogs", _resp)
 
 def get_CompareTrials(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     endBatches: "typing.Optional[int]" = None,
     group: "typing.Optional[str]" = None,
@@ -17926,7 +17937,7 @@ def get_CompareTrials(
     raise APIHttpError("get_CompareTrials", _resp)
 
 def post_CompleteTrialSearcherValidation(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CompleteValidateAfterOperation",
     trialId: int,
@@ -17953,7 +17964,7 @@ def post_CompleteTrialSearcherValidation(
     raise APIHttpError("post_CompleteTrialSearcherValidation", _resp)
 
 def post_ContinueExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ContinueExperimentRequest",
 ) -> "v1ContinueExperimentResponse":
@@ -17976,7 +17987,7 @@ def post_ContinueExperiment(
     raise APIHttpError("post_ContinueExperiment", _resp)
 
 def post_CreateExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CreateExperimentRequest",
 ) -> "v1CreateExperimentResponse":
@@ -17997,7 +18008,7 @@ def post_CreateExperiment(
     raise APIHttpError("post_CreateExperiment", _resp)
 
 def post_CreateGenericTask(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CreateGenericTaskRequest",
 ) -> "v1CreateGenericTaskResponse":
@@ -18018,7 +18029,7 @@ def post_CreateGenericTask(
     raise APIHttpError("post_CreateGenericTask", _resp)
 
 def post_CreateGroup(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CreateGroupRequest",
 ) -> "v1CreateGroupResponse":
@@ -18039,7 +18050,7 @@ def post_CreateGroup(
     raise APIHttpError("post_CreateGroup", _resp)
 
 def post_CreateTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CreateTrialRequest",
 ) -> "v1CreateTrialResponse":
@@ -18060,7 +18071,7 @@ def post_CreateTrial(
     raise APIHttpError("post_CreateTrial", _resp)
 
 def get_CurrentUser(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1CurrentUserResponse":
     """Get the current user."""
     _params = None
@@ -18079,7 +18090,7 @@ def get_CurrentUser(
     raise APIHttpError("get_CurrentUser", _resp)
 
 def delete_DeleteCheckpoints(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1DeleteCheckpointsRequest",
 ) -> None:
@@ -18100,7 +18111,7 @@ def delete_DeleteCheckpoints(
     raise APIHttpError("delete_DeleteCheckpoints", _resp)
 
 def delete_DeleteClusterMessage(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> None:
     """Clear the cluster-wide message shown to all users."""
     _params = None
@@ -18119,7 +18130,7 @@ def delete_DeleteClusterMessage(
     raise APIHttpError("delete_DeleteClusterMessage", _resp)
 
 def delete_DeleteExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> None:
@@ -18143,7 +18154,7 @@ def delete_DeleteExperiment(
     raise APIHttpError("delete_DeleteExperiment", _resp)
 
 def delete_DeleteExperimentLabel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
     label: str,
@@ -18171,7 +18182,7 @@ def delete_DeleteExperimentLabel(
     raise APIHttpError("delete_DeleteExperimentLabel", _resp)
 
 def delete_DeleteExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1DeleteExperimentsRequest",
     projectId: int,
@@ -18196,7 +18207,7 @@ def delete_DeleteExperiments(
     raise APIHttpError("delete_DeleteExperiments", _resp)
 
 def delete_DeleteGroup(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     groupId: int,
 ) -> None:
@@ -18220,7 +18231,7 @@ def delete_DeleteGroup(
     raise APIHttpError("delete_DeleteGroup", _resp)
 
 def delete_DeleteModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
 ) -> None:
@@ -18246,7 +18257,7 @@ def delete_DeleteModel(
     raise APIHttpError("delete_DeleteModel", _resp)
 
 def delete_DeleteModelVersion(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
     modelVersionNum: int,
@@ -18274,7 +18285,7 @@ def delete_DeleteModelVersion(
     raise APIHttpError("delete_DeleteModelVersion", _resp)
 
 def delete_DeleteProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1DeleteProjectResponse":
@@ -18298,7 +18309,7 @@ def delete_DeleteProject(
     raise APIHttpError("delete_DeleteProject", _resp)
 
 def post_DeleteRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1DeleteRunsRequest",
 ) -> "v1DeleteRunsResponse":
@@ -18319,7 +18330,7 @@ def post_DeleteRuns(
     raise APIHttpError("post_DeleteRuns", _resp)
 
 def delete_DeleteTemplate(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     templateName: str,
 ) -> None:
@@ -18345,7 +18356,7 @@ def delete_DeleteTemplate(
     raise APIHttpError("delete_DeleteTemplate", _resp)
 
 def delete_DeleteTensorboardFiles(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> None:
@@ -18369,7 +18380,7 @@ def delete_DeleteTensorboardFiles(
     raise APIHttpError("delete_DeleteTensorboardFiles", _resp)
 
 def delete_DeleteWebhook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -18393,7 +18404,7 @@ def delete_DeleteWebhook(
     raise APIHttpError("delete_DeleteWebhook", _resp)
 
 def delete_DeleteWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1DeleteWorkspaceResponse":
@@ -18417,7 +18428,7 @@ def delete_DeleteWorkspace(
     raise APIHttpError("delete_DeleteWorkspace", _resp)
 
 def delete_DeleteWorkspaceNamespaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     workspaceId: int,
     clusterNames: "typing.Optional[typing.Sequence[str]]" = None,
@@ -18445,7 +18456,7 @@ def delete_DeleteWorkspaceNamespaceBindings(
     raise APIHttpError("delete_DeleteWorkspaceNamespaceBindings", _resp)
 
 def post_DisableAgent(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
     body: "v1DisableAgentRequest",
@@ -18472,7 +18483,7 @@ def post_DisableAgent(
     raise APIHttpError("post_DisableAgent", _resp)
 
 def post_DisableSlot(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
     body: "v1DisableSlotRequest",
@@ -18503,7 +18514,7 @@ def post_DisableSlot(
     raise APIHttpError("post_DisableSlot", _resp)
 
 def post_EnableAgent(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
 ) -> "v1EnableAgentResponse":
@@ -18529,7 +18540,7 @@ def post_EnableAgent(
     raise APIHttpError("post_EnableAgent", _resp)
 
 def post_EnableSlot(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
     slotId: str,
@@ -18559,7 +18570,7 @@ def post_EnableSlot(
     raise APIHttpError("post_EnableSlot", _resp)
 
 def get_ExpMetricNames(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     ids: "typing.Sequence[int]",
     periodSeconds: "typing.Optional[int]" = None,
@@ -18599,7 +18610,7 @@ def get_ExpMetricNames(
     raise APIHttpError("get_ExpMetricNames", _resp)
 
 def get_GetActiveTasksCount(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetActiveTasksCountResponse":
     """Get a count of active tasks."""
     _params = None
@@ -18618,7 +18629,7 @@ def get_GetActiveTasksCount(
     raise APIHttpError("get_GetActiveTasksCount", _resp)
 
 def get_GetAgent(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
 ) -> "v1GetAgentResponse":
@@ -18644,7 +18655,7 @@ def get_GetAgent(
     raise APIHttpError("get_GetAgent", _resp)
 
 def get_GetAgents(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     excludeContainers: "typing.Optional[bool]" = None,
     excludeSlots: "typing.Optional[bool]" = None,
@@ -18694,7 +18705,7 @@ denote number of agents to skip from the end before returning results.
     raise APIHttpError("get_GetAgents", _resp)
 
 def get_GetAllocation(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
 ) -> "v1GetAllocationResponse":
@@ -18720,7 +18731,7 @@ def get_GetAllocation(
     raise APIHttpError("get_GetAllocation", _resp)
 
 def get_GetBestSearcherValidationMetric(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetBestSearcherValidationMetricResponse":
@@ -18744,7 +18755,7 @@ def get_GetBestSearcherValidationMetric(
     raise APIHttpError("get_GetBestSearcherValidationMetric", _resp)
 
 def get_GetCheckpoint(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     checkpointUuid: str,
 ) -> "v1GetCheckpointResponse":
@@ -18770,7 +18781,7 @@ def get_GetCheckpoint(
     raise APIHttpError("get_GetCheckpoint", _resp)
 
 def get_GetClusterMessage(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetClusterMessageResponse":
     """Get the currently configured cluster-wide message."""
     _params = None
@@ -18789,7 +18800,7 @@ def get_GetClusterMessage(
     raise APIHttpError("get_GetClusterMessage", _resp)
 
 def get_GetCommand(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     commandId: str,
 ) -> "v1GetCommandResponse":
@@ -18815,7 +18826,7 @@ def get_GetCommand(
     raise APIHttpError("get_GetCommand", _resp)
 
 def get_GetCommands(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -18872,7 +18883,7 @@ accessible workspaces.
     raise APIHttpError("get_GetCommands", _resp)
 
 def get_GetCurrentTrialSearcherOperation(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
 ) -> "v1GetCurrentTrialSearcherOperationResponse":
@@ -18896,7 +18907,7 @@ def get_GetCurrentTrialSearcherOperation(
     raise APIHttpError("get_GetCurrentTrialSearcherOperation", _resp)
 
 def get_GetExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetExperimentResponse":
@@ -18920,7 +18931,7 @@ def get_GetExperiment(
     raise APIHttpError("get_GetExperiment", _resp)
 
 def get_GetExperimentCheckpoints(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
     limit: "typing.Optional[int]" = None,
@@ -18984,7 +18995,7 @@ configuration setting.
     raise APIHttpError("get_GetExperimentCheckpoints", _resp)
 
 def get_GetExperimentLabels(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     projectId: "typing.Optional[int]" = None,
 ) -> "v1GetExperimentLabelsResponse":
@@ -19010,7 +19021,7 @@ def get_GetExperimentLabels(
     raise APIHttpError("get_GetExperimentLabels", _resp)
 
 def get_GetExperimentTrials(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
     limit: "typing.Optional[int]" = None,
@@ -19093,7 +19104,7 @@ Running is a substate of the Active state.
     raise APIHttpError("get_GetExperimentTrials", _resp)
 
 def get_GetExperimentValidationHistory(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetExperimentValidationHistoryResponse":
@@ -19117,7 +19128,7 @@ def get_GetExperimentValidationHistory(
     raise APIHttpError("get_GetExperimentValidationHistory", _resp)
 
 def get_GetExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     archived: "typing.Optional[bool]" = None,
     description: "typing.Optional[str]" = None,
@@ -19248,7 +19259,7 @@ usernames.
     raise APIHttpError("get_GetExperiments", _resp)
 
 def get_GetGenericTaskConfig(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> "v1GetGenericTaskConfigResponse":
@@ -19274,7 +19285,7 @@ def get_GetGenericTaskConfig(
     raise APIHttpError("get_GetGenericTaskConfig", _resp)
 
 def get_GetGroup(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     groupId: int,
 ) -> "v1GetGroupResponse":
@@ -19298,7 +19309,7 @@ def get_GetGroup(
     raise APIHttpError("get_GetGroup", _resp)
 
 def post_GetGroups(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1GetGroupsRequest",
 ) -> "v1GetGroupsResponse":
@@ -19319,7 +19330,7 @@ def post_GetGroups(
     raise APIHttpError("post_GetGroups", _resp)
 
 def get_GetGroupsAndUsersAssignedToWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     workspaceId: int,
     name: "typing.Optional[str]" = None,
@@ -19350,7 +19361,7 @@ for users.
     raise APIHttpError("get_GetGroupsAndUsersAssignedToWorkspace", _resp)
 
 def get_GetJobQueueStats(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     resourcePools: "typing.Optional[typing.Sequence[str]]" = None,
 ) -> "v1GetJobQueueStatsResponse":
@@ -19376,7 +19387,7 @@ def get_GetJobQueueStats(
     raise APIHttpError("get_GetJobQueueStats", _resp)
 
 def get_GetJobs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -19424,7 +19435,7 @@ jobs ahead.
     raise APIHttpError("get_GetJobs", _resp)
 
 def get_GetJobsV2(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -19472,7 +19483,7 @@ jobs ahead.
     raise APIHttpError("get_GetJobsV2", _resp)
 
 def get_GetKubernetesResourceManagers(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetKubernetesResourceManagersResponse":
     """Get a list of all Kubernetes cluster names."""
     _params = None
@@ -19491,7 +19502,7 @@ def get_GetKubernetesResourceManagers(
     raise APIHttpError("get_GetKubernetesResourceManagers", _resp)
 
 def get_GetKubernetesResourceQuotas(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1GetKubernetesResourceQuotasResponse":
@@ -19515,7 +19526,7 @@ def get_GetKubernetesResourceQuotas(
     raise APIHttpError("get_GetKubernetesResourceQuotas", _resp)
 
 def get_GetMaster(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetMasterResponse":
     """Get master information."""
     _params = None
@@ -19534,7 +19545,7 @@ def get_GetMaster(
     raise APIHttpError("get_GetMaster", _resp)
 
 def get_GetMasterConfig(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetMasterConfigResponse":
     """Get master config."""
     _params = None
@@ -19553,7 +19564,7 @@ def get_GetMasterConfig(
     raise APIHttpError("get_GetMasterConfig", _resp)
 
 def get_GetMe(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetMeResponse":
     """Get the current user."""
     _params = None
@@ -19572,7 +19583,7 @@ def get_GetMe(
     raise APIHttpError("get_GetMe", _resp)
 
 def get_GetMetadataValues(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     key: str,
     projectId: int,
@@ -19601,7 +19612,7 @@ def get_GetMetadataValues(
     raise APIHttpError("get_GetMetadataValues", _resp)
 
 def get_GetMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     group: str,
     trialIds: "typing.Sequence[int]",
@@ -19641,7 +19652,7 @@ def get_GetMetrics(
     raise APIHttpError("get_GetMetrics", _resp)
 
 def get_GetModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
 ) -> "v1GetModelResponse":
@@ -19667,7 +19678,7 @@ def get_GetModel(
     raise APIHttpError("get_GetModel", _resp)
 
 def get_GetModelDef(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetModelDefResponse":
@@ -19691,7 +19702,7 @@ def get_GetModelDef(
     raise APIHttpError("get_GetModelDef", _resp)
 
 def post_GetModelDefFile(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1GetModelDefFileRequest",
     experimentId: int,
@@ -19716,7 +19727,7 @@ def post_GetModelDefFile(
     raise APIHttpError("post_GetModelDefFile", _resp)
 
 def get_GetModelDefTree(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetModelDefTreeResponse":
@@ -19740,7 +19751,7 @@ def get_GetModelDefTree(
     raise APIHttpError("get_GetModelDefTree", _resp)
 
 def get_GetModelLabels(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     workspaceId: "typing.Optional[int]" = None,
 ) -> "v1GetModelLabelsResponse":
@@ -19766,7 +19777,7 @@ def get_GetModelLabels(
     raise APIHttpError("get_GetModelLabels", _resp)
 
 def get_GetModelVersion(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
     modelVersionNum: int,
@@ -19794,7 +19805,7 @@ def get_GetModelVersion(
     raise APIHttpError("get_GetModelVersion", _resp)
 
 def get_GetModelVersions(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
     limit: "typing.Optional[int]" = None,
@@ -19842,7 +19853,7 @@ denote number of models to skip from the end before returning results.
     raise APIHttpError("get_GetModelVersions", _resp)
 
 def get_GetModels(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     archived: "typing.Optional[bool]" = None,
     description: "typing.Optional[str]" = None,
@@ -19917,7 +19928,7 @@ denote number of models to skip from the end before returning results.
     raise APIHttpError("get_GetModels", _resp)
 
 def get_GetNotebook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     notebookId: str,
 ) -> "v1GetNotebookResponse":
@@ -19943,7 +19954,7 @@ def get_GetNotebook(
     raise APIHttpError("get_GetNotebook", _resp)
 
 def get_GetNotebooks(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -20001,7 +20012,7 @@ accessible workspaces.
     raise APIHttpError("get_GetNotebooks", _resp)
 
 def get_GetPermissionsSummary(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetPermissionsSummaryResponse":
     """List all permissions for the logged in user in all scopes."""
     _params = None
@@ -20020,7 +20031,7 @@ def get_GetPermissionsSummary(
     raise APIHttpError("get_GetPermissionsSummary", _resp)
 
 def get_GetProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1GetProjectResponse":
@@ -20044,7 +20055,7 @@ def get_GetProject(
     raise APIHttpError("get_GetProject", _resp)
 
 def get_GetProjectByKey(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     key: str,
 ) -> "v1GetProjectByKeyResponse":
@@ -20070,7 +20081,7 @@ def get_GetProjectByKey(
     raise APIHttpError("get_GetProjectByKey", _resp)
 
 def get_GetProjectColumns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
     tableType: "typing.Optional[v1TableType]" = None,
@@ -20102,7 +20113,7 @@ def get_GetProjectColumns(
     raise APIHttpError("get_GetProjectColumns", _resp)
 
 def get_GetProjectNumericMetricsRange(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1GetProjectNumericMetricsRangeResponse":
@@ -20126,7 +20137,7 @@ def get_GetProjectNumericMetricsRange(
     raise APIHttpError("get_GetProjectNumericMetricsRange", _resp)
 
 def get_GetProjectsByUserActivity(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
 ) -> "v1GetProjectsByUserActivityResponse":
@@ -20152,7 +20163,7 @@ def get_GetProjectsByUserActivity(
     raise APIHttpError("get_GetProjectsByUserActivity", _resp)
 
 def get_GetResourcePools(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -20186,7 +20197,7 @@ results.
     raise APIHttpError("get_GetResourcePools", _resp)
 
 def get_GetRolesAssignedToGroup(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     groupId: int,
 ) -> "v1GetRolesAssignedToGroupResponse":
@@ -20210,7 +20221,7 @@ def get_GetRolesAssignedToGroup(
     raise APIHttpError("get_GetRolesAssignedToGroup", _resp)
 
 def get_GetRolesAssignedToUser(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     userId: int,
 ) -> "v1GetRolesAssignedToUserResponse":
@@ -20234,7 +20245,7 @@ def get_GetRolesAssignedToUser(
     raise APIHttpError("get_GetRolesAssignedToUser", _resp)
 
 def post_GetRolesByID(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1GetRolesByIDRequest",
 ) -> "v1GetRolesByIDResponse":
@@ -20255,7 +20266,7 @@ def post_GetRolesByID(
     raise APIHttpError("post_GetRolesByID", _resp)
 
 def get_GetRunMetadata(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     runId: int,
 ) -> "v1GetRunMetadataResponse":
@@ -20279,7 +20290,7 @@ def get_GetRunMetadata(
     raise APIHttpError("get_GetRunMetadata", _resp)
 
 def get_GetSearcherEvents(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
 ) -> "v1GetSearcherEventsResponse":
@@ -20303,7 +20314,7 @@ def get_GetSearcherEvents(
     raise APIHttpError("get_GetSearcherEvents", _resp)
 
 def get_GetShell(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     shellId: str,
 ) -> "v1GetShellResponse":
@@ -20329,7 +20340,7 @@ def get_GetShell(
     raise APIHttpError("get_GetShell", _resp)
 
 def get_GetShells(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -20385,7 +20396,7 @@ accessible workspaces.
     raise APIHttpError("get_GetShells", _resp)
 
 def get_GetSlot(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
     slotId: str,
@@ -20415,7 +20426,7 @@ def get_GetSlot(
     raise APIHttpError("get_GetSlot", _resp)
 
 def get_GetSlots(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     agentId: str,
 ) -> "v1GetSlotsResponse":
@@ -20441,7 +20452,7 @@ def get_GetSlots(
     raise APIHttpError("get_GetSlots", _resp)
 
 def get_GetTask(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> "v1GetTaskResponse":
@@ -20467,7 +20478,7 @@ def get_GetTask(
     raise APIHttpError("get_GetTask", _resp)
 
 def get_GetTaskAcceleratorData(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> "v1GetTaskAcceleratorDataResponse":
@@ -20494,7 +20505,7 @@ def get_GetTaskAcceleratorData(
     raise APIHttpError("get_GetTaskAcceleratorData", _resp)
 
 def get_GetTaskContextDirectory(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> "v1GetTaskContextDirectoryResponse":
@@ -20520,7 +20531,7 @@ def get_GetTaskContextDirectory(
     raise APIHttpError("get_GetTaskContextDirectory", _resp)
 
 def get_GetTasks(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetTasksResponse":
     """Get all tasks."""
     _params = None
@@ -20539,7 +20550,7 @@ def get_GetTasks(
     raise APIHttpError("get_GetTasks", _resp)
 
 def get_GetTelemetry(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetTelemetryResponse":
     """Get telemetry information."""
     _params = None
@@ -20558,7 +20569,7 @@ def get_GetTelemetry(
     raise APIHttpError("get_GetTelemetry", _resp)
 
 def get_GetTemplate(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     templateName: str,
 ) -> "v1GetTemplateResponse":
@@ -20584,7 +20595,7 @@ def get_GetTemplate(
     raise APIHttpError("get_GetTemplate", _resp)
 
 def get_GetTemplates(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     name: "typing.Optional[str]" = None,
@@ -20633,7 +20644,7 @@ denote number of templates to skip from the end before returning results.
     raise APIHttpError("get_GetTemplates", _resp)
 
 def get_GetTensorboard(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     tensorboardId: str,
 ) -> "v1GetTensorboardResponse":
@@ -20659,7 +20670,7 @@ def get_GetTensorboard(
     raise APIHttpError("get_GetTensorboard", _resp)
 
 def get_GetTensorboards(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     limit: "typing.Optional[int]" = None,
     offset: "typing.Optional[int]" = None,
@@ -20718,7 +20729,7 @@ all accessible workspaces.
     raise APIHttpError("get_GetTensorboards", _resp)
 
 def get_GetTrainingMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialIds: "typing.Optional[typing.Sequence[int]]" = None,
 ) -> "typing.Iterable[v1GetTrainingMetricsResponse]":
@@ -20755,7 +20766,7 @@ def get_GetTrainingMetrics(
     raise APIHttpError("get_GetTrainingMetrics", _resp)
 
 def get_GetTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
 ) -> "v1GetTrialResponse":
@@ -20779,7 +20790,7 @@ def get_GetTrial(
     raise APIHttpError("get_GetTrial", _resp)
 
 def get_GetTrialByExternalID(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     externalExperimentId: str,
     externalTrialId: str,
@@ -20809,7 +20820,7 @@ def get_GetTrialByExternalID(
     raise APIHttpError("get_GetTrialByExternalID", _resp)
 
 def get_GetTrialCheckpoints(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
     limit: "typing.Optional[int]" = None,
@@ -20873,7 +20884,7 @@ configuration setting.
     raise APIHttpError("get_GetTrialCheckpoints", _resp)
 
 def get_GetTrialMetricsByCheckpoint(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     checkpointUuid: str,
     metricGroup: "typing.Optional[str]" = None,
@@ -20911,7 +20922,7 @@ all groups).
     raise APIHttpError("get_GetTrialMetricsByCheckpoint", _resp)
 
 def get_GetTrialMetricsByModelVersion(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
     modelVersionNum: int,
@@ -20951,7 +20962,7 @@ all groups).
     raise APIHttpError("get_GetTrialMetricsByModelVersion", _resp)
 
 def get_GetTrialProfilerAvailableSeries(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
     follow: "typing.Optional[bool]" = None,
@@ -20990,7 +21001,7 @@ def get_GetTrialProfilerAvailableSeries(
     raise APIHttpError("get_GetTrialProfilerAvailableSeries", _resp)
 
 def get_GetTrialProfilerMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     labels_trialId: int,
     follow: "typing.Optional[bool]" = None,
@@ -21047,7 +21058,7 @@ from the dataloader took.
     raise APIHttpError("get_GetTrialProfilerMetrics", _resp)
 
 def get_GetTrialRemainingLogRetentionDays(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1GetTrialRemainingLogRetentionDaysResponse":
@@ -21071,7 +21082,7 @@ def get_GetTrialRemainingLogRetentionDays(
     raise APIHttpError("get_GetTrialRemainingLogRetentionDays", _resp)
 
 def get_GetTrialWorkloads(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
     filter: "typing.Optional[GetTrialWorkloadsRequestFilterOption]" = None,
@@ -21139,7 +21150,7 @@ denote number of workloads to skip from the end before returning results.
     raise APIHttpError("get_GetTrialWorkloads", _resp)
 
 def get_GetUser(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     userId: int,
 ) -> "v1GetUserResponse":
@@ -21163,7 +21174,7 @@ def get_GetUser(
     raise APIHttpError("get_GetUser", _resp)
 
 def get_GetUserByUsername(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     username: str,
 ) -> "v1GetUserByUsernameResponse":
@@ -21189,7 +21200,7 @@ def get_GetUserByUsername(
     raise APIHttpError("get_GetUserByUsername", _resp)
 
 def get_GetUserSetting(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetUserSettingResponse":
     """Get a user's settings for website"""
     _params = None
@@ -21208,7 +21219,7 @@ def get_GetUserSetting(
     raise APIHttpError("get_GetUserSetting", _resp)
 
 def get_GetUsers(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     active: "typing.Optional[bool]" = None,
     admin: "typing.Optional[bool]" = None,
@@ -21270,7 +21281,7 @@ denote number of projects to skip from the end before returning results.
     raise APIHttpError("get_GetUsers", _resp)
 
 def get_GetValidationMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialIds: "typing.Optional[typing.Sequence[int]]" = None,
 ) -> "typing.Iterable[v1GetValidationMetricsResponse]":
@@ -21307,7 +21318,7 @@ def get_GetValidationMetrics(
     raise APIHttpError("get_GetValidationMetrics", _resp)
 
 def get_GetWebhooks(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetWebhooksResponse":
     """Get a list of webhooks."""
     _params = None
@@ -21326,7 +21337,7 @@ def get_GetWebhooks(
     raise APIHttpError("get_GetWebhooks", _resp)
 
 def get_GetWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1GetWorkspaceResponse":
@@ -21350,7 +21361,7 @@ def get_GetWorkspace(
     raise APIHttpError("get_GetWorkspace", _resp)
 
 def get_GetWorkspaceProjects(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
     archived: "typing.Optional[bool]" = None,
@@ -21412,7 +21423,7 @@ denote number of projects to skip from the end before returning results.
     raise APIHttpError("get_GetWorkspaceProjects", _resp)
 
 def get_GetWorkspaces(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     archived: "typing.Optional[bool]" = None,
     limit: "typing.Optional[int]" = None,
@@ -21474,7 +21485,7 @@ denote number of workspaces to skip from the end before returning results.
     raise APIHttpError("get_GetWorkspaces", _resp)
 
 def get_GetWorkspacesWithDefaultNamespaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "v1GetWorkspacesWithDefaultNamespaceBindingsResponse":
     """Gets the ids of all workspaces that are bound to the default namespace for
     atleast one cluster.
@@ -21495,7 +21506,7 @@ def get_GetWorkspacesWithDefaultNamespaceBindings(
     raise APIHttpError("get_GetWorkspacesWithDefaultNamespaceBindings", _resp)
 
 def put_IdleNotebook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1IdleNotebookRequest",
     notebookId: str,
@@ -21522,7 +21533,7 @@ def put_IdleNotebook(
     raise APIHttpError("put_IdleNotebook", _resp)
 
 def post_KillCommand(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     commandId: str,
 ) -> "v1KillCommandResponse":
@@ -21548,7 +21559,7 @@ def post_KillCommand(
     raise APIHttpError("post_KillCommand", _resp)
 
 def post_KillExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -21572,7 +21583,7 @@ def post_KillExperiment(
     raise APIHttpError("post_KillExperiment", _resp)
 
 def post_KillExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1KillExperimentsRequest",
     projectId: int,
@@ -21597,7 +21608,7 @@ def post_KillExperiments(
     raise APIHttpError("post_KillExperiments", _resp)
 
 def post_KillGenericTask(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1KillGenericTaskRequest",
     taskId: str,
@@ -21624,7 +21635,7 @@ def post_KillGenericTask(
     raise APIHttpError("post_KillGenericTask", _resp)
 
 def post_KillNotebook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     notebookId: str,
 ) -> "v1KillNotebookResponse":
@@ -21650,7 +21661,7 @@ def post_KillNotebook(
     raise APIHttpError("post_KillNotebook", _resp)
 
 def post_KillRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1KillRunsRequest",
 ) -> "v1KillRunsResponse":
@@ -21671,7 +21682,7 @@ def post_KillRuns(
     raise APIHttpError("post_KillRuns", _resp)
 
 def post_KillShell(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     shellId: str,
 ) -> "v1KillShellResponse":
@@ -21697,7 +21708,7 @@ def post_KillShell(
     raise APIHttpError("post_KillShell", _resp)
 
 def post_KillTensorboard(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     tensorboardId: str,
 ) -> "v1KillTensorboardResponse":
@@ -21723,7 +21734,7 @@ def post_KillTensorboard(
     raise APIHttpError("post_KillTensorboard", _resp)
 
 def post_KillTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -21747,7 +21758,7 @@ def post_KillTrial(
     raise APIHttpError("post_KillTrial", _resp)
 
 def post_LaunchCommand(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1LaunchCommandRequest",
 ) -> "v1LaunchCommandResponse":
@@ -21768,7 +21779,7 @@ def post_LaunchCommand(
     raise APIHttpError("post_LaunchCommand", _resp)
 
 def post_LaunchNotebook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1LaunchNotebookRequest",
 ) -> "v1LaunchNotebookResponse":
@@ -21789,7 +21800,7 @@ def post_LaunchNotebook(
     raise APIHttpError("post_LaunchNotebook", _resp)
 
 def post_LaunchShell(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1LaunchShellRequest",
 ) -> "v1LaunchShellResponse":
@@ -21810,7 +21821,7 @@ def post_LaunchShell(
     raise APIHttpError("post_LaunchShell", _resp)
 
 def post_LaunchTensorboard(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1LaunchTensorboardRequest",
 ) -> "v1LaunchTensorboardResponse":
@@ -21831,7 +21842,7 @@ def post_LaunchTensorboard(
     raise APIHttpError("post_LaunchTensorboard", _resp)
 
 def get_ListRPsBoundToWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     workspaceId: int,
     limit: "typing.Optional[int]" = None,
@@ -21863,7 +21874,7 @@ def get_ListRPsBoundToWorkspace(
     raise APIHttpError("get_ListRPsBoundToWorkspace", _resp)
 
 def post_ListRoles(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ListRolesRequest",
 ) -> "v1ListRolesResponse":
@@ -21884,7 +21895,7 @@ def post_ListRoles(
     raise APIHttpError("post_ListRoles", _resp)
 
 def get_ListWorkspaceNamespaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1ListWorkspaceNamespaceBindingsResponse":
@@ -21908,7 +21919,7 @@ def get_ListWorkspaceNamespaceBindings(
     raise APIHttpError("get_ListWorkspaceNamespaceBindings", _resp)
 
 def get_ListWorkspacesBoundToRP(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     resourcePoolName: str,
     limit: "typing.Optional[int]" = None,
@@ -21941,7 +21952,7 @@ def get_ListWorkspacesBoundToRP(
     raise APIHttpError("get_ListWorkspacesBoundToRP", _resp)
 
 def post_Login(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1LoginRequest",
 ) -> "v1LoginResponse":
@@ -21962,7 +21973,7 @@ def post_Login(
     raise APIHttpError("post_Login", _resp)
 
 def post_Logout(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> None:
     """Logout the user."""
     _params = None
@@ -21981,7 +21992,7 @@ def post_Logout(
     raise APIHttpError("post_Logout", _resp)
 
 def post_MarkAllocationResourcesDaemon(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1MarkAllocationResourcesDaemonRequest",
@@ -22016,7 +22027,7 @@ def post_MarkAllocationResourcesDaemon(
     raise APIHttpError("post_MarkAllocationResourcesDaemon", _resp)
 
 def get_MasterLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     follow: "typing.Optional[bool]" = None,
     limit: "typing.Optional[int]" = None,
@@ -22060,7 +22071,7 @@ denote number of master logs to skip from the end before returning results.
     raise APIHttpError("get_MasterLogs", _resp)
 
 def get_MetricBatches(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
     metricName: str,
@@ -22114,7 +22125,7 @@ def get_MetricBatches(
     raise APIHttpError("get_MetricBatches", _resp)
 
 def post_MoveExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1MoveExperimentRequest",
     experimentId: int,
@@ -22139,7 +22150,7 @@ def post_MoveExperiment(
     raise APIHttpError("post_MoveExperiment", _resp)
 
 def post_MoveExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1MoveExperimentsRequest",
     projectId: int,
@@ -22164,7 +22175,7 @@ def post_MoveExperiments(
     raise APIHttpError("post_MoveExperiments", _resp)
 
 def post_MoveModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1MoveModelRequest",
     modelName: str,
@@ -22191,7 +22202,7 @@ def post_MoveModel(
     raise APIHttpError("post_MoveModel", _resp)
 
 def post_MoveProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1MoveProjectRequest",
     projectId: int,
@@ -22216,7 +22227,7 @@ def post_MoveProject(
     raise APIHttpError("post_MoveProject", _resp)
 
 def post_MoveRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1MoveRunsRequest",
 ) -> "v1MoveRunsResponse":
@@ -22237,7 +22248,7 @@ def post_MoveRuns(
     raise APIHttpError("post_MoveRuns", _resp)
 
 def post_NotifyContainerRunning(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1NotifyContainerRunningRequest",
@@ -22269,7 +22280,7 @@ def post_NotifyContainerRunning(
     raise APIHttpError("post_NotifyContainerRunning", _resp)
 
 def put_OverwriteRPWorkspaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1OverwriteRPWorkspaceBindingsRequest",
     resourcePoolName: str,
@@ -22296,7 +22307,7 @@ def put_OverwriteRPWorkspaceBindings(
     raise APIHttpError("put_OverwriteRPWorkspaceBindings", _resp)
 
 def patch_PatchCheckpoints(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchCheckpointsRequest",
 ) -> None:
@@ -22317,7 +22328,7 @@ def patch_PatchCheckpoints(
     raise APIHttpError("patch_PatchCheckpoints", _resp)
 
 def patch_PatchExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchExperiment",
     experiment_id: int,
@@ -22343,7 +22354,7 @@ def patch_PatchExperiment(
     raise APIHttpError("patch_PatchExperiment", _resp)
 
 def patch_PatchMasterConfig(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchMasterConfigRequest",
 ) -> None:
@@ -22364,7 +22375,7 @@ def patch_PatchMasterConfig(
     raise APIHttpError("patch_PatchMasterConfig", _resp)
 
 def patch_PatchModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchModel",
     modelName: str,
@@ -22392,7 +22403,7 @@ def patch_PatchModel(
     raise APIHttpError("patch_PatchModel", _resp)
 
 def patch_PatchModelVersion(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchModelVersion",
     modelName: str,
@@ -22422,7 +22433,7 @@ def patch_PatchModelVersion(
     raise APIHttpError("patch_PatchModelVersion", _resp)
 
 def patch_PatchProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchProject",
     id: int,
@@ -22448,7 +22459,7 @@ def patch_PatchProject(
     raise APIHttpError("patch_PatchProject", _resp)
 
 def patch_PatchTemplateConfig(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "typing.Dict[str, typing.Any]",
     templateName: str,
@@ -22476,7 +22487,7 @@ def patch_PatchTemplateConfig(
     raise APIHttpError("patch_PatchTemplateConfig", _resp)
 
 def patch_PatchTemplateName(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchTemplateNameRequest",
 ) -> "v1PatchTemplateNameResponse":
@@ -22497,7 +22508,7 @@ def patch_PatchTemplateName(
     raise APIHttpError("patch_PatchTemplateName", _resp)
 
 def patch_PatchTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchTrialRequest",
     trialId: int,
@@ -22522,7 +22533,7 @@ def patch_PatchTrial(
     raise APIHttpError("patch_PatchTrial", _resp)
 
 def patch_PatchUser(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchUser",
     userId: int,
@@ -22548,7 +22559,7 @@ def patch_PatchUser(
     raise APIHttpError("patch_PatchUser", _resp)
 
 def patch_PatchUsers(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchUsersRequest",
 ) -> "v1PatchUsersResponse":
@@ -22569,7 +22580,7 @@ def patch_PatchUsers(
     raise APIHttpError("patch_PatchUsers", _resp)
 
 def patch_PatchWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PatchWorkspace",
     id: int,
@@ -22595,7 +22606,7 @@ def patch_PatchWorkspace(
     raise APIHttpError("patch_PatchWorkspace", _resp)
 
 def post_PauseExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -22619,7 +22630,7 @@ def post_PauseExperiment(
     raise APIHttpError("post_PauseExperiment", _resp)
 
 def post_PauseExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PauseExperimentsRequest",
     projectId: int,
@@ -22644,7 +22655,7 @@ def post_PauseExperiments(
     raise APIHttpError("post_PauseExperiments", _resp)
 
 def post_PauseGenericTask(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> None:
@@ -22670,7 +22681,7 @@ def post_PauseGenericTask(
     raise APIHttpError("post_PauseGenericTask", _resp)
 
 def post_PauseRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PauseRunsRequest",
 ) -> "v1PauseRunsResponse":
@@ -22691,7 +22702,7 @@ def post_PauseRuns(
     raise APIHttpError("post_PauseRuns", _resp)
 
 def post_PinWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -22715,7 +22726,7 @@ def post_PinWorkspace(
     raise APIHttpError("post_PinWorkspace", _resp)
 
 def post_PostAllocationAcceleratorData(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1PostAllocationAcceleratorDataRequest",
@@ -22742,7 +22753,7 @@ def post_PostAllocationAcceleratorData(
     raise APIHttpError("post_PostAllocationAcceleratorData", _resp)
 
 def post_PostAllocationProxyAddress(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     allocationId: str,
     body: "v1PostAllocationProxyAddressRequest",
@@ -22771,7 +22782,7 @@ def post_PostAllocationProxyAddress(
     raise APIHttpError("post_PostAllocationProxyAddress", _resp)
 
 def post_PostCheckpointMetadata(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostCheckpointMetadataRequest",
     checkpoint_uuid: str,
@@ -22798,7 +22809,7 @@ def post_PostCheckpointMetadata(
     raise APIHttpError("post_PostCheckpointMetadata", _resp)
 
 def post_PostModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostModelRequest",
 ) -> "v1PostModelResponse":
@@ -22819,7 +22830,7 @@ def post_PostModel(
     raise APIHttpError("post_PostModel", _resp)
 
 def post_PostModelVersion(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostModelVersionRequest",
     modelName: str,
@@ -22846,7 +22857,7 @@ def post_PostModelVersion(
     raise APIHttpError("post_PostModelVersion", _resp)
 
 def post_PostProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostProjectRequest",
     workspaceId: int,
@@ -22871,7 +22882,7 @@ def post_PostProject(
     raise APIHttpError("post_PostProject", _resp)
 
 def post_PostRunMetadata(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostRunMetadataRequest",
     runId: int,
@@ -22896,7 +22907,7 @@ def post_PostRunMetadata(
     raise APIHttpError("post_PostRunMetadata", _resp)
 
 def post_PostSearcherOperations(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostSearcherOperationsRequest",
     experimentId: int,
@@ -22921,7 +22932,7 @@ def post_PostSearcherOperations(
     raise APIHttpError("post_PostSearcherOperations", _resp)
 
 def post_PostTaskLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostTaskLogsRequest",
 ) -> None:
@@ -22942,7 +22953,7 @@ def post_PostTaskLogs(
     raise APIHttpError("post_PostTaskLogs", _resp)
 
 def post_PostTemplate(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1Template",
     template_name: str,
@@ -22970,7 +22981,7 @@ def post_PostTemplate(
     raise APIHttpError("post_PostTemplate", _resp)
 
 def post_PostTrialProfilerMetricsBatch(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostTrialProfilerMetricsBatchRequest",
 ) -> None:
@@ -22991,7 +23002,7 @@ def post_PostTrialProfilerMetricsBatch(
     raise APIHttpError("post_PostTrialProfilerMetricsBatch", _resp)
 
 def post_PostTrialRunnerMetadata(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1TrialRunnerMetadata",
     trialId: int,
@@ -23017,7 +23028,7 @@ def post_PostTrialRunnerMetadata(
     raise APIHttpError("post_PostTrialRunnerMetadata", _resp)
 
 def post_PostUser(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostUserRequest",
 ) -> "v1PostUserResponse":
@@ -23038,7 +23049,7 @@ def post_PostUser(
     raise APIHttpError("post_PostUser", _resp)
 
 def post_PostUserActivity(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostUserActivityRequest",
 ) -> None:
@@ -23059,7 +23070,7 @@ def post_PostUserActivity(
     raise APIHttpError("post_PostUserActivity", _resp)
 
 def post_PostUserSetting(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostUserSettingRequest",
 ) -> None:
@@ -23080,7 +23091,7 @@ def post_PostUserSetting(
     raise APIHttpError("post_PostUserSetting", _resp)
 
 def post_PostWebhook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1Webhook",
 ) -> "v1PostWebhookResponse":
@@ -23105,7 +23116,7 @@ def post_PostWebhook(
     raise APIHttpError("post_PostWebhook", _resp)
 
 def post_PostWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PostWorkspaceRequest",
 ) -> "v1PostWorkspaceResponse":
@@ -23126,7 +23137,7 @@ def post_PostWorkspace(
     raise APIHttpError("post_PostWorkspace", _resp)
 
 def post_PreviewHPSearch(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PreviewHPSearchRequest",
 ) -> "v1PreviewHPSearchResponse":
@@ -23147,7 +23158,7 @@ def post_PreviewHPSearch(
     raise APIHttpError("post_PreviewHPSearch", _resp)
 
 def put_PutExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1CreateExperimentRequest",
     externalExperimentId: str,
@@ -23175,7 +23186,7 @@ def put_PutExperiment(
     raise APIHttpError("put_PutExperiment", _resp)
 
 def put_PutExperimentLabel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
     label: str,
@@ -23203,7 +23214,7 @@ def put_PutExperimentLabel(
     raise APIHttpError("put_PutExperimentLabel", _resp)
 
 def put_PutExperimentRetainLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PutExperimentRetainLogsRequest",
     experimentId: int,
@@ -23228,7 +23239,7 @@ def put_PutExperimentRetainLogs(
     raise APIHttpError("put_PutExperimentRetainLogs", _resp)
 
 def put_PutExperimentsRetainLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PutExperimentsRetainLogsRequest",
     projectId: int,
@@ -23253,7 +23264,7 @@ def put_PutExperimentsRetainLogs(
     raise APIHttpError("put_PutExperimentsRetainLogs", _resp)
 
 def put_PutProjectNotes(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PutProjectNotesRequest",
     projectId: int,
@@ -23278,7 +23289,7 @@ def put_PutProjectNotes(
     raise APIHttpError("put_PutProjectNotes", _resp)
 
 def put_PutTemplate(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1Template",
     template_name: str,
@@ -23306,7 +23317,7 @@ def put_PutTemplate(
     raise APIHttpError("put_PutTemplate", _resp)
 
 def put_PutTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PutTrialRequest",
 ) -> "v1PutTrialResponse":
@@ -23327,7 +23338,7 @@ def put_PutTrial(
     raise APIHttpError("put_PutTrial", _resp)
 
 def put_PutTrialRetainLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1PutTrialRetainLogsRequest",
     trialId: int,
@@ -23352,7 +23363,7 @@ def put_PutTrialRetainLogs(
     raise APIHttpError("put_PutTrialRetainLogs", _resp)
 
 def post_RemoveAssignments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1RemoveAssignmentsRequest",
 ) -> None:
@@ -23373,7 +23384,7 @@ def post_RemoveAssignments(
     raise APIHttpError("post_RemoveAssignments", _resp)
 
 def post_ReportCheckpoint(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1Checkpoint",
 ) -> None:
@@ -23397,7 +23408,7 @@ def post_ReportCheckpoint(
     raise APIHttpError("post_ReportCheckpoint", _resp)
 
 def post_ReportTrialMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ReportTrialMetricsRequest",
     metrics_trialId: int,
@@ -23422,7 +23433,7 @@ def post_ReportTrialMetrics(
     raise APIHttpError("post_ReportTrialMetrics", _resp)
 
 def post_ReportTrialProgress(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: float,
     trialId: int,
@@ -23450,7 +23461,7 @@ the searcher.
     raise APIHttpError("post_ReportTrialProgress", _resp)
 
 def post_ReportTrialSearcherEarlyExit(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1TrialEarlyExit",
     trialId: int,
@@ -23478,7 +23489,7 @@ def post_ReportTrialSearcherEarlyExit(
     raise APIHttpError("post_ReportTrialSearcherEarlyExit", _resp)
 
 def post_ReportTrialSourceInfo(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ReportTrialSourceInfoRequest",
 ) -> "v1ReportTrialSourceInfoResponse":
@@ -23499,7 +23510,7 @@ def post_ReportTrialSourceInfo(
     raise APIHttpError("post_ReportTrialSourceInfo", _resp)
 
 def post_ReportTrialTrainingMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1TrialMetrics",
     trainingMetrics_trialId: int,
@@ -23525,7 +23536,7 @@ def post_ReportTrialTrainingMetrics(
     raise APIHttpError("post_ReportTrialTrainingMetrics", _resp)
 
 def post_ReportTrialValidationMetrics(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1TrialMetrics",
     validationMetrics_trialId: int,
@@ -23551,7 +23562,7 @@ def post_ReportTrialValidationMetrics(
     raise APIHttpError("post_ReportTrialValidationMetrics", _resp)
 
 def post_ResetUserSetting(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> None:
     """Reset a user's settings for website"""
     _params = None
@@ -23570,7 +23581,7 @@ def post_ResetUserSetting(
     raise APIHttpError("post_ResetUserSetting", _resp)
 
 def get_ResourceAllocationAggregated(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     endDate: str,
     period: "v1ResourceAllocationAggregationPeriod",
@@ -23609,7 +23620,7 @@ of the day).
     raise APIHttpError("get_ResourceAllocationAggregated", _resp)
 
 def get_ResourceAllocationRaw(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     timestampAfter: str,
     timestampBefore: str,
@@ -23638,7 +23649,7 @@ def get_ResourceAllocationRaw(
     raise APIHttpError("get_ResourceAllocationRaw", _resp)
 
 def post_ResumeRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1ResumeRunsRequest",
 ) -> "v1ResumeRunsResponse":
@@ -23659,7 +23670,7 @@ def post_ResumeRuns(
     raise APIHttpError("post_ResumeRuns", _resp)
 
 def post_RunPrepareForReporting(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1RunPrepareForReportingRequest",
 ) -> "v1RunPrepareForReportingResponse":
@@ -23682,7 +23693,7 @@ def post_RunPrepareForReporting(
     raise APIHttpError("post_RunPrepareForReporting", _resp)
 
 def post_SearchExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SearchExperimentsRequest",
 ) -> "v1SearchExperimentsResponse":
@@ -23703,7 +23714,7 @@ def post_SearchExperiments(
     raise APIHttpError("post_SearchExperiments", _resp)
 
 def post_SearchRolesAssignableToScope(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SearchRolesAssignableToScopeRequest",
 ) -> "v1SearchRolesAssignableToScopeResponse":
@@ -23724,7 +23735,7 @@ def post_SearchRolesAssignableToScope(
     raise APIHttpError("post_SearchRolesAssignableToScope", _resp)
 
 def post_SearchRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SearchRunsRequest",
 ) -> "v1SearchRunsResponse":
@@ -23745,7 +23756,7 @@ def post_SearchRuns(
     raise APIHttpError("post_SearchRuns", _resp)
 
 def put_SetClusterMessage(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetClusterMessageRequest",
 ) -> None:
@@ -23768,7 +23779,7 @@ def put_SetClusterMessage(
     raise APIHttpError("put_SetClusterMessage", _resp)
 
 def post_SetCommandPriority(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetCommandPriorityRequest",
     commandId: str,
@@ -23795,7 +23806,7 @@ def post_SetCommandPriority(
     raise APIHttpError("post_SetCommandPriority", _resp)
 
 def post_SetNotebookPriority(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetNotebookPriorityRequest",
     notebookId: str,
@@ -23822,7 +23833,7 @@ def post_SetNotebookPriority(
     raise APIHttpError("post_SetNotebookPriority", _resp)
 
 def post_SetResourceQuotas(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetResourceQuotasRequest",
     id: int,
@@ -23847,7 +23858,7 @@ def post_SetResourceQuotas(
     raise APIHttpError("post_SetResourceQuotas", _resp)
 
 def post_SetShellPriority(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetShellPriorityRequest",
     shellId: str,
@@ -23874,7 +23885,7 @@ def post_SetShellPriority(
     raise APIHttpError("post_SetShellPriority", _resp)
 
 def post_SetTensorboardPriority(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetTensorboardPriorityRequest",
     tensorboardId: str,
@@ -23901,7 +23912,7 @@ def post_SetTensorboardPriority(
     raise APIHttpError("post_SetTensorboardPriority", _resp)
 
 def post_SetUserPassword(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: str,
     userId: int,
@@ -23927,7 +23938,7 @@ def post_SetUserPassword(
     raise APIHttpError("post_SetUserPassword", _resp)
 
 def post_SetWorkspaceNamespaceBindings(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1SetWorkspaceNamespaceBindingsRequest",
     workspaceId: int,
@@ -23952,7 +23963,7 @@ def post_SetWorkspaceNamespaceBindings(
     raise APIHttpError("post_SetWorkspaceNamespaceBindings", _resp)
 
 def post_StartTrial(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1StartTrialRequest",
     trialId: int,
@@ -23977,7 +23988,7 @@ def post_StartTrial(
     raise APIHttpError("post_StartTrial", _resp)
 
 def get_TaskLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
     agentIds: "typing.Optional[typing.Sequence[str]]" = None,
@@ -24066,7 +24077,7 @@ def get_TaskLogs(
     raise APIHttpError("get_TaskLogs", _resp)
 
 def get_TaskLogsFields(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
     follow: "typing.Optional[bool]" = None,
@@ -24107,7 +24118,7 @@ def get_TaskLogsFields(
     raise APIHttpError("get_TaskLogsFields", _resp)
 
 def post_TestWebhook(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> "v1TestWebhookResponse":
@@ -24131,7 +24142,7 @@ def post_TestWebhook(
     raise APIHttpError("post_TestWebhook", _resp)
 
 def get_TrialLogs(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
     agentIds: "typing.Optional[typing.Sequence[str]]" = None,
@@ -24215,7 +24226,7 @@ def get_TrialLogs(
     raise APIHttpError("get_TrialLogs", _resp)
 
 def get_TrialLogsFields(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     trialId: int,
     follow: "typing.Optional[bool]" = None,
@@ -24254,7 +24265,7 @@ def get_TrialLogsFields(
     raise APIHttpError("get_TrialLogsFields", _resp)
 
 def get_TrialsSample(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     experimentId: int,
     metricName: str,
@@ -24319,7 +24330,7 @@ def get_TrialsSample(
     raise APIHttpError("get_TrialsSample", _resp)
 
 def get_TrialsSnapshot(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     batchesProcessed: int,
     experimentId: int,
@@ -24379,7 +24390,7 @@ def get_TrialsSnapshot(
     raise APIHttpError("get_TrialsSnapshot", _resp)
 
 def post_UnarchiveExperiment(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -24403,7 +24414,7 @@ def post_UnarchiveExperiment(
     raise APIHttpError("post_UnarchiveExperiment", _resp)
 
 def post_UnarchiveExperiments(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1UnarchiveExperimentsRequest",
     projectId: int,
@@ -24428,7 +24439,7 @@ def post_UnarchiveExperiments(
     raise APIHttpError("post_UnarchiveExperiments", _resp)
 
 def post_UnarchiveModel(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     modelName: str,
 ) -> None:
@@ -24454,7 +24465,7 @@ def post_UnarchiveModel(
     raise APIHttpError("post_UnarchiveModel", _resp)
 
 def post_UnarchiveProject(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -24478,7 +24489,7 @@ def post_UnarchiveProject(
     raise APIHttpError("post_UnarchiveProject", _resp)
 
 def post_UnarchiveRuns(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1UnarchiveRunsRequest",
 ) -> "v1UnarchiveRunsResponse":
@@ -24499,7 +24510,7 @@ def post_UnarchiveRuns(
     raise APIHttpError("post_UnarchiveRuns", _resp)
 
 def post_UnarchiveWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -24523,7 +24534,7 @@ def post_UnarchiveWorkspace(
     raise APIHttpError("post_UnarchiveWorkspace", _resp)
 
 def delete_UnbindRPFromWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1UnbindRPFromWorkspaceRequest",
     resourcePoolName: str,
@@ -24550,7 +24561,7 @@ def delete_UnbindRPFromWorkspace(
     raise APIHttpError("delete_UnbindRPFromWorkspace", _resp)
 
 def post_UnpauseGenericTask(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     taskId: str,
 ) -> None:
@@ -24576,7 +24587,7 @@ def post_UnpauseGenericTask(
     raise APIHttpError("post_UnpauseGenericTask", _resp)
 
 def post_UnpinWorkspace(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     id: int,
 ) -> None:
@@ -24600,7 +24611,7 @@ def post_UnpinWorkspace(
     raise APIHttpError("post_UnpinWorkspace", _resp)
 
 def put_UpdateGroup(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1UpdateGroupRequest",
     groupId: int,
@@ -24625,7 +24636,7 @@ def put_UpdateGroup(
     raise APIHttpError("put_UpdateGroup", _resp)
 
 def post_UpdateJobQueue(
-    session: "api.BaseSession",
+    session: "RequestHandler",
     *,
     body: "v1UpdateJobQueueRequest",
 ) -> None:
@@ -24646,7 +24657,7 @@ def post_UpdateJobQueue(
     raise APIHttpError("post_UpdateJobQueue", _resp)
 
 def get_health(
-    session: "api.BaseSession",
+    session: "RequestHandler",
 ) -> "HealthCheck":
     """Get health of Determined and the dependencies."""
     _params = None


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Remove the dependency on determined package and `BaseSession` 

https://hpe-aiatscale.slack.com/archives/C6D7MDSQ5/p1722972189991699

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
