### PR TITLE
build: INFENG-812: fix model_hub Docker tag

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1741,7 +1741,10 @@ jobs:
       - run:
           name: Build and publish model_hub docker images
           command: |
-            if [ ${CIRCLE_BRANCH} = 'main' ] || [[ ${CIRCLE_BRANCH} == *"release-"* ]]; then
+            # Match on either "main", or any branch beginning with
+            # "release-". Note: because of Bash quoting rules, the start-of-line
+            # caret in our regex must be outside of the quotes.
+            if [[ ${CIRCLE_BRANCH} == "main" ]] || [[ ${CIRCLE_BRANCH} =~ ^"release-" ]]; then
                 # For main and release branches, we will tag and publish both the environment
                 # with the git hash as well as the version.  This will make that image available
                 # immediately for nightly tests.
@@ -1785,7 +1788,10 @@ jobs:
       - run:
           name: Build and publish model_hub docker images
           command: |
-            if [ ${CIRCLE_BRANCH} = 'main' ] || [[ ${CIRCLE_BRANCH} == *"release-"* ]]; then
+            # Match on either "main", or any branch beginning with
+            # "release-". Note: because of Bash quoting rules, the start-of-line
+            # caret in our regex must be outside of the quotes.
+            if [[ ${CIRCLE_BRANCH} == "main" ]] || [[ ${CIRCLE_BRANCH} =~ ^"release-" ]]; then
                 # For main and release branches, we will tag and publish both the environment
                 # with the git hash as well as the version.  This will make that image available
                 # immediately for nightly tests.


### PR DESCRIPTION
## Ticket
INFENG-812

## Description
This changeset fixes a CircleCI bug that results in building release-flavored Docker images for things like `model_hub` even during non-release builds. Specifically, update `package-and-push-system-dev` and `package-and-push-system-dev-ee` CircleCI jobs to build dev Docker images correctly by fixing a bash if statement to check for if we're running the job from the "main" branch or a branch prefixed with "release-". The previous behavior would match on any git branch regardless, because of the position of the glob characters.

This behavior doesn't seem to cause problems now because the production path builds images with the version specified in `VERSION`, which is something like `0.36.0-dev0`, so it shouldn't clobber anything existing, but I believe this will build and push the same tag every time a branch is merged. I'm not sure of all what is different between the code paths, though, and the behavior is not what was intended.

## Testing

Verify that the CI job that runs after merging any branch that isn't `main` or `release-*` runs:

```
make -C model_hub build-docker-dev
tools/scripts/retry.sh make -C model_hub publish-docker-dev
```

and not:

```
make -C model_hub build-docker
tools/scripts/retry.sh make -C model_hub publish-docker
```

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code