### PR TITLE
ci: restore "get project columns for runs table" to performance tests

### DIFF
--- a/performance/daist/daist/rest_api/tasks.py
+++ b/performance/daist/daist/rest_api/tasks.py
@@ -88,6 +88,10 @@ def read_only_tasks(resources: Resources) -> LocustTasksWithMeta:
         tasks.append(LocustPostTaskWithMeta(
             "/api/v1/experiments-search", test_name="search experiments",
             body={"projectId": resources.project_id}))
+
+        tasks.append(LocustGetTaskWithMeta(
+            f"/api/v1/projects/{resources.project_id}/columns?table_type=TABLE_TYPE_RUN",
+            test_name="get project columns for runs table"))
         if flags.SCALE_33:
             tasks.append(LocustGetTaskWithMeta(
                 f"/api/v1/projects/{resources.project_id}/columns",


### PR DESCRIPTION
## Description
We missed this when we added the Locust tests. I'm guessing this was added to K6 recently. We're not testing this endpoint without parameters because of performance reasons, so it's important to at least be testing this variant.

## Test Plan
I think there's an option to run this in CI - if not I'll run it locally to be sure. I will update this before merging either way.

## Checklist

- [ ] Changes have been manually QA'd
- [ N/A ] New features have been approved by the corresponding PM
- [ N/A ] User-facing API changes have the "User-facing API Change" label
- [ N/A ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ N/A ] Licenses have been included for new code which was copied and/or modified from any external code