### PR TITLE
docs: Describe basic lineage steps

### DIFF
--- a/docs/integrations/data-transformers/pachyderm.rst
+++ b/docs/integrations/data-transformers/pachyderm.rst
@@ -13,34 +13,26 @@ and on-premise installations.
 
 .. tip::
 
-   To get started with Pachyderm, visit the `Pachyderm documentation
+   To learn how to use Determined and Pachyderm together, follow this quick :ref:`tutorial
+   <det-pach-cat-dog>`, after which you'll have created a batch inferencing pipeline with editable
+   experiment configuration files.
+
+.. tip::
+
+   To learn more about how to get started with Pachyderm, visit the `Pachyderm documentation
    <https://docs.pachyderm.com/>`_.
 
 ****************************************
  Viewing Pachyderm Data from Determined
 ****************************************
 
-You can view your Pachyderm repo when running a trial or when viewing checkpoints derived from your
-Pachyderm data.
+Determined provides a basic data lineage to your Pachyderm repo. This allows you to view your
+Pachyderm repo when running an experiment or when viewing checkpoints derived from your Pachyderm
+data.
 
-**Prerequisites**
-
--  Determined and Pachyderm installed and running.
-
-   -  Follow a quick :ref:`tutorial <det-pach-cat-dog>` to learn how to set up Determined and
-      Pachyderm after which you'll have created a batch inferencing pipeline with editable
-      experiment configuration files.
-
--  The most recent commit ID from your Pachyderm repo (you can find this by visiting Repo Actions or
-   by running ``pachctl find commit``). For more information about Pachyderm repo input files, visit
-   the `documentation
-   <https://docs.pachyderm.com/products/mldm/latest/learn/console-guide/repo-actions/view-inputs//>`_.
-
-**Add an Integrations Section to Your Experiment Configuration File**
-
-To configure this basic data lineage, you must add an ``integrations`` section to your
-:ref:`experiment configuration <experiment-config-reference>` file. This section must include your
-Pachyderm repo ``dataset``, ``pachd``, and ``proxy``. For example:
+To enable basic data lineage, add an ``integrations`` section to your :ref:`experiment configuration
+<experiment-config-reference>` file. This section should include your Pachyderm repo ``dataset``,
+``pachd``, and ``proxy``. For example:
 
 .. code:: yaml
 
@@ -60,13 +52,38 @@ Pachyderm repo ``dataset``, ``pachd``, and ``proxy``. For example:
             host: "12.345.67.89"
             port: 80
 
-After running the experiment, go to the Determined WebUI and then visit the experiment's
-**Overview** tab. Select the data hyperlink to view your Pachyderm repo.
+.. note::
+
+   You can find the most recent commit ID from your Pachyderm repo by visiting Repo Actions or by
+   running ``pachctl find commit``. For more information about Pachyderm repo input files, visit the
+   `documentation
+   <https://docs.pachyderm.com/products/mldm/latest/learn/console-guide/repo-actions/view-inputs//>`_.
+
+Optionally, you can make the configuration more dynamic by setting the environment variables that
+your training script will use to automatically generate or modify the ``config.yaml`` file.
+
+For example:
+
+.. code:: bash
+
+   export PACH_PROJECT="your-project"
+   export PACH_REPO="your-repo"
+   export PACH_COMMIT="your-commit"
+   export PACH_BRANCH="your-branch"
+   export PACH_TOKEN="your-token"
+   export PACHD_HOST="your-pachd-host"
+   export PACHD_PORT=12345
+   export PACH_PROXY_SCHEME="http"
+   export PACH_PROXY_HOST="your-proxy-host"
+   export PACH_PROXY_PORT=8080
+
+After running your training script, go to the Determined WebUI and visit the experiment's **Overview** tab. Select the data
+hyperlink to view your Pachyderm repo.
 
    .. image:: /assets/images/webui-data-link.png
       :alt: Determined trial run showing link to Pachyderm data repo
 
 **Next Steps**
 
-You can then reuse this ``integrations`` section in your other experiment configuration files such
-as in your checkpointing configuration file.
+You can reuse this ``integrations`` section or the dynamic configuration method in your other
+experiment configuration files, such as in your checkpointing configuration file.

--- a/docs/integrations/data-transformers/pachyderm.rst
+++ b/docs/integrations/data-transformers/pachyderm.rst
@@ -11,19 +11,61 @@ and on-premise installations.
 -  Use Pachyderm to store and version your data via repositories and pipelines.
 -  Use Determined to train your models on Pachyderm data.
 
-****************************************
- Viewing Pachyderm Data from Determined
-****************************************
-
--  To view your Pachyderm repo when running a trial or when viewing checkpoints derived from your
-   Pachyderm data, click the data hyperlink. For more information about Pachyderm repo input files,
-   visit the `documentation
-   <https://docs.pachyderm.com/products/mldm/latest/learn/console-guide/repo-actions/view-inputs//>`_.
-
-   .. image:: /assets/images/webui-data-link.png
-      :alt: Determined trial run showing link to Pachyderm data repo
-
 .. tip::
 
    To get started with Pachyderm, visit the `Pachyderm documentation
    <https://docs.pachyderm.com/>`_.
+
+****************************************
+ Viewing Pachyderm Data from Determined
+****************************************
+
+You can view your Pachyderm repo when running a trial or when viewing checkpoints derived from your
+Pachyderm data.
+
+**Prerequisites**
+
+-  Determined and Pachyderm installed and running.
+
+   -  Follow a quick :ref:`tutorial <det-pach-cat-dog>` to learn how to set up Determined and
+      Pachyderm after which you'll have created a batch inferencing pipeline with editable
+      experiment configuration files.
+
+-  The most recent commit ID from your Pachyderm repo (you can find this by visiting Repo Actions).
+   For more information about Pachyderm repo input files, visit the `documentation
+   <https://docs.pachyderm.com/products/mldm/latest/learn/console-guide/repo-actions/view-inputs//>`_.
+
+**Add an Integrations Section to Your Experiment Configuration File**
+
+To configure this basic data lineage, you must add an ``integrations`` section to your
+:ref:`experiment configuration <experiment-config-reference>` file. This section must include your
+Pachyderm repo ``dataset``, ``pachd``, and ``proxy``. For example:
+
+.. code:: yaml
+
+   integrations:
+      pachyderm:
+         dataset:
+            project: "test-project"
+            repo: "test-repo"
+            commit: "your commit id"
+            branch: "master"
+            token: "PACHD Token"
+         pachd:
+            host: "IP address for pachd"
+            port: 30650
+         proxy:
+            scheme: "http"
+            host: "12.345.67.89"
+            port: 80
+
+After running the experiment, go to the Determined WebUI and then visit the experiment's
+**Overview** tab. Select the data hyperlink to view your Pachyderm repo.
+
+   .. image:: /assets/images/webui-data-link.png
+      :alt: Determined trial run showing link to Pachyderm data repo
+
+**Next Steps**
+
+You can then reuse this ``integrations`` section in your other experiment configuration files such
+as in your checkpointing configuration file.

--- a/docs/integrations/data-transformers/pachyderm.rst
+++ b/docs/integrations/data-transformers/pachyderm.rst
@@ -77,8 +77,8 @@ For example:
    export PACH_PROXY_HOST="your-proxy-host"
    export PACH_PROXY_PORT=8080
 
-After running your training script, go to the Determined WebUI and visit the experiment's **Overview** tab. Select the data
-hyperlink to view your Pachyderm repo.
+After running your training script, go to the Determined WebUI and visit the experiment's
+**Overview** tab. Select the data hyperlink to view your Pachyderm repo.
 
    .. image:: /assets/images/webui-data-link.png
       :alt: Determined trial run showing link to Pachyderm data repo

--- a/docs/integrations/data-transformers/pachyderm.rst
+++ b/docs/integrations/data-transformers/pachyderm.rst
@@ -31,8 +31,9 @@ Pachyderm data.
       Pachyderm after which you'll have created a batch inferencing pipeline with editable
       experiment configuration files.
 
--  The most recent commit ID from your Pachyderm repo (you can find this by visiting Repo Actions).
-   For more information about Pachyderm repo input files, visit the `documentation
+-  The most recent commit ID from your Pachyderm repo (you can find this by visiting Repo Actions or
+   by running ``pachctl find commit``). For more information about Pachyderm repo input files, visit
+   the `documentation
    <https://docs.pachyderm.com/products/mldm/latest/learn/console-guide/repo-actions/view-inputs//>`_.
 
 **Add an Integrations Section to Your Experiment Configuration File**

--- a/docs/tutorials/pachyderm-cat-dog.rst
+++ b/docs/tutorials/pachyderm-cat-dog.rst
@@ -58,9 +58,9 @@ The following prerequisites are required:
  Get the Tutorial Files
 ************************
 
--  Before starting this tutorial, ensure you have copied the files from the `Github repository
-   <https://github.com/pachyderm/examples/tree/master/determined-pachyderm-batch-inferencing>`_ to
-   your local directory.
+-  Before starting this tutorial, ensure you have copied the
+   ``determined-pachyderm-batch-inferencing`` files from the `Pachyderm examples repository
+   <https://github.com/pachyderm/examples/tree/master/>`_ to your local directory.
 
 .. note::
 


### PR DESCRIPTION
Describe how to configure the experiment config yaml file to view the basic data lineage (pach repo).

Include option to set variables dynamically.

Ensure the cat dog tutorial is updated.

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ