### PR TITLE
docs: Getting a list of files in a checkpoint

### DIFF
--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug-basic.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug-basic.rst
@@ -140,9 +140,10 @@ the :download:`core_api.tgz </examples/core_api.tgz>` download or in the `Github
  Report Checkpoints
 ********************
 
-By checkpointing periodically during training and reporting those checkpoints to the master, you can
-stop and restart training in two different ways: either by pausing and reactivating training using
-the WebUI, or by clicking the Continue Trial button after the experiment completes.
+By checkpointing periodically during training and reporting those :ref:`checkpoints <checkpoints>`
+to the master, you can stop and restart training in two different ways: either by pausing and
+reactivating training using the WebUI, or by clicking the Continue Trial button after the experiment
+completes.
 
 These two types of continuations have different behaviors. While you always want to preserve the
 value you are incrementing (the "model weight"), you do not always want to preserve the batch index.

--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
@@ -191,9 +191,9 @@ script to report checkpoints.
  Step 3: Checkpointing
 ***********************
 
-Checkpointing periodically during training and reporting the checkpoints to the master gives us the
-ability to stop and restart training. In this section, we’ll modify our script for the purpose of
-checkpointing.
+Checkpointing periodically during training and reporting the :ref:`checkpoints <checkpoints>` to the
+master gives us the ability to stop and restart training. In this section, we’ll modify our script
+for the purpose of checkpointing.
 
 In this step, we’ll run our experiment using the ``model_def_checkpoints.py`` script and its
 accompanying ``checkpoints.yaml`` experiment configuration file.

--- a/docs/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.rst
@@ -331,9 +331,9 @@ Checkpointing
 
 A checkpoint includes the model definition (Python source code), experiment configuration file,
 network architecture, and the values of the model's parameters (i.e., weights) and hyperparameters.
-When using a stateful optimizer during training, checkpoints will also include the state of the
-optimizer (i.e., learning rate). You can also embed arbitrary metadata in checkpoints via a
-:ref:`Python SDK <store-checkpoint-metadata>`.
+When using a stateful optimizer during training, :ref:`checkpoints <checkpoints>` will also include
+the state of the optimizer (i.e., learning rate). You can also embed arbitrary metadata in
+checkpoints via a :ref:`Python SDK <store-checkpoint-metadata>`.
 
 PyTorch trials are checkpointed as a ``state-dict.pth`` file. This file is created in a similar
 manner to the procedure described in the `PyTorch documentation

--- a/docs/model-dev-guide/model-management/_index.rst
+++ b/docs/model-dev-guide/model-management/_index.rst
@@ -6,9 +6,8 @@
  Use Checkpoints
 *****************
 
-When a model is trained with Determined, checkpoints are automatically saved to external storage.
-These checkpoints can then be exported for use outside Determined. See :ref:`use-trained-models` for
-details.
+When a model is trained with Determined, :ref:`checkpoints <checkpoints>` are automatically saved to
+external storage. These checkpoints can then be exported for use outside Determined.
 
 *********************
  Archive Experiments

--- a/docs/model-dev-guide/model-management/checkpoints.rst
+++ b/docs/model-dev-guide/model-management/checkpoints.rst
@@ -381,6 +381,56 @@ checkpoints.
               |                                      |     }
               |                                      | }
 
+*****************************************
+ Getting a List of Files in a Checkpoint
+*****************************************
+
+To quickly inspect the contents of a checkpoint directory without downloading large files, use the
+:ref:`Checkpoint.resources <python-sdk-checkpoint>` attribute. This provides a simple map of
+filenames to their sizes, allowing you to view what's inside a checkpoint without triggering a
+download.
+
+You can achieve this using the SDK, CLI, or API.
+
+Via the CLI
+===========
+
+The CLI provides a straightforward way to list the files in a checkpoint without downloading them:
+
+.. code:: bash
+
+   det experiment list-checkpoints <experiment_id> --include-resources
+
+Via the SDK
+===========
+
+You can also list the files within a checkpoint using the Determined SDK:
+
+.. code:: python
+
+   from determined.experimental import client
+
+   # Replace 'your_experiment_id' with the actual experiment ID
+   exp_id = your_experiment_id
+
+   checkpoints = client.get_experiment(exp_id).list_checkpoints()
+
+   for checkpoint in checkpoints:
+       print(f"Experiment ID: {exp_id}, Checkpoint UUID: {checkpoint.uuid}")
+
+       for filepath, size_in_bytes in checkpoint.resources.items():
+           print(f"Filepath: {filepath}, Size: {size_in_bytes} bytes")
+
+In this example, ``checkpoint.resources`` is a dictionary where the keys are file paths within the
+checkpoint and the values are the sizes of those files in bytes. This allows you to inspect the
+contents of the checkpoint without downloading the files.
+
+Via the REST API
+================
+
+Finally, you can also retrieve the list of files in a checkpoint via the REST API by calling the
+``GetExperimentCheckpoints`` endpoint.
+
 ************
  Next Steps
 ************

--- a/docs/model-dev-guide/model-management/checkpoints.rst
+++ b/docs/model-dev-guide/model-management/checkpoints.rst
@@ -1,3 +1,5 @@
+.. _checkpoints:
+
 .. _use-trained-models:
 
 #############
@@ -9,7 +11,7 @@
    :keywords: checkpoints, Python, checkpoint APIs
 
 Determined provides APIs for downloading checkpoints and loading them into memory in a Python
-process.
+process. You can also get a list of files in a checkpoint without downloading the files.
 
 This guide discusses:
 
@@ -17,6 +19,7 @@ This guide discusses:
 #. Loading model checkpoints in Python.
 #. Storing additional user-defined metadata in a checkpoint.
 #. Using the Determined CLI to download checkpoints to disk.
+#. Getting a list of files in a checkpoint without downloading the files.
 
 The Checkpoint Export API is a subset of the features found in the
 :mod:`~determined.experimental.client` module.

--- a/docs/model-dev-guide/model-management/checkpoints.rst
+++ b/docs/model-dev-guide/model-management/checkpoints.rst
@@ -432,7 +432,9 @@ Via the REST API
 ================
 
 Finally, you can also retrieve the list of files in a checkpoint via the REST API by calling the
-``GetExperimentCheckpoints`` endpoint.
+`GetExperimentCheckpoints
+<https://docs.determined.ai/latest/rest-api/index.html#/Experiments/GetExperimentCheckpoints>`__
+endpoint.
 
 ************
  Next Steps

--- a/docs/reference/python-sdk/python-sdk.rst
+++ b/docs/reference/python-sdk/python-sdk.rst
@@ -24,6 +24,8 @@ code with an object-oriented interface.
    :members:
    :member-order: bysource
 
+.. _python-sdk-checkpoint:
+
 ****************
  ``Checkpoint``
 ****************


### PR DESCRIPTION
as discussed in eng-det-halp
https://hpe-aiatscale.slack.com/archives/CSG3W08JY/p1723492042530919

docs ticket #634

update this page
https://docs.determined.ai/latest/model-dev-guide/model-management/checkpoints.html#using-the-checkpoint-class

problem domain:

users are unsure what `get_checkpoint` returns. 

this doc implies that you can only really just download the checkpoint with the Checkpoint class. Perhaps it would be a good idea to add "getting a list of files in the checkpoint" as an example?

i.e.,
it is not at all clear that `Checkpoint.resources` is a map of `filename` to `size` in the checkpoint.

use case:
a user already has the checkpoint directory path and just wants to list files.



<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ