### PR TITLE
chore: fix torch version to 2.2.2 for intel mac

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -32,6 +32,6 @@ tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy<2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,6 +30,7 @@ boto3>=1.24.4,<2.0
 # build requirements
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torch==2.3.0
+torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
+torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torchvision==0.18.0
 numpy<2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -32,5 +32,6 @@ tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.18.0
+torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 numpy<2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,8 +30,9 @@ boto3>=1.24.4,<2.0
 # build requirements
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+# Intel MAC only supports torch <= 2.2.2
+torch==2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torch==2.3.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
+torchvision==0.17.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torchvision==0.18.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
 numpy<2

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -4,7 +4,7 @@ pytest>=6.0.1
 pytest-timeout
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -2,7 +2,8 @@ appdirs
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 pytest-timeout
-torch==2.3.0
+torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
+torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torchvision==0.18.0
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -4,7 +4,8 @@ pytest>=6.0.1
 pytest-timeout
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.18.0
+torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 pandas

--- a/e2e_tests/tests/requirements.txt
+++ b/e2e_tests/tests/requirements.txt
@@ -2,10 +2,11 @@ appdirs
 # pytest 6.0 has linter-breaking changes
 pytest>=6.0.1
 pytest-timeout
-torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+# Intel MAC only supports torch <= 2.2.2
+torch==2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torch==2.3.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
+torchvision==0.17.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torchvision==0.18.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 pandas

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -9,7 +9,8 @@ deepspeed==0.8.3
 # lightning not tested but required for linter checks
 lightning
 transformers>=4.8.2,<4.29.0
-torch==2.3.0
+torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
+torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 torchvision==0.18.0
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -11,7 +11,8 @@ lightning
 transformers>=4.8.2,<4.29.0
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.18.0
+torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 attrdict3

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -11,7 +11,7 @@ lightning
 transformers>=4.8.2,<4.29.0
 torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.0; sys_platform != 'darwin' or platform_machine != 'arm64'
+torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
 torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/harness/tests/requirements/requirements-harness.txt
+++ b/harness/tests/requirements/requirements-harness.txt
@@ -9,10 +9,11 @@ deepspeed==0.8.3
 # lightning not tested but required for linter checks
 lightning
 transformers>=4.8.2,<4.29.0
-torch==2.2.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torch==2.3.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-torchvision==0.17.2; sys_platform != 'darwin' or platform_machine != 'arm64'
-torchvision==0.18.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+# Intel MAC only supports torch <= 2.2.2
+torch==2.2.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torch==2.3.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
+torchvision==0.17.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
+torchvision==0.18.0; sys_platform != 'darwin' or platform_machine != 'x86_64'
 tensorflow==2.12.0; sys_platform != 'darwin' or platform_machine != 'arm64'
 tensorflow-macos==2.11.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 attrdict3


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
https://hpe-aiatscale.slack.com/archives/CSG3W08JY/p1723649552010439

> As new Intel Mac’s are no longer produced and with time fewer will remain in use, we will be stopping testing and eventually building macOS x86_64 binaries after the release 2.2.0 is complete (mid January 2024). We will not be producing macOS x86_64 binaries for Release 2.3.0.

Support for PyTorch on Intel Mac deprecated. The highest version it can go is 2.2.2.

Solution: Set up PyTorch 2.2.2 specifically for Intel MAC while keeping other environments using 2.3.0.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI passes.
`make all` and `make -C harness check` don't have error on an Intel MAC.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ