### PR TITLE
fix: hide metadata section if there's no metadata

### DIFF
--- a/webui/react/src/components/Metadata.test.tsx
+++ b/webui/react/src/components/Metadata.test.tsx
@@ -86,11 +86,11 @@ vi.mock('utils/browser', () => ({
 
 const user = userEvent.setup();
 
-const setup = (empty?: boolean) => {
+const setup = () => {
   render(
     <UIProvider theme={DefaultTheme.Light}>
       <ThemeProvider>
-        <Metadata trial={empty ? undefined : mockTrial} />,
+        <Metadata trial={mockTrial} />,
       </ThemeProvider>
     </UIProvider>,
   );

--- a/webui/react/src/components/Metadata.test.tsx
+++ b/webui/react/src/components/Metadata.test.tsx
@@ -7,7 +7,7 @@ import { JsonObject, TrialDetails } from 'types';
 import { downloadText } from 'utils/browser';
 import { isJsonObject } from 'utils/data';
 
-import Metadata, { EMPTY_MESSAGE } from './Metadata';
+import Metadata from './Metadata';
 import { ThemeProvider } from './ThemeProvider';
 
 const mockMetadata = {
@@ -97,12 +97,6 @@ const setup = (empty?: boolean) => {
 };
 
 describe('Metadata', () => {
-  it('should display empty state', () => {
-    setup(true);
-    expect(screen.getByText(EMPTY_MESSAGE)).toBeInTheDocument();
-    expect(screen.getByRole('button')).toBeDisabled();
-  });
-
   it('should allow metadata download', async () => {
     setup();
     await user.click(screen.getByRole('button'));

--- a/webui/react/src/components/Metadata.tsx
+++ b/webui/react/src/components/Metadata.tsx
@@ -14,7 +14,7 @@ import css from './Metadata.module.scss';
 import Section from './Section';
 
 interface Props {
-  trial?: TrialDetails;
+  trial: TrialDetails;
 }
 
 export const EMPTY_MESSAGE = 'No metadata found';
@@ -45,10 +45,10 @@ const Metadata: React.FC<Props> = ({ trial }: Props) => {
   };
 
   const downloadMetadata = () => {
-    downloadText(`${trial?.id}_metadata.json`, [JSON.stringify(trial?.metadata)]);
+    downloadText(`${trial.id}_metadata.json`, [JSON.stringify(trial.metadata)]);
   };
 
-  const treeData = (trial?.metadata && getNodes(trial?.metadata)) ?? [];
+  const treeData = (trial.metadata && getNodes(trial.metadata)) ?? [];
 
   return (
     <Section

--- a/webui/react/src/components/Metadata.tsx
+++ b/webui/react/src/components/Metadata.tsx
@@ -17,8 +17,6 @@ interface Props {
   trial: TrialDetails;
 }
 
-export const EMPTY_MESSAGE = 'No metadata found';
-
 const Metadata: React.FC<Props> = ({ trial }: Props) => {
   const { tokens } = useTheme();
 

--- a/webui/react/src/components/Metadata.tsx
+++ b/webui/react/src/components/Metadata.tsx
@@ -50,11 +50,6 @@ const Metadata: React.FC<Props> = ({ trial }: Props) => {
 
   const treeData = (trial?.metadata && getNodes(trial?.metadata)) ?? [];
 
-  if (treeData.length === 0) {
-    // dont show metadata section when there's no metadata
-    return null;
-  }
-
   return (
     <Section
       options={[

--- a/webui/react/src/components/Metadata.tsx
+++ b/webui/react/src/components/Metadata.tsx
@@ -1,6 +1,5 @@
 import Button from 'hew/Button';
 import Icon from 'hew/Icon';
-import Message from 'hew/Message';
 import Surface from 'hew/Surface';
 import { useTheme } from 'hew/Theme';
 import Tooltip from 'hew/Tooltip';
@@ -51,6 +50,11 @@ const Metadata: React.FC<Props> = ({ trial }: Props) => {
 
   const treeData = (trial?.metadata && getNodes(trial?.metadata)) ?? [];
 
+  if (treeData.length === 0) {
+    // dont show metadata section when there's no metadata
+    return null;
+  }
+
   return (
     <Section
       options={[
@@ -65,13 +69,9 @@ const Metadata: React.FC<Props> = ({ trial }: Props) => {
       ]}
       title="Metadata">
       <Surface>
-        {treeData.length ? (
-          <div className={css.base}>
-            <Tree defaultExpandAll treeData={treeData} />
-          </div>
-        ) : (
-          <Message title={EMPTY_MESSAGE} />
-        )}
+        <div className={css.base}>
+          <Tree defaultExpandAll treeData={treeData} />
+        </div>
       </Surface>
     </Section>
   );

--- a/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsOverview.tsx
@@ -111,7 +111,7 @@ const TrialDetailsOverview: React.FC<Props> = ({ experiment, trial }: Props) => 
           ) : (
             <Spinner spinning />
           )}
-          <Metadata trial={trial} />
+          {trial?.metadata !== undefined && <Metadata trial={trial} />}
         </>
       ) : null}
     </>


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
- Hide `Metadata` section if there's no data to show


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Check if metadata section appears if metadata exits
- Check if metadata section is hidden if no metadata exits


## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ