### PR TITLE
fix: experiment single trial tabs don't scroll on load

### DIFF
--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetails.tsx
@@ -15,6 +15,7 @@ import ExperimentSingleTrialTabs from 'pages/ExperimentDetails/ExperimentSingleT
 import { TrialInfoBoxMultiTrial } from 'pages/TrialDetails/TrialInfoBox';
 import { paths } from 'routes/utils';
 import { getExperimentDetails } from 'services/api';
+import userSettings from 'stores/userSettings';
 import workspaceStore from 'stores/workspaces';
 import { ExperimentBase, TrialItem, Workspace } from 'types';
 import { isSingleTrialExperiment } from 'utils/experiment';
@@ -28,6 +29,8 @@ type Params = {
 export const INVALID_ID_MESSAGE = 'Invalid Experiment ID';
 export const ERROR_MESSAGE = 'Unable to fetch Experiment';
 
+const settingsLoadedObs = userSettings.getAll().select((l) => l.isLoaded);
+
 const ExperimentDetails: React.FC = () => {
   const { experimentId } = useParams<Params>();
   const [experiment, setExperiment] = useState<ExperimentBase>();
@@ -40,8 +43,11 @@ const ExperimentDetails: React.FC = () => {
   const id = parseInt(experimentId ?? '');
   const navigate = useNavigate();
   const f_flat_runs = useFeature().isOn('flat_runs');
+  const isSettingsLoaded = useObservable(settingsLoadedObs);
 
-  if (f_flat_runs) navigate(paths.searchDetails(id), { replace: true });
+  if (isSettingsLoaded && f_flat_runs) {
+    navigate(paths.searchDetails(id), { replace: true });
+  }
 
   const fetchExperimentDetails = useCallback(async () => {
     try {

--- a/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentSingleTrialTabs.module.scss
@@ -5,8 +5,5 @@
     &:global(.ant-tabs-nav-wrap)::before {
       box-shadow: none;
     }
-    > div {
-      transform: translate(0) !important;
-    }
   }
 }


### PR DESCRIPTION


<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-628



## Description
This fixes an issue where loading a single trial experiment page tab near the end of the tab list would hide the tab on mobile. We disabled the scrolling behavior of the tab list because on certain occasions it could scroll offpage. on removing that fix, i'm unable to reproduce the initial issue on firefox, chrome or safari.



## Test Plan
- ensure run centric ux is off
- visit a single trial experiment
- click the logs tab
- use the developer tools responsive view to ensure the viewport is less than 480px
- refresh the page
- the tab should be scrolled into view.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ