### PR TITLE
chore: add EOL notice regarding Aurora V1 & Postgres 12 along with Master Log warnings for Postgres <=12 [CM-413] [CM-416]

### DIFF
--- a/docs/release-notes/aurora-upcoming-unsupport.rst
+++ b/docs/release-notes/aurora-upcoming-unsupport.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+**Deprecations**
+
+-  Cluster: Amazon Aurora V1 will reach End of Life at the end of 2024, and will no longer be the default
+    persistent storage for AWS Determined deployments at that point in time. Users are encouraged to migrate 
+    to Amazon RDS for PostgreSQL.
+
+-  Database: Postgres 12 will reach End of Life on November 14, 2024. Determined instances using a Postgres 12 or 
+    earlier versions are encouraged to upgrade to Postgres 13 or later to ensure continued support.

--- a/docs/release-notes/aurora-upcoming-unsupport.rst
+++ b/docs/release-notes/aurora-upcoming-unsupport.rst
@@ -6,8 +6,9 @@
       persistent storage for AWS Determined deployments at that point in time. Users are encouraged
       to migrate to Amazon RDS for PostgreSQL.
 
--  Cluster: ``det deploy aws`` in Determined 0.37.0 and later will no longer support Amazon Aurora V1 as the
-      default persistent storage, instead defaulting to the ``simple-rds`` deployment type.
+-  Cluster: Once Amazon Aurora V1 reaches End of Life, ``det deploy aws`` is planned to no longer support Amazon Aurora V1 as the
+      default persistent storage, instead defaulting to the ``simple-rds`` deployment type which
+      uses Amazon RDS.
 
 -  Database: Postgres 12 will reach End of Life on November 14, 2024. Determined instances using a Postgres 12 or
       earlier versions are encouraged to upgrade to Postgres 13 or later to ensure continued

--- a/docs/release-notes/aurora-upcoming-unsupport.rst
+++ b/docs/release-notes/aurora-upcoming-unsupport.rst
@@ -3,10 +3,12 @@
 **Deprecations**
 
 -  Cluster: Amazon Aurora V1 will reach End of Life at the end of 2024, and will no longer be the default
-    persistent storage for AWS Determined deployments at that point in time. Users are encouraged to migrate 
-    to Amazon RDS for PostgreSQL. 
--  Cluster: ``det deploy aws`` in Determined 0.37.0 and later will no longer support Amazon Aurora V1 as the 
-    default persistent storage, instead defaulting to the ``simple-rds`` deployment type.
+      persistent storage for AWS Determined deployments at that point in time. Users are encouraged
+      to migrate to Amazon RDS for PostgreSQL.
 
--  Database: Postgres 12 will reach End of Life on November 14, 2024. Determined instances using a Postgres 12 or 
-    earlier versions are encouraged to upgrade to Postgres 13 or later to ensure continued support.
+-  Cluster: ``det deploy aws`` in Determined 0.37.0 and later will no longer support Amazon Aurora V1 as the
+      default persistent storage, instead defaulting to the ``simple-rds`` deployment type.
+
+-  Database: Postgres 12 will reach End of Life on November 14, 2024. Determined instances using a Postgres 12 or
+      earlier versions are encouraged to upgrade to Postgres 13 or later to ensure continued
+      support.

--- a/docs/release-notes/aurora-upcoming-unsupport.rst
+++ b/docs/release-notes/aurora-upcoming-unsupport.rst
@@ -4,7 +4,9 @@
 
 -  Cluster: Amazon Aurora V1 will reach End of Life at the end of 2024, and will no longer be the default
     persistent storage for AWS Determined deployments at that point in time. Users are encouraged to migrate 
-    to Amazon RDS for PostgreSQL.
+    to Amazon RDS for PostgreSQL. 
+-  Cluster: ``det deploy aws`` in Determined 0.37.0 and later will no longer support Amazon Aurora V1 as the 
+    default persistent storage, instead defaulting to the ``simple-rds`` deployment type.
 
 -  Database: Postgres 12 will reach End of Life on November 14, 2024. Determined instances using a Postgres 12 or 
     earlier versions are encouraged to upgrade to Postgres 13 or later to ensure continued support.

--- a/master/internal/db/setup.go
+++ b/master/internal/db/setup.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"database/sql"
 	"fmt"
+	"regexp"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -68,6 +69,37 @@ func InitAuthKeys() error {
 	return nil
 }
 
+// checkPostgresVersion checks the version of the connected Postgres database,
+// and logs a warning if the version is unsupported.
+func checkPostgresVersion(db *PgDB) error {
+	var dbVersion string
+	err := Bun().NewSelect().ColumnExpr("version()").Scan(context.TODO(), &dbVersion)
+	if err != nil {
+		return err
+	}
+	versionRegex := regexp.MustCompile(`PostgreSQL (\d+)(?:\.\d+)?`)
+
+	matches := versionRegex.FindStringSubmatch(dbVersion)
+	if len(matches) < 2 {
+		return fmt.Errorf("could not parse Postgres version: %s", dbVersion)
+	}
+	version := matches[1]
+	// TODO (CM-443): Bump this to 12 once Postgres 12 has reached EOL.
+	if version <= "11" {
+		log.Errorf(
+			"Postgres %s has reached it's end of life. Upgrading to a supported version is strongly recommended.",
+			version,
+		)
+	} else if version == "12" {
+		// TODO (CM-443): Remove above warning once Postgres 12 has reached EOL.
+		log.Warnf(
+			"Postgres %s will reach it's end of life on November 14, 2024. Please upgrade to a supported version.",
+			version)
+	}
+
+	return nil
+}
+
 // Connect connects to the database, but doesn't run migrations & inits.
 func Connect(opts *config.DBConfig) (*PgDB, error) {
 	dbURL := fmt.Sprintf(cnxTpl, opts.User, opts.Password, opts.Host, opts.Port, opts.Name)
@@ -79,6 +111,11 @@ func Connect(opts *config.DBConfig) (*PgDB, error) {
 	}
 
 	db.sql.SetMaxOpenConns(maxOpenConns)
+
+	err = checkPostgresVersion(db)
+	if err != nil {
+		return nil, fmt.Errorf("error checking Postgres version: %s", err)
+	}
 
 	return db, nil
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-413] [CM-416]

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
With the upcoming End of Life of Amazon Aurora V1 & Postgres 12; this PR adds a release note informing users that that Aurora V1 is planned to no longer be supported in future releases of Determined and the in the upcoming future `det deploy aws` will default to the `simple-rds` deployment type.

Additionally, this PR adds a check after the determined master connects to the Postgres DB instance and retrieves the version. If the Postgres version is <=12, then an error or warning is logged.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Launch a devcluster using Postgres 10 or 11; confirm the following error is logged to the master:
    - `Postgres <version> has reached it's end of life. Upgrading to a supported version is strongly recommended.`
- Launch a devcluster using Postgres 12; confirm the following error is logged to the master:
    - `Postgres 12 will reach it's end of life on November 14, 2024. Please upgrade to a supported version.`


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
