### PR TITLE
feat: configurable preemption timeout [MD-500]

### DIFF
--- a/.circleci/devcluster/double-reattach.devcluster.yaml
+++ b/.circleci/devcluster/double-reattach.devcluster.yaml
@@ -14,8 +14,6 @@ stages:
           password: postgres
           user: postgres
           name: determined
-        __internal:
-          preemption_timeout: 60s
         checkpoint_storage:
           type: shared_fs
           host_path: /tmp
@@ -49,6 +47,8 @@ stages:
             type: basic
             username: determined
             password: password
+        task_container_defaults:
+          preemption_timeout: 60
 
   - custom:
       name: proxy

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -73,8 +73,9 @@ webhooks:
 		},
 	}
 	expected.TaskContainerDefaults = model.TaskContainerDefaultsConfig{
-		ShmSizeBytes: 4294967296,
-		NetworkMode:  "bridge",
+		ShmSizeBytes:      4294967296,
+		NetworkMode:       "bridge",
+		PreemptionTimeout: model.DefaultPreemptionTimeout,
 	}
 	expected.TaskContainerDefaults.CPUPodSpec = &k8sV1.Pod{
 		TypeMeta: metaV1.TypeMeta{
@@ -181,6 +182,49 @@ func TestApplyBackwardsCompatibility(t *testing.T) {
 						"type":           "priority",
 					},
 					"master_service_name": "k8s-det",
+				},
+			},
+		},
+		{
+			name: "preemption timeout (__internal set)",
+			before: map[string]interface{}{
+				"__internal": map[string]interface{}{
+					"audit_logging_enabled": false,
+					"preemption_timeout":    "1h10m10s",
+				},
+				"task_container_defaults": map[string]interface{}{
+					"shm_size_bytes": 4294967296,
+				},
+			},
+			expected: map[string]interface{}{
+				"__internal": map[string]interface{}{
+					"audit_logging_enabled": false,
+				},
+				"task_container_defaults": map[string]interface{}{
+					"shm_size_bytes":     4294967296,
+					"preemption_timeout": 4210,
+				},
+			},
+		},
+		{
+			name: "preemption timeout (both set)",
+			before: map[string]interface{}{
+				"__internal": map[string]interface{}{
+					"audit_logging_enabled": false,
+					"preemption_timeout":    "1h10m10s",
+				},
+				"task_container_defaults": map[string]interface{}{
+					"shm_size_bytes":     4294967296,
+					"preemption_timeout": 1000,
+				},
+			},
+			expected: map[string]interface{}{
+				"__internal": map[string]interface{}{
+					"audit_logging_enabled": false,
+				},
+				"task_container_defaults": map[string]interface{}{
+					"shm_size_bytes":     4294967296,
+					"preemption_timeout": 1000,
 				},
 			},
 		},

--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -663,8 +663,11 @@ func (a *apiServer) UnpauseGenericTask(
 				FittingRequirements: sproto.FittingRequirements{
 					SingleAgent: isSingleNode,
 				},
-				Preemptible: true,
-				Restore:     false,
+				Preemption: sproto.PreemptionConfig{
+					Preemptible:     true,
+					TimeoutDuration: time.Duration(genericTaskSpec.GenericTaskConfig.PreemptionTimeout) * time.Second,
+				},
+				Restore: false,
 			}, a.m.db, a.m.rm, genericTaskSpec, onAllocationExit)
 		if err != nil {
 			return nil, err

--- a/master/internal/config/config.go
+++ b/master/internal/config/config.go
@@ -502,7 +502,6 @@ type InternalConfig struct {
 	AuditLoggingEnabled bool                   `json:"audit_logging_enabled"`
 	ExternalSessions    model.ExternalSessions `json:"external_sessions"`
 	ProxiedServers      []ProxiedServerConfig  `json:"proxied_servers"`
-	PreemptionTimeout   *model.Duration        `json:"preemption_timeout"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/internal/config/config_test.go
+++ b/master/internal/config/config_test.go
@@ -129,6 +129,7 @@ integrations:
 					TaskContainerDefaults: &model.TaskContainerDefaultsConfig{
 						ShmSizeBytes:           4294967296,
 						NetworkMode:            "bridge",
+						PreemptionTimeout:      model.DefaultPreemptionTimeout,
 						DtrainNetworkInterface: "if0",
 					},
 					AgentReconnectWait: model.Duration(aproto.AgentReconnectWait),
@@ -654,8 +655,9 @@ additional_resource_managers:
 				Username: "yo-yo-ma",
 				Password: registryAuthSecret,
 			},
-			ShmSizeBytes: 4294967296,
-			NetworkMode:  "bridge",
+			ShmSizeBytes:      4294967296,
+			NetworkMode:       "bridge",
+			PreemptionTimeout: model.DefaultPreemptionTimeout,
 		},
 		ResourceConfig: ResourceConfig{
 			AdditionalResourceManagersInternal: []*ResourceManagerWithPoolsConfig{

--- a/master/internal/rm/agentrm/fair_share.go
+++ b/master/internal/rm/agentrm/fair_share.go
@@ -198,7 +198,7 @@ func calculateGroupStates(
 			case !taskList.IsScheduled(req.AllocationID):
 				state.pendingReqs = append(state.pendingReqs, req)
 			default:
-				if !req.Preemptible {
+				if !req.Preemption.Preemptible {
 					state.presubscribedSlots += req.SlotsNeeded
 				}
 				state.allocatedReqs = append(state.allocatedReqs, req)
@@ -371,7 +371,7 @@ func assignTasks(
 			// the count of offered slots.
 			// TODO: We should terminate running tasks more intelligently.
 			for _, req := range state.allocatedReqs {
-				if req.Preemptible {
+				if req.Preemption.Preemptible {
 					toRelease = append(toRelease, req.AllocationID)
 					state.activeSlots -= req.SlotsNeeded
 					if state.activeSlots <= state.offered {

--- a/master/internal/rm/agentrm/mock_test.go
+++ b/master/internal/rm/agentrm/mock_test.go
@@ -55,12 +55,14 @@ func MockTaskToAllocateRequest(mockTask *MockTask) *sproto.AllocateRequest {
 	}
 
 	req := &sproto.AllocateRequest{
-		TaskID:            mockTask.TaskID,
-		AllocationID:      mockTask.ID,
-		JobID:             model.JobID(jobID),
-		SlotsNeeded:       mockTask.SlotsNeeded,
-		IsUserVisible:     true,
-		Preemptible:       !mockTask.NonPreemptible,
+		TaskID:        mockTask.TaskID,
+		AllocationID:  mockTask.ID,
+		JobID:         model.JobID(jobID),
+		SlotsNeeded:   mockTask.SlotsNeeded,
+		IsUserVisible: true,
+		Preemption: sproto.PreemptionConfig{
+			Preemptible: !mockTask.NonPreemptible,
+		},
 		JobSubmissionTime: jobSubmissionTime,
 		BlockedNodes:      mockTask.BlockedNodes,
 	}

--- a/master/internal/rm/agentrm/priority.go
+++ b/master/internal/rm/agentrm/priority.go
@@ -127,7 +127,7 @@ func (p priorityScheduler) prioritySchedulerWithFilter(
 				}
 			} else if p.preemptionEnabled {
 				for _, allocatedTask := range successfulAllocations {
-					if !allocatedTask.Preemptible {
+					if !allocatedTask.Preemption.Preemptible {
 						continue
 					}
 					log.Debugf("scheduled task via backfilling: %s", allocatedTask.Name)
@@ -221,7 +221,7 @@ func (p priorityScheduler) trySchedulingTaskViaPreemption(
 				break
 			}
 			preemptionCandidate := priorityToScheduledTaskMap[priority][i]
-			if !preemptionCandidate.Preemptible || !filter(preemptionCandidate) {
+			if !preemptionCandidate.Preemption.Preemptible || !filter(preemptionCandidate) {
 				continue
 			}
 

--- a/master/internal/rm/agentrm/scheduler_test.go
+++ b/master/internal/rm/agentrm/scheduler_test.go
@@ -105,7 +105,9 @@ func newFakeAgentState(
 	if slotsUsed > 0 {
 		req := &sproto.AllocateRequest{
 			SlotsNeeded: slotsUsed,
-			Preemptible: true,
+			Preemption: sproto.PreemptionConfig{
+				Preemptible: true,
+			},
 		}
 		if _, err := state.allocateFreeDevices(req.SlotsNeeded, cproto.NewID()); err != nil {
 			panic(err)

--- a/master/internal/rm/kubernetesrm/resource_pool.go
+++ b/master/internal/rm/kubernetesrm/resource_pool.go
@@ -175,7 +175,7 @@ func (k *kubernetesResourcePool) SetGroupPriority(msg sproto.SetGroupPriority) e
 	// priority is immutable. If so, respond with an error.
 	for it := k.reqList.Iterator(); it.Next(); {
 		if it.Value().JobID == msg.JobID {
-			if req := it.Value(); !req.Preemptible {
+			if req := it.Value(); !req.Preemption.Preemptible {
 				return rmerrors.UnsupportedError(fmt.Sprintf(
 					"priority is immutable for %s in k8s because it may be destructive",
 					req.Name,

--- a/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
+++ b/master/internal/rm/kubernetesrm/resource_pool_intg_test.go
@@ -1168,8 +1168,10 @@ func TestSetGroupPriority(t *testing.T) {
 			jobID := model.NewJobID()
 
 			rp.AllocateRequest(sproto.AllocateRequest{
-				JobID:       jobID,
-				Preemptible: tt.preemptible,
+				JobID: jobID,
+				Preemption: sproto.PreemptionConfig{
+					Preemptible: tt.preemptible,
+				},
 			})
 
 			err := rp.SetGroupPriority(sproto.SetGroupPriority{

--- a/master/internal/sproto/task.go
+++ b/master/internal/sproto/task.go
@@ -41,7 +41,7 @@ type (
 		FittingRequirements FittingRequirements
 
 		// Behavioral configuration.
-		Preemptible bool
+		Preemption  PreemptionConfig
 		IdleTimeout *IdleTimeoutConfig
 		ProxyPorts  []*ProxyPortConfig
 		Restore     bool
@@ -60,6 +60,12 @@ type (
 		UseRunnerState  bool
 		TimeoutDuration time.Duration
 		Debug           bool
+	}
+
+	// PreemptionConfig configures task preemption.
+	PreemptionConfig struct {
+		Preemptible     bool
+		TimeoutDuration time.Duration
 	}
 
 	// ProxyPortConfig configures a proxy the allocation should start.

--- a/master/internal/task/allocation_intg_test.go
+++ b/master/internal/task/allocation_intg_test.go
@@ -192,7 +192,9 @@ func setup(t *testing.T) (
 		TaskID:       task.TaskID,
 		AllocationID: model.AllocationID(fmt.Sprintf("%s.0", task.TaskID)),
 		SlotsNeeded:  2,
-		Preemptible:  true,
+		Preemption: sproto.PreemptionConfig{
+			Preemptible: true,
+		},
 		// ...
 	}
 	q := queue.New[sproto.ResourcesEvent]()

--- a/master/internal/task/allocation_service_test.go
+++ b/master/internal/task/allocation_service_test.go
@@ -355,7 +355,7 @@ func TestPreemption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			closeDB, _, id, q, exitFuture := requireStarted(t, func(ar *sproto.AllocateRequest) {
-				ar.Preemptible = true
+				ar.Preemption.Preemptible = true
 			})
 			defer closeDB()
 			defer requireKilled(t, id, exitFuture)
@@ -623,7 +623,10 @@ func stubAllocateRequest(task *model.Task) sproto.AllocateRequest {
 		TaskID:       task.TaskID,
 		AllocationID: model.AllocationID(fmt.Sprintf("%s.0", task.TaskID)),
 		SlotsNeeded:  2,
-		Preemptible:  true,
+		Preemption: sproto.PreemptionConfig{
+			Preemptible:     true,
+			TimeoutDuration: time.Hour,
+		},
 		ResourcePool: stubResourcePoolName,
 	}
 }

--- a/master/internal/task/preemptible/preemptible_test.go
+++ b/master/internal/task/preemptible/preemptible_test.go
@@ -30,7 +30,7 @@ func TestPreemption(t *testing.T) {
 
 	// on preemption, it should receive status.
 	var timedOut atomic.Bool
-	p.Preempt(func(ctx context.Context, err error) { timedOut.Store(true) })
+	p.Preempt(time.Hour, func(ctx context.Context, err error) { timedOut.Store(true) })
 	select {
 	case <-w.C:
 	default:
@@ -60,9 +60,6 @@ func TestPreemption(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	preemptible.DefaultTimeout = time.Microsecond
-	defer func() { preemptible.DefaultTimeout = time.Hour }()
-
 	// "task" is allocated.
 	p := preemptible.New()
 
@@ -71,7 +68,7 @@ func TestTimeout(t *testing.T) {
 
 	// on preemption, it should receive status.
 	var timedOut atomic.Bool
-	p.Preempt(func(ctx context.Context, err error) { timedOut.Store(true) })
+	p.Preempt(time.Microsecond, func(ctx context.Context, err error) { timedOut.Store(true) })
 
 	waitForCondition(t, time.Second, timedOut.Load)
 
@@ -107,10 +104,10 @@ func waitForCondition(
 	timeout time.Duration,
 	condition func() bool,
 ) {
-	for i := 0; i < int(timeout/preemptible.DefaultTimeout); i++ {
+	for i := 0; i < int(timeout/time.Hour); i++ {
 		if condition() {
 			return
 		}
-		time.Sleep(preemptible.DefaultTimeout)
+		time.Sleep(time.Hour)
 	}
 }

--- a/master/internal/task/preemptible/service.go
+++ b/master/internal/task/preemptible/service.go
@@ -1,6 +1,8 @@
 package preemptible
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 
 	"github.com/determined-ai/determined/master/pkg/syncx/mapx"
@@ -67,10 +69,10 @@ func Acknowledged(id string) bool {
 // Preempt preempts all watchers, marks us as preempted and begins the preemption deadline.
 // The preemption deadline callback can fire until Close is called.
 // ID must be a globally unique identifier for the preemptible.
-func Preempt(id string, timeoutCallback TimeoutFn) {
+func Preempt(id string, timeoutDuration time.Duration, timeoutCallback TimeoutFn) {
 	p, ok := preemptibles.Load(id)
 	if !ok {
 		return
 	}
-	p.Preempt(timeoutCallback)
+	p.Preempt(timeoutDuration, timeoutCallback)
 }

--- a/master/pkg/model/generic_task_config.go
+++ b/master/pkg/model/generic_task_config.go
@@ -45,8 +45,9 @@ type GenericTaskConfig struct {
 	WorkDir     *string                 `json:"work_dir"`
 	Debug       bool                    `json:"debug"`
 
-	Pbs   expconf.PbsConfig   `json:"pbs,omitempty"`
-	Slurm expconf.SlurmConfig `json:"slurm,omitempty"`
+	Pbs               expconf.PbsConfig   `json:"pbs,omitempty"`
+	Slurm             expconf.SlurmConfig `json:"slurm,omitempty"`
+	PreemptionTimeout int                 `json:"preemption_timeout,omitempty"`
 }
 
 // Validate implements the check.Validatable interface.

--- a/master/pkg/model/task_container_defaults_test.go
+++ b/master/pkg/model/task_container_defaults_test.go
@@ -18,9 +18,12 @@ import (
 func TestEnvironmentVarsDefaultMerging(t *testing.T) {
 	defaultGpuType := "tesla"
 	defaultSlotsPerNode := 99
+	defaultPreemptionTimeout := DefaultPreemptionTimeout
 
 	expGpuType := "a100"
 	expSlurmSlotsPerNode := 8
+	expPreemptionTimeout := 60
+
 	expSlurmConfig := expconf.SlurmConfigV0{
 		RawGpuType:      &expGpuType,
 		RawSlotsPerNode: &expSlurmSlotsPerNode,
@@ -44,6 +47,7 @@ func TestEnvironmentVarsDefaultMerging(t *testing.T) {
 			RawSlotsPerNode: &defaultSlotsPerNode,
 			RawSbatchArgs:   []string{"-WpbsTaskDefault"},
 		},
+		PreemptionTimeout: defaultPreemptionTimeout,
 	}
 	conf := expconf.ExperimentConfig{
 		RawEnvironment: &expconf.EnvironmentConfig{
@@ -52,8 +56,9 @@ func TestEnvironmentVarsDefaultMerging(t *testing.T) {
 				RawCUDA: []string{"extra=expconf"},
 			},
 		},
-		RawSlurmConfig: &expSlurmConfig,
-		RawPbsConfig:   &expPbsConfig,
+		RawSlurmConfig:       &expSlurmConfig,
+		RawPbsConfig:         &expPbsConfig,
+		RawPreemptionTimeout: &expPreemptionTimeout,
 	}
 
 	defaults.MergeIntoExpConfig(&conf)
@@ -69,6 +74,7 @@ func TestEnvironmentVarsDefaultMerging(t *testing.T) {
 	require.Equal(t, []string{"-SlrumTaskDefault", "-SlrumExpConf"}, conf.RawSlurmConfig.SbatchArgs())
 	require.Equal(t, defaultSlotsPerNode, *conf.RawPbsConfig.RawSlotsPerNode)
 	require.Equal(t, []string{"-WpbsTaskDefault", "-PbsExpConf"}, conf.RawPbsConfig.SbatchArgs())
+	require.Equal(t, expPreemptionTimeout, *conf.RawPreemptionTimeout)
 }
 
 func TestTaskContainerDefaultsConfigMerging(t *testing.T) {
@@ -184,6 +190,7 @@ func TestTaskContainerDefaultsConfigMerging(t *testing.T) {
 				GLOOPortRange:          "5-6",
 				ShmSizeBytes:           6789,
 				NetworkMode:            "bridge",
+				PreemptionTimeout:      60,
 				CPUPodSpec: &k8sV1.Pod{
 					Spec: k8sV1.PodSpec{
 						Volumes: []k8sV1.Volume{
@@ -270,6 +277,7 @@ func TestTaskContainerDefaultsConfigMerging(t *testing.T) {
 				GLOOPortRange:          "5-6",
 				ShmSizeBytes:           6789,
 				NetworkMode:            "bridge",
+				PreemptionTimeout:      60,
 				CPUPodSpec: &k8sV1.Pod{
 					Spec: k8sV1.PodSpec{
 						Volumes: []k8sV1.Volume{
@@ -438,8 +446,9 @@ func TestLogPatternUnmarshal(t *testing.T) {
 		}`)), &tcd))
 
 	expected := TaskContainerDefaultsConfig{
-		ShmSizeBytes: 4294967296,
-		NetworkMode:  "bridge",
+		ShmSizeBytes:      4294967296,
+		NetworkMode:       "bridge",
+		PreemptionTimeout: DefaultPreemptionTimeout,
 		LogPolicies: expconf.LogPoliciesConfig{
 			expconf.LogPolicy{RawPattern: "test", RawAction: expconf.LogAction{
 				RawExcludeNode: &expconf.LogActionExcludeNode{},

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -49,6 +49,7 @@ type ExperimentConfigV0 struct {
 	RawWorkspace                *string                     `json:"workspace"`
 	RawSlurmConfig              *SlurmConfigV0              `json:"slurm,omitempty"`
 	RawPbsConfig                *PbsConfigV0                `json:"pbs,omitempty"`
+	RawPreemptionTimeout        *int                        `json:"preemption_timeout"`
 }
 
 // Unit implements the model.InUnits interface.

--- a/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
+++ b/master/pkg/schemas/expconf/zgen_experiment_config_v0.go
@@ -313,6 +313,14 @@ func (e *ExperimentConfigV0) SetPbsConfig(val PbsConfigV0) {
 	e.RawPbsConfig = &val
 }
 
+func (e ExperimentConfigV0) PreemptionTimeout() *int {
+	return e.RawPreemptionTimeout
+}
+
+func (e *ExperimentConfigV0) SetPreemptionTimeout(val *int) {
+	e.RawPreemptionTimeout = val
+}
+
 func (e ExperimentConfigV0) ParsedSchema() interface{} {
 	return schemas.ParsedExperimentConfigV0()
 }

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -919,6 +919,13 @@ var (
             ],
             "default": false
         },
+        "preemption_timeout": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
         "profiling": {
             "type": [
                 "object",

--- a/schemas/expconf/v0/experiment.json
+++ b/schemas/expconf/v0/experiment.json
@@ -192,6 +192,13 @@
             ],
             "default": false
         },
+        "preemption_timeout": {
+            "type": [
+                "integer",
+                "null"
+            ],
+            "default": null
+        },
         "profiling": {
             "type": [
                 "object",

--- a/schemas/test_cases/v0/experiment.yaml
+++ b/schemas/test_cases/v0/experiment.yaml
@@ -216,6 +216,7 @@
       tensor_fusion_threshold: 64
     pbs: {}
     perform_initial_validation: false
+    preemption_timeout: null
     profiling:
       enabled: false
       begin_on_batch: 0


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Adds a configuration option in experiment config (`task_container_defaults`) that specifies how long to wait after preemption before the task is killed. 

Previously, this configuration already existed in the master config, so it has been moved. 

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- [ ] Submit any experiment. In the trial logs, verify that the printed experiment config contains `task_container_defaults: preemption_timeout: 3600`
- [ ] Submit a somewhat long-running experiment that does not check for preemption, such as:
```python3
import logging
import time

import determined as det
from determined import core


def main(core_context):
    for batch in range(100):
        time.sleep(10)
        steps_completed = batch + 1
        if steps_completed % 5 == 0:
            core_context.train.report_training_metrics(
                steps_completed=steps_completed, metrics={"x": batch}
            )
        if steps_completed % 10 == 0:
            core_context.train.report_validation_metrics(
                steps_completed=steps_completed, metrics={"x": batch}
            )

if __name__ == "__main__":
    logging.basicConfig(level=logging.DEBUG, format=det.LOG_FORMAT)
    with core.init() as core_context:
        main(core_context=core_context)
```
with `preemption_timeout` configured in the expconf:
```yaml
name: metrics
entrypoint: python3 metrics.py

searcher:
   name: single
   metric: x
   max_length: 1

preemption_timeout: 60
max_restarts: 0
```
Stop the experiment. In the trial logs you should see metrics continue to be reported for 60s, at which point the trial should be killed.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ