### PR TITLE
fix: replace rawsource attribute with node directly, due to removal of rawsource in Docutil 2.0

### DIFF
--- a/docs/rebrand-docs.py
+++ b/docs/rebrand-docs.py
@@ -74,13 +74,12 @@ class Formatters(OrigFormatters):
         exclude_types = (docutils.nodes.literal_block, docutils.nodes.literal)
         if isinstance(node.parent, exclude_types) or isinstance(node.parent.parent, exclude_types):
             yield node.astext()
-        # The rawsource attribute tends not to be set for text nodes not directly under paragraphs.
         elif isinstance(node.parent, docutils.nodes.paragraph):
             # Any instance of "\ " disappears in the parsing. It may have an effect if it separates
             # this text from adjacent inline markup, but in that case it will be replaced by the
             # wrapping algorithm. Other backslashes may be unnecessary (e.g., "a\` b" or "a\b"), but
             # finding all of those is future work.
-            yield rewrite_text(node.rawsource.replace(r"\ ", ""))
+            yield rewrite_text(node.replace(r"\ ", ""))
         else:
             yield rewrite_text(node.astext())
 


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Docutils removed `rawsource` in V2.0, which was being used in our rebranding script breaking the release party process.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Ensure that the rebranding script does not fail on `rawsource` attribute missing
- Ensure that the rebranded docs in the EE cluster are rebranded properly. 


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ