### PR TITLE
docs: Document rbac editorprojectrestricted role

### DIFF
--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -455,7 +455,6 @@ To list all existing cluster roles and the concrete permissions they include:
 
    det rbac list-roles
 
-
 ``ModelRegistryViewer``
 =======================
 

--- a/docs/manage/security/rbac.rst
+++ b/docs/manage/security/rbac.rst
@@ -455,6 +455,7 @@ To list all existing cluster roles and the concrete permissions they include:
 
    det rbac list-roles
 
+
 ``ModelRegistryViewer``
 =======================
 
@@ -480,6 +481,18 @@ edit, or delete projects and experiments within its scope.
    only additional permissions granted by the ``Editor`` role include the ability to create
    notebooks, shells, and commands (NSC tasks), as well as the permission to update these tasks,
    such as changing the task's priority or deleting it.
+
+``EditorProjectRestricted``
+===========================
+
+The ``EditorProjectRestricted`` role supersedes the ``Viewer`` role and precedes the ``Editor``
+role. Assign the ``EditorProjectRestricted`` to users who need ``Editor`` permissions without the
+ability to create or update projects. More specifically:
+
+-  ``EditorRestricted`` users can create, edit, or delete experiments and notebook, shell, or
+   Command (NSC) type workloads within their designated scope, just like those with the ``Editor``
+   role. However, ``EditorProjectRestricted`` users lack the permissions to create or update
+   projects.
 
 ``Editor``
 ==========


### PR DESCRIPTION
New to determined: customers can now add an "editor-like" role that doesn't allow creating or updating of projects

Feature: #9796 

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ