### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,6 +171,7 @@ linkcheck_anchors_ignore = [
     "join-metrics",
     "exposed-metrics",
     "L139-L169",
+    "/Experiments/GetExperimentCheckpoints",
 ]
 
 # Some pages block python requests. Set user-agent to appear as a browser.

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -906,7 +906,7 @@ to ``determinedai/determined-agent:<master version>``.
 ------------------------
 
 The Docker network to use for the Determined agent and task containers. If this is set to ``host``,
-`Docker host-mode networking <https://docs.docker.com/network/drivers/host/>`__ will be used
+`Docker host-mode networking <https://docs.docker.com/engine/network/drivers/host/>`__ will be used
 instead. The default value is ``determined``.
 
 ``agent_docker_runtime``

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -707,8 +707,8 @@ written to and read from the ``host_path``.
 ---------------
 
 Optional. `Propagation behavior
-<https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation>`__ for replicas of the
-bind-mount. Defaults to ``rprivate``.
+<https://docs.docker.com/engine/storage/bind-mounts/#configure-bind-propagation>`__ for replicas of
+the bind-mount. Defaults to ``rprivate``.
 
 Local Directory
 ===============

--- a/docs/setup-cluster/aws/aws-spot.rst
+++ b/docs/setup-cluster/aws/aws-spot.rst
@@ -101,8 +101,8 @@ to use spot instances:
 
    AWS error while launching spot instances, AuthFailure.ServiceLinkedRoleCreationNotPermitted, The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.
 
-When this error occurs, please check the `AWS documentation
-<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#service-linked-roles-spot-instance-requests>`__.
+For more information, visit the `AWS documentation
+<https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/service-linked-roles-spot-instance-requests.html>`__.
 Most likely, you will need to use the AWS CLI to create the ``AWSServiceRoleForEC2Spot`` role:
 
 .. code::

--- a/docs/setup-cluster/on-prem/options/docker.rst
+++ b/docs/setup-cluster/on-prem/options/docker.rst
@@ -211,5 +211,5 @@ By default, ``docker run`` will run in the foreground, so that a container can b
 pressing Control-C. If you wish to keep Determined running for the long term, consider running the
 containers `detached <ttps://docs.docker.com/engine/reference/commandline/container_run/#detach>`_
 and/or with `restart policies
-<https://docs.docker.com/config/containers/start-containers-automatically/>`_. Using :ref:`our
+<https://docs.docker.com/engine/containers/start-containers-automatically/>`_. Using :ref:`our
 deployment tool <install-using-deploy>` is also an option.


### PR DESCRIPTION
## Description

Fix broken links found by `make check-links`.

## Test Plan
- `make check-links`

## What this Does Not Fix

There is a broken link found in line 1049 of `determined/harness/determined/keras/tfkerastrial.py`

https://github.com/determined-ai/determined/blob/e13de2042dc5ae3d5106bc83783bb29542c91ec8/harness/determined/keras/_tf_keras_trial.py#L975

To fix it, replace

`https://tensorflow.org/api_docs/python/tf/keras/utils/Sequence` 

with
 `https://www.tensorflow.org/api_docs/python/tf/keras/utils/PyDataset`

then run `make -C docs check-links`
