### PR TITLE
perf: remove duplicate ids in `ExpMetricNames` api

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1818,6 +1818,10 @@ var (
 func (a *apiServer) ExpMetricNames(req *apiv1.ExpMetricNamesRequest,
 	resp apiv1.Determined_ExpMetricNamesServer,
 ) error {
+	// remove duplicate ids to improve performance
+	slices.Sort(req.Ids)
+	req.Ids = slices.Compact(req.Ids)
+
 	if len(req.Ids) == 0 {
 		return status.Error(codes.InvalidArgument, "must specify at least one experiment id")
 	}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
https://hpe-aiatscale.slack.com/archives/CLCE8D998/p1724182588030219


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Remove duplicate ids to improve API performance.
In a certain environment that has relatively lots of run data (50k~), `v1/experiments/metrics-stream/metric-names` takes some time. For example, `https://gcloud.determined.ai/api/v1/experiments/metrics-stream/metric-names?ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=1&ids=2&ids=3&ids=4&ids=5` takes 6s. It would take longer if there are more run data or more `ids` query parameters.
This PR is to improve the API response speed performance by removing the duplicate `ids`.

After this fix, the above API call takes around 1s, so 6 times faster than before. We can do some more improvement around the API, but this is the first step.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- call `ExpMetricNames` api with duplicate ids, and check if duplicated ids are removed in the API function
  - id: [1, 1, 1, 3, 4, 1] -> [1, 3, 4]


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ