### PR TITLE
ci: pin chromadb version to avoid incompatibility

### DIFF
--- a/examples/features/torch_batch_process_embeddings/requirements.txt
+++ b/examples/features/torch_batch_process_embeddings/requirements.txt
@@ -2,5 +2,5 @@ accelerate>=0.12.0
 transformers>=4.28.1,<4.29.0
 tokenizers>=0.13.3
 datasets
-chromadb
+chromadb==0.5.3 # Should be able to use > 0.5.5 once one exists
 huggingface_hub<0.23.0


### PR DESCRIPTION
## Pin ChromaDB version to avoid a recent incompatibility in their releases

## Description
See https://github.com/chroma-core/chroma/issues/2687. There are mixed reports of this working in 0.5.3 and some other recent versions - but I think this has been broken for us roughly since 0.5.4 came out.

## Test Plan
Going to request the e2e-gpu-distributed tests to make sure this worked. Update: aaaand they did.

## Checklist
- [ N/A ] Changes have been manually QA'd
- [ N/A ] New features have been approved by the corresponding PM
- [ N/A ] User-facing API changes have the "User-facing API Change" label
- [ N/A ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ N/A ] Licenses have been included for new code which was copied and/or modified from any external code