### PR TITLE
fix: reset pinned column state when resetting columns

### DIFF
--- a/webui/react/src/components/ColumnPickerMenu.test.tsx
+++ b/webui/react/src/components/ColumnPickerMenu.test.tsx
@@ -26,6 +26,7 @@ const setup = (initCols?: string[]) => {
     <UIProvider theme={DefaultTheme.Light}>
       <ThemeProvider>
         <ColumnPickerMenu
+          defaultPinnedCount={3}
           defaultVisibleColumns={initialVisibleColumns}
           initialVisibleColumns={initCols ?? initialVisibleColumns}
           pinnedColumnsCount={PINNED_COLUMNS_COUNT}
@@ -81,7 +82,7 @@ describe('ColumnPickerMenu', () => {
     );
     const resets = await screen.findAllByText('Reset');
     await user.click(resets[0]);
-    expect(onVisibleColumnChange).toHaveBeenCalledWith(initialVisibleColumns);
+    expect(onVisibleColumnChange).toHaveBeenCalledWith(initialVisibleColumns, 3);
   });
 
   it('should switch tabs and display correct columns', async () => {

--- a/webui/react/src/components/ColumnPickerMenu.tsx
+++ b/webui/react/src/components/ColumnPickerMenu.tsx
@@ -39,6 +39,7 @@ interface ColumnMenuProps {
   isMobile?: boolean;
   initialVisibleColumns: string[];
   defaultVisibleColumns: string[];
+  defaultPinnedCount: number;
   onVisibleColumnChange?: (newColumns: string[], pinnedCount?: number) => void;
   onHeatmapSelectionRemove?: (id: string) => void;
   projectColumns: Loadable<ProjectColumn[]>;
@@ -227,6 +228,7 @@ const ColumnPickerMenu: React.FC<ColumnMenuProps> = ({
   projectColumns,
   initialVisibleColumns,
   defaultVisibleColumns,
+  defaultPinnedCount,
   projectId,
   isMobile = false,
   onVisibleColumnChange,
@@ -250,9 +252,9 @@ const ColumnPickerMenu: React.FC<ColumnMenuProps> = ({
   );
 
   const handleShowSuggested = useCallback(() => {
-    onVisibleColumnChange?.(defaultVisibleColumns);
+    onVisibleColumnChange?.(defaultVisibleColumns, defaultPinnedCount);
     closeMenu();
-  }, [onVisibleColumnChange, defaultVisibleColumns]);
+  }, [onVisibleColumnChange, defaultVisibleColumns, defaultPinnedCount]);
 
   return (
     <Dropdown

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -20,6 +20,7 @@ import { FilterFormStore } from 'components/FilterForm/components/FilterFormStor
 import TableFilter from 'components/FilterForm/TableFilter';
 import MultiSortMenu from 'components/MultiSortMenu';
 import { OptionsMenu, RowHeight } from 'components/OptionsMenu';
+import { defaultProjectSettings } from 'components/Searches/Searches.settings';
 import useMobile from 'hooks/useMobile';
 import usePermissions from 'hooks/usePermissions';
 import { defaultExperimentColumns } from 'pages/F_ExpList/expListColumns';
@@ -400,6 +401,7 @@ const TableActionBar: React.FC<Props> = ({
             />
             <ColumnPickerMenu
               compare={compareViewOn}
+              defaultPinnedCount={defaultProjectSettings.pinnedColumnsCount}
               defaultVisibleColumns={defaultExperimentColumns}
               initialVisibleColumns={initialVisibleColumns}
               isMobile={isMobile}

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1085,6 +1085,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             />
             <ColumnPickerMenu
               compare={settings.compare}
+              defaultPinnedCount={defaultFlatRunsSettings.pinnedColumnsCount}
               defaultVisibleColumns={searchId ? defaultSearchRunColumns : defaultRunColumns}
               initialVisibleColumns={columnsIfLoaded}
               isMobile={isMobile}


### PR DESCRIPTION

## Ticket
ET-278



## Description
this fixes an issue where the pinned column state wasn't restored when resetting columns.



## Test Plan
* visit a new table page (either runs, searches, or the new experiment list)
* ensure no columns are pinned
* open the columns menu and click the reset button
* the default columns should have the correct pinned state (id, state and start time should be pinned)



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ