### PR TITLE
fix: use task sessions in Core API [MD-509]

### DIFF
--- a/harness/determined/common/api/__init__.py
+++ b/harness/determined/common/api/__init__.py
@@ -1,5 +1,5 @@
 from determined.common.api import authentication, errors, metric, bindings
-from determined.common.api._session import BaseSession, UnauthSession, Session
+from determined.common.api._session import BaseSession, UnauthSession, Session, TaskSession
 from determined.common.api._util import (
     PageOpts,
     get_ntsc_details,

--- a/harness/determined/common/api/_session.py
+++ b/harness/determined/common/api/_session.py
@@ -281,6 +281,8 @@ class Session(BaseSession):
     By far, most BaseSessions in the codebase will be this Session subclass.
     """
 
+    AUTH_HEADER = "Authorization"
+
     def __init__(
         self,
         master: str,
@@ -308,8 +310,25 @@ class Session(BaseSession):
             server_hostname=self.cert.name if self.cert else None,
             verify=self.cert.bundle if self.cert else None,
             max_retries=self._max_retries,
-            headers={"Authorization": f"Bearer {self.token}"},
+            headers={self.AUTH_HEADER: f"Bearer {self.token}"},
         )
+
+
+class TaskSession(Session):
+    """
+    ``TaskSession`` is a subclass of ``Session`` designed to be used for authenticating requests
+    using a task session token. It simply overrides the authentication header name used for
+    requests.
+
+    Most sessions that are created from user input should use ``Session`` instead, which
+    authenticates requests using a user token (i.e. the CLI, SDK).
+
+    Task session tokens really only have a longer expiration, and should be used for internal
+    sessions that may persist throughout a long training job (i.e. Core API).
+    """
+
+    # Authentication header name for task session tokens
+    AUTH_HEADER = "Grpc-Metadata-x-allocation-token"
 
 
 class _HTTPSAdapter(adapters.HTTPAdapter):

--- a/harness/determined/common/api/authentication.py
+++ b/harness/determined/common/api/authentication.py
@@ -101,6 +101,10 @@ def get_det_password_from_env() -> Optional[str]:
     return os.environ.get("DET_PASS")
 
 
+def get_det_session_token_from_env() -> Optional[str]:
+    return os.environ.get("DET_SESSION_TOKEN")
+
+
 def login(
     master_address: str,
     username: str,
@@ -305,6 +309,27 @@ def logout_all(master_address: str, cert: Optional[certs.Cert]) -> None:
 
     for user in users:
         logout(master_address, user, cert)
+
+
+def login_from_task(
+    master_address: str,
+    cert: Optional[certs.Cert],
+) -> "api.TaskSession":
+    """
+    Creates a ``TaskSession`` from environment variables to be used for authenticating subsequent
+    requests.
+
+    This method should only be called on-cluster, from inside a task container.
+    """
+    session_token = get_det_session_token_from_env()
+    if not session_token:
+        raise ValueError("DET_SESSION_TOKEN environment variable not set.")
+
+    username = get_det_username_from_env()
+    if not username:
+        raise ValueError("DET_USER environment variable not set.")
+
+    return api.TaskSession(master=master_address, username=username, token=session_token, cert=cert)
 
 
 def _is_token_valid(master_address: str, token: str, cert: Optional[certs.Cert]) -> bool:

--- a/harness/determined/core/_context.py
+++ b/harness/determined/core/_context.py
@@ -242,9 +242,10 @@ def init(
 
     # We are on the cluster.
     cert = certs.default_load(info.master_url)
-    session = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
-        util.get_max_retries_config()
-    )
+    session = authentication.login_from_task(
+        master_address=info.master_url,
+        cert=cert,
+    ).with_retry(util.get_max_retries_config())
 
     if distributed is None:
         if len(info.container_addrs) > 1 or len(info.slot_ids) > 1:

--- a/harness/determined/exec/gc_checkpoints.py
+++ b/harness/determined/exec/gc_checkpoints.py
@@ -27,7 +27,7 @@ def patch_checkpoints(storage_ids_to_resources: Dict[str, Dict[str, int]]) -> No
 
     cert = certs.default_load(info.master_url)
     # With backoff retries for 64 seconds
-    sess = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+    sess = authentication.login_from_task(info.master_url, cert=cert).with_retry(
         urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
     )
 

--- a/harness/determined/exec/launch.py
+++ b/harness/determined/exec/launch.py
@@ -22,7 +22,7 @@ def trigger_preemption(signum: int, frame: types.FrameType) -> None:
         logger.info("SIGTERM: Preemption imminent.")
         # Notify the master that we need to be preempted
         cert = certs.default_load(info.master_url)
-        sess = authentication.login_with_cache(info.master_url, cert=cert)
+        sess = authentication.login_from_task(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/signals/pending_preemption")
 
 

--- a/harness/determined/exec/prep_container.py
+++ b/harness/determined/exec/prep_container.py
@@ -388,7 +388,7 @@ if __name__ == "__main__":
 
     cert = certs.default_load(info.master_url)
     # With backoff retries for 64 seconds
-    sess = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
+    sess = authentication.login_from_task(info.master_url, cert=cert).with_retry(
         urllib3.util.retry.Retry(total=6, backoff_factor=0.5)
     )
 

--- a/harness/determined/experimental/core_v2/_core_context_v2.py
+++ b/harness/determined/experimental/core_v2/_core_context_v2.py
@@ -6,7 +6,7 @@ import appdirs
 
 import determined as det
 from determined import core, experimental, tensorboard
-from determined.common import constants, storage, util
+from determined.common import api, constants, storage, util
 from determined.common.api import authentication, certs
 
 logger = logging.getLogger("determined.core")
@@ -43,9 +43,9 @@ def _make_v2_context(
 
         # We are on the cluster.
         cert = certs.default_load(info.master_url)
-        session = authentication.login_with_cache(info.master_url, cert=cert).with_retry(
-            util.get_max_retries_config()
-        )
+        session: api.Session = authentication.login_from_task(
+            info.master_url, cert=cert
+        ).with_retry(util.get_max_retries_config())
     else:
         unmanaged = True
 

--- a/harness/determined/launch/deepspeed.py
+++ b/harness/determined/launch/deepspeed.py
@@ -286,7 +286,7 @@ def main(script: List[str]) -> int:
         # Mark sshd containers as daemon containers that the master should kill when all non-daemon
         # containers (deepspeed launcher, in this case) have exited.
         cert = certs.default_load(info.master_url)
-        sess = authentication.login_with_cache(info.master_url, cert=cert)
+        sess = authentication.login_from_task(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/resources/{resources_id}/daemon")
 
         # Wrap it in a pid_server to ensure that we can't hang if a worker fails.

--- a/harness/determined/launch/horovod.py
+++ b/harness/determined/launch/horovod.py
@@ -128,7 +128,7 @@ def main(hvd_args: List[str], script: List[str], autohorovod: bool) -> int:
         # Mark sshd containers as daemon resources that the master should kill when all non-daemon
         # containers (horovodrun, in this case) have exited.
         cert = certs.default_load(info.master_url)
-        sess = authentication.login_with_cache(info.master_url, cert=cert)
+        sess = authentication.login_from_task(info.master_url, cert=cert)
         sess.post(f"/api/v1/allocations/{info.allocation_id}/resources/{resources_id}/daemon")
 
         pid_server_cmd, run_sshd_command = create_sshd_worker_cmd(

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -75,7 +75,7 @@ def test_launch_multi_slot_chief(
 
     mock_subprocess.side_effect = mock_process
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         deeplaunch.main(script)
 
     mock_cluster_info.assert_called_once()
@@ -149,7 +149,7 @@ def test_launch_multi_slot_fail(
 
     mock_subprocess.side_effect = mock_process
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         with pytest.raises(ValueError, match="no sshd greeting"):
             deeplaunch.main(script)
 
@@ -195,7 +195,7 @@ def test_launch_one_slot(
     log_redirect_cmd = deeplaunch.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         deeplaunch.main(script)
 
     mock_cluster_info.assert_called_once()
@@ -223,7 +223,7 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
     log_redirect_cmd = deeplaunch.create_log_redirect_cmd()
     launch_cmd = pid_server_cmd + deepspeed_cmd + pid_client_cmd + log_redirect_cmd + script
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         assert deeplaunch.main(script) == 1
 
     mock_cluster_info.assert_called_once()
@@ -245,7 +245,12 @@ def test_launch_worker(
     mock_cluster_info.return_value = cluster_info
     mock_session = mock.MagicMock()
     mock_login.return_value = mock_session
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars(
+        {
+            "DET_RESOURCES_ID": "resourcesId",
+            "DET_SESSION_TOKEN": cluster_info.session_token,
+        }
+    ):
         deeplaunch.main(["script"])
 
     mock_cluster_info.assert_called_once()

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -235,7 +235,7 @@ def test_launch_fail(mock_cluster_info: mock.MagicMock, mock_subprocess: mock.Ma
 
 @mock.patch("subprocess.Popen")
 @mock.patch("determined.get_cluster_info")
-@mock.patch("determined.common.api.authentication.login_with_cache")
+@mock.patch("determined.common.api.authentication.login_from_task")
 def test_launch_worker(
     mock_login: mock.MagicMock,
     mock_cluster_info: mock.MagicMock,

--- a/harness/tests/launch/test_deepspeed.py
+++ b/harness/tests/launch/test_deepspeed.py
@@ -249,6 +249,7 @@ def test_launch_worker(
         {
             "DET_RESOURCES_ID": "resourcesId",
             "DET_SESSION_TOKEN": cluster_info.session_token,
+            "DET_USER": "abcd",
         }
     ):
         deeplaunch.main(["script"])

--- a/harness/tests/launch/test_horovod.py
+++ b/harness/tests/launch/test_horovod.py
@@ -147,6 +147,7 @@ def test_sshd_worker(
         {
             "DET_RESOURCES_ID": "resourcesId",
             "DET_SESSION_TOKEN": info.session_token,
+            "DET_USER": "abcd",
         }
     ):
         assert launch.horovod.main(hvd_args, script, True) == 99

--- a/harness/tests/launch/test_horovod.py
+++ b/harness/tests/launch/test_horovod.py
@@ -116,7 +116,7 @@ def test_horovod_chief(
 
 @mock.patch("subprocess.Popen")
 @mock.patch("determined.get_cluster_info")
-@mock.patch("determined.common.api.authentication.login_with_cache")
+@mock.patch("determined.common.api.authentication.login_from_task")
 def test_sshd_worker(
     mock_login: mock.MagicMock,
     mock_cluster_info: mock.MagicMock,

--- a/harness/tests/launch/test_horovod.py
+++ b/harness/tests/launch/test_horovod.py
@@ -86,7 +86,7 @@ def test_horovod_chief(
     os.environ.pop("DET_CHIEF_IP", None)
     os.environ.pop("USE_HOROVOD", None)
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         assert launch.horovod.main(hvd_args, script, autohorovod) == 99
 
     if autohorovod and nnodes == 1 and nslots == 1:
@@ -143,7 +143,12 @@ def test_sshd_worker(
 
     os.environ.pop("DET_CHIEF_IP", None)
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars(
+        {
+            "DET_RESOURCES_ID": "resourcesId",
+            "DET_SESSION_TOKEN": info.session_token,
+        }
+    ):
         assert launch.horovod.main(hvd_args, script, True) == 99
 
     mock_cluster_info.assert_called_once()

--- a/harness/tests/launch/test_launch.py
+++ b/harness/tests/launch/test_launch.py
@@ -42,7 +42,7 @@ def test_launch_list() -> None:
 @mock.patch("determined.common.storage.validate_config")
 def test_launch_script(mock_validate_config: mock.MagicMock) -> None:
     # Use runpy to actually run the whole launch script.
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         with test_util.set_mock_cluster_info(["0.0.0.1"], 0, 1) as info:
             # Successful entrypoints exit 0.
             info.trial._config["entrypoint"] = ["true"]

--- a/harness/tests/launch/test_torch_distributed.py
+++ b/harness/tests/launch/test_torch_distributed.py
@@ -38,7 +38,7 @@ def test_launch_single_slot(
     script = ["python3", "-m", "determined.exec.harness", "my_module:MyTrial"]
     override_args = ["--max_restarts", "1"]
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         launch.torch_distributed.main(override_args, script)
 
     launch_cmd = launch.torch_distributed.create_pid_server_cmd(
@@ -78,7 +78,7 @@ def test_launch_distributed(
 
     mock_subprocess.return_value = mock_proc
 
-    with test_util.set_resources_id_env_var():
+    with test_util.set_env_vars({"DET_RESOURCES_ID": "resourcesId"}):
         assert launch.torch_distributed.main(override_args, script) == mock_success_code
 
     launch_cmd = launch.torch_distributed.create_pid_server_cmd(

--- a/harness/tests/launch/test_util.py
+++ b/harness/tests/launch/test_util.py
@@ -64,13 +64,13 @@ def set_mock_cluster_info(
 
 
 @contextlib.contextmanager
-def set_env_vars(env_vars: dict[str, str]) -> Iterator[None]:
+def set_env_vars(env_vars: Dict[str, str]) -> Iterator[None]:
     try:
         for k, v in env_vars.items():
             os.environ[k] = v
         yield
     finally:
-        for k, v in env_vars.items():
+        for k, _ in env_vars.items():
             del os.environ[k]
 
 

--- a/harness/tests/launch/test_util.py
+++ b/harness/tests/launch/test_util.py
@@ -64,12 +64,14 @@ def set_mock_cluster_info(
 
 
 @contextlib.contextmanager
-def set_resources_id_env_var() -> Iterator[None]:
+def set_env_vars(env_vars: dict[str, str]) -> Iterator[None]:
     try:
-        os.environ["DET_RESOURCES_ID"] = "resourcesId"
+        for k, v in env_vars.items():
+            os.environ[k] = v
         yield
     finally:
-        del os.environ["DET_RESOURCES_ID"]
+        for k, v in env_vars.items():
+            del os.environ[k]
 
 
 def parse_args_check(positive_cases: Dict, negative_cases: Dict, parse_func: Callable) -> None:

--- a/master/static/srv/check_idle.py
+++ b/master/static/srv/check_idle.py
@@ -83,7 +83,7 @@ def main():
     notebook_server = f"https://127.0.0.1:{port}/proxy/{notebook_id}"
     master_url = api.canonicalize_master_url(os.environ["DET_MASTER"])
     cert = certs.default_load(master_url)
-    sess = authentication.login_with_cache(master_url, cert=cert)
+    sess = authentication.login_from_task(master_url, cert=cert)
     try:
         idle_type = IdleType[os.environ["NOTEBOOK_IDLE_TYPE"].upper()]
     except KeyError:

--- a/master/static/srv/check_ready_logs.py
+++ b/master/static/srv/check_ready_logs.py
@@ -37,7 +37,7 @@ def main(ready: Pattern, waiting: Optional[Pattern] = None):
     cert = certs.default_load(master_url)
     # This only runs on-cluster, so it is expected the username and session token are present in the
     # environment.
-    sess = authentication.login_with_cache(master_url, cert=cert)
+    sess = authentication.login_from_task(master_url, cert=cert)
     allocation_id = str(os.environ["DET_ALLOCATION_ID"])
     for line in sys.stdin:
         if ready.match(line):
@@ -49,11 +49,15 @@ def main(ready: Pattern, waiting: Optional[Pattern] = None):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Read STDIN for a match and mark a task as ready")
+    parser = argparse.ArgumentParser(
+        description="Read STDIN for a match and mark a task as ready"
+    )
     parser.add_argument(
         "--ready-regex", type=str, help="the pattern to match task ready", required=True
     )
-    parser.add_argument("--waiting-regex", type=str, help="the pattern to match task waiting")
+    parser.add_argument(
+        "--waiting-regex", type=str, help="the pattern to match task waiting"
+    )
     args = parser.parse_args()
 
     ready_regex = re.compile(args.ready_regex)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

use task session tokens instead of user session tokens in the `CoreContext` and other internal tasks, since some experiments are long running and will expire within the 7 day user token deadline.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

- Make sure a normal experiment (mnist_pytorch for example) runs successfully
- submit a script that checks the tokens being used in sessions:
```python3
import logging
import os

import determined as det
from determined import core


if __name__ == "__main__":
    logging.basicConfig(level=logging.DEBUG, format=det.LOG_FORMAT)
    with core.init() as core_context:
        core_session_token = core_context.train._session.token
        session_token_env = os.environ["DET_SESSION_TOKEN"]
        user_token_env = os.environ["DET_USER_TOKEN"]
        print(f"Token on `core.Context`: {core_context.train._session.token}")
        print(f"Task token environment variable: {os.environ['DET_SESSION_TOKEN']}")
        print(f"User token environment variable: {os.environ['DET_USER_TOKEN']}")
        assert core_session_token == session_token_env
        assert core_session_token != user_token_env
```
make sure that the session token is being used on the core context, and that it's not the user token

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ