### PR TITLE
fix: allow for objects inside array metadata to be typed properly

### DIFF
--- a/master/internal/run/runs.go
+++ b/master/internal/run/runs.go
@@ -112,7 +112,7 @@ func flattenMetadata(data map[string]any) (flatMetadata []model.RunMetadataIndex
 					key:    key,
 					value:  value,
 					depth:  entry.depth + 1,
-					array:  entry.array,
+					array:  false,
 				})
 			}
 		// if the value is a slice, push each element onto the stack.

--- a/master/internal/run/runs.go
+++ b/master/internal/run/runs.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -101,19 +102,35 @@ func flattenMetadata(data map[string]any) (flatMetadata []model.RunMetadataIndex
 				flatMetadata = append(flatMetadata, newIndex)
 				continue
 			}
-			for key, value := range typedVal {
-				newPrefix := entry.prefix + entry.key + "."
-				if newPrefix == "." {
-					newPrefix = ""
+			if entry.array {
+				newIndex := model.RunMetadataIndex{
+					FlatKey:        entry.prefix + entry.key,
+					IsArrayElement: true,
 				}
-				// push the key-value pair onto the stack
-				stack = append(stack, metadataEntry{
-					prefix: newPrefix,
-					key:    key,
-					value:  value,
-					depth:  entry.depth + 1,
-					array:  false,
-				})
+				objJSON, err := json.Marshal(entry.value)
+				if err != nil {
+					return nil, fmt.Errorf(
+						"failed to marshall metadata object in array %w",
+						err,
+					)
+				}
+				newIndex.StringValue = ptrs.Ptr(string(objJSON))
+				flatMetadata = append(flatMetadata, newIndex)
+			} else {
+				for key, value := range typedVal {
+					newPrefix := entry.prefix + entry.key + "."
+					if newPrefix == "." {
+						newPrefix = ""
+					}
+					// push the key-value pair onto the stack
+					stack = append(stack, metadataEntry{
+						prefix: newPrefix,
+						key:    key,
+						value:  value,
+						depth:  entry.depth + 1,
+						array:  false,
+					})
+				}
 			}
 		// if the value is a slice, push each element onto the stack.
 		case []any:

--- a/master/internal/run/runs_test.go
+++ b/master/internal/run/runs_test.go
@@ -79,7 +79,7 @@ func TestFlattenMetadata(t *testing.T) {
 			FlatKey:        "key7.key8",
 			IntegerValue:   ptrs.Ptr(3),
 			ProjectID:      0,
-			IsArrayElement: true,
+			IsArrayElement: false,
 		},
 		{
 			RunID:          0,
@@ -173,7 +173,7 @@ func TestFlattenMetadataArrayNested(t *testing.T) {
 			FlatKey:        "key1.key2",
 			IntegerValue:   ptrs.Ptr(1),
 			ProjectID:      0,
-			IsArrayElement: true,
+			IsArrayElement: false,
 		},
 	}, flattened)
 }

--- a/master/internal/run/runs_test.go
+++ b/master/internal/run/runs_test.go
@@ -76,10 +76,9 @@ func TestFlattenMetadata(t *testing.T) {
 		},
 		{
 			RunID:          0,
-			FlatKey:        "key7.key8",
-			IntegerValue:   ptrs.Ptr(3),
-			ProjectID:      0,
-			IsArrayElement: false,
+			FlatKey:        "key7",
+			StringValue:    ptrs.Ptr(`{"key8":3}`),
+			IsArrayElement: true,
 		},
 		{
 			RunID:          0,
@@ -170,10 +169,10 @@ func TestFlattenMetadataArrayNested(t *testing.T) {
 	require.ElementsMatch(t, []model.RunMetadataIndex{
 		{
 			RunID:          0,
-			FlatKey:        "key1.key2",
-			IntegerValue:   ptrs.Ptr(1),
+			FlatKey:        "key1",
+			StringValue:    ptrs.Ptr("{\"key2\":1}"),
 			ProjectID:      0,
-			IsArrayElement: false,
+			IsArrayElement: true,
 		},
 	}, flattened)
 }
@@ -284,25 +283,6 @@ func TestFlattenMetadataArrayElementTooLongKey(t *testing.T) {
 		err,
 		fmt.Sprintf(
 			"metadata key exceeds maximum length of %d characters",
-			MaxMetadataKeyLength,
-		),
-	)
-}
-
-func TestFlattenMetadataArrayElementTooLongKeyInNestedArray(t *testing.T) {
-	data := map[string]interface{}{
-		"key1": []interface{}{
-			map[string]interface{}{
-				"key2": 1,
-			},
-		},
-	}
-	data["key1"].([]interface{})[0].(map[string]interface{})[strings.Repeat("a", MaxMetadataKeyLength+1)] = 2
-	_, err := FlattenMetadata(data)
-	require.ErrorContains(
-		t,
-		err,
-		fmt.Sprintf("metadata key exceeds maximum length of %d characters",
 			MaxMetadataKeyLength,
 		),
 	)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
ET-744


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
When an object metadata is inside an array, the object elements are now displayable.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Add metadata to a run that has a list of objects (i.e `"a": [{"b": 3}, {"c":2}]`) then, on the run table select and confirm that the elements are viewable.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ