### PR TITLE
feat: Logic of different modes for webhook

### DIFF
--- a/e2e_tests/tests/cluster/test_webhooks.py
+++ b/e2e_tests/tests/cluster/test_webhooks.py
@@ -127,16 +127,16 @@ def test_log_pattern_send_webhook(should_match: bool) -> None:
     )
 
     workspace = bindings.post_PostWorkspace(
-            sess, body=bindings.v1PostWorkspaceRequest(name=f"webhook-test{random.random()}")
-        ).workspace
-    project =  bindings.post_PostProject(
-            sess,
-            body=bindings.v1PostProjectRequest(
-                name=f"webhook-test{random.random()}",
-                workspaceId=workspace.id,
-            ),
+        sess, body=bindings.v1PostWorkspaceRequest(name=f"webhook-test{random.random()}")
+    ).workspace
+    project = bindings.post_PostProject(
+        sess,
+        body=bindings.v1PostProjectRequest(
+            name=f"webhook-test{random.random()}",
             workspaceId=workspace.id,
-        ).project
+        ),
+        workspaceId=workspace.id,
+    ).project
 
     specific_path = f"/test/path/here/{str(uuid.uuid4())}"
     bindings.post_PostWebhook(
@@ -168,7 +168,14 @@ def test_log_pattern_send_webhook(should_match: bool) -> None:
         sess,
         conf.fixtures_path("no_op/single-medium-train-step.yaml"),
         conf.fixtures_path("no_op"),
-        ["--config", "hyperparameters.metrics_sigma=-1.0", "--config", f"integrations.webhooks.webhook_name=['specific-webhook']", "--project_id", f"{project.id}"],
+        [
+            "--config",
+            "hyperparameters.metrics_sigma=-1.0",
+            "--config",
+            "integrations.webhooks.webhook_name=['specific-webhook']",
+            "--project_id",
+            f"{project.id}",
+        ],
     )
     exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
 
@@ -191,6 +198,7 @@ def test_log_pattern_send_webhook(should_match: bool) -> None:
         assert specific_path not in responses
         assert specific_path_unmatch not in responses
 
+
 @pytest.mark.e2e_cpu
 def test_specific_webhook() -> None:
     port1 = 5007
@@ -200,16 +208,16 @@ def test_specific_webhook() -> None:
     sess = api_utils.admin_session()
 
     workspace = bindings.post_PostWorkspace(
-            sess, body=bindings.v1PostWorkspaceRequest(name=f"webhook-test{random.random()}")
-        ).workspace
-    project =  bindings.post_PostProject(
-            sess,
-            body=bindings.v1PostProjectRequest(
-                name=f"webhook-test{random.random()}",
-                workspaceId=workspace.id,
-            ),
+        sess, body=bindings.v1PostWorkspaceRequest(name=f"webhook-test{random.random()}")
+    ).workspace
+    project = bindings.post_PostProject(
+        sess,
+        body=bindings.v1PostProjectRequest(
+            name=f"webhook-test{random.random()}",
             workspaceId=workspace.id,
-        ).project
+        ),
+        workspaceId=workspace.id,
+    ).project
 
     webhook_trigger = bindings.v1Trigger(
         triggerType=bindings.v1TriggerType.EXPERIMENT_STATE_CHANGE,
@@ -240,8 +248,15 @@ def test_specific_webhook() -> None:
     assert webhook_res_2.url == webhook_2.url
 
     experiment_id = exp.create_experiment(
-        sess, conf.fixtures_path("no_op/single-one-short-step.yaml"), conf.fixtures_path("no_op"),
-        ["--project_id", f"{project.id}", "--config", f"integrations.webhooks.webhook_id=[{webhook_res_1.id},{webhook_res_2.id}]"],
+        sess,
+        conf.fixtures_path("no_op/single-one-short-step.yaml"),
+        conf.fixtures_path("no_op"),
+        [
+            "--project_id",
+            f"{project.id}",
+            "--config",
+            f"integrations.webhooks.webhook_id=[{webhook_res_1.id},{webhook_res_2.id}]",
+        ],
     )
 
     exp.wait_for_experiment_state(

--- a/e2e_tests/tests/cluster/test_webhooks.py
+++ b/e2e_tests/tests/cluster/test_webhooks.py
@@ -190,7 +190,7 @@ def test_log_pattern_send_webhook(should_match: bool) -> None:
         # Further tested in integrations.
         assert "TASK_LOG" in responses[default_path]
         assert "This log matched the regex" in responses[slack_path]
-        assert "TASK_LOG" in responses[default_path]
+        assert "TASK_LOG" in responses[specific_path]
         assert specific_path_unmatch not in responses
     else:
         assert default_path not in responses

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -2349,7 +2349,7 @@ func (a *apiServer) GetModelDef(
 func (a *apiServer) GetTaskContextDirectory(
 	ctx context.Context, req *apiv1.GetTaskContextDirectoryRequest,
 ) (*apiv1.GetTaskContextDirectoryResponse, error) {
-	if err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId),
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId),
 		experiment.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}

--- a/master/internal/api_task.go
+++ b/master/internal/api_task.go
@@ -16,7 +16,7 @@ import (
 func (a *apiServer) GetTask(
 	ctx context.Context, req *apiv1.GetTaskRequest,
 ) (resp *apiv1.GetTaskResponse, err error) {
-	if err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId),
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId),
 		expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (a *apiServer) GetTask(
 func (a *apiServer) GetGenericTaskConfig(
 	ctx context.Context, req *apiv1.GetGenericTaskConfigRequest,
 ) (resp *apiv1.GetGenericTaskConfigResponse, err error) {
-	if err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId)); err != nil {
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId)); err != nil {
 		return nil, err
 	}
 

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -60,7 +60,9 @@ func expFromTaskID(
 	return true, exp, nil
 }
 
-func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.TaskID) (bool, model.AccessScopeID, error) {
+func canAccessNTSCTask(
+	ctx context.Context, curUser model.User, taskID model.TaskID,
+) (bool, model.AccessScopeID, error) {
 	spec, err := command.IdentifyTask(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) {
 		// Non NTSC case like checkpointGC case or the task just does not exist.
@@ -123,7 +125,7 @@ func (a *apiServer) canDoActionsOnTask(
 			}
 			return nil, nil, err
 		}
-		// When error is nil, workspaceID is guarenteed not nil
+		// When error is nil, workspaceID is guaranteed not nil
 		return &workspaceID, nil, nil
 	}
 }

--- a/master/internal/api_tasks.go
+++ b/master/internal/api_tasks.go
@@ -26,6 +26,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/task"
 	"github.com/determined-ai/determined/master/internal/webhooks"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 	"github.com/determined-ai/determined/proto/pkg/taskv1"
 )
@@ -59,65 +60,72 @@ func expFromTaskID(
 	return true, exp, nil
 }
 
-func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.TaskID) (bool, error) {
+func canAccessNTSCTask(ctx context.Context, curUser model.User, taskID model.TaskID) (bool, model.AccessScopeID, error) {
 	spec, err := command.IdentifyTask(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) {
 		// Non NTSC case like checkpointGC case or the task just does not exist.
 		// TODO(nick) eventually control access to checkpointGC.
-		return true, nil
+		return true, spec.WorkspaceID, nil
 	} else if err != nil {
-		return false, err
+		return false, spec.WorkspaceID, err
 	}
 	err = command.AuthZProvider.Get().CanGetNSC(
 		ctx, curUser, spec.WorkspaceID)
-	return !authz.IsPermissionDenied(err), err
+	return !authz.IsPermissionDenied(err), spec.WorkspaceID, err
 }
 
 func (a *apiServer) canDoActionsOnTask(
 	ctx context.Context, taskID model.TaskID,
 	actions ...func(context.Context, model.User, *model.Experiment) error,
-) error {
+) (*model.AccessScopeID, *int, error) {
 	errTaskNotFound := api.NotFoundErrs("task", fmt.Sprint(taskID), true)
 	t, err := db.TaskByID(ctx, taskID)
 	if errors.Is(err, db.ErrNotFound) {
-		return errTaskNotFound
+		return nil, nil, errTaskNotFound
 	} else if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	switch t.TaskType {
 	case model.TaskTypeTrial:
 		isExp, exp, err := expFromTaskID(ctx, taskID)
 		if !isExp {
-			return fmt.Errorf("error we failed to look up an experiment "+
+			return nil, nil, fmt.Errorf("error we failed to look up an experiment "+
 				"from taskID %s when we think it is a trial task", taskID)
 		}
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 
 		if err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp); err != nil {
-			return authz.SubIfUnauthorized(err, errTaskNotFound)
+			return nil, nil, authz.SubIfUnauthorized(err, errTaskNotFound)
 		}
 		for _, action := range actions {
 			if err = action(ctx, *curUser, exp); err != nil {
-				return status.Error(codes.PermissionDenied, err.Error())
+				return nil, nil, status.Error(codes.PermissionDenied, err.Error())
 			}
 		}
+		workspaceID, err := expauth.GetWorkspaceFromExperiment(ctx, exp)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ptrs.Ptr(model.AccessScopeID(workspaceID)), ptrs.Ptr(exp.ID), nil
 	default: // NTSC case + checkpointGC.
-		if ok, err := canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
+		ok, workspaceID, err := canAccessNTSCTask(ctx, *curUser, taskID)
+		if err != nil {
 			if !ok || authz.IsPermissionDenied(err) {
-				return errTaskNotFound
+				return nil, nil, errTaskNotFound
 			}
-			return err
+			return nil, nil, err
 		}
+		// When error is nil, workspaceID is guarenteed not nil
+		return &workspaceID, nil, nil
 	}
-	return nil
 }
 
 func (a *apiServer) canGetTaskAcceleration(ctx context.Context, taskID string) error {
@@ -131,7 +139,7 @@ func (a *apiServer) canGetTaskAcceleration(ctx context.Context, taskID string) e
 	}
 	if !isExp {
 		var ok bool
-		if ok, err = canAccessNTSCTask(ctx, *curUser, model.TaskID(taskID)); err != nil {
+		if ok, _, err = canAccessNTSCTask(ctx, *curUser, model.TaskID(taskID)); err != nil {
 			return err
 		} else if !ok {
 			return api.NotFoundErrs("task", taskID, true)
@@ -163,7 +171,7 @@ func (a *apiServer) canGetAllocation(ctx context.Context, allocationID string) e
 	}
 	if !isExp {
 		var ok bool
-		if ok, err = canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
+		if ok, _, err = canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
 			return err
 		} else if !ok {
 			return api.NotFoundErrs("allocation", allocationID, true)
@@ -196,7 +204,7 @@ func (a *apiServer) canEditAllocation(ctx context.Context, allocationID string) 
 	}
 	if !isExp {
 		var ok bool
-		if ok, err = canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
+		if ok, _, err = canAccessNTSCTask(ctx, *curUser, taskID); err != nil {
 			return err
 		} else if !ok {
 			return api.NotFoundErrs("allocation", allocationID, true)
@@ -460,8 +468,9 @@ func (a *apiServer) PostTaskLogs(
 	}
 	taskID := req.Logs[0].TaskId
 
-	if err := a.canDoActionsOnTask(ctx, model.TaskID(taskID),
-		expauth.AuthZProvider.Get().CanEditExperiment); err != nil {
+	workspaceID, expID, err := a.canDoActionsOnTask(ctx, model.TaskID(taskID),
+		expauth.AuthZProvider.Get().CanEditExperiment)
+	if err != nil {
 		return nil, err
 	}
 
@@ -486,7 +495,7 @@ func (a *apiServer) PostTaskLogs(
 		return nil, fmt.Errorf("adding task logs to task log backend: %w", err)
 	}
 
-	switch err := webhooks.ScanLogs(ctx, logs); {
+	switch err := webhooks.ScanLogs(ctx, logs, *workspaceID, expID); {
 	case err != nil && errors.Is(err, context.Canceled):
 		return nil, err
 	case err != nil:
@@ -580,7 +589,7 @@ func (a *apiServer) GetTasks(
 		}
 
 		if !isExp {
-			_, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
+			_, _, err = canAccessNTSCTask(ctx, *curUser, summary[allocationID].TaskID)
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, *curUser, exp)
 		}
@@ -612,7 +621,7 @@ func (a *apiServer) taskLogs(
 	var timeSinceLastAuth time.Time
 	fetch := func(r api.BatchRequest) (api.Batch, error) {
 		if time.Since(timeSinceLastAuth) >= recheckAuthPeriod {
-			if err = a.canDoActionsOnTask(ctx, taskID,
+			if _, _, err = a.canDoActionsOnTask(ctx, taskID,
 				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 				return nil, err
 			}
@@ -735,7 +744,7 @@ func (a *apiServer) TaskLogsFields(
 	var timeSinceLastAuth time.Time
 	fetch := func(lr api.BatchRequest) (api.Batch, error) {
 		if time.Since(timeSinceLastAuth) >= recheckAuthPeriod {
-			if err := a.canDoActionsOnTask(resp.Context(), taskID,
+			if _, _, err := a.canDoActionsOnTask(resp.Context(), taskID,
 				expauth.AuthZProvider.Get().CanGetExperimentArtifacts); err != nil {
 				return nil, err
 			}

--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -1459,7 +1459,7 @@ func (a *apiServer) ReportTrialValidationMetrics(
 func (a *apiServer) ReportCheckpoint(
 	ctx context.Context, req *apiv1.ReportCheckpointRequest,
 ) (*apiv1.ReportCheckpointResponse, error) {
-	if err := a.canDoActionsOnTask(ctx, model.TaskID(req.Checkpoint.TaskId),
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.Checkpoint.TaskId),
 		experiment.AuthZProvider.Get().CanEditExperiment); err != nil {
 		return nil, err
 	}

--- a/master/internal/core_task.go
+++ b/master/internal/core_task.go
@@ -23,7 +23,7 @@ func (m *Master) getTasks(c echo.Context) (interface{}, error) {
 		}
 
 		if !isExp {
-			_, err = canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID)
+			_, _, err = canAccessNTSCTask(ctx, curUser, summary[allocationID].TaskID)
 		} else {
 			err = expauth.AuthZProvider.Get().CanGetExperiment(ctx, curUser, exp)
 		}

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -332,6 +332,7 @@ type MockExperimentParams struct {
 	ProjectID            *int
 	ExternalExperimentID *string
 	State                *model.State
+	Integrations         *expconf.IntegrationsConfigV0
 }
 
 // RequireMockExperimentParams returns a mock experiment with various parameters.
@@ -378,6 +379,9 @@ func RequireMockExperimentParams(
 				},
 			}
 		}
+	}
+	if p.Integrations != nil {
+		notDefaulted.RawIntegrations = p.Integrations
 	}
 
 	cfg := schemas.WithDefaults(notDefaulted)

--- a/master/internal/experiment/authz_rbac.go
+++ b/master/internal/experiment/authz_rbac.go
@@ -32,8 +32,13 @@ type permissionMatch struct {
 func GetWorkspaceFromExperiment(ctx context.Context, e *model.Experiment,
 ) (int32, error) {
 	var workspaceID int32
-	err := db.Bun().NewRaw("SELECT workspace_id FROM projects WHERE id = ?",
-		e.ProjectID).Scan(ctx, &workspaceID)
+	var q interface{}
+	q = db.Bun().NewSelect().Table("experiments").Column("project_id").Where("id = ?", e.ID)
+	if e.ProjectID > 0 {
+		q = e.ProjectID
+	}
+	err := db.Bun().NewSelect().Table("projects").Column("workspace_id").Where("id = (?)",
+		q).Scan(ctx, &workspaceID)
 	return workspaceID, err
 }
 

--- a/master/internal/experiment/authz_rbac.go
+++ b/master/internal/experiment/authz_rbac.go
@@ -28,7 +28,8 @@ type permissionMatch struct {
 	Permitted bool
 }
 
-func getWorkspaceFromExperiment(ctx context.Context, e *model.Experiment,
+// GetWorkspaceFromExperiment gets the workspace id given an experiment id.
+func GetWorkspaceFromExperiment(ctx context.Context, e *model.Experiment,
 ) (int32, error) {
 	var workspaceID int32
 	err := db.Bun().NewRaw("SELECT workspace_id FROM projects WHERE id = ?",
@@ -74,7 +75,7 @@ func (a *ExperimentAuthZRBAC) CanGetExperiment(
 		}
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -93,7 +94,7 @@ func (a *ExperimentAuthZRBAC) CanGetExperimentArtifacts(
 		audit.LogFromErr(fields, err)
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -112,7 +113,7 @@ func (a *ExperimentAuthZRBAC) CanDeleteExperiment(
 		audit.LogFromErr(fields, err)
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -278,7 +279,7 @@ func (a *ExperimentAuthZRBAC) CanEditExperiment(
 		audit.LogFromErr(fields, err)
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -297,7 +298,7 @@ func (a *ExperimentAuthZRBAC) CanEditExperimentsMetadata(
 		audit.LogFromErr(fields, err)
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}
@@ -334,7 +335,7 @@ func (a *ExperimentAuthZRBAC) CanForkFromExperiment(
 		audit.LogFromErr(fields, err)
 	}()
 
-	workspaceID, err := getWorkspaceFromExperiment(ctx, e)
+	workspaceID, err := GetWorkspaceFromExperiment(ctx, e)
 	if err != nil {
 		return err
 	}

--- a/master/internal/webhooks/postgres_webhook.go
+++ b/master/internal/webhooks/postgres_webhook.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"sync"
 	"time"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/determined-ai/determined/master/internal/project"
 	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 
 	"github.com/google/uuid"
@@ -30,8 +33,9 @@ type regexTriggers struct {
 
 // WebhookManager manages webhooks.
 type WebhookManager struct {
-	mu              sync.RWMutex
-	regexToTriggers map[string]regexTriggers
+	mu                 sync.RWMutex
+	regexToTriggers    map[string]regexTriggers
+	expToWebhookConfig map[int]*expconf.WebhooksConfigV0
 }
 
 // New creates a new webhook manager.
@@ -44,7 +48,8 @@ func New(ctx context.Context) (*WebhookManager, error) {
 	}
 
 	m := &WebhookManager{
-		regexToTriggers: make(map[string]regexTriggers),
+		regexToTriggers:    make(map[string]regexTriggers),
+		expToWebhookConfig: make(map[int]*expconf.WebhooksConfigV0),
 	}
 	if err := m.addTriggers(triggers); err != nil {
 		return nil, fmt.Errorf("adding each trigger: %w", err)
@@ -108,8 +113,75 @@ func (l *WebhookManager) removeTriggers(triggers []*Trigger) error {
 	return nil
 }
 
-func (l *WebhookManager) scanLogs(ctx context.Context, logs []*model.TaskLog) error {
+func (l *WebhookManager) getWebhookConfig(ctx context.Context, expID *int) (*expconf.WebhooksConfigV0, error) {
+	if expID == nil {
+		return nil, nil
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	if config := l.expToWebhookConfig[*expID]; config != nil {
+		return config, nil
+	}
+	var expConfigBytes []byte
+	err := db.Bun().NewSelect().Table("experiments").Column("config").Where("id = ?", *expID).Scan(ctx, &expConfigBytes)
+	if err != nil {
+		return nil, err
+	}
+	expConfig, err := expconf.ParseAnyExperimentConfigYAML(expConfigBytes)
+	if err != nil {
+		return nil, err
+	}
+	if integration := schemas.WithDefaults(expConfig).Integrations(); integration != nil {
+		l.expToWebhookConfig[*expID] = integration.Webhooks
+		return integration.Webhooks, nil
+	}
+	l.expToWebhookConfig[*expID] = nil
+	return nil, nil
+}
+
+func matchWebhook(t *Trigger, config *expconf.WebhooksConfigV0, workspaceID int32, expID *int) bool {
+	if config != nil && config.Exclude {
+		return false
+	}
+	// Global webhooks (no workspace ID and not specific) trigger for all tasks
+	if t.Webhook.Mode == WebhookModeSpecific || t.Webhook.WorkspaceID != nil {
+		if t.Webhook.WorkspaceID != nil {
+			// Webhook is workspace level instead of global level
+			if *t.Webhook.WorkspaceID != workspaceID {
+				// Skip webhook from other workspaces
+				return false
+			}
+		}
+		if t.Webhook.Mode == WebhookModeSpecific {
+			// Skip specific webhook if task is not an experiment
+			if expID == nil || config == nil {
+				return false
+			}
+			// For webhook with mode specific, only proceed for experiments with matching config
+			if config.WebhookID != nil && !slices.Contains(*config.WebhookID, int(t.Webhook.ID)) {
+				return false
+			}
+			if config.WebhookName != nil && !slices.Contains(*config.WebhookName, t.Webhook.Name) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (l *WebhookManager) scanLogs(ctx context.Context, logs []*model.TaskLog, workspaceID model.AccessScopeID, expID *int) error {
 	if len(logs) == 0 {
+		return nil
+	}
+
+	config, err := l.getWebhookConfig(ctx, expID)
+	if err != nil {
+		return err
+	}
+
+	if config != nil && config.Exclude {
 		return nil
 	}
 
@@ -129,9 +201,11 @@ func (l *WebhookManager) scanLogs(ctx context.Context, logs []*model.TaskLog) er
 			}
 			if cacheItem.re.MatchString(log.Log) {
 				for _, t := range cacheItem.triggerIDToTrigger {
-					if err := addTaskLogEvent(ctx,
-						model.TaskID(log.TaskID), *log.AgentID, log.Log, t); err != nil {
-						return err
+					if matchWebhook(t, config, int32(workspaceID), expID) {
+						if err := addTaskLogEvent(ctx,
+							model.TaskID(log.TaskID), *log.AgentID, log.Log, t); err != nil {
+							return err
+						}
 					}
 				}
 			}
@@ -222,6 +296,7 @@ func GetWebhooks(ctx context.Context) (Webhooks, error) {
 }
 
 // ReportExperimentStateChanged adds webhook events to the queue.
+// This function assumes ID presents in e, and valid workspace information presents in activeConfig.
 // TODO(DET-8577): Remove unnecessary active config usage (remove the activeConfig parameter).
 func ReportExperimentStateChanged(
 	ctx context.Context, e model.Experiment, activeConfig expconf.ExperimentConfig,
@@ -243,8 +318,20 @@ func ReportExperimentStateChanged(
 		return nil
 	}
 
+	var ws model.Workspace
+	if err := db.Bun().NewSelect().Model(&ws).Where("name = ?", activeConfig.Workspace()).Scan(ctx); err != nil {
+		return fmt.Errorf("getting workspace information from experiment config: %w\nactiveConfig: %s\nexperiment: %+v", err, activeConfig.Workspace(), e)
+	}
+	var webhookConfig *expconf.WebhooksConfigV0
+	if activeConfig.Integrations() != nil {
+		webhookConfig = activeConfig.Integrations().Webhooks
+	}
+
 	var es []Event
 	for _, t := range ts {
+		if !matchWebhook(&t, webhookConfig, int32(ws.ID), ptrs.Ptr(e.ID)) {
+			continue
+		}
 		p, err := generateEventPayload(
 			ctx, t.Webhook.WebhookType, e, activeConfig, e.State, TriggerTypeStateChange,
 		)
@@ -253,6 +340,10 @@ func ReportExperimentStateChanged(
 		}
 		es = append(es, Event{Payload: p, URL: t.Webhook.URL})
 	}
+	if len(es) == 0 {
+		return nil
+	}
+
 	if _, err := db.Bun().NewInsert().Model(&es).Exec(ctx); err != nil {
 		return fmt.Errorf("report experiment state changed inserting event trigger: %w", err)
 	}

--- a/master/internal/webhooks/shipper_test.go
+++ b/master/internal/webhooks/shipper_test.go
@@ -141,7 +141,12 @@ func TestShipper(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		var config expconf.ExperimentConfig
+		workspaceName := uuid.New().String()
+		_, _ = db.RequireMockWorkspaceID(t, pgDB, workspaceName)
+
+		config := expconf.ExperimentConfig{
+			RawWorkspace: &workspaceName,
+		}
 		config = schemas.WithDefaults(config)
 		for id, delay := range schedule {
 			time.Sleep(scheduledWaitToDuration(delay))

--- a/master/internal/webhooks/singleton.go
+++ b/master/internal/webhooks/singleton.go
@@ -16,13 +16,13 @@ func SetDefault(w *WebhookManager) {
 }
 
 // ScanLogs sends webhooks for task logs. This should be called wherever we add task logs.
-func ScanLogs(ctx context.Context, logs []*model.TaskLog) error {
+func ScanLogs(ctx context.Context, logs []*model.TaskLog, workspaceID model.AccessScopeID, expID *int) error {
 	if defaultManager == nil {
 		log.Error("webhook manager is uninitialized")
 		return nil
 	}
 
-	return defaultManager.scanLogs(ctx, logs)
+	return defaultManager.scanLogs(ctx, logs, workspaceID, expID)
 }
 
 // AddWebhook adds a Webhook and its Triggers to the DB.

--- a/master/pkg/schemas/expconf/integrations.go
+++ b/master/pkg/schemas/expconf/integrations.go
@@ -3,6 +3,14 @@ package expconf
 // IntegrationsConfigV0 configures experiment-level integrations.
 type IntegrationsConfigV0 struct {
 	Pachyderm *PachydermConfigV0 `json:"pachyderm,omitempty"`
+	Webhooks  *WebhooksConfigV0  `json:"webhooks,omitempty"`
+}
+
+// WebhooksConfigV0 configures experiments with fields relevant to webhooks.
+type WebhooksConfigV0 struct {
+	WebhookID   *[]int    `json:"webhook_id,omitempty"`
+	WebhookName *[]string `json:"webhook_name,omitempty"`
+	Exclude     bool      `json:"exclude,omitempty"`
 }
 
 // PachydermConfigV0 configures experiments with fields relevant to the pachyderm integration.

--- a/master/pkg/schemas/zgen_schemas.go
+++ b/master/pkg/schemas/zgen_schemas.go
@@ -1414,6 +1414,14 @@ var (
             ],
             "default": null,
             "optionalRef": "http://determined.ai/schemas/expconf/v0/pachyderm.json"
+        },
+        "webhooks": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null,
+            "optionalRef": "http://determined.ai/schemas/expconf/v0/webhooks.json"
         }
     }
 }
@@ -3352,6 +3360,44 @@ var (
     }
 }
 `)
+	textWebhooksConfigV0 = []byte(`{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v0/webhooks.json",
+    "title": "WebhooksConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "eventuallyRequired": [],
+    "properties": {
+        "webhook_id": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "integer"
+            }
+        },
+        "webhook_name": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "string"
+            }
+        },
+        "exclude": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        }
+    }
+}
+`)
 	schemaAzureConfigV0 interface{}
 
 	schemaBindMountV0 interface{}
@@ -3479,6 +3525,8 @@ var (
 	schemaTestUnionBV0 interface{}
 
 	schemaTestUnionV0 interface{}
+
+	schemaWebhooksConfigV0 interface{}
 
 	cacheLock sync.RWMutex
 
@@ -4767,6 +4815,26 @@ func ParsedTestUnionV0() interface{} {
 	return schemaTestUnionV0
 }
 
+func ParsedWebhooksConfigV0() interface{} {
+	cacheLock.RLock()
+	if schemaWebhooksConfigV0 != nil {
+		cacheLock.RUnlock()
+		return schemaWebhooksConfigV0
+	}
+	cacheLock.RUnlock()
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+	if schemaWebhooksConfigV0 != nil {
+		return schemaWebhooksConfigV0
+	}
+	err := json.Unmarshal(textWebhooksConfigV0, &schemaWebhooksConfigV0)
+	if err != nil {
+		panic("invalid embedded json for WebhooksConfigV0")
+	}
+	return schemaWebhooksConfigV0
+}
+
 func schemaBytesMap() map[string][]byte {
 	cacheLock.RLock()
 	if cachedSchemaBytesMap != nil {
@@ -4910,5 +4978,7 @@ func schemaBytesMap() map[string][]byte {
 	cachedSchemaBytesMap[url] = textTestUnionBV0
 	url = "http://determined.ai/schemas/expconf/v0/test-union.json"
 	cachedSchemaBytesMap[url] = textTestUnionV0
+	url = "http://determined.ai/schemas/expconf/v0/webhooks.json"
+	cachedSchemaBytesMap[url] = textWebhooksConfigV0
 	return cachedSchemaBytesMap
 }

--- a/schemas/expconf/v0/integrations.json
+++ b/schemas/expconf/v0/integrations.json
@@ -12,6 +12,14 @@
             ],
             "default": null,
             "optionalRef": "http://determined.ai/schemas/expconf/v0/pachyderm.json"
+        },
+        "webhooks": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "default": null,
+            "optionalRef": "http://determined.ai/schemas/expconf/v0/webhooks.json"
         }
     }
 }

--- a/schemas/expconf/v0/webhooks.json
+++ b/schemas/expconf/v0/webhooks.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://determined.ai/schemas/expconf/v0/webhooks.json",
+    "title": "WebhooksConfig",
+    "type": "object",
+    "additionalProperties": false,
+    "eventuallyRequired": [],
+    "properties": {
+        "webhook_id": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "integer"
+            }
+        },
+        "webhook_name": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "default": null,
+            "items": {
+                "type": "string"
+            }
+        },
+        "exclude": {
+            "type": [
+                "boolean",
+                "null"
+            ],
+            "default": false
+        }
+    }
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[MD-479]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Part of workload alerting project.
ERD link: https://hpe-aiatscale.atlassian.net/wiki/spaces/ENGINEERIN/pages/1666809868/Workload+Alerting+ERD

Expand the experiment config -> integrations -> webhooks
```
integrations:
  webhooks:
    webhook_name:
      - test-webhook
```

Below is a table for which group of experiments can trigger which mode of webhooks.
workspace \ mode     |                             Specific                         |                       Workspace
| :------------------- | :-------------------------------------: | :------------------------------------: |
workspace defined    |  match workspace && match config      |      all experiments within workspace
workspace null           |                      match config                       |                     all experiments


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Unit tests and e2e tests should be able to cover it. 
To test from WebUI:

> - Create a webhook with workspace ID
> - Triggering the webhook with experiments within that workspace should work
> - The webhook should not be triggered with experiments outside of that workspace

> - Create a webhook with mode specific
> - experiment should only trigger that webhook with matching config


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[MD-479]: https://hpe-aiatscale.atlassian.net/browse/MD-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ