### PR TITLE
test: cover project id filtering on bulk actions [ET-138]

### DIFF
--- a/master/internal/experiment/bulk_action_intg_test.go
+++ b/master/internal/experiment/bulk_action_intg_test.go
@@ -253,9 +253,8 @@ func TestIntegrationKillAllExperimentsInProject(t *testing.T) {
 		},
 	}
 
-	allExperimentIds := make([]int, len(testModels))
+	allExperimentIds := make([]int, 0, len(testModels))
 	editableExperiments := map[string]*model.Experiment{}
-	i := 0
 	for name, model := range testModels {
 		exp := db.RequireMockExperimentParams(
 			t, db.SingleDB(), testUser,
@@ -263,8 +262,7 @@ func TestIntegrationKillAllExperimentsInProject(t *testing.T) {
 			*model.ProjectID,
 		)
 		editableExperiments[name] = exp
-		allExperimentIds[i] = exp.ID
-		i++
+		allExperimentIds = append(allExperimentIds, exp.ID)
 	}
 	defer func(ids []int) {
 		_ = db.SingleDB().DeleteExperiments(ctx, ids)

--- a/master/internal/experiment/bulk_action_test.go
+++ b/master/internal/experiment/bulk_action_test.go
@@ -86,7 +86,7 @@ func TestActivateExperiments(t *testing.T) {
 			expectedErr:         true,
 		},
 		{
-			name: "three experiments selected, one found",
+			name: "three experiments selected, one eligible",
 			args: args{
 				projectID:     1,
 				experimentIds: []int32{132, 142, 152},
@@ -111,7 +111,7 @@ func TestActivateExperiments(t *testing.T) {
 			},
 		},
 		{
-			name: "filters are used",
+			name: "basic label filter",
 			args: args{
 				projectID:     1,
 				experimentIds: []int32{132, 142, 152},


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-138]

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
As requested [here](https://github.com/determined-ai/determined/pull/9658/files/a0af8b0e292098cda3bd459e299a7530428b9d6a#r1681208318), puts some additional coverage on the filtering tests and enables some additional controls to improve on coverage further.

One observation out of this is that the filter logic appears to always return empty results if the project ID (outside the filters) is left zero-valued and the filter project ID must either be zero or match the other project ID. As I recall, we were questioning this design in our audit of the API for the run-centric story; I think we have a slightly clearer answer, thanks to this. I definitely think this behavior is quirky, and I lean toward thinking we probably shouldn't have `ProjectID` in the filters if `ProjectID` is already mandatory field and we don't (contrary to the godoc for the filter attributes) actually support using `ProjectID: 0,` to search across multiple projects. That said, I'm not sure if this deserves to be filed as a new ticket since I'm not sure what (if anything) this ought to change to.

What's committed here are versions of the unit tests that pass -- we can add to the setup logic and testing tables to construct tests that _fail_ in various ways (see above).

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
N/A

## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-138]: https://hpe-aiatscale.atlassian.net/browse/ET-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-241]: https://hpe-aiatscale.atlassian.net/browse/ET-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ