### PR TITLE
fix: sorting by arbitrary metadata

### DIFF
--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -235,15 +235,15 @@ func sortRuns(sortString *string, runQuery *bun.SelectQuery) error {
 			runQuery.OrderExpr(fmt.Sprintf(`r.hparams->%s ?`, hpQuery), queryArgs...)
 		case strings.HasPrefix(paramDetail[0], "metadata."):
 			param := strings.ReplaceAll(paramDetail[0], "'", "")
-			hp := strings.Split(strings.TrimPrefix(param, "metadata."), ".")
+			mdt := strings.Split(strings.TrimPrefix(param, "metadata."), ".")
 			var queryArgs []interface{}
-			for i := 0; i < len(hp); i++ {
-				queryArgs = append(queryArgs, hp[i])
-				hp[i] = "?"
+			for i := 0; i < len(mdt); i++ {
+				queryArgs = append(queryArgs, mdt[i])
+				mdt[i] = "?"
 			}
-			hpQuery := strings.Join(hp, "->")
+			mdtQuery := strings.Join(mdt, "->")
 			queryArgs = append(queryArgs, bun.Safe(sortDirection))
-			runQuery.OrderExpr(fmt.Sprintf(`rm.metadata->%s ?`, hpQuery), queryArgs...)
+			runQuery.OrderExpr(fmt.Sprintf(`rm.metadata->%s ?`, mdtQuery), queryArgs...)
 		case strings.Contains(paramDetail[0], "."):
 			metricGroup, metricName, metricQualifier, err := parseMetricsName(paramDetail[0])
 			if err != nil {

--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -233,6 +233,17 @@ func sortRuns(sortString *string, runQuery *bun.SelectQuery) error {
 			hpQuery := strings.Join(hp, "->")
 			queryArgs = append(queryArgs, bun.Safe(sortDirection))
 			runQuery.OrderExpr(fmt.Sprintf(`r.hparams->%s ?`, hpQuery), queryArgs...)
+		case strings.HasPrefix(paramDetail[0], "metadata."):
+			param := strings.ReplaceAll(paramDetail[0], "'", "")
+			hp := strings.Split(strings.TrimPrefix(param, "metadata."), ".")
+			var queryArgs []interface{}
+			for i := 0; i < len(hp); i++ {
+				queryArgs = append(queryArgs, hp[i])
+				hp[i] = "?"
+			}
+			hpQuery := strings.Join(hp, "->")
+			queryArgs = append(queryArgs, bun.Safe(sortDirection))
+			runQuery.OrderExpr(fmt.Sprintf(`rm.metadata->%s ?`, hpQuery), queryArgs...)
 		case strings.Contains(paramDetail[0], "."):
 			metricGroup, metricName, metricQualifier, err := parseMetricsName(paramDetail[0])
 			if err != nil {

--- a/master/internal/api_runs_intg_test.go
+++ b/master/internal/api_runs_intg_test.go
@@ -193,6 +193,32 @@ func TestSearchRunsSort(t *testing.T) {
 		HParams:      hyperparameters2,
 	}, task2.TaskID))
 
+	rawMetadata := map[string]any{
+		"number_key": 1,
+		"nested": map[string]any{
+			"number_key": 1,
+		},
+	}
+	metadata := newProtoStruct(t, rawMetadata)
+	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    resp.Runs[0].Id,
+		Metadata: metadata,
+	})
+	require.NoError(t, err)
+
+	rawMetadata = map[string]any{
+		"number_key": 2,
+		"nested": map[string]any{
+			"number_key": 2,
+		},
+	}
+	metadata = newProtoStruct(t, rawMetadata)
+	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    resp.Runs[1].Id,
+		Metadata: metadata,
+	})
+	require.NoError(t, err)
+
 	// Sort by start time
 	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
 		ProjectId: req.ProjectId,
@@ -217,6 +243,26 @@ func TestSearchRunsSort(t *testing.T) {
 	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
 		ProjectId: req.ProjectId,
 		Sort:      ptrs.Ptr("hp.test1.test2=desc"),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int32(exp2.ID), resp.Runs[0].Experiment.Id)
+	require.Equal(t, int32(exp.ID), resp.Runs[1].Experiment.Id)
+
+	// Sort by custom metadata
+	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
+		ProjectId: req.ProjectId,
+		Sort:      ptrs.Ptr("metadata.number_key=desc"),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int32(exp2.ID), resp.Runs[0].Experiment.Id)
+	require.Equal(t, int32(exp.ID), resp.Runs[1].Experiment.Id)
+
+	// Sort by nested custom metadata
+	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
+		ProjectId: req.ProjectId,
+		Sort:      ptrs.Ptr("metadata.nested.number_key=desc"),
 	})
 
 	require.NoError(t, err)

--- a/master/internal/api_runs_intg_test.go
+++ b/master/internal/api_runs_intg_test.go
@@ -193,32 +193,6 @@ func TestSearchRunsSort(t *testing.T) {
 		HParams:      hyperparameters2,
 	}, task2.TaskID))
 
-	rawMetadata := map[string]any{
-		"number_key": 1,
-		"nested": map[string]any{
-			"number_key": 1,
-		},
-	}
-	metadata := newProtoStruct(t, rawMetadata)
-	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
-		RunId:    resp.Runs[0].Id,
-		Metadata: metadata,
-	})
-	require.NoError(t, err)
-
-	rawMetadata = map[string]any{
-		"number_key": 2,
-		"nested": map[string]any{
-			"number_key": 2,
-		},
-	}
-	metadata = newProtoStruct(t, rawMetadata)
-	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
-		RunId:    resp.Runs[1].Id,
-		Metadata: metadata,
-	})
-	require.NoError(t, err)
-
 	// Sort by start time
 	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{
 		ProjectId: req.ProjectId,
@@ -248,6 +222,32 @@ func TestSearchRunsSort(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int32(exp2.ID), resp.Runs[0].Experiment.Id)
 	require.Equal(t, int32(exp.ID), resp.Runs[1].Experiment.Id)
+
+	rawMetadata := map[string]any{
+		"number_key": 1,
+		"nested": map[string]any{
+			"number_key": 1,
+		},
+	}
+	metadata := newProtoStruct(t, rawMetadata)
+	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    resp.Runs[1].Id,
+		Metadata: metadata,
+	})
+	require.NoError(t, err)
+
+	rawMetadata = map[string]any{
+		"number_key": 2,
+		"nested": map[string]any{
+			"number_key": 2,
+		},
+	}
+	metadata = newProtoStruct(t, rawMetadata)
+	_, err = api.PostRunMetadata(ctx, &apiv1.PostRunMetadataRequest{
+		RunId:    resp.Runs[0].Id,
+		Metadata: metadata,
+	})
+	require.NoError(t, err)
 
 	// Sort by custom metadata
 	resp, err = api.SearchRuns(ctx, &apiv1.SearchRunsRequest{


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
ET-748


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add sorting for arbitrary metadata


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Go to run table and select a metadata column and sort


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ