### PR TITLE
fix: prevent out of bounds navigation on new list views

### DIFF
--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -339,12 +339,13 @@ const Searches: React.FC<Props> = ({ project }) => {
         kind: 'group',
       };
 
+      const offset = page * settings.pageLimit;
       const response = await searchExperiments(
         {
           ...experimentFilters,
           filter: JSON.stringify(filters),
           limit: settings.pageLimit,
-          offset: page * settings.pageLimit,
+          offset,
           sort: sortString || undefined,
         },
         { signal: canceler.signal },
@@ -355,6 +356,10 @@ const Searches: React.FC<Props> = ({ project }) => {
       setTotal(
         response.pagination.total !== undefined ? Loaded(response.pagination.total) : NotLoaded,
       );
+      // oob check
+      if ((response.pagination.total || 0) < offset) {
+        resetPagination();
+      }
     } catch (e) {
       handleError(e, { publicSubject: 'Unable to fetch experiments.' });
     } finally {
@@ -367,6 +372,7 @@ const Searches: React.FC<Props> = ({ project }) => {
     isLoadingSettings,
     loadableFormset,
     page,
+    resetPagination,
     sortString,
     settings.pageLimit,
   ]);


### PR DESCRIPTION


<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-650


## Description
This fixes an issue where it's possible for the user to navigate outside of the list bounds in the new experiment view, the searches view, and the runs view. When doing so, the user sees a blank page, which can be confusing. In the case that the user tries to load pages beyond the result set, we now reset the pagination back to the first page of results.



## Test Plan
* on any project, open the runs page.
* navigate to the last page
* in the address bar, edit the page query parameter such that it's higher than the existing number
* press enter
* you should be redirected to the first page of results.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ