### PR TITLE
fix: reset Model Registry page number on pageload [ET-640]

### DIFF
--- a/webui/react/src/components/ModelRegistry.settings.ts
+++ b/webui/react/src/components/ModelRegistry.settings.ts
@@ -1,6 +1,6 @@
 import { array, boolean, literal, number, string, undefined as undefinedType, union } from 'io-ts';
 
-import { InteractiveTableReducedSettings } from 'components/Table/InteractiveTable';
+import { InteractiveTableSettings } from 'components/Table/InteractiveTable';
 import { MINIMUM_PAGE_SIZE } from 'components/Table/Table';
 import { SettingsConfig } from 'hooks/useSettings';
 import { V1GetModelsRequestSortBy } from 'services/api-ts-sdk';
@@ -43,7 +43,7 @@ export const isOfSortKey = (sortKey: React.Key): sortKey is V1GetModelsRequestSo
   return sortKeys.includes(String(sortKey));
 };
 
-export interface ReducedSettings extends InteractiveTableReducedSettings {
+export interface Settings extends Omit<InteractiveTableSettings, 'tableOffset'> {
   archived?: boolean;
   columns: ModelColumnName[];
   description?: string;
@@ -54,7 +54,7 @@ export interface ReducedSettings extends InteractiveTableReducedSettings {
   workspace?: number[];
 }
 
-const config = (id: string): SettingsConfig<ReducedSettings> => {
+const config = (id: string): SettingsConfig<Settings> => {
   const storagePath = `model-registry-${id}`;
 
   return {

--- a/webui/react/src/components/ModelRegistry.settings.ts
+++ b/webui/react/src/components/ModelRegistry.settings.ts
@@ -1,6 +1,6 @@
 import { array, boolean, literal, number, string, undefined as undefinedType, union } from 'io-ts';
 
-import { InteractiveTableSettings } from 'components/Table/InteractiveTable';
+import { InteractiveTableReducedSettings } from 'components/Table/InteractiveTable';
 import { MINIMUM_PAGE_SIZE } from 'components/Table/Table';
 import { SettingsConfig } from 'hooks/useSettings';
 import { V1GetModelsRequestSortBy } from 'services/api-ts-sdk';
@@ -43,7 +43,7 @@ export const isOfSortKey = (sortKey: React.Key): sortKey is V1GetModelsRequestSo
   return sortKeys.includes(String(sortKey));
 };
 
-export interface Settings extends InteractiveTableSettings {
+export interface ReducedSettings extends InteractiveTableReducedSettings {
   archived?: boolean;
   columns: ModelColumnName[];
   description?: string;
@@ -54,7 +54,7 @@ export interface Settings extends InteractiveTableSettings {
   workspace?: number[];
 }
 
-const config = (id: string): SettingsConfig<Settings> => {
+const config = (id: string): SettingsConfig<ReducedSettings> => {
   const storagePath = `model-registry-${id}`;
 
   return {
@@ -120,11 +120,6 @@ const config = (id: string): SettingsConfig<Settings> => {
       tableLimit: {
         defaultValue: MINIMUM_PAGE_SIZE,
         storageKey: 'tableLimit',
-        type: number,
-      },
-      tableOffset: {
-        defaultValue: 0,
-        storageKey: 'tableOffset',
         type: number,
       },
       tags: {

--- a/webui/react/src/components/ModelRegistry.tsx
+++ b/webui/react/src/components/ModelRegistry.tsx
@@ -117,6 +117,10 @@ const ModelRegistry: React.FC<Props> = ({ workspace }: Props) => {
     [isLoading, isLoadingSettings],
   );
 
+  useEffect(() => {
+    resetSettings(['tableOffset']);
+  }, [resetSettings]);
+
   const fetchModels = useCallback(async () => {
     if (!settings) return;
 

--- a/webui/react/src/components/Table/InteractiveTable.tsx
+++ b/webui/react/src/components/Table/InteractiveTable.tsx
@@ -54,24 +54,6 @@ export interface InteractiveTableSettings {
   tableOffset: number;
 }
 
-export interface InteractiveTableReducedSettings {
-  /**
-   * ColumnWidths: Array of column widths, corresponding to columns array below
-   */
-  columnWidths: number[];
-  /**
-   * Columns: Array of column names
-   */
-  columns: string[];
-  /**
-   * Row: Array of selected row IDs
-   */
-  row?: number[] | string[];
-  sortDesc: boolean;
-  sortKey?: Primitive;
-  tableLimit: number;
-}
-
 export const WIDGET_COLUMN_WIDTH = 46;
 const DEFAULT_RESIZE_THROTTLE_TIME = 30;
 const SOURCE_TYPE = 'DraggableColumn';

--- a/webui/react/src/components/Table/InteractiveTable.tsx
+++ b/webui/react/src/components/Table/InteractiveTable.tsx
@@ -54,6 +54,24 @@ export interface InteractiveTableSettings {
   tableOffset: number;
 }
 
+export interface InteractiveTableReducedSettings {
+  /**
+   * ColumnWidths: Array of column widths, corresponding to columns array below
+   */
+  columnWidths: number[];
+  /**
+   * Columns: Array of column names
+   */
+  columns: string[];
+  /**
+   * Row: Array of selected row IDs
+   */
+  row?: number[] | string[];
+  sortDesc: boolean;
+  sortKey?: Primitive;
+  tableLimit: number;
+}
+
 export const WIDGET_COLUMN_WIDTH = 46;
 const DEFAULT_RESIZE_THROTTLE_TIME = 30;
 const SOURCE_TYPE = 'DraggableColumn';


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-640]



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Resets the user setting of `tableOffset` on page load. I investigated more elegant ways to solve this, such as removing tableOffset from the settings config and only storing it in the URL params, but InteractiveTable and useSettings are tightly coupled enough that it would take a not-insignificant refactor to do so.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Go to Model Registry page
- Use the Pagination component to change the table page number
- Navigate away from Model Registry page
- Navigate back to Model Registry page
- Confirm that the table is on its first page, not the one you navigated to in the second step


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-640]: https://hpe-aiatscale.atlassian.net/browse/ET-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ