### PR TITLE
build: INFENG-809: Update CircleCI tag logic and add release dryrun workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           command: |
             VERSION=$(./version.sh)
             echo "Version is: [${VERSION}]"
+            echo "CIRCLE_TAG is: [${CIRCLE_TAG}]"
             jq --arg version "${VERSION}" '. += {"det-version": $version}' < "<<pipeline.parameters.params_basename>>" > tmpfile
             mv -v tmpfile "<<pipeline.parameters.params_basename>>"
             cat "<<pipeline.parameters.params_basename>>"

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -86,6 +86,14 @@ release-filters: &release-filters
     only:
       - /v\d+\.\d+\.\d+/
 
+release-dryrun: &release-dryrun
+  branches:
+    ignore:
+      - /.*/
+  tags:
+    only:
+      - /v\d+\.\d+\.\d+-dryrun/
+
 upstream-feature-branch: &upstream-feature-branch
   branches:
     ignore:
@@ -5716,40 +5724,27 @@ workflows:
   release-dryrun:
     jobs:
       - build-helm:
-          filters: *release-and-rc-filters
+          filters: *release-dryrun
+
       - build-proto:
-          filters: *release-and-rc-filters
+          filters: *release-dryrun
+
       - build-react:
           context: determined-production
-          filters: *release-and-rc-filters
+          filters: *release-dryrun
+
       - build-docs:
           context: determined-production
-          filters: *release-and-rc-filters
+          filters: *release-dryrun
           requires:
             - build-helm
             - build-proto
+
       - upload-docs-search-index:
           requires:
             - build-docs
           context: determined-production
-          filters: *release-and-rc-filters
-      - package-and-push-system-rc:
-          dryrun: true
-          requires:
-            - build-react
-            - build-docs
-          context: determined-production
-          filters: *rc-filters
-      - publish-python-package:
-          name: publish-python-package-rc
-          matrix:
-            parameters:
-              path: ["harness", "model_hub"]
-              dryrun: [true]
-          context: determined-dryrun
-          filters: *rc-filters
-          requires:
-            - package-and-push-system-rc
+          filters: *release-dryrun
 
       - package-and-push-system-release:
           dryrun: true
@@ -5757,7 +5752,7 @@ workflows:
             - build-react
             - build-docs
           context: determined-production
-          filters: *release-filters
+          filters: *release-dryrun
 
       - publish-python-package:
           name: publish-python-package-release
@@ -5766,31 +5761,24 @@ workflows:
               path: ["harness", "model_hub"]
               dryrun: [true]
           context: determined-dryrun
-          filters: *release-filters
+          filters: *release-dryrun
           requires:
             - package-and-push-system-release
 
       - publish-docs:
           dryrun: true
-          name: publish-docs-rc
+          name: publish-docs
           requires:
             - build-docs
           context: determined-production
-          filters: *rc-filters
-
-      - publish-docs:
-          dryrun: true
-          requires:
-            - build-docs
-          context: determined-production
-          filters: *release-filters
+          filters: *release-dryrun
 
       - publish-helm-gh:
           dryrun: true
           requires:
             - build-helm
           context: determined-production
-          filters: *release-filters
+          filters: *release-dryrun
 
   release:
     jobs:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1454,12 +1454,21 @@ commands:
             - run: make -C agent check
 
   make-package:
+    parameters:
+      dryrun:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: .
       - run:
           no_output_timeout: 30m
-          command: make package
+          command: |
+            if <<parameters.dryrun>>; then
+              make package-dryrun
+            else
+              make package
+            fi
 
   make-package-ee:
     steps:
@@ -1490,6 +1499,32 @@ commands:
       - run:
           command: devcluster --oneshot -c .circleci/devcluster/<<parameters.devcluster-config>> --target-stage <<parameters.target-stage>> || circleci-agent step halt
           background: true
+
+  make-component:
+    description: "Basic parameterized version of make for building Determined components."
+    parameters:
+      component:
+        type: string
+        default: ""
+      target:
+        type: string
+        default: ""
+      dryrun:
+        type: boolean
+        default: false
+      no_output_timeout:
+        type: string
+        default: "10m"
+    steps:
+      - run:
+          no_output_timeout: <<parameters.no_output_timeout>>
+          command: |
+            set -vx
+            if <<parameters.dryrun>>; then
+              make -C <<parameters.component>> <<parameters.target>>
+            else
+              make -C <<parameters.component>> <<parameters.target>>-dryrun
+            fi
 
 jobs:
   build-helm:
@@ -1582,7 +1617,7 @@ jobs:
       ee:
         type: boolean
         default: false
-      dry-run:
+      dryrun:
         type: boolean
         default: false
     docker:
@@ -1594,7 +1629,7 @@ jobs:
       - run: apk add make curl py3-pip
       - run: pip install --break-system-packages awscli  # used in the terraform apply
       - run: |
-          if <<parameters.dry-run>>; then
+          if <<parameters.dryrun>>; then
             echo 'Doing a dry run!'
             if <<parameters.ee>>; then
               export DET_VARIANT=EE
@@ -1804,6 +1839,10 @@ jobs:
       - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
 
   package-and-push-system-rc:
+    parameters:
+      dryrun:
+        type: boolean
+        default: false
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -1824,11 +1863,29 @@ jobs:
           username: ${NGC_API_USERNAME}
           password: ${NGC_API_KEY}
       - pre-package-and-push-system
-      - make-package
-      - run: make -C master publish
-      - run: make -C agent publish
-      - run: make -C model_hub build-docker
-      - run: tools/scripts/retry.sh make -C model_hub publish-docker
+      # - make-package
+      - make-package:
+          dryrun: <<parameters.dryrun>>
+      # - run: make -C master publish
+      - make-component:
+          component: master
+          target: publish
+          dryrun: <<parameters.dryrun>>
+      # - run: make -C agent publish
+      - make-component:
+          component: agent
+          target: publish
+          dryrun: <<parameters.dryrun>>
+      # - run: make -C model_hub build-docker
+      - make-component:
+          component: model_hub
+          target: build-docker
+          dryrun: <<parameters.dryrun>>
+      #- run: tools/scripts/retry.sh make -C model_hub publish-docker
+      - make-component:
+          component: model_hub
+          target: publish-docker
+          dryrun: <<parameters.dryrun>>
       - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
       - store_artifacts:
           path: /tmp/pkgs
@@ -1857,6 +1914,10 @@ jobs:
       - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
 
   package-and-push-system-release:
+    parameters:
+      dryrun:
+        type: boolean
+        default: false
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -1877,14 +1938,22 @@ jobs:
           username: ${NGC_API_USERNAME}
           password: ${NGC_API_KEY}
       - pre-package-and-push-system
-      - run:
-          no_output_timeout: 30m
-          command: make -C master release
-      - run:
-          no_output_timeout: 30m
-          command: make -C agent release
-      - run: make -C model_hub build-docker
-      - run: make -C model_hub publish-docker
+      - make-component:
+          component: master
+          target: release
+          no_output_timeout: "30m"
+      - make-component:
+          component: agent
+          target: release
+          no_output_timeout: "30m"
+      - make-component:
+          component: model_hub
+          target: build-docker
+          dryrun: <<parameters.dryrun>>
+      - make-component:
+          component: model_hub
+          target: publish-docker
+          dryrun: <<parameters.dryrun>>
       - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
       - store_artifacts:
           path: /tmp/pkgs
@@ -1929,7 +1998,6 @@ jobs:
       - attach_workspace:
           at: .
       - reinstall-go
-      - run: make -C helm release-gh
       - run: |
           if <<parameters.ee>>; then
             make -C helm release-gh-ee
@@ -1944,6 +2012,9 @@ jobs:
       ee:
         type: boolean
         default: false
+      dryrun:
+        type: boolean
+        default: false
     docker:
       - image: <<pipeline.parameters.docker-image>>
     steps:
@@ -1953,11 +2024,21 @@ jobs:
           extras-requires: "build twine"
           executor: <<pipeline.parameters.docker-image>>
       - run: make -C <<parameters.path>> build
+        # The following run step is right about at the point where it should be
+        # split off into its own shell script.
       - run: |
           if <<parameters.ee>>; then
-            make -C <<parameters.path>> publish-ee
+            if <<parameters.dryrun>>; then
+              make -C <<parameters.path>> publish-ee-dryrun
+            else
+              make -C <<parameters.path>> publish-ee
+            fi
           else
-            make -C <<parameters.path>> publish
+            if <<parameters.dryrun>>; then
+              make -C <<parameters.path>> publish-dryrun
+            else
+              make -C <<parameters.path>> publish
+            fi
           fi
 
   check-ts-bindings:
@@ -5621,6 +5702,81 @@ workflows:
             - github-read
             - dev-ci-cluster-default-user-credentials
 
+  release-dryrun:
+    jobs:
+      - build-helm:
+          filters: *release-and-rc-filters
+      - build-proto:
+          filters: *release-and-rc-filters
+      - build-react:
+          context: determined-production
+          filters: *release-and-rc-filters
+      - build-docs:
+          context: determined-production
+          filters: *release-and-rc-filters
+          requires:
+            - build-helm
+            - build-proto
+      - upload-docs-search-index:
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *release-and-rc-filters
+      - package-and-push-system-rc:
+          dryrun: true
+          requires:
+            - build-recat
+            - build-docs
+          context: determined-production
+          filters: *rc-filters
+      - publish-python-package:
+          name: publish-python-package-rc
+          matrix:
+            parameters:
+              path: ["harness", "model_hub"]
+              dryrun: true
+          context: determined-production
+          filters: *rc-filters
+          requires:
+            - package-and-push-system-rc
+
+      - package-and-push-system-release:
+          dryrun: true
+          requires:
+            - build-react
+            - build-docs
+          context: determined-production
+          filters: *release-filters
+
+      - publish-python-package:
+          name: publish-python-package-release
+          matrix:
+            parameters:
+              path: ["harness", "model_hub"]
+              dryrun: true
+          context: determined-production
+          filters: *release-filters
+          requires:
+            - package-and-push-system-release
+
+      - publish-docs:
+          dryrun: true
+          name: publish-docs-rc
+          matrix:
+            parameters:
+              dryrun: [true]
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *rc-filters
+
+      - publish-docs:
+          dryrun: true
+          requires:
+            - build-docs
+          context: determined-production
+          filters: *release-filters
+
   release:
     jobs:
       - build-helm:
@@ -5681,7 +5837,7 @@ workflows:
           name: publish-docs-rc
           matrix:
             parameters:
-              dry-run: [true]
+              dryrun: [true]
           requires:
             - build-docs
           context: determined-production

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -5736,7 +5736,7 @@ workflows:
       - package-and-push-system-rc:
           dryrun: true
           requires:
-            - build-recat
+            - build-react
             - build-docs
           context: determined-production
           filters: *rc-filters

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1871,25 +1871,20 @@ jobs:
           username: ${NGC_API_USERNAME}
           password: ${NGC_API_KEY}
       - pre-package-and-push-system
-      # - make-package
       - make-package:
           dryrun: <<parameters.dryrun>>
-      # - run: make -C master publish
       - make-component:
           component: master
           target: publish
           dryrun: <<parameters.dryrun>>
-      # - run: make -C agent publish
       - make-component:
           component: agent
           target: publish
           dryrun: <<parameters.dryrun>>
-      # - run: make -C model_hub build-docker
       - make-component:
           component: model_hub
           target: build-docker
           dryrun: <<parameters.dryrun>>
-      #- run: tools/scripts/retry.sh make -C model_hub publish-docker
       - make-component:
           component: model_hub
           target: publish-docker

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -5742,7 +5742,7 @@ workflows:
           matrix:
             parameters:
               path: ["harness", "model_hub"]
-              dryrun: true
+              dryrun: [true]
           context: determined-production
           filters: *rc-filters
           requires:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1989,6 +1989,9 @@ jobs:
       ee:
         type: boolean
         default: false
+      dryrun:
+        type: boolean
+        default: false
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -5783,6 +5786,7 @@ workflows:
           filters: *release-filters
 
       - publish-helm-gh:
+          dryrun: true
           requires:
             - build-helm
           context: determined-production

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1527,7 +1527,6 @@ commands:
       - run:
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
-            set -vx
             if <<parameters.dryrun>>; then
               make -C <<parameters.component>> <<parameters.target>>
             else

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -64,28 +64,39 @@ parameters:
 
 release-and-rc-filters: &release-and-rc-filters
   branches:
+    only:
+      # Temporary branch name for testing without merging.
+      # TODO(davidfluck-hpe): remove.
+      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:
     only:
-      - /(\d)+(\.(\d)+)+/
-      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
+      - /v\d+\.\d+\.\d+(rc\d+)?/
 
 rc-filters: &rc-filters
   branches:
+    only:
+      # Temporary branch name for testing without merging.
+      # TODO(davidfluck-hpe): remove.
+      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:
     only:
-      - /((\d)+(\.(\d)+)+)(-rc)(\d)+/
+      - /v\d+\.\d+\.\d+rc\d+/
 
 release-filters: &release-filters
   branches:
+    only:
+      # Temporary branch name for testing without merging.
+      # TODO(davidfluck-hpe): remove.
+      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:
     only:
-      - /(\d)+(\.(\d)+)+/
+      - /v\d+\.\d+\.\d+/
 
 upstream-feature-branch: &upstream-feature-branch
   branches:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1741,7 +1741,10 @@ jobs:
       - run:
           name: Build and publish model_hub docker images
           command: |
-            if [ ${CIRCLE_BRANCH} = 'main' ] || [[ ${CIRCLE_BRANCH} == *"release-"* ]]; then
+            # Match on either "main", or any branch beginning with
+            # "release-". Note: because of Bash quoting rules, the start-of-line
+            # caret in our regex must be outside of the quotes.
+            if [[ ${CIRCLE_BRANCH} == "main" ]] || [[ ${CIRCLE_BRANCH} =~ ^"release-" ]]; then
                 # For main and release branches, we will tag and publish both the environment
                 # with the git hash as well as the version.  This will make that image available
                 # immediately for nightly tests.
@@ -1785,7 +1788,10 @@ jobs:
       - run:
           name: Build and publish model_hub docker images
           command: |
-            if [ ${CIRCLE_BRANCH} = 'main' ] || [[ ${CIRCLE_BRANCH} == *"release-"* ]]; then
+            # Match on either "main", or any branch beginning with
+            # "release-". Note: because of Bash quoting rules, the start-of-line
+            # caret in our regex must be outside of the quotes.
+            if [[ ${CIRCLE_BRANCH} == "main" ]] || [[ ${CIRCLE_BRANCH} =~ ^"release-" ]]; then
                 # For main and release branches, we will tag and publish both the environment
                 # with the git hash as well as the version.  This will make that image available
                 # immediately for nightly tests.

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2000,9 +2000,17 @@ jobs:
       - reinstall-go
       - run: |
           if <<parameters.ee>>; then
-            make -C helm release-gh-ee
+            if <<parameters.dryrun>>; then
+              make -C helm release-gh-ee-dryrun
+            else
+              make -C helm release-gh-ee
+            fi
           else
-            make -C helm release-gh
+            if <<parameters.dryrun>>; then
+              make -C helm release-gh-dryrun
+            else
+              make -C helm release-gh
+            fi
           fi
 
   publish-python-package:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -5746,7 +5746,7 @@ workflows:
             parameters:
               path: ["harness", "model_hub"]
               dryrun: [true]
-          context: determined-production
+          context: determined-dryrun
           filters: *rc-filters
           requires:
             - package-and-push-system-rc
@@ -5765,7 +5765,7 @@ workflows:
             parameters:
               path: ["harness", "model_hub"]
               dryrun: [true]
-          context: determined-production
+          context: determined-dryrun
           filters: *release-filters
           requires:
             - package-and-push-system-release

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -5753,7 +5753,7 @@ workflows:
           matrix:
             parameters:
               path: ["harness", "model_hub"]
-              dryrun: true
+              dryrun: [true]
           context: determined-production
           filters: *release-filters
           requires:
@@ -5762,9 +5762,6 @@ workflows:
       - publish-docs:
           dryrun: true
           name: publish-docs-rc
-          matrix:
-            parameters:
-              dryrun: [true]
           requires:
             - build-docs
           context: determined-production
@@ -5774,6 +5771,12 @@ workflows:
           dryrun: true
           requires:
             - build-docs
+          context: determined-production
+          filters: *release-filters
+
+      - publish-helm-gh:
+          requires:
+            - build-helm
           context: determined-production
           filters: *release-filters
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -64,10 +64,6 @@ parameters:
 
 release-and-rc-filters: &release-and-rc-filters
   branches:
-    only:
-      # Temporary branch name for testing without merging.
-      # TODO(davidfluck-hpe): remove.
-      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:
@@ -76,10 +72,6 @@ release-and-rc-filters: &release-and-rc-filters
 
 rc-filters: &rc-filters
   branches:
-    only:
-      # Temporary branch name for testing without merging.
-      # TODO(davidfluck-hpe): remove.
-      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:
@@ -88,10 +80,6 @@ rc-filters: &rc-filters
 
 release-filters: &release-filters
   branches:
-    only:
-      # Temporary branch name for testing without merging.
-      # TODO(davidfluck-hpe): remove.
-      - /INFENG-809-circleci-tag/
     ignore:
       - /.*/
   tags:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -92,7 +92,7 @@ release-dryrun: &release-dryrun
       - /.*/
   tags:
     only:
-      - /v\d+\.\d+\.\d+-dryrun/
+      - /v\d+\.\d+\.\d+\+dryrun/
 
 upstream-feature-branch: &upstream-feature-branch
   branches:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ package:
 	$(MAKE) -C agent $@
 	$(MAKE) -C master $@
 
+.PHONY: package-dryrun
+package-dryrun:
+	$(MAKE) -C agent $@
+	$(MAKE) -C master $@
+
 .PHONY: package-ee
 package-ee:
 	$(MAKE) -C agent $@

--- a/agent/.goreleaser_dryrun.yml
+++ b/agent/.goreleaser_dryrun.yml
@@ -62,7 +62,7 @@ brews:
 
 nfpms:
   - maintainer: "Determined AI <ai-open-source@hpe.com>"
-    file_name_template: "determined-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}"
+    file_name_template: "determined-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     formats:
       - deb
       - rpm

--- a/agent/.goreleaser_dryrun.yml
+++ b/agent/.goreleaser_dryrun.yml
@@ -5,6 +5,8 @@ snapshot:
 
 builds:
   - main: ./cmd/determined-agent
+    id: determined-agent
+    binary: determined-agent
     goos:
       - linux
       - darwin
@@ -15,6 +17,7 @@ builds:
 archives:
   - wrap_in_directory: "true"
     rlcp: true
+    name_template: "determined_agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     files:
       - src: "packaging/agent.yaml"
         dst: "etc/determined/"

--- a/agent/.goreleaser_dryrun.yml
+++ b/agent/.goreleaser_dryrun.yml
@@ -62,6 +62,7 @@ brews:
 
 nfpms:
   - maintainer: "Determined AI <ai-open-source@hpe.com>"
+    file_name_template: "determined-agent_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}"
     formats:
       - deb
       - rpm

--- a/agent/.goreleaser_dryrun.yml
+++ b/agent/.goreleaser_dryrun.yml
@@ -1,0 +1,142 @@
+project_name: determined-agent-dryrun
+
+snapshot:
+  name_template: "{{ .Env.VERSION }}"
+
+builds:
+  - main: ./cmd/determined-agent
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - wrap_in_directory: "true"
+    rlcp: true
+    files:
+      - src: "packaging/agent.yaml"
+        dst: "etc/determined/"
+        strip_parent: true
+      - src: "packaging/LICENSE"
+        strip_parent: true
+
+brews:
+  - name: determined-agent
+    tap:
+      owner: determined-ai
+      name: homebrew-determined-dryrun
+    url_template: "https://github.com/determined-ai/determined-dryrun/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    caveats: |
+      Determined agent config is located at #{etc}/determined/agent.yaml
+    homepage: "https://github.com/determined-ai/determined-dryrun"
+    license: "Apache-2.0"
+    folder: Formula
+    install: |
+      bin.install "determined-agent"
+
+      doc.install "LICENSE"
+
+      (var/"log/determined").mkpath
+
+      (etc/"determined").mkpath
+      inreplace "etc/determined/agent.yaml" do |s|
+        s.gsub! "# master_host: 0.0.0.0", "master_host: 127.0.0.1"
+        s.gsub! "# master_port: 80", "master_port: 8080"
+      end
+
+      Pathname("etc/determined/agent.yaml").append_lines <<~EOS
+        container_master_host: host.docker.internal
+      EOS
+
+      etc.install "etc/determined/agent.yaml" => "determined/agent.yaml"
+    service: |
+      run [opt_bin/"determined-agent", "--config-file", etc/"determined/agent.yaml"]
+      keep_alive false
+      error_log_path var/"log/determined/agent-stderr.log"
+      log_path var/"log/determined/agent-stdout.log"
+
+nfpms:
+  - maintainer: "Determined AI <ai-open-source@hpe.com>"
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: "packaging/agent.yaml"
+        dst: "/etc/determined/agent.yaml"
+        type: config|noreplace
+        file_info:
+            mode: 0644
+      - src: "packaging/determined-agent.service"
+        dst: "/lib/systemd/system/determined-agent.service"
+
+      - src: "packaging/LICENSE"
+        dst: "/usr/share/licenses/determined-agent/LICENSE"
+        packager: rpm
+
+      - src: "packaging/LICENSE"
+        dst: "/usr/share/doc/determined-agent/copyright"
+        packager: deb
+
+    overrides:
+      deb:
+        scripts:
+          postinstall: packaging/debian/agent.postinst
+          preremove: packaging/debian/agent.prerm
+          postremove: packaging/debian/agent.postrm
+
+release:
+  github:
+    owner: determined-ai
+    name: determined-dryrun
+
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined-dryrun/blob/{{ .Tag }}/docs/release-notes.rst)
+
+dockers:
+  # amd64
+  - goos: linux
+    goarch: amd64
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --builder=buildx-build
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+    extra_files:
+      - packaging/entrypoint.sh
+      - packaging/LICENSE
+  # arm64
+  - goos: linux
+    goarch: arm64
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --builder=buildx-build
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+    extra_files:
+      - packaging/entrypoint.sh
+      - packaging/LICENSE
+
+docker_manifests:
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"

--- a/agent/.goreleaser_dryrun.yml
+++ b/agent/.goreleaser_dryrun.yml
@@ -136,7 +136,7 @@ docker_manifests:
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION_DOCKER}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -3,6 +3,7 @@ SHELL := bash
 
 export VERSION:=$(shell ../version.sh)
 export VERSION_TAG:=$(shell ../version.sh -t)
+
 export VERSION_DOCKER := $(shell ../version.sh -d)
 
 export GO111MODULE := on

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -2,6 +2,7 @@
 SHELL := bash
 
 export VERSION:=$(shell ../version.sh)
+export VERSION_TAG:=$(shell ../version.sh -t)
 export GO111MODULE := on
 export DOCKER_REPO ?= determinedai
 
@@ -109,37 +110,37 @@ packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
 	../tools/scripts/gen-attributions.py agent $@
 
 .PHONY: package
-package: export GORELEASER_CURRENT_TAG := $(VERSION)
+package: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 package: packaging/LICENSE buildx
 	goreleaser --snapshot --rm-dist
 
 .PHONY: package-dryrun
-package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 package-dryrun: packaging/LICENSE buildx
 	goreleaser --snapshot --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: package-ee
-package-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
+package-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
 package-ee: packaging/LICENSE buildx
 	goreleaser --snapshot --rm-dist -f ./.goreleaser_ee.yml
 
 .PHONY: release
-release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release: packaging/LICENSE buildx
 	goreleaser --rm-dist
 	make publish-nvcr
 
 .PHONY: release-dryrun
-release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 # We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
 release-dryrun: packaging/LICENSE buildx
 	goreleaser --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-ee
-release-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
-release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION)-ee" -A1 | sed -n '2 p')
+release-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
+release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-ee: packaging/LICENSE buildx
 	goreleaser --rm-dist -f ./.goreleaser_ee.yml
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -3,7 +3,6 @@ SHELL := bash
 
 export VERSION:=$(shell ../version.sh)
 export VERSION_TAG:=$(shell ../version.sh -t)
-
 export VERSION_DOCKER := $(shell ../version.sh -d)
 
 export GO111MODULE := on

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -8,9 +8,11 @@ export DOCKER_REPO ?= determinedai
 FULL_COMMIT = $(shell git rev-parse HEAD)
 SHORT_COMMIT = $(shell git rev-parse HEAD | head -c9)
 PROJECT_NAME = determined-agent
+PROJECT_NAME_DRYRUN = determined-agent-dryrun
 EE_PROJECT_NAME = hpe-mlde-agent
 ARCHS = amd64 arm64
 MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
+MULTI_ARCH_IMAGES_DRYRUN = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)$(PROJECT_NAME_DRYRUN):$(FULL_COMMIT)-$$arch; done)
 EE_MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
 
 NVCR_REPO ?= nvcr.io/isv-ngc-partner/determined
@@ -19,6 +21,11 @@ PUB_MANIFESTS = \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT) \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(SHORT_COMMIT) \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(VERSION)
+
+PUB_MANIFESTS_DRYRUN = \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(FULL_COMMIT) \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(SHORT_COMMIT) \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(VERSION)
 
 EE_PUB_MANIFESTS = \
 	$(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT) \
@@ -106,6 +113,11 @@ package: export GORELEASER_CURRENT_TAG := $(VERSION)
 package: packaging/LICENSE buildx
 	goreleaser --snapshot --rm-dist
 
+.PHONY: package-dryrun
+package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+package-dryrun: packaging/LICENSE buildx
+	goreleaser --snapshot --rm-dist -f ./.goreleaser_dryrun.yml
+
 .PHONY: package-ee
 package-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
 package-ee: packaging/LICENSE buildx
@@ -117,6 +129,13 @@ release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate |
 release: packaging/LICENSE buildx
 	goreleaser --rm-dist
 	make publish-nvcr
+
+.PHONY: release-dryrun
+release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+# We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
+release-dryrun: packaging/LICENSE buildx
+	goreleaser --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-ee
 release-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
@@ -146,6 +165,10 @@ publish-dev-ee:
 .PHONY: publish
 publish:
 	@$(call manifest_publish, $(PUB_MANIFESTS), $(MULTI_ARCH_IMAGES))
+
+.PHONY: publish-dryrun
+publish-dryrun:
+	@$(call manifest_publish, $(PUB_MANIFESTS_DRYRUN), $(MULTI_ARCH_IMAGES_DRYRUN))
 
 .PHONY: publish-ee
 publish-ee:

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -3,6 +3,8 @@ SHELL := bash
 
 export VERSION:=$(shell ../version.sh)
 export VERSION_TAG:=$(shell ../version.sh -t)
+export VERSION_DOCKER := $(shell ../version.sh -d)
+
 export GO111MODULE := on
 export DOCKER_REPO ?= determinedai
 

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -17,6 +17,12 @@ publish:
 publish-ee:
 	twine upload --verbose --non-interactive dist/* --repository-url https://push.fury.io/determined-ai
 
+.PHONY: publish-dryrun
+publish-dryrun:
+	twine upload --verbose --non-interactive --repository testpypi dist/*
+
+publish-ee-dryrun: ;
+
 .PHONY: fmt
 fmt:
 	isort .

--- a/helm/.goreleaser_dryrun.yml
+++ b/helm/.goreleaser_dryrun.yml
@@ -1,0 +1,19 @@
+project_name: determined-helm
+
+build:
+  skip: true
+
+release:
+  github:
+    owner: determined-ai
+    name: determined-dryrun
+  mode: keep-existing
+  extra_files:
+    - glob: build/determined-latest.tgz
+      name_template: "determined-helm-chart_{{ .Env.VERSION }}.tgz"
+
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined/blob/{{ .Tag }}/docs/release-notes.rst)

--- a/helm/.goreleaser_dryrun.yml
+++ b/helm/.goreleaser_dryrun.yml
@@ -16,4 +16,4 @@ release:
   # the "include" functionality is only in the pro version
   header: |
     ## Release Notes
-    [{{ .Tag }}](https://github.com/determined-ai/determined/blob/{{ .Tag }}/docs/release-notes.rst)
+    [{{ .Tag }}](https://github.com/determined-ai/determined-dryrun/blob/{{ .Tag }}/docs/release-notes.rst)

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -31,7 +31,7 @@ release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-cre
 release-gh-dryrun:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
-	goreleaser --rm-dist
+	goreleaser --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-gh-ee
 release-gh-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -40,3 +40,5 @@ release-gh-ee:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
 	goreleaser --rm-dist
+
+release-gh-ee-dryrun: ;

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -25,6 +25,14 @@ release-gh:
 	git clean -df
 	goreleaser --rm-dist
 
+.PHONY: release-gh-dryrun
+release-gh-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-gh-dryrun:
+	go install github.com/goreleaser/goreleaser@v1.14.1
+	git clean -df
+	goreleaser --rm-dist
+
 .PHONY: release-gh-ee
 release-gh-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
 release-gh-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION)-ee" -A1 | sed -n '2 p')

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -1,4 +1,5 @@
 export VERSION:=$(shell ../version.sh)
+export VERSION_TAG:=$(shell ../version.sh -t)
 
 build/stamp: $(shell find charts -type f)
 	mkdir -p build
@@ -18,24 +19,24 @@ clean:
 	rm -rf build/
 
 .PHONY: release-gh
-release-gh: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-gh: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release-gh:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
 	goreleaser --rm-dist
 
 .PHONY: release-gh-dryrun
-release-gh-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-gh-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release-gh-dryrun:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
 	goreleaser --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-gh-ee
-release-gh-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
-release-gh-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION)-ee" -A1 | sed -n '2 p')
+release-gh-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
+release-gh-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-gh-ee:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -1,0 +1,199 @@
+project_name: determined-master-dryrun
+
+before:
+  hooks:
+    - make pre-package
+
+snapshot:
+  name_template: "{{ .Tag }}"
+
+builds:
+  - main: ./cmd/determined-master
+    ldflags:
+      - -X github.com/determined-ai/determined/master/version.Version={{.Env.VERSION}}
+      - -X github.com/determined-ai/determined/master/internal/config.DefaultSegmentMasterKey={{.Env.DET_SEGMENT_MASTER_KEY}}
+      - -X github.com/determined-ai/determined/master/internal/config.DefaultSegmentWebUIKey={{.Env.DET_SEGMENT_WEBUI_KEY}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+  - main: ./cmd/determined-gotmpl
+    id: determined-gotmpl
+    binary: determined-gotmpl
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - wrap_in_directory: "true"
+    rlcp: true
+    files:
+      - src: "packaging/master.yaml"
+        dst: "etc/determined/"
+        strip_parent: true
+
+      - src: "packaging/determined-master.service"
+        dst: "lib/systemd/system/"
+        strip_parent: true
+      - src: "packaging/determined-master.socket"
+        dst: "lib/systemd/system/"
+        strip_parent: true
+      - src: "packaging/LICENSE"
+        strip_parent: true
+      - src: "static/**/*"
+        dst: "share/static"
+      - src: "build/**/*"
+        dst: "share"
+
+brews:
+  - name: determined-master
+    tap:
+      owner: determined-ai
+      name: homebrew-determined-dryrun
+    url_template: "https://github.com/determined-ai/determined-dryrun/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    caveats: |
+      Determined master config is located at #{etc}/determined/master.yaml
+
+      Make sure to setup the determined database:
+        brew services start postgresql@14
+        createuser postgres
+        createdb determined
+
+      Checkpoints are stored in #{var}/determined/data by default.
+      Make sure to configure it as a shared path for Docker for Mac in
+      Docker -> Preferences... -> Resources -> File Sharing.
+    homepage: "https://github.com/determined-ai/determined-dryrun"
+    license: "Apache-2.0"
+    folder: Formula
+    dependencies:
+      - "postgresql@14"
+    install: |
+      bin.install "determined-master"
+
+      doc.install "LICENSE"
+      pkgshare.install Dir["share/*"]
+
+      (var/"cache/determined").mkpath
+      (var/"determined/data").mkpath
+      (var/"log/determined").mkpath
+
+      (etc/"determined").mkpath
+      inreplace "etc/determined/master.yaml" do |s|
+        s.gsub! "  host_path: /tmp", "  host_path: #{var}/determined/data"
+      end
+      Pathname("etc/determined/master.yaml").append_lines <<~EOS
+        root: #{opt_pkgshare}
+        cache:
+          cache_dir: #{var}/cache/determined
+      EOS
+      etc.install "etc/determined/master.yaml" => "determined/master.yaml"
+    service: |
+      run [opt_bin/"determined-master", "--config-file", etc/"determined/master.yaml"]
+      keep_alive false
+      error_log_path var/"log/determined/master-stderr.log"
+      log_path var/"log/determined/master-stdout.log"
+
+nfpms:
+  - maintainer: "Determined AI <ai-open-source@hpe.com>"
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: "packaging/master.yaml"
+        dst: "/etc/determined/master.yaml"
+        type: config|noreplace
+        file_info:
+            mode: 0600
+      - src: "build/**/*"
+        dst: "/usr/share/determined/master"
+      - src: "static/**/*"
+        dst: "/usr/share/determined/master/static"
+      - src: "packaging/determined-master.service"
+        dst: "/lib/systemd/system/determined-master.service"
+      - src: "packaging/determined-master.socket"
+        dst: "/lib/systemd/system/determined-master.socket"
+
+      - src: "packaging/LICENSE"
+        dst: "/usr/share/doc/determined-master/copyright"
+        packager: deb
+
+      - src: "packaging/LICENSE"
+        dst: "/usr/share/licenses/determined-master/LICENSE"
+        packager: rpm
+
+    overrides:
+      deb:
+        scripts:
+          postinstall: packaging/debian/master.postinst
+          preremove: packaging/debian/master.prerm
+          postremove: packaging/debian/master.postrm
+
+release:
+  github:
+    owner: determined-ai
+    name: determined-dryrun
+
+  # be sure to keep this in sync between agent/master/helm
+  # the "include" functionality is only in the pro version
+  header: |
+    ## Release Notes
+    [{{ .Tag }}](https://github.com/determined-ai/determined-dryrun/blob/{{ .Tag }}/docs/release-notes.rst)
+
+dockers:
+  # amd64
+  - goos: linux
+    goarch: amd64
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --builder=buildx-build
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+    extra_files:
+      - "packaging/master.yaml"
+      - "packaging/LICENSE"
+      - "build"
+      - "static"
+    ids:
+      - determined-master
+      - determined-gotmpl
+  # arm64
+  - goos: linux
+    goarch: arm64
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --builder=buildx-build
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+    extra_files:
+      - "packaging/master.yaml"
+      - "packaging/LICENSE"
+      - "build"
+      - "static"
+    ids:
+      - determined-master
+      - determined-gotmpl
+
+docker_manifests:
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.ShortCommit}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:latest"
+    image_templates:
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
+      - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -193,7 +193,7 @@ docker_manifests:
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"
-  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION}}"
+  - name_template: "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.Env.VERSION_DOCKER}}"
     image_templates:
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-amd64"
       - "{{.Env.DOCKER_REPO}}/{{.ProjectName}}:{{.FullCommit}}-arm64"

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -103,7 +103,7 @@ brews:
 
 nfpms:
   - maintainer: "Determined AI <ai-open-source@hpe.com>"
-    file_name_template: "determined-master_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}"
+    file_name_template: "determined-master_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     formats:
       - deb
       - rpm

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -9,6 +9,8 @@ snapshot:
 
 builds:
   - main: ./cmd/determined-master
+    id: determined-master
+    binary: determined-master
     ldflags:
       - -X github.com/determined-ai/determined/master/version.Version={{.Env.VERSION}}
       - -X github.com/determined-ai/determined/master/internal/config.DefaultSegmentMasterKey={{.Env.DET_SEGMENT_MASTER_KEY}}

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -34,6 +34,7 @@ builds:
 archives:
   - wrap_in_directory: "true"
     rlcp: true
+    name_template: "determined_master_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     files:
       - src: "packaging/master.yaml"
         dst: "etc/determined/"

--- a/master/.goreleaser_dryrun.yml
+++ b/master/.goreleaser_dryrun.yml
@@ -103,6 +103,7 @@ brews:
 
 nfpms:
   - maintainer: "Determined AI <ai-open-source@hpe.com>"
+    file_name_template: "determined-master_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}"
     formats:
       - deb
       - rpm

--- a/master/Makefile
+++ b/master/Makefile
@@ -10,6 +10,7 @@ GORELEASER = goreleaser
 
 export VERSION := $(shell ../version.sh)
 export VERSION_TAG:=$(shell ../version.sh -t)
+export VERSION_DOCKER := $(shell ../version.sh -d)
 
 export GO111MODULE := on
 

--- a/master/Makefile
+++ b/master/Makefile
@@ -11,15 +11,19 @@ GORELEASER = goreleaser
 export VERSION := $(shell ../version.sh)
 
 export GO111MODULE := on
+
+# The Docker Hub organization.
 export DOCKER_REPO ?= determinedai
 
 FULL_COMMIT = $(shell git rev-parse HEAD)
 SHORT_COMMIT = $(shell git rev-parse HEAD | head -c9)
 PROJECT_NAME = determined-master
+PROJECT_NAME_DRYRUN = determined-master-dryrun
 EE_PROJECT_NAME = hpe-mlde-master
 ARCHS = amd64 arm64
 ARCH_SMALL = amd64-shared-cluster
 MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
+MULTI_ARCH_IMAGES_DRYRUN = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(FULL_COMMIT)-$$arch; done)
 EE_MULTI_ARCH_IMAGES = $(shell for arch in $(ARCHS); do echo $(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT)-$$arch; done)
 SHARED_CLUSTER_IMAGE=$(shell echo $(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT)-$(ARCH_SMALL))
 
@@ -29,6 +33,11 @@ PUB_MANIFESTS = \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(FULL_COMMIT) \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(SHORT_COMMIT) \
 	$(DOCKER_REPO)/$(PROJECT_NAME):$(VERSION)
+
+PUB_MANIFESTS_DRYRUN = \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(FULL_COMMIT) \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(SHORT_COMMIT) \
+	$(DOCKER_REPO)/$(PROJECT_NAME_DRYRUN):$(VERSION)
 
 EE_PUB_MANIFESTS = \
 	$(DOCKER_REPO)/$(EE_PROJECT_NAME):$(FULL_COMMIT) \
@@ -230,7 +239,14 @@ package: export DET_SEGMENT_MASTER_KEY ?=
 package: export DET_SEGMENT_WEBUI_KEY ?=
 package: export GORELEASER_CURRENT_TAG := $(VERSION)
 package: gen buildx
-	$(GORELEASER) --snapshot --rm-dist 
+	$(GORELEASER) --snapshot --rm-dist
+
+.PHONY: package-dryrun
+package-dryrun: export DET_SEGMENT_MASTER_KEY ?=
+package-dryrun: export DET_SEGMENT_WEBUI_KEY ?=
+package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+package-dryrun: gen buildx
+	$(GORELEASER) --snapshot --rm-dist ./.goreleaser_dryrun.yml
 
 .PHONY: package-ee
 package-ee: export DET_SEGMENT_MASTER_KEY ?=
@@ -256,6 +272,15 @@ release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate |
 release: gen buildx
 	$(GORELEASER) --rm-dist
 	make publish-nvcr
+
+.PHONY: release-dryrun
+release-dryrun: export DET_SEGMENT_MASTER_KEY ?=
+release-dryrun: export DET_SEGMENT_WEBUI_KEY ?=
+release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+# We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
+release-dryrun: gen buildx
+	$(GORELEASER) --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-ee
 release-ee: export DET_SEGMENT_MASTER_KEY ?=
@@ -293,6 +318,12 @@ publish-dev-small:
 .PHONY: publish
 publish:
 	@$(call manifest_publish, $(PUB_MANIFESTS), $(MULTI_ARCH_IMAGES))
+
+.PHONY: publish-dryrun
+# Build and upload production images to the determinedai/determined-dryrun
+# repository.
+publish-dryrun:
+	@$(call manifest_publish, $(PUB_MANIFESTS_DRYRUN), $(MULTI_ARCH_IMAGES_DRYRUN))
 
 .PHONY: publish-ee
 publish-ee:

--- a/master/Makefile
+++ b/master/Makefile
@@ -9,6 +9,7 @@ MOCK_INPUTS = Makefile ./internal/sproto/task.go ./internal/db/database.go ./int
 GORELEASER = goreleaser
 
 export VERSION := $(shell ../version.sh)
+export VERSION_TAG:=$(shell ../version.sh -t)
 
 export GO111MODULE := on
 
@@ -237,14 +238,14 @@ packaging/LICENSE: $(shell find ../tools/scripts/licenses -type f)
 .PHONY: package
 package: export DET_SEGMENT_MASTER_KEY ?=
 package: export DET_SEGMENT_WEBUI_KEY ?=
-package: export GORELEASER_CURRENT_TAG := $(VERSION)
+package: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 package: gen buildx
 	$(GORELEASER) --snapshot --rm-dist
 
 .PHONY: package-dryrun
 package-dryrun: export DET_SEGMENT_MASTER_KEY ?=
 package-dryrun: export DET_SEGMENT_WEBUI_KEY ?=
-package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
+package-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 package-dryrun: gen buildx
 	$(GORELEASER) --snapshot --rm-dist ./.goreleaser_dryrun.yml
 
@@ -253,22 +254,22 @@ package-ee: export DET_SEGMENT_MASTER_KEY ?=
 package-ee: export DET_SEGMENT_WEBUI_KEY ?=
 package-ee: export DET_EE_LICENSE_KEY = $(shell cat ../license.txt)
 package-ee: export DET_EE_PUBLIC_KEY = $(shell cat ../public.txt)
-package-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
+package-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
 package-ee: gen buildx
 	$(GORELEASER) --snapshot --rm-dist -f ./.goreleaser_ee.yml
 
 .PHONY: package-small
 package-small: export DET_SEGMENT_MASTER_KEY ?=
 package-small: export DET_SEGMENT_WEBUI_KEY ?=
-package-small: export GORELEASER_CURRENT_TAG := $(VERSION)
+package-small: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 package-small: gen buildx-small
 	$(GORELEASER) --snapshot --rm-dist -f ./.goreleaser_sharedcluster.yml
 
 .PHONY: release
 release: export DET_SEGMENT_MASTER_KEY ?=
 release: export DET_SEGMENT_WEBUI_KEY ?=
-release: export GORELEASER_CURRENT_TAG := $(VERSION)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release: gen buildx
 	$(GORELEASER) --rm-dist
 	make publish-nvcr
@@ -276,8 +277,8 @@ release: gen buildx
 .PHONY: release-dryrun
 release-dryrun: export DET_SEGMENT_MASTER_KEY ?=
 release-dryrun: export DET_SEGMENT_WEBUI_KEY ?=
-release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION)
-release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION)" -A1 | sed -n '2 p')
+release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 # We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
 release-dryrun: gen buildx
 	$(GORELEASER) --rm-dist -f ./.goreleaser_dryrun.yml
@@ -288,7 +289,7 @@ release-ee: export DET_SEGMENT_WEBUI_KEY ?=
 release-ee: export DET_EE_LICENSE_KEY = $(shell cat ../license.txt)
 release-ee: export DET_EE_PUBLIC_KEY = $(shell cat ../public.txt)
 release-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
-release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION)-ee" -A1 | sed -n '2 p')
+release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-ee: gen buildx
 	$(GORELEASER) --rm-dist -f ./.goreleaser_ee.yml
 

--- a/master/pkg/tasks/copy.go
+++ b/master/pkg/tasks/copy.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -40,6 +41,9 @@ func harnessArchive(harnessPath string, aug *model.AgentUserGroup) cproto.RunArc
 		panic(errors.Wrapf(err, "error finding Python wheel files for version %s in path: %s",
 			version.Version, harnessPath))
 	}
+
+	spew.Dump(wheelPaths)
+
 	for _, path := range wheelPaths {
 		info, err := os.Stat(path)
 		if err != nil {

--- a/master/pkg/tasks/copy.go
+++ b/master/pkg/tasks/copy.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/determined-ai/determined/master/pkg/archive"
 	"github.com/determined-ai/determined/master/pkg/cproto"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -41,8 +40,6 @@ func harnessArchive(harnessPath string, aug *model.AgentUserGroup) cproto.RunArc
 		panic(errors.Wrapf(err, "error finding Python wheel files for version %s in path: %s",
 			version.Version, harnessPath))
 	}
-
-	spew.Dump(wheelPaths)
 
 	for _, path := range wheelPaths {
 		info, err := os.Stat(path)

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 export VERSION := $(shell ../version.sh)
+export VERSION_DOCKER := $(shell ../version.sh -d)
 SHORT_GIT_HASH := $(shell git rev-parse --short HEAD)
 
 ARTIFACTS_DIR := /tmp/artifacts
@@ -113,7 +114,7 @@ build-transformers:
 		--build-arg DATASETS_VERSION=$(DATASETS_VERSION) \
 		--build-arg MODEL_HUB_VERSION=$(VERSION) \
 		-t $(TRANSFORMERS_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
-		-t $(TRANSFORMERS_ENVIRONMENT_ROOT):$(VERSION) \
+		-t $(TRANSFORMERS_ENVIRONMENT_ROOT):$(DOCKER_VERSION) \
 		.
 
 .PHONY: build-transformers-dryrun
@@ -124,18 +125,18 @@ build-transformers-dryrun:
 		--build-arg DATASETS_VERSION=$(DATASETS_VERSION) \
 		--build-arg MODEL_HUB_VERSION=$(VERSION) \
 		-t $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
-		-t $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) \
+		-t $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(DOCKER_VERSION) \
 		.
 
 .PHONY: publish-transformers
 publish-transformers:
 	./docker/publish-docker.sh transformers-gpu-hash $(TRANSFORMERS_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
-	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_ENVIRONMENT_ROOT):$(DOCKER_VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-transformers-dryrun
 publish-transformers-dryrun:
 	./docker/publish-docker.sh transformers-gpu-hash $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
-	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(DOCKER_VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: build-mmdetection
 build-mmdetection:
@@ -147,7 +148,7 @@ build-mmdetection:
 		--build-arg MMDETECTION_VERSION=$(MMDETECTION_VERSION) \
 		--build-arg MODEL_HUB_VERSION=$(VERSION) \
 		-t $(MMDETECTION_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
-		-t $(MMDETECTION_ENVIRONMENT_ROOT):$(VERSION) \
+		-t $(MMDETECTION_ENVIRONMENT_ROOT):$(DOCKER_VERSION) \
 		.
 
 .PHONY: build-mmdetection-dryrun
@@ -160,18 +161,18 @@ build-mmdetection-dryrun:
 		--build-arg MMDETECTION_VERSION=$(MMDETECTION_VERSION) \
 		--build-arg MODEL_HUB_VERSION=$(VERSION) \
 		-t $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
-		-t $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) \
+		-t $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(DOCKER_VERSION) \
 		.
 
 .PHONY: publish-mmdetection
 publish-mmdetection:
 	./docker/publish-docker.sh mmdetection-gpu-hash $(MMDETECTION_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
-	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_ENVIRONMENT_ROOT):$(DOCKER_VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: publish-mmdetection-dryrun
 publish-mmdetection-dryrun:
 	./docker/publish-docker.sh mmdetection-gpu-hash $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
-	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(DOCKER_VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: build-docker
 build-docker: build-transformers build-mmdetection

--- a/model_hub/Makefile
+++ b/model_hub/Makefile
@@ -16,12 +16,14 @@ DEFAULT_GPU_IMAGE := determinedai/pytorch-tensorflow-cuda-dev:5432424
 TRANSFORMERS_VERSION := 4.8.2
 DATASETS_VERSION := 1.9.0
 TRANSFORMERS_ENVIRONMENT_ROOT := determinedai/model-hub-transformers
+TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT := determinedai/model-hub-transformers-dryrun
 # MMDetection Args
 MMCV_CUDA_VERSION := cu113 # Needs to match DEFAULT_GPU_IMAGE
 TORCH_VERSION := 1.12.0 # Needs to match DEFAULT_GPU_IMAGE
 MMCV_VERSION := 1.7.1 # Needs to support the above Torch version
 MMDETECTION_VERSION := 2.27.0
 MMDETECTION_ENVIRONMENT_ROOT := determinedai/model-hub-mmdetection
+MMDETECTION_DRYRUN_ENVIRONMENT_ROOT := determinedai/model-hub-mmdetection-dryrun
 
 .PHONY: clean
 clean:
@@ -43,6 +45,10 @@ build:
 .PHONY: publish
 publish:
 	twine upload --verbose --non-interactive dist/*
+
+.PHONY: publish-dryrun
+publish-dryrun:
+	twine upload --verbose --non-interactive --repository testpypi dist/*
 
 .PHONY: fmt
 fmt:
@@ -110,10 +116,26 @@ build-transformers:
 		-t $(TRANSFORMERS_ENVIRONMENT_ROOT):$(VERSION) \
 		.
 
+.PHONY: build-transformers-dryrun
+build-transformers-dryrun:
+	docker build -f docker/Dockerfile.transformers \
+		--build-arg BASE_IMAGE=$(DEFAULT_GPU_IMAGE) \
+		--build-arg TRANSFORMERS_VERSION=$(TRANSFORMERS_VERSION) \
+		--build-arg DATASETS_VERSION=$(DATASETS_VERSION) \
+		--build-arg MODEL_HUB_VERSION=$(VERSION) \
+		-t $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
+		-t $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) \
+		.
+
 .PHONY: publish-transformers
 publish-transformers:
 	./docker/publish-docker.sh transformers-gpu-hash $(TRANSFORMERS_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
 	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+
+.PHONY: publish-transformers-dryrun
+publish-transformers-dryrun:
+	./docker/publish-docker.sh transformers-gpu-hash $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh transformers-gpu-version $(TRANSFORMERS_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
 
 .PHONY: build-mmdetection
 build-mmdetection:
@@ -128,13 +150,37 @@ build-mmdetection:
 		-t $(MMDETECTION_ENVIRONMENT_ROOT):$(VERSION) \
 		.
 
+.PHONY: build-mmdetection-dryrun
+build-mmdetection-dryrun:
+	docker build -f docker/Dockerfile.mmdetection \
+		--build-arg BASE_IMAGE=$(DEFAULT_GPU_IMAGE) \
+		--build-arg MMCV_CUDA_VERSION=$(MMCV_CUDA_VERSION) \
+		--build-arg TORCH_VERSION=$(TORCH_VERSION) \
+		--build-arg MMCV_VERSION=$(MMCV_VERSION) \
+		--build-arg MMDETECTION_VERSION=$(MMDETECTION_VERSION) \
+		--build-arg MODEL_HUB_VERSION=$(VERSION) \
+		-t $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) \
+		-t $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) \
+		.
+
 .PHONY: publish-mmdetection
 publish-mmdetection:
 	./docker/publish-docker.sh mmdetection-gpu-hash $(MMDETECTION_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
 	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
 
+.PHONY: publish-mmdetection-dryrun
+publish-mmdetection-dryrun:
+	./docker/publish-docker.sh mmdetection-gpu-hash $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(SHORT_GIT_HASH) $(ARTIFACTS_DIR)
+	./docker/publish-docker.sh mmdetection-gpu-version $(MMDETECTION_DRYRUN_ENVIRONMENT_ROOT):$(VERSION) $(ARTIFACTS_DIR)
+
 .PHONY: build-docker
 build-docker: build-transformers build-mmdetection
 
+.PHONY: build-docker-dryrun
+build-docker-dryrun: build-transformers-dryrun build-mmdetection-dryrun
+
 .PHONY: publish-docker
 publish-docker: publish-transformers publish-mmdetection
+
+.PHONY: publish-docker-dryrun
+publish-docker-dryrun: publish-transformers-dryrun publish-mmdetection-dryrun

--- a/version.sh
+++ b/version.sh
@@ -47,9 +47,9 @@ while getopts ${OPTSTRING} opt; do
         t)
             TAG_OUTPUT=1
             ;;
-		d)
-			DOCKER_OUTPUT=1
-			;;
+        d)
+            DOCKER_OUTPUT=1
+            ;;
         ?)
             echo "Invalid option: -${OPTARG}."
             exit 1
@@ -60,7 +60,7 @@ done
 # Set VERSION to CIRCLE_TAG in case we're running in CircleCI. This makes it
 # easier to avoid fiddling with environment variables there.
 if [[ ! -z ${CIRCLE_TAG} ]]; then
-	VERSION=${CIRCLE_TAG}
+    VERSION=${CIRCLE_TAG}
 fi
 
 # If VERSION is unset or the empty string, "". This will be the default case for
@@ -99,10 +99,10 @@ if [[ -z ${VERSION} ]]; then
     if [[ -n ${TAG_OUTPUT} ]]; then
         echo -n "${MAYBE_TAG}+${SHA}"
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
-		# Docker image tags must have the following format:
-		# [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
-		echo -n "${MAYBE_TAG#v}-${SHA}" | tr '+' '-'
-	else
+        # Docker image tags must have the following format:
+        # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
+        echo -n "${MAYBE_TAG#v}-${SHA}" | tr '+' '-'
+    else
         echo -n "${MAYBE_TAG#v}+${SHA}"
     fi
 else
@@ -115,10 +115,10 @@ else
     # string without the 'v'.
     if [[ -n ${TAG_OUTPUT} ]]; then
         echo -n "${VERSION#v}"
-	elif [[ -n ${DOCKER_OUTPUT} ]]; then
-		# Docker image tags must have the following format:
-		# [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
-		echo -n "${VERSION#v}" | tr '+' '-'
+    elif [[ -n ${DOCKER_OUTPUT} ]]; then
+        # Docker image tags must have the following format:
+        # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
+        echo -n "${VERSION#v}" | tr '+' '-'
     else
         echo -n "${VERSION}"
     fi

--- a/version.sh
+++ b/version.sh
@@ -36,6 +36,10 @@
 # So, in our diagram, if run from B, C, D, E, F, I, J, or K, the script will return
 # 1.1.0. If run from L, M, N, or O, it will return 1.2.0. And so on.
 
+# Set VERSION to CIRCLE_TAG in case we're running in CircleCI. This makes it
+# easier to avoid fiddling with environment variables there.
+VERSION=${CIRCLE_TAG}
+
 # If VERSION is unset or the empty string, "". This will be the default case for
 # local builds.
 if [ -z ${VERSION} ]; then

--- a/version.sh
+++ b/version.sh
@@ -114,12 +114,12 @@ else
     # the full tag version string if it's set. Otherwise, return the version
     # string without the 'v'.
     if [[ -n ${TAG_OUTPUT} ]]; then
-        echo -n "${VERSION#v}"
+        echo -n "${VERSION}"
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
         # Docker image tags must have the following format:
         # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
         echo -n "${VERSION#v}" | tr '+' '-'
     else
-        echo -n "${VERSION}"
+        echo -n "${VERSION#v}"
     fi
 fi

--- a/version.sh
+++ b/version.sh
@@ -59,7 +59,7 @@ done
 
 # Set VERSION to CIRCLE_TAG in case we're running in CircleCI. This makes it
 # easier to avoid fiddling with environment variables there.
-if [[ ! -z ${CIRCLE_TAG} ]]; then
+if [[ -n ${CIRCLE_TAG} ]]; then
     VERSION=${CIRCLE_TAG}
 fi
 

--- a/version.sh
+++ b/version.sh
@@ -68,7 +68,7 @@ fi
 if [[ -z ${VERSION} ]]; then
     # Check if this branch has any tags (typically, only release branches will
     # have tags).
-    MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+    MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null | grep -Eo 'v?\d+\.\d+\.\d+')
     SHA=$(git rev-parse --short HEAD)
 
     # No tag on current branch.
@@ -97,13 +97,13 @@ if [[ -z ${VERSION} ]]; then
     # like it will be more consistent and result in fewer surprises, but also it
     # might help indicate that this is a local version.
     if [[ -n ${TAG_OUTPUT} ]]; then
-        echo -n "${MAYBE_TAG}+${SHA}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
+        echo -n "${MAYBE_TAG}+${SHA}"
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
         # Docker image tags must have the following format:
         # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
         echo -n "${MAYBE_TAG#v}-${SHA}" | sed -e 's/\+/-/g'
     else
-        echo -n "${MAYBE_TAG#v}+${SHA}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
+        echo -n "${MAYBE_TAG#v}+${SHA}"
     fi
 else
     # Use existing VERSION, which is much easier. This should be the default
@@ -114,12 +114,12 @@ else
     # the full tag version string if it's set. Otherwise, return the version
     # string without the 'v'.
     if [[ -n ${TAG_OUTPUT} ]]; then
-        echo -n "${VERSION}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
+        echo -n "${VERSION}"
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
         # Docker image tags must have the following format:
         # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
         echo -n "${VERSION#v}" | sed -e 's/\+/-/g'
     else
-        echo -n "${VERSION#v}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
+        echo -n "${VERSION#v}"
     fi
 fi

--- a/version.sh
+++ b/version.sh
@@ -97,13 +97,13 @@ if [[ -z ${VERSION} ]]; then
     # like it will be more consistent and result in fewer surprises, but also it
     # might help indicate that this is a local version.
     if [[ -n ${TAG_OUTPUT} ]]; then
-        echo -n "${MAYBE_TAG}+${SHA}"
+        echo -n "${MAYBE_TAG}+${SHA}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
         # Docker image tags must have the following format:
         # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
-        echo -n "${MAYBE_TAG#v}-${SHA}" | tr '+' '-'
+        echo -n "${MAYBE_TAG#v}-${SHA}" | sed -e 's/\+/-/g'
     else
-        echo -n "${MAYBE_TAG#v}+${SHA}"
+        echo -n "${MAYBE_TAG#v}+${SHA}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
     fi
 else
     # Use existing VERSION, which is much easier. This should be the default
@@ -114,12 +114,12 @@ else
     # the full tag version string if it's set. Otherwise, return the version
     # string without the 'v'.
     if [[ -n ${TAG_OUTPUT} ]]; then
-        echo -n "${VERSION}"
+        echo -n "${VERSION}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
     elif [[ -n ${DOCKER_OUTPUT} ]]; then
         # Docker image tags must have the following format:
         # [A-Za-z0-9_][A-Za-z0-9_\.\-]{0,127}
-        echo -n "${VERSION#v}" | tr '+' '-'
+        echo -n "${VERSION#v}" | sed -e 's/\+/-/g'
     else
-        echo -n "${VERSION#v}"
+        echo -n "${VERSION#v}" | sed -e 's/\+/-/g' | sed -e 's/-/+/'
     fi
 fi


### PR DESCRIPTION
## Ticket(s)
INFENG-809
INFENG-831

## Description

The following changeset does a few different things, and I apologize for its size, but it was easier to wrap it all together. Broadly speaking, this introduces a new CircleCI `release-dryrun` workflow to test the release process, as well as some important tweaks to the `version.sh` script that fix a critical bug in how we tag Docker images.

### `release-dryrun` CircleCI workflow

I've introduced a new CircleCI workflow called `release-dryrun`. The goal was to test all of the recent release process changes with a separate workflow that didn't risk publishing public artifacts that would either conflict with existing versions or otherwise pollute package indexes. This has also been a separate Determined feature request for a little bit now anyway.

There were several ways to do this, but I opted for separating out all of the necessary Makefile targets into corresponding `-dryrun` targets, which mostly do what their production counterparts do, except in cases that involve pushing things to external services.

As you can see, this got a little verbose; every make target that's used as part of the production `release` workflow should have a corresponding new `-dryrun` target. I think this was sensible, though. One alternative would be to set some sort of environment variable to signal to `make` that we should be running a separate dryrun version of different targets, but I don't like the lack of visibility that entails (if a make target ever fails, you have to go back and check that its behavior wasn't subtly modified out-of-band). I think it makes it more difficult to reason about what's happening.

This also means that if any of the production make targets change, and they have a corresponding dryrun target, the dryrun target will have to be updated as well. This is one of the downsides. Since the dryrun release is just a test, though, at least the consequences of it breaking are pretty low. We'll just need to make a conscious effort to keep it in sync with the actual production release.

I also had to introduce new GoReleaser configurations where necessary, in the form of `.goreleaser_dryrun.yml` files. The dryrun versions are mostly the same, except in certain spots where I had to explicitly add some dryrun-specific names/IDs to get GoReleaser to put things in the correct places.

If it's helpful, the following table attempts to illustrate the differences between various components of the production release vs. the dryrun:

| Thing | Production | Dryrun |
| --- | --- | --- |
| Master Docker Hub repository | determinedai/determined-master | determinedai/determined-master-dryrun |
| Agent Docker Hub repository | determinedai/determined-agent | determinedai/determined-agent-dryrun |
| GitHub repository (release notes, binaries, Helm chart) | determined-ai/determined | determined-ai/determined-dryrun |
| Homebrew GitHub repository | determined-ai/homebrew-determined | determined-ai/homebrew-determined-dryrun |
| GoReleaser OSS config | `.goreleaser.yml` | `.goreleaser_dryrun.yml` |
| CircleCI workflow | `release` | `release-dryrun` |
| `make` targets (example, follows pattern) | `package` | `package-dryrun` |


### Dryrun tag format

To kick off a dry run, the tag must conform to the following regular expression (in Java syntax): `v\d+\.\d+\.\d+\+dryrun`. For example, `v2.4.1+dryrun`.

### `version.sh` tweaks

I had to add command-line flags to `version.sh`, specifically `-t` and `-d`. `-t` returns the full git tag itself; this was necessary because GoReleaser uses tags specifically in some spots, and because we've introduced a split between the tag itself (with a leading `v`) and the version string (without a leading `v`), I needed a way to differentiate the two. Now, `version.sh -t` can be used anywhere the full git tag is needed.

Similarly, `-d` will return a Docker-friendly version of the string. For now, this just replaces plus signs `+` with hyphens `-`, although that should suffice for us. `version.sh -d` may be invoked any time you need a Docker-friendly image tag.

I've also added an additional `grep` to the part of the script that searches git for tags, which matches only on the semantic version part of the string itself. This is to prevent issues when running the script on a branch that has a previous tag with a plus sign `+` in it. For example, before, if a previous tag was `v2.4.3+dryrun`, `version.sh` would return something like `v2.4.3+dryrun+a1b2c3d4`. The additional grep ensures that we ignore any previous tag metadata when constructing a new local version string.

### Other changes

I've tweaked some of the tag filters in CircleCI to match the new desired tag format, as well as consolidate some of the regular expressions.

I've modularized some repetitive `make <target>` steps in CircleCI by creating a new `make-component` command, which also takes a `dryrun` parameter. `dryrun` is false by default, so the command runs whatever `make` target you give it. If `dryrun` is `true`, it will run the `-dryrun` variant of the target you pass. This isn't perfect, but it works well enough for now, and brings a little order to things.

I've fixed a bash bug in `real_config.yml` that causes some issues during the release.

## Test Plan
There are a lot of moving parts, but it should be sufficient to test `version.sh` and the release dryrun process.

### Release dryrun

1. Check out this branch.
1. Tag `HEAD` by running `git tag` with a high-numbered version tag that ends in `+dryrun`. For example, `git tag v0.760.0+dryrun`. Note: the leading `v` is important.
1. Push the tag: `git push origin v0.760.0+dryrun`. (If someone has already used this tag, bump the patch version and try again.)
1. Navigate to [CircleCI](https://app.circleci.com/pipelines/github/determined-ai/determined) and watch for your tag build to come through.
1. You should see only a `release-dryrun` workflow running. If `release` and `release-ee` show up, **cancel them immediately**, and let me know on this pull request.
1. The workflow itself will fail because the Test PyPI package publishing step is temporarily broken while we await some administrivia regarding `determined` package ownership, but all of the jobs before that should succeed.
1. Spot check various external services. [determined-master-dryrun](https://hub.docker.com/repository/docker/determinedai/determined-master-dryrun/general) on Docker Hub should have a new image with your published version, [determined-dryrun](https://github.com/determined-ai/determined-dryrun) on GitHub should have release notes with binaries and the Helm chart, and the [Homebrew repository](https://github.com/determined-ai/homebrew-determined-dryrun/) should be updated with whatever version you pushed (note that because we only publish the latest version, there could be contention if someone else pushes a dryrun tag around the same time. This is unlikely).

Clean up:

1. Run `git tag -d v0.760.0+dryrun` (or whatever you called your tag).
1. Run `git push origin :v0.760.0+dryrun` to delete the tag on the remote.

### `version.sh`

1. Run `./version.sh` from `HEAD`. It ought to return `0.35.0+c2a656e4b0` (it doesn't return `0.36.0+c2a656e4b0` because `0.36.0` is currently ahead of this branch, as I have not rebased in a while).
1. Run `./version.sh -t` from `HEAD`. It ought to return `0.35.0+c2a656e4b0`. (Note: the tag and the version string match exactly because the current release tagging scheme doesn't use a leading `v`. If it did, it would be printed as well. This is a consequence of how we do tags now; the script is working as intended.)
1. Run `./version.sh -d` from `HEAD`. It ought to return `0.35.0-c2a656e4b0`.

Now, test with `VERSION` set:

1. Run `export VERSION="v0.750.0+dryrun"`.
1. Run `./version.sh` from `HEAD`. It ought to print `0.750.0+dryrun`.
1. Run `./version.sh -t` from `HEAD`. It ought to print `v0.750.0+dryrun`. (Curious thing to note: this tag doesn't actually exist. I should make the semantics of the `VERSION` variable clearer, at some point.)
1. Run `./version.sh -d` from `HEAD`. It ought to print `0.750.0-dryrun`.

Finally, test with a tag on a previous commit:

1. Run `git tag v0.755.0+7aca6130f6 7aca6130f6c714fe234ab3ee9697f9942a2f2488` to tag a previous commit on this branch.
1. Run `unset VERSION`.
1. Run `version.sh` on `HEAD`. It ought to return `0.755.0+c2a656e4b0`.
1. Run `version.sh -t` on `HEAD`. It ought to return `v0.755.0+c2a656e4b0` (note the leading `v`).
1. Run `version.sh -d` on `HEAD`. It ought to return `0.755.0-c2a656e4b0`.

Clean up:

1. Run `git tag -d v0.755.0+7aca6130f6`.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ