### PR TITLE
fix: add backwards compatibility for Pods to Jobs for k8s <v1.27 [CM-461]

### DIFF
--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -63,7 +63,7 @@ const (
 	jobNameAnnotation         = "determined.ai/job-name"
 
 	kubernetesJobNameLabel     = "batch.kubernetes.io/job-name"
-	kubernetesFallbackJobLabel = "job-name" // used when the above label is not present.
+	kubernetesFallbackJobLabel = "job-name" // used in k8s versions < 1.27
 
 	resourceTypeNvidia = "nvidia.com/gpu"
 	resourceTypeAMD    = "amd.com/gpu"


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-461]



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Older version of Kubernetes don't have the expected label (`batch.kubernetes.io/job-name`), instead they use `job-name`.
https://kubernetes.io/docs/reference/labels-annotations-taints/#job-name

This PR adds a fallback to handle backwards compatibility in the event that version of k8s being used does not support the latest job label key.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- CI Passes


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-461]: https://hpe-aiatscale.atlassian.net/browse/CM-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ