### PR TITLE
fix: use new ruamel yaml APIs

### DIFF
--- a/examples/tutorials/mnist_pytorch/train.py
+++ b/examples/tutorials/mnist_pytorch/train.py
@@ -101,7 +101,8 @@ def run(local: bool = False):
 
     if local:
         # For convenience, use hparams from const.yaml for local mode.
-        conf = yaml.safe_load(pathlib.Path("./const.yaml").read_text())
+        yml = yaml.YAML(typ="safe", pure=True)
+        conf = yml.load(pathlib.Path("./const.yaml").read_text())
         hparams = conf["hyperparameters"]
         max_length = pytorch.Batch(100)  # Train for 100 batches.
         latest_checkpoint = None
@@ -120,7 +121,7 @@ def run(local: bool = False):
 
 if __name__ == "__main__":
     # Configure logging
-    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
+    logging.basicConfig(level=logging.DEBUG, format=det.LOG_FORMAT)
 
     local_training = det.get_cluster_info() is None
     run(local=local_training)

--- a/examples/tutorials/mnist_pytorch/train.py
+++ b/examples/tutorials/mnist_pytorch/train.py
@@ -121,7 +121,7 @@ def run(local: bool = False):
 
 if __name__ == "__main__":
     # Configure logging
-    logging.basicConfig(level=logging.DEBUG, format=det.LOG_FORMAT)
+    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
 
     local_training = det.get_cluster_info() is None
     run(local=local_training)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
ruamel changed their APIs and previous method call no longer exists.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
run MNIST locally: go to `examples/tutorials/mnist_pytorch` and run `python3 train.py`, make sure it runs and exits successfully.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ