### PR TITLE
fix: Hf callback metric naming

### DIFF
--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -60,7 +60,7 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
             return
         metrics, metric_type = self._get_metrics(logs)
         logger.debug(f"on_log metrics, global_step {state.global_step}", metrics)
-        if metric_type in [TRAIN,TRAIN_AVG]:
+        if metric_type in [TRAIN, TRAIN_AVG]:
             # Prevents reporting metrics for the same step twice. This happens after
             # training is completed and average training metrics are reported with
             # the same step as the in-progress training metrics.

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -290,7 +290,7 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
 EVAL = "eval_"
 TEST = "test_"
 TRAIN = "train_"
-DEFAULT = "train_progress"
+DEFAULT = "uncategorized"
 
 
 def get_metric_type(d: Dict[str, Any]) -> str:

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -60,7 +60,7 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
             return
         metrics, metric_type = self._get_metrics(logs)
         logger.debug(f"on_log metrics, global_step {state.global_step}", metrics)
-        if metric_type in [TRAIN, TRAIN_AVG]:
+        if metric_type == TRAIN:
             # Prevents reporting metrics for the same step twice. This happens after
             # training is completed and average training metrics are reported with
             # the same step as the in-progress training metrics.
@@ -289,8 +289,8 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
 
 EVAL = "eval_"
 TEST = "test_"
-TRAIN_AVG = "train_"
-TRAIN = "train_progress"
+TRAIN = "train_"
+DEFAULT = "train_progress"
 
 
 def get_metric_type(d: Dict[str, Any]) -> str:
@@ -299,11 +299,11 @@ def get_metric_type(d: Dict[str, Any]) -> str:
             return EVAL
         elif k.startswith(TEST):
             return TEST
-        elif k.startswith(TRAIN_AVG):
-            return TRAIN_AVG
-        else:
+        elif k.startswith(TRAIN):
             return TRAIN
-    return TRAIN
+        else:
+            return DEFAULT
+    return DEFAULT
 
 
 def get_ds_config_path_from_args(args: List[str]) -> Optional[str]:

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -60,7 +60,7 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
             return
         metrics, metric_type = self._get_metrics(logs)
         logger.debug(f"on_log metrics, global_step {state.global_step}", metrics)
-        if metric_type == TRAIN:
+        if metric_type in [TRAIN,TRAIN_AVG]:
             # Prevents reporting metrics for the same step twice. This happens after
             # training is completed and average training metrics are reported with
             # the same step as the in-progress training metrics.

--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -290,7 +290,6 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
 EVAL = "eval_"
 TEST = "test_"
 TRAIN = "train_"
-DEFAULT = "uncategorized"
 
 
 def get_metric_type(d: Dict[str, Any]) -> str:
@@ -299,11 +298,9 @@ def get_metric_type(d: Dict[str, Any]) -> str:
             return EVAL
         elif k.startswith(TEST):
             return TEST
-        elif k.startswith(TRAIN):
-            return TRAIN
         else:
-            return DEFAULT
-    return DEFAULT
+            return TRAIN
+    return TRAIN
 
 
 def get_ds_config_path_from_args(args: List[str]) -> Optional[str]:


### PR DESCRIPTION
## Ticket
https://hpe-aiatscale.atlassian.net/browse/MD-511



## Description
`TRAIN = "train_progress"` appears to be a confusing variable name for a value that is intended as a placeholder. This caused an issue in the behavior of `on_log()`. This PR renames `TRAIN` to `DEFAULT` and `TRAIN_PROGRESS` to `TRAIN`



## Test Plan
Run an example with huggingface callback and make sure metrics are being recorded properly.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ