### PR TITLE
fix: inconsistent timezone handling in daily allocation aggregation

### DIFF
--- a/master/internal/db/postgres_cluster.go
+++ b/master/internal/db/postgres_cluster.go
@@ -91,7 +91,7 @@ SELECT jsonb_build_object(
 func (db *PgDB) UpdateResourceAllocationAggregation() error {
 	var lastDatePtr *time.Time
 	err := db.sql.QueryRow(
-		`SELECT date_trunc('day', max(date)) FROM resource_aggregates`,
+		`SELECT date_trunc('day', max(date)::timestamp) FROM resource_aggregates`,
 	).Scan(&lastDatePtr)
 	if err != nil {
 		return errors.Wrap(err, "failed to find last aggregate")

--- a/master/internal/db/postgres_cluster_intg_test.go
+++ b/master/internal/db/postgres_cluster_intg_test.go
@@ -5,10 +5,15 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
 
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
@@ -25,32 +30,8 @@ func TestClusterAPI(t *testing.T) {
 	_, err := db.GetOrCreateClusterID("")
 	require.NoError(t, err, "failed to get or create cluster id")
 
-	// Add a mock user
-	user := RequireMockUser(t, db)
-
-	// Add a job
-	jID := model.NewJobID()
-	jIn := &model.Job{
-		JobID:   jID,
-		JobType: model.JobTypeExperiment,
-		OwnerID: &user.ID,
-	}
-
-	err = AddJob(jIn)
-	require.NoError(t, err, "failed to add job")
-
-	// Add a task
-	tID := model.NewTaskID()
-	tIn := &model.Task{
-		TaskID:    tID,
-		JobID:     &jID,
-		TaskType:  model.TaskTypeTrial,
-		StartTime: time.Now().UTC().Truncate(time.Millisecond),
-	}
-
-	err = AddTask(context.TODO(), tIn)
-	require.NoError(t, err, "failed to add task")
-
+	_, tIn := CreateMockJobAndTask(t, db)
+	tID := tIn.TaskID
 	// Add an allocation
 	aID := model.AllocationID(string(tID) + "-1")
 	aIn := &model.Allocation{
@@ -86,4 +67,182 @@ func TestClusterAPI(t *testing.T) {
 	require.Equal(t, *aOut.EndTime, clusterHeartbeat,
 		"Expected end time of open allocation is = %q but it is = %q instead",
 		clusterHeartbeat.String(), aOut.EndTime.String())
+}
+
+func CreateMockJobAndTask(t *testing.T, db *PgDB) (*model.Job, *model.Task) {
+	// Add a mock user
+	user := RequireMockUser(t, db)
+
+	// Add a job
+	jID := model.NewJobID()
+	jIn := &model.Job{
+		JobID:   jID,
+		JobType: model.JobTypeExperiment,
+		OwnerID: &user.ID,
+	}
+
+	err := AddJob(jIn)
+	require.NoError(t, err, "failed to add job")
+
+	// Add a task
+	tID := model.NewTaskID()
+	tIn := &model.Task{
+		TaskID:    tID,
+		JobID:     &jID,
+		TaskType:  model.TaskTypeTrial,
+		StartTime: time.Now().UTC().Truncate(time.Millisecond),
+	}
+
+	err = AddTask(context.TODO(), tIn)
+	require.NoError(t, err, "failed to add task")
+
+	return jIn, tIn
+}
+
+type allocAggTest struct {
+	name      string
+	tzQuery   string
+	timeOfDay string
+	numSlots  int
+	seconds   int
+}
+
+func TestUpdateResourceAllocationAggregation(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(RootFromDB))
+
+	db, closeDB := MustResolveTestPostgres(t)
+	defer closeDB()
+	MustMigrateTestPostgres(t, db, MigrationsFromDB)
+
+	ctx := context.Background()
+	bunDB := bun.NewDB(db.sql.DB, pgdialect.New())
+
+	today := time.Now()
+
+	tests := []allocAggTest{
+		{
+			name:      "UTC basic add",
+			tzQuery:   `SET TIME ZONE 'Etc/UTC'`,
+			timeOfDay: "04:20:00AM",
+			numSlots:  5,
+			seconds:   5,
+		},
+		{
+			name:      "Positive UTC offset",
+			tzQuery:   `SET TIME ZONE 'Europe/Athens'`,
+			timeOfDay: "11:30:00PM",
+			numSlots:  5,
+			seconds:   10,
+		},
+		{
+			name:      "Negative UTC offset",
+			tzQuery:   `SET TIME ZONE 'America/Montreal'`,
+			timeOfDay: "01:20:00AM",
+			numSlots:  7,
+			seconds:   2,
+		},
+	}
+
+	type resourceAggregate struct {
+		bun.BaseModel `bun:"table:resource_aggregates"`
+		Date          time.Time `bun:"date"`
+		Seconds       float64   `bun:"seconds"`
+	}
+
+	for ind, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			offset := -1 * (480 - (24 * ind))
+			recentDate := today.Add(time.Hour * time.Duration(offset))
+			formattedDate, prevSeconds := setupUpdateResourceAllocationAggregation(ctx, t, db,
+				bunDB, recentDate, test)
+			err := db.UpdateResourceAllocationAggregation()
+			require.NoError(t, err)
+
+			ra := resourceAggregate{}
+			err = bunDB.NewSelect().
+				Model(&ra).
+				Where("date = ? AND aggregation_type = ?", formattedDate, "total").
+				Scan(ctx)
+			require.NoError(t, err)
+
+			var expectedSeconds interface{} = float64(test.numSlots*test.seconds) + prevSeconds
+			var seconds interface{} = ra.Seconds
+			require.InEpsilon(t, expectedSeconds, seconds, 0.5)
+		})
+	}
+}
+
+func setupUpdateResourceAllocationAggregation(ctx context.Context, t *testing.T, db *PgDB,
+	bunDB *bun.DB, recentDate time.Time, test allocAggTest,
+) (string, float64) {
+	// (Setup) Set the timezone.
+	_, err := bunDB.NewRaw(test.tzQuery).Exec(ctx)
+	require.NoError(t, err)
+
+	_, tIn := CreateMockJobAndTask(t, db)
+	tID := tIn.TaskID
+
+	formattedDate := recentDate.Format(time.DateOnly)
+	yearMonthDay := strings.Split(formattedDate, "-")
+	startDate := fmt.Sprintf("%s/%s %s %s +00", yearMonthDay[1], yearMonthDay[2], test.timeOfDay,
+		yearMonthDay[0])
+
+	// (Setup) the allocation's start and end time.
+	startTime, err := time.Parse("01/02 03:04:05PM 2006 -07", startDate)
+	require.NoError(t, err)
+
+	var prevSeconds float64
+	err = bunDB.NewRaw(`
+	WITH d AS (
+    SELECT
+        tsrange(
+            ?::timestamp,
+            (?::timestamp + interval '1 day')
+        ) AS period
+	),
+	allocs_in_range AS (
+    SELECT
+        extract(
+            EPOCH
+            FROM
+            upper(d.period * alloc.range) - lower(d.period * alloc.range)
+        ) * alloc.slots::float AS seconds
+    FROM
+        (
+            SELECT
+				slots,
+                tsrange(start_time, greatest(start_time, end_time)) AS range
+            FROM
+                allocations
+            WHERE
+                start_time IS NOT NULL
+        ) AS alloc,
+        d
+    WHERE
+        d.period && alloc.range
+	)
+	SELECT coalesce(sum(allocs_in_range.seconds), 0) FROM allocs_in_range
+	`, formattedDate, formattedDate).Scan(ctx, &prevSeconds)
+	require.NoError(t, err)
+
+	endTime := startTime.Add(time.Second * time.Duration(test.seconds))
+	allocID := uuid.NewString()
+	alloc := model.Allocation{
+		AllocationID: *model.NewAllocationID(&allocID),
+		TaskID:       tID,
+		Slots:        test.numSlots,
+		ResourcePool: uuid.NewString(),
+		StartTime:    &startTime,
+		EndTime:      &endTime,
+	}
+	_, err = bunDB.NewDelete().
+		Table("resource_aggregates").
+		Where("date >= ?", formattedDate).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = bunDB.NewInsert().Model(&alloc).Exec(ctx)
+	require.NoError(t, err)
+
+	return formattedDate, prevSeconds
 }

--- a/master/static/srv/update_aggregated_allocation.sql
+++ b/master/static/srv/update_aggregated_allocation.sql
@@ -1,8 +1,8 @@
 WITH const AS (
     SELECT
-        tstzrange(
-            $1::timestamptz,
-            ($1::timestamptz + interval '1 day')
+        tsrange(
+            $1::timestamp,
+            ($1::timestamp + interval '1 day')
         ) AS period
 ),
 
@@ -21,7 +21,7 @@ allocs_in_range AS (
         (
             SELECT
                 *,
-                tstzrange(start_time, greatest(start_time, end_time)) AS range
+                tsrange(start_time, greatest(start_time, end_time)) AS range
             FROM
                 allocations
             WHERE


### PR DESCRIPTION
## Ticket
CM-440

## Description
Our Historical Usage page fetches allocations by date in UTC time specifically, and we store allocations without a timezone, which converts the input time to UTC before storing the timestamp without the timezone internally. 

However, fetching timestamps with no timezone and then casting to `timestamptz` (with a timezone) only adds a timezone to the stored time stamp, doing no internal conversion from UTC to the corresponding time in the user's set timezone. (so `('2024-10-02 01:30'::timestamp)::timestamptz = 2024-10-02 01:30 <user_set_timezone>`, which isn't what we want.

With the changes in this PR, we keep consistent with how allocations are stored and continue to handle them in the `resource_aggregates` table without casting to a `timestamptz`. 

## Test Plan
CI passes (automated testing).


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ