### PR TITLE
fix: timezone handling error in queued allocation time update

### DIFF
--- a/master/static/srv/update_aggregated_queued_time.sql
+++ b/master/static/srv/update_aggregated_queued_time.sql
@@ -57,7 +57,7 @@ all_aggs AS (
 INSERT INTO
 resource_aggregates (
     SELECT
-        const.target_date AS date,
+        timezone('Etc/UTC', const.target_date) AS date,
         all_aggs.*
     FROM
         all_aggs, const


### PR DESCRIPTION
## Ticket
CM-440


## Description
This is an extension of [#9988](https://github.com/determined-ai/determined/pull/9888).
The testing of `UpdateResourceAllocationAggregation` didn't account for the `update_aggregated_queued_time` script, which truncates a timestamp with a timezone to an arbitrary date when updating the `resource_aggregates`table.  
We fix this here by interpreting the timestamp in UTC time before passing it in as a date since the Historical Usage page and CSV downloads that fetch and display allocation information aggregate for a given day using UTC time.

## Test Plan
CI passes (automated testing).


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ