### PR TITLE
chore: add unmarshal functions for task config policies

### DIFF
--- a/harness/determined/common/api/bindings.py
+++ b/harness/determined/common/api/bindings.py
@@ -7144,7 +7144,7 @@ class v1GetWebhooksResponse(Printable):
         return out
 
 class v1GetWorkspaceConfigPoliciesResponse(Printable):
-    """Response to GetWorkspaceConfigPolicies request."""
+    """Response to GetWorkspaceConfigPoliciesRequest."""
     configPolicies: "typing.Optional[typing.Dict[str, typing.Any]]" = None
 
     def __init__(
@@ -12127,7 +12127,7 @@ class v1PutExperimentsRetainLogsResponse(Printable):
         return out
 
 class v1PutGlobalConfigPoliciesResponse(Printable):
-    """Response to PutGlobalConfigPolicies request."""
+    """Response to PutGlobalConfigPoliciesRequest."""
     configPolicies: "typing.Optional[typing.Dict[str, typing.Any]]" = None
 
     def __init__(
@@ -12365,7 +12365,7 @@ class v1PutWorkspaceConfigPoliciesRequest(Printable):
         return out
 
 class v1PutWorkspaceConfigPoliciesResponse(Printable):
-    """Response to PutWorkspaceConfigPolicies request."""
+    """Response to PutWorkspaceConfigPoliciesRequest."""
     configPolicies: "typing.Optional[typing.Dict[str, typing.Any]]" = None
 
     def __init__(
@@ -18431,8 +18431,7 @@ def delete_DeleteGlobalConfigPolicies(
 ) -> None:
     """Delete global task config policies.
 
-    - workloadType: Specifies which workload type the config policies apply to: EXPERIMENT or
-NTSC.
+    - workloadType: The workload type the config policies apply to: EXPERIMENT or NTSC.
     """
     _params = None
     if type(workloadType) == str:
@@ -18681,7 +18680,7 @@ def delete_DeleteWorkspaceConfigPolicies(
     """Delete workspace task config policies.
 
     - workloadType: The workload type the config policies apply to: EXPERIMENT or NTSC.
-    - workspaceId: Specifies which workspace the config policies apply to. Use global API for
+    - workspaceId: The workspace the config policies apply to. Use global API for
 global config policies.
     """
     _params = None
@@ -19565,8 +19564,7 @@ def get_GetGlobalConfigPolicies(
 ) -> "v1GetGlobalConfigPoliciesResponse":
     """Get global task config policies.
 
-    - workloadType: Specifies which workload type the config policies apply to: EXPERIMENT or
-NTSC.
+    - workloadType: The workload type the config policies apply to: EXPERIMENT or NTSC.
     """
     _params = None
     if type(workloadType) == str:
@@ -21670,7 +21668,7 @@ def get_GetWorkspaceConfigPolicies(
     """Get workspace task config policies.
 
     - workloadType: The workload type the config policies apply to: EXPERIMENT or NTSC.
-    - workspaceId: Specifies which workspace the config policies apply to. Use global API for
+    - workspaceId: The workspace the config policies apply to. Use global API for
 global config policies.
     """
     _params = None
@@ -23727,8 +23725,7 @@ def put_PutWorkspaceConfigPolicies(
 ) -> "v1PutWorkspaceConfigPoliciesResponse":
     """Add or update workspace task config policies.
 
-    - workloadType: Specifies which workload type the config policies apply to: EXPERIMENT or
-NTSC.
+    - workloadType: The workload type the config policies apply to: EXPERIMENT or NTSC.
     - workspaceId: The workspace the config policies apply to. Use global API for
 global config policies.
     """

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -7,31 +7,13 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 
+	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
-// workload types are used to distinguish configuration for experiments and NTSCs.
-const (
-	// Should not be used.
-	WorkloadTypeUnspecified = "UNKNOWN"
-	// Configuration policies for experiments.
-	WorkloadTypeExperiment = "EXPERIMENT"
-	// Configuration policies for NTSC.
-	WorkloadTypeNTSC = "NTSC"
-)
-
-func validWorkloadEnum(val string) bool {
-	switch val {
-	case WorkloadTypeExperiment, WorkloadTypeNTSC:
-		return true
-	default:
-		return false
-	}
-}
-
 func stubData() (*structpb.Struct, error) {
 	const yamlString = `
-invariant_configs:
+invariant_config:
   description: "test"
 constraints:
   resources:
@@ -44,19 +26,14 @@ constraints:
 		return nil, fmt.Errorf("unable to unmarshal yaml: %w", err)
 	}
 
-	// convert map to protobuf struct
-	yamlStruct, err := structpb.NewStruct(yamlMap)
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert map to protobuf struct: %w", err)
-	}
-	return yamlStruct, nil
+	return configpolicy.MarshalConfigPolicy(yamlMap), nil
 }
 
 // Add or update workspace task config policies.
 func (*apiServer) PutWorkspaceConfigPolicies(
 	ctx context.Context, req *apiv1.PutWorkspaceConfigPoliciesRequest,
 ) (*apiv1.PutWorkspaceConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	data, err := stubData()
@@ -67,7 +44,7 @@ func (*apiServer) PutWorkspaceConfigPolicies(
 func (*apiServer) PutGlobalConfigPolicies(
 	ctx context.Context, req *apiv1.PutGlobalConfigPoliciesRequest,
 ) (*apiv1.PutGlobalConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	data, err := stubData()
@@ -78,7 +55,7 @@ func (*apiServer) PutGlobalConfigPolicies(
 func (*apiServer) GetWorkspaceConfigPolicies(
 	ctx context.Context, req *apiv1.GetWorkspaceConfigPoliciesRequest,
 ) (*apiv1.GetWorkspaceConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	data, err := stubData()
@@ -89,7 +66,7 @@ func (*apiServer) GetWorkspaceConfigPolicies(
 func (*apiServer) GetGlobalConfigPolicies(
 	ctx context.Context, req *apiv1.GetGlobalConfigPoliciesRequest,
 ) (*apiv1.GetGlobalConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	data, err := stubData()
@@ -100,7 +77,7 @@ func (*apiServer) GetGlobalConfigPolicies(
 func (*apiServer) DeleteWorkspaceConfigPolicies(
 	ctx context.Context, req *apiv1.DeleteWorkspaceConfigPoliciesRequest,
 ) (*apiv1.DeleteWorkspaceConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	return &apiv1.DeleteWorkspaceConfigPoliciesResponse{}, nil
@@ -110,7 +87,7 @@ func (*apiServer) DeleteWorkspaceConfigPolicies(
 func (*apiServer) DeleteGlobalConfigPolicies(
 	ctx context.Context, req *apiv1.DeleteGlobalConfigPoliciesRequest,
 ) (*apiv1.DeleteGlobalConfigPoliciesResponse, error) {
-	if !validWorkloadEnum(req.WorkloadType) {
+	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
 		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
 	}
 	return &apiv1.DeleteGlobalConfigPoliciesResponse{}, nil

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -26,7 +26,7 @@ type Constraints struct {
 // Submitted experiments whose constraint fields vary from the respective Constraint fields set
 // within a given scope are rejected.
 type ExperimentConfigPolicy struct {
-	InvariantConfig *expconf.ExperimentConfig `json:"config"`
+	InvariantConfig *expconf.ExperimentConfig `json:"invariant_config"`
 	Constraints     *Constraints              `json:"constraints"`
 }
 
@@ -36,6 +36,6 @@ type ExperimentConfigPolicy struct {
 // Submitted NTSC tasks whose constraint fields vary from the respective Constraint fields set
 // within a given scope are rejected.
 type NTSCConfigPolicy struct {
-	InvariantConfig *model.CommandConfig `json:"config"`
+	InvariantConfig *model.CommandConfig `json:"invariant_config"`
 	Constraints     *Constraints         `json:"constraints"`
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -56,5 +56,4 @@ func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
 
 func MarshalConfigPolicy(configPolicy interface{}) *structpb.Struct {
 	return protoutils.ToStruct(configPolicy)
-
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -1,6 +1,7 @@
 package configpolicy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -26,7 +27,9 @@ func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error
 	var expConfigPolicy ExperimentConfigPolicy
 	var err error
 
-	if err = json.Unmarshal([]byte(str), &expConfigPolicy); err == nil {
+	dec := json.NewDecoder(bytes.NewReader([]byte(str)))
+	dec.DisallowUnknownFields()
+	if err = dec.Decode(&expConfigPolicy); err == nil {
 		// valid JSON input
 		return &expConfigPolicy, nil
 	}
@@ -44,7 +47,9 @@ func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
 	var ntscConfigPolicy NTSCConfigPolicy
 	var err error
 
-	if err = json.Unmarshal([]byte(str), &ntscConfigPolicy); err == nil {
+	dec := json.NewDecoder(bytes.NewReader([]byte(str)))
+	dec.DisallowUnknownFields()
+	if err = dec.Decode(&ntscConfigPolicy); err == nil {
 		// valid JSON input
 		return &ntscConfigPolicy, nil
 	}

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/protoutils"
 	"github.com/ghodss/yaml"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/protoutils"
 )
 
-// ValidWorkloadType checks if the string is an accepted WorkloadType
+// ValidWorkloadType checks if the string is an accepted WorkloadType.
 func ValidWorkloadType(val string) bool {
 	switch val {
 	case string(model.ExperimentType), string(model.NTSCType):
@@ -20,6 +21,7 @@ func ValidWorkloadType(val string) bool {
 	}
 }
 
+// UnmarshalExperimentConfigPolicy unpacks a string into ExperimentConfigPolicy struct.
 func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error) {
 	var expConfigPolicy ExperimentConfigPolicy
 	var err error
@@ -37,6 +39,7 @@ func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error
 	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
 }
 
+// UnmarshalNTSCConfigPolicy unpacks a string into NTSCConfigPolicy struct.
 func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
 	var ntscConfigPolicy NTSCConfigPolicy
 	var err error
@@ -54,6 +57,7 @@ func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
 	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
 }
 
+// MarshalConfigPolicy packs a config policy into a proto struct.
 func MarshalConfigPolicy(configPolicy interface{}) *structpb.Struct {
 	return protoutils.ToStruct(configPolicy)
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -1,0 +1,60 @@
+package configpolicy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/protoutils"
+	"github.com/ghodss/yaml"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ValidWorkloadType checks if the string is an accepted WorkloadType
+func ValidWorkloadType(val string) bool {
+	switch val {
+	case string(model.ExperimentType), string(model.NTSCType):
+		return true
+	default:
+		return false
+	}
+}
+
+func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error) {
+	var expConfigPolicy ExperimentConfigPolicy
+	var err error
+
+	if err = json.Unmarshal([]byte(str), &expConfigPolicy); err == nil {
+		// valid JSON input
+		return &expConfigPolicy, nil
+	}
+
+	if err = yaml.Unmarshal([]byte(str), &expConfigPolicy, yaml.DisallowUnknownFields); err == nil {
+		// valid Yaml input
+		return &expConfigPolicy, nil
+	}
+	// invalid JSON & invalid Yaml input
+	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
+}
+
+func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
+	var ntscConfigPolicy NTSCConfigPolicy
+	var err error
+
+	if err = json.Unmarshal([]byte(str), &ntscConfigPolicy); err == nil {
+		// valid JSON input
+		return &ntscConfigPolicy, nil
+	}
+
+	if err = yaml.Unmarshal([]byte(str), &ntscConfigPolicy, yaml.DisallowUnknownFields); err == nil {
+		// valid Yaml input
+		return &ntscConfigPolicy, nil
+	}
+	// invalid JSON & Yaml input
+	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
+}
+
+func MarshalConfigPolicy(configPolicy interface{}) *structpb.Struct {
+	return protoutils.ToStruct(configPolicy)
+
+}

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -3,10 +3,11 @@ package configpolicy
 import (
 	"testing"
 
-	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 const yamlConstraints = `
@@ -15,6 +16,7 @@ constraints:
     max_slots: 4
   priority_limit: 10
 `
+
 const yamlExperiment = `
 invariant_config:
   description: "test\nspecial\tchar"
@@ -27,38 +29,40 @@ invariant_config:
     slots: 1
 `
 
+var (
+	description   = "test\nspecial\tchar"
+	slots         = 1
+	forcePull     = false
+	maxSlots      = 4
+	priorityLimit = 10
+)
+
+var structExperiment = ExperimentConfigPolicy{
+	InvariantConfig: &expconf.ExperimentConfig{
+		RawDescription: &description,
+		RawResources: &expconf.ResourcesConfig{
+			RawSlots: &slots,
+		},
+		RawEnvironment: &expconf.EnvironmentConfigV0{
+			RawForcePullImage:  &forcePull,
+			RawAddCapabilities: []string{"cap1", "cap2"},
+		},
+	},
+	Constraints: &Constraints{
+		ResourceConstraints: &ResourceConstraints{
+			MaxSlots: &maxSlots,
+		},
+		PriorityLimit: &priorityLimit,
+	},
+}
+
 func TestUnmarshalYamlExperiment(t *testing.T) {
-	description := "test\nspecial\tchar"
-	slots := 1
-	forcePull := false
-	maxSlots := 4
-	priorityLimit := 10
-
-	structExperiment := ExperimentConfigPolicy{
-		InvariantConfig: &expconf.ExperimentConfig{
-			RawDescription: &description,
-			RawResources: &expconf.ResourcesConfig{
-				RawSlots: &slots,
-			},
-			RawEnvironment: &expconf.EnvironmentConfigV0{
-				RawForcePullImage:  &forcePull,
-				RawAddCapabilities: []string{"cap1", "cap2"},
-			},
-		},
-		Constraints: &Constraints{
-			ResourceConstraints: &ResourceConstraints{
-				MaxSlots: &maxSlots,
-			},
-			PriorityLimit: &priorityLimit,
-		},
-	}
-
 	justConfig := structExperiment
 	justConfig.Constraints = nil
 	justConstraints := structExperiment
 	justConstraints.InvariantConfig = nil
 
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		input  string
 		noErr  bool
@@ -97,34 +101,32 @@ invariant_config:
     slots: 1
 `
 
-func TestUnmarshalYamlNTSC(t *testing.T) {
-	maxSlots := 4
-	priorityLimit := 10
-	structNTSC := NTSCConfigPolicy{
-		InvariantConfig: &model.CommandConfig{
-			Description: "test\nspecial\tchar",
-			Resources: model.ResourcesConfig{
-				Slots: 10,
-			},
-			Environment: model.Environment{
-				ForcePullImage:  false,
-				AddCapabilities: []string{"cap1", "cap2"},
-			},
+var structNTSC = NTSCConfigPolicy{
+	InvariantConfig: &model.CommandConfig{
+		Description: "test\nspecial\tchar",
+		Resources: model.ResourcesConfig{
+			Slots: 10,
 		},
-		Constraints: &Constraints{
-			ResourceConstraints: &ResourceConstraints{
-				MaxSlots: &maxSlots,
-			},
-			PriorityLimit: &priorityLimit,
+		Environment: model.Environment{
+			ForcePullImage:  false,
+			AddCapabilities: []string{"cap1", "cap2"},
 		},
-	}
+	},
+	Constraints: &Constraints{
+		ResourceConstraints: &ResourceConstraints{
+			MaxSlots: &maxSlots,
+		},
+		PriorityLimit: &priorityLimit,
+	},
+}
 
+func TestUnmarshalYamlNTSC(t *testing.T) {
 	justConfig := structNTSC
 	justConfig.Constraints = nil
 	justConstraints := structNTSC
 	justConstraints.InvariantConfig = nil
 
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		input  string
 		noErr  bool
@@ -174,37 +176,12 @@ invariant_config: {
 `
 
 func TestUnmarshalJSONExperiment(t *testing.T) {
-	description := "test\nspecial\tchar"
-	slots := 1
-	forcePull := false
-	maxSlots := 4
-	priorityLimit := 10
-
-	structExperiment := ExperimentConfigPolicy{
-		InvariantConfig: &expconf.ExperimentConfig{
-			RawDescription: &description,
-			RawResources: &expconf.ResourcesConfig{
-				RawSlots: &slots,
-			},
-			RawEnvironment: &expconf.EnvironmentConfigV0{
-				RawForcePullImage:  &forcePull,
-				RawAddCapabilities: []string{"cap1", "cap2"},
-			},
-		},
-		Constraints: &Constraints{
-			ResourceConstraints: &ResourceConstraints{
-				MaxSlots: &maxSlots,
-			},
-			PriorityLimit: &priorityLimit,
-		},
-	}
-
 	justConfig := structExperiment
 	justConfig.Constraints = nil
 	justConstraints := structExperiment
 	justConstraints.InvariantConfig = nil
 
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		input  string
 		noErr  bool
@@ -245,33 +222,12 @@ invariant_config: {
 `
 
 func TestUnmarshalJSONNTSC(t *testing.T) {
-	maxSlots := 4
-	priorityLimit := 10
-	structNTSC := NTSCConfigPolicy{
-		InvariantConfig: &model.CommandConfig{
-			Description: "test\nspecial\tchar",
-			Resources: model.ResourcesConfig{
-				Slots: 10,
-			},
-			Environment: model.Environment{
-				ForcePullImage:  false,
-				AddCapabilities: []string{"cap1", "cap2"},
-			},
-		},
-		Constraints: &Constraints{
-			ResourceConstraints: &ResourceConstraints{
-				MaxSlots: &maxSlots,
-			},
-			PriorityLimit: &priorityLimit,
-		},
-	}
-
 	justConfig := structNTSC
 	justConfig.Constraints = nil
 	justConstraints := structNTSC
 	justConstraints.InvariantConfig = nil
 
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		input  string
 		noErr  bool

--- a/proto/pkg/apiv1/config_policies.pb.go
+++ b/proto/pkg/apiv1/config_policies.pb.go
@@ -29,8 +29,7 @@ type PutWorkspaceConfigPoliciesRequest struct {
 	// The workspace the config policies apply to. Use global API for
 	// global config policies.
 	WorkspaceId int32 `protobuf:"varint,1,opt,name=workspace_id,json=workspaceId,proto3" json:"workspace_id,omitempty"`
-	// Specifies which workload type the config policies apply to: EXPERIMENT or
-	// NTSC.
+	// The workload type the config policies apply to: EXPERIMENT or NTSC.
 	WorkloadType string `protobuf:"bytes,2,opt,name=workload_type,json=workloadType,proto3" json:"workload_type,omitempty"`
 	// The config policies to use. Contains both invariant configs and constraints
 	// in yaml or json format.
@@ -90,7 +89,7 @@ func (x *PutWorkspaceConfigPoliciesRequest) GetConfigPolicies() string {
 	return ""
 }
 
-// Response to PutWorkspaceConfigPolicies request.
+// Response to PutWorkspaceConfigPoliciesRequest.
 type PutWorkspaceConfigPoliciesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -200,7 +199,7 @@ func (x *PutGlobalConfigPoliciesRequest) GetConfigPolicies() string {
 	return ""
 }
 
-// Response to PutGlobalConfigPolicies request.
+// Response to PutGlobalConfigPoliciesRequest.
 type PutGlobalConfigPoliciesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -257,7 +256,7 @@ type GetWorkspaceConfigPoliciesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Specifies which workspace the config policies apply to. Use global API for
+	// The workspace the config policies apply to. Use global API for
 	// global config policies.
 	WorkspaceId int32 `protobuf:"varint,1,opt,name=workspace_id,json=workspaceId,proto3" json:"workspace_id,omitempty"`
 	// The workload type the config policies apply to: EXPERIMENT or NTSC.
@@ -310,7 +309,7 @@ func (x *GetWorkspaceConfigPoliciesRequest) GetWorkloadType() string {
 	return ""
 }
 
-// Response to GetWorkspaceConfigPolicies request.
+// Response to GetWorkspaceConfigPoliciesRequest.
 type GetWorkspaceConfigPoliciesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -367,8 +366,7 @@ type GetGlobalConfigPoliciesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Specifies which workload type the config policies apply to: EXPERIMENT or
-	// NTSC.
+	// The workload type the config policies apply to: EXPERIMENT or NTSC.
 	WorkloadType string `protobuf:"bytes,1,opt,name=workload_type,json=workloadType,proto3" json:"workload_type,omitempty"`
 }
 
@@ -468,7 +466,7 @@ type DeleteWorkspaceConfigPoliciesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Specifies which workspace the config policies apply to. Use global API for
+	// The workspace the config policies apply to. Use global API for
 	// global config policies.
 	WorkspaceId int32 `protobuf:"varint,1,opt,name=workspace_id,json=workspaceId,proto3" json:"workspace_id,omitempty"`
 	// The workload type the config policies apply to: EXPERIMENT or NTSC.
@@ -521,7 +519,7 @@ func (x *DeleteWorkspaceConfigPoliciesRequest) GetWorkloadType() string {
 	return ""
 }
 
-// Response to DeleteWorkspaceConfigPolicies request.
+// Response to DeleteWorkspaceConfigPoliciesRequest.
 type DeleteWorkspaceConfigPoliciesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -567,8 +565,7 @@ type DeleteGlobalConfigPoliciesRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Specifies which workload type the config policies apply to: EXPERIMENT or
-	// NTSC.
+	// The workload type the config policies apply to: EXPERIMENT or NTSC.
 	WorkloadType string `protobuf:"bytes,1,opt,name=workload_type,json=workloadType,proto3" json:"workload_type,omitempty"`
 }
 
@@ -611,7 +608,7 @@ func (x *DeleteGlobalConfigPoliciesRequest) GetWorkloadType() string {
 	return ""
 }
 
-// Response to DeleteGlobalConfigPolicies request.
+// Response to DeleteGlobalConfigPoliciesRequest.
 type DeleteGlobalConfigPoliciesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto/src/determined/api/v1/config_policies.proto
+++ b/proto/src/determined/api/v1/config_policies.proto
@@ -11,15 +11,14 @@ message PutWorkspaceConfigPoliciesRequest {
   // The workspace the config policies apply to. Use global API for
   // global config policies.
   int32 workspace_id = 1;
-  // Specifies which workload type the config policies apply to: EXPERIMENT or
-  // NTSC.
+  // The workload type the config policies apply to: EXPERIMENT or NTSC.
   string workload_type = 2;
   // The config policies to use. Contains both invariant configs and constraints
   // in yaml or json format.
   string config_policies = 3;
 }
 
-// Response to PutWorkspaceConfigPolicies request.
+// Response to PutWorkspaceConfigPoliciesRequest.
 message PutWorkspaceConfigPoliciesResponse {
   // The config policies saved. Contains both invariant configs and constraints
   // in yaml or json format.
@@ -36,7 +35,7 @@ message PutGlobalConfigPoliciesRequest {
   string config_policies = 2;
 }
 
-// Response to PutGlobalConfigPolicies request.
+// Response to PutGlobalConfigPoliciesRequest.
 message PutGlobalConfigPoliciesResponse {
   // The config policies saved. Contains both invariant configs and constraints
   // in yaml or json format.
@@ -46,14 +45,14 @@ message PutGlobalConfigPoliciesResponse {
 // GetWorkspaceConfigPoliciesRequest lists task config policies
 // for a given workspace and workload type.
 message GetWorkspaceConfigPoliciesRequest {
-  // Specifies which workspace the config policies apply to. Use global API for
+  // The workspace the config policies apply to. Use global API for
   // global config policies.
   int32 workspace_id = 1;
   //  The workload type the config policies apply to: EXPERIMENT or NTSC.
   string workload_type = 2;
 }
 
-// Response to GetWorkspaceConfigPolicies request.
+// Response to GetWorkspaceConfigPoliciesRequest.
 message GetWorkspaceConfigPoliciesResponse {
   // The current config policies saved for the workspace. Contains both
   // invariant configs and constraints in yaml or json format.
@@ -63,8 +62,7 @@ message GetWorkspaceConfigPoliciesResponse {
 // GetGlobalConfigPoliciesRequest lists global task config
 // policies for a given workload type.
 message GetGlobalConfigPoliciesRequest {
-  // Specifies which workload type the config policies apply to: EXPERIMENT or
-  // NTSC.
+  //  The workload type the config policies apply to: EXPERIMENT or NTSC.
   string workload_type = 1;
 }
 
@@ -78,23 +76,22 @@ message GetGlobalConfigPoliciesResponse {
 // DeleteWorkspaceConfigPoliciesRequest is used to delete all task config
 // policies for the workspace and workload type.
 message DeleteWorkspaceConfigPoliciesRequest {
-  // Specifies which workspace the config policies apply to. Use global API for
+  // The workspace the config policies apply to. Use global API for
   // global config policies.
   int32 workspace_id = 1;
   // The workload type the config policies apply to: EXPERIMENT or NTSC.
   string workload_type = 2;
 }
 
-// Response to DeleteWorkspaceConfigPolicies request.
+// Response to DeleteWorkspaceConfigPoliciesRequest.
 message DeleteWorkspaceConfigPoliciesResponse {}
 
 // DeleteGlobalConfigPoliciesRequest is used to delete all global task config
 // policies for the workload type.
 message DeleteGlobalConfigPoliciesRequest {
-  // Specifies which workload type the config policies apply to: EXPERIMENT or
-  // NTSC.
+  // The workload type the config policies apply to: EXPERIMENT or NTSC.
   string workload_type = 1;
 }
 
-// Response to DeleteGlobalConfigPolicies request.
+// Response to DeleteGlobalConfigPoliciesRequest.
 message DeleteGlobalConfigPoliciesResponse {}

--- a/webui/react/src/services/api-ts-sdk/api.ts
+++ b/webui/react/src/services/api-ts-sdk/api.ts
@@ -2651,7 +2651,7 @@ export interface V1DeleteExperimentsResponse {
     results: Array<V1ExperimentActionResult>;
 }
 /**
- * Response to DeleteGlobalConfigPolicies request.
+ * Response to DeleteGlobalConfigPoliciesRequest.
  * @export
  * @interface V1DeleteGlobalConfigPoliciesResponse
  */
@@ -2751,7 +2751,7 @@ export interface V1DeleteTensorboardFilesResponse {
 export interface V1DeleteWebhookResponse {
 }
 /**
- * Response to DeleteWorkspaceConfigPolicies request.
+ * Response to DeleteWorkspaceConfigPoliciesRequest.
  * @export
  * @interface V1DeleteWorkspaceConfigPoliciesResponse
  */
@@ -5280,7 +5280,7 @@ export interface V1GetWebhooksResponse {
     webhooks: Array<V1Webhook>;
 }
 /**
- * Response to GetWorkspaceConfigPolicies request.
+ * Response to GetWorkspaceConfigPoliciesRequest.
  * @export
  * @interface V1GetWorkspaceConfigPoliciesResponse
  */
@@ -8817,7 +8817,7 @@ export interface V1PutExperimentsRetainLogsResponse {
     results: Array<V1ExperimentActionResult>;
 }
 /**
- * Response to PutGlobalConfigPolicies request.
+ * Response to PutGlobalConfigPoliciesRequest.
  * @export
  * @interface V1PutGlobalConfigPoliciesResponse
  */
@@ -8945,7 +8945,7 @@ export interface V1PutWorkspaceConfigPoliciesRequest {
      */
     workspaceId?: number;
     /**
-     * Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+     * The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @type {string}
      * @memberof V1PutWorkspaceConfigPoliciesRequest
      */
@@ -8958,7 +8958,7 @@ export interface V1PutWorkspaceConfigPoliciesRequest {
     configPolicies?: string;
 }
 /**
- * Response to PutWorkspaceConfigPolicies request.
+ * Response to PutWorkspaceConfigPoliciesRequest.
  * @export
  * @interface V1PutWorkspaceConfigPoliciesResponse
  */
@@ -12752,7 +12752,7 @@ export const AlphaApiFetchParamCreator = function (configuration?: Configuration
         /**
          * 
          * @summary Delete global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -12788,7 +12788,7 @@ export const AlphaApiFetchParamCreator = function (configuration?: Configuration
         /**
          * 
          * @summary Delete workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -12830,7 +12830,7 @@ export const AlphaApiFetchParamCreator = function (configuration?: Configuration
         /**
          * 
          * @summary Get global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -12866,7 +12866,7 @@ export const AlphaApiFetchParamCreator = function (configuration?: Configuration
         /**
          * 
          * @summary Get workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -12945,7 +12945,7 @@ export const AlphaApiFetchParamCreator = function (configuration?: Configuration
          * 
          * @summary Add or update workspace task config policies.
          * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {V1PutWorkspaceConfigPoliciesRequest} body
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13003,7 +13003,7 @@ export const AlphaApiFp = function (configuration?: Configuration) {
         /**
          * 
          * @summary Delete global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -13022,7 +13022,7 @@ export const AlphaApiFp = function (configuration?: Configuration) {
         /**
          * 
          * @summary Delete workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13042,7 +13042,7 @@ export const AlphaApiFp = function (configuration?: Configuration) {
         /**
          * 
          * @summary Get global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -13061,7 +13061,7 @@ export const AlphaApiFp = function (configuration?: Configuration) {
         /**
          * 
          * @summary Get workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13101,7 +13101,7 @@ export const AlphaApiFp = function (configuration?: Configuration) {
          * 
          * @summary Add or update workspace task config policies.
          * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {V1PutWorkspaceConfigPoliciesRequest} body
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13130,7 +13130,7 @@ export const AlphaApiFactory = function (configuration?: Configuration, fetch?: 
         /**
          * 
          * @summary Delete global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -13140,7 +13140,7 @@ export const AlphaApiFactory = function (configuration?: Configuration, fetch?: 
         /**
          * 
          * @summary Delete workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13151,7 +13151,7 @@ export const AlphaApiFactory = function (configuration?: Configuration, fetch?: 
         /**
          * 
          * @summary Get global task config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -13161,7 +13161,7 @@ export const AlphaApiFactory = function (configuration?: Configuration, fetch?: 
         /**
          * 
          * @summary Get workspace task config policies.
-         * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+         * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
          * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13183,7 +13183,7 @@ export const AlphaApiFactory = function (configuration?: Configuration, fetch?: 
          * 
          * @summary Add or update workspace task config policies.
          * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
-         * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+         * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
          * @param {V1PutWorkspaceConfigPoliciesRequest} body
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13204,7 +13204,7 @@ export class AlphaApi extends BaseAPI {
     /**
      * 
      * @summary Delete global task config policies.
-     * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+     * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AlphaApi
@@ -13216,7 +13216,7 @@ export class AlphaApi extends BaseAPI {
     /**
      * 
      * @summary Delete workspace task config policies.
-     * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+     * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
      * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13229,7 +13229,7 @@ export class AlphaApi extends BaseAPI {
     /**
      * 
      * @summary Get global task config policies.
-     * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+     * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AlphaApi
@@ -13241,7 +13241,7 @@ export class AlphaApi extends BaseAPI {
     /**
      * 
      * @summary Get workspace task config policies.
-     * @param {number} workspaceId Specifies which workspace the config policies apply to. Use global API for global config policies.
+     * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
      * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13267,7 +13267,7 @@ export class AlphaApi extends BaseAPI {
      * 
      * @summary Add or update workspace task config policies.
      * @param {number} workspaceId The workspace the config policies apply to. Use global API for global config policies.
-     * @param {string} workloadType Specifies which workload type the config policies apply to: EXPERIMENT or NTSC.
+     * @param {string} workloadType The workload type the config policies apply to: EXPERIMENT or NTSC.
      * @param {V1PutWorkspaceConfigPoliciesRequest} body
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-502]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Introduce unmarshal functions to process user input for task config policies.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Covered by unit tests.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-502]: https://hpe-aiatscale.atlassian.net/browse/CM-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ