### PR TITLE
chore: remove unused languages from code editor

### DIFF
--- a/webui/react/package-lock.json
+++ b/webui/react/package-lock.json
@@ -18,7 +18,7 @@
         "fp-ts": "^2.16.5",
         "fuse.js": "^7.0.0",
         "hermes-parallel-coordinates": "^0.6.17",
-        "hew": "npm:@hpe.com/hew@^0.6.45",
+        "hew": "npm:@hpe.com/hew@^0.6.46",
         "humanize-duration": "^3.28.0",
         "immutable": "^4.3.0",
         "io-ts": "^2.2.21",

--- a/webui/react/package.json
+++ b/webui/react/package.json
@@ -42,7 +42,7 @@
     "fp-ts": "^2.16.5",
     "fuse.js": "^7.0.0",
     "hermes-parallel-coordinates": "^0.6.17",
-    "hew": "npm:@hpe.com/hew@^0.6.45",
+    "hew": "npm:@hpe.com/hew@^0.6.46",
     "humanize-duration": "^3.28.0",
     "immutable": "^4.3.0",
     "io-ts": "^2.2.21",


### PR DESCRIPTION


<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-751



## Description
This updates the hew package, which has been updated to reduce the number of available code editor languages to just javascript, yaml, json and markdown. this should shrink the package size by 2MB unpacked, 500KB packed.



## Test Plan
React build size should be smaller. otherwise no testing is required



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ