### PR TITLE
chore: re-split code editor

### DIFF
--- a/webui/react/.eslintrc.js
+++ b/webui/react/.eslintrc.js
@@ -116,7 +116,13 @@ module.exports = {
     'no-empty': ['error', { allowEmptyCatch: false }],
     'no-multi-spaces': ['error', { ignoreEOLComments: true }],
     'no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
-    'no-restricted-imports': ['error', { patterns: ['..*'] }],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [{ message: 'Please use components/CodeEditor instead', name: 'hew/CodeEditor' }],
+        patterns: ['..*'],
+      },
+    ],
     'no-throw-literal': 'error',
     'no-trailing-spaces': ['error', {}],
     'no-unused-vars': 'off',

--- a/webui/react/src/components/CodeEditor.tsx
+++ b/webui/react/src/components/CodeEditor.tsx
@@ -1,0 +1,13 @@
+import Spinner from 'hew/Spinner';
+import { ComponentPropsWithoutRef, FC, lazy, Suspense } from 'react';
+
+// eslint-disable-next-line no-restricted-imports
+const HewCodeEditor = lazy(() => import('hew/CodeEditor'));
+
+export const CodeEditor: FC<ComponentPropsWithoutRef<typeof HewCodeEditor>> = (props) => (
+  <Suspense fallback={<Spinner spinning tip="Loading code viewer..." />}>
+    <HewCodeEditor {...props} />
+  </Suspense>
+);
+
+export default CodeEditor;

--- a/webui/react/src/components/ExperimentContinueModal.tsx
+++ b/webui/react/src/components/ExperimentContinueModal.tsx
@@ -6,13 +6,13 @@ import Input from 'hew/Input';
 import InputNumber from 'hew/InputNumber';
 import { Modal } from 'hew/Modal';
 import Row from 'hew/Row';
-import Spinner from 'hew/Spinner';
 import { Body } from 'hew/Typography';
 import { Loaded } from 'hew/utils/loadable';
 import yaml from 'js-yaml';
 import _ from 'lodash';
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import useFeature from 'hooks/useFeature';
 import { paths } from 'routes/utils';
 import { continueExperiment, createExperiment } from 'services/api';
@@ -95,8 +95,6 @@ interface ModalState {
   trial?: TrialItem;
   type: ContinueExperimentType;
 }
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 const DEFAULT_MODAL_STATE = {
   config: {},
@@ -439,15 +437,13 @@ const ExperimentContinueModalComponent = ({
           <Alert message={modalState.configError} showIcon type="error" />
         )}
         {modalIsInAdvancedMode && (
-          <React.Suspense fallback={<Spinner spinning tip="Loading text editor..." />}>
-            <CodeEditor
-              file={Loaded(modalState.configString)}
-              files={[{ key: 'config.yaml' }]}
-              height="40vh"
-              onChange={handleEditorChange}
-              onError={handleError}
-            />
-          </React.Suspense>
+          <CodeEditor
+            file={Loaded(modalState.configString)}
+            files={[{ key: 'config.yaml' }]}
+            height="40vh"
+            onChange={handleEditorChange}
+            onError={handleError}
+          />
         )}
         {!modalIsInAdvancedMode && (
           <Body>

--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -3,12 +3,12 @@ import Button from 'hew/Button';
 import Form, { hasErrors } from 'hew/Form';
 import Input from 'hew/Input';
 import { Modal } from 'hew/Modal';
-import Spinner from 'hew/Spinner';
 import { Loaded } from 'hew/utils/loadable';
 import yaml from 'js-yaml';
 import _ from 'lodash';
-import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import useFeature from 'hooks/useFeature';
 import { paths } from 'routes/utils';
 import { createExperiment } from 'services/api';
@@ -84,8 +84,6 @@ interface ModalState {
   trial?: TrialItem;
   type: CreateExperimentType;
 }
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 const DEFAULT_MODAL_STATE = {
   config: {},
@@ -371,15 +369,13 @@ const ExperimentCreateModalComponent = ({
           <Alert message={modalState.configError} type="error" />
         )}
         {modalState.isAdvancedMode && (
-          <React.Suspense fallback={<Spinner spinning tip="Loading text editor..." />}>
-            <CodeEditor
-              file={Loaded(modalState.configString)}
-              files={[{ key: 'config.yaml' }]}
-              height="40vh"
-              onChange={handleEditorChange}
-              onError={handleError}
-            />
-          </React.Suspense>
+          <CodeEditor
+            file={Loaded(modalState.configString)}
+            files={[{ key: 'config.yaml' }]}
+            height="40vh"
+            onChange={handleEditorChange}
+            onError={handleError}
+          />
         )}
         <Form
           form={form}

--- a/webui/react/src/components/JupyterLabModal.tsx
+++ b/webui/react/src/components/JupyterLabModal.tsx
@@ -11,6 +11,7 @@ import { number, string, undefined as undefinedType, union } from 'io-ts';
 import yaml from 'js-yaml';
 import React, { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import Link from 'components/Link';
 import useFeature from 'hooks/useFeature';
 import usePermissions from 'hooks/usePermissions';
@@ -79,8 +80,6 @@ interface FullConfigProps {
 interface Props {
   workspace?: Workspace;
 }
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 const JupyterLabModalComponent: React.FC<Props> = ({ workspace }: Props) => {
   const idPrefix = useId();

--- a/webui/react/src/components/Markdown.tsx
+++ b/webui/react/src/components/Markdown.tsx
@@ -1,15 +1,13 @@
 import Pivot, { PivotProps } from 'hew/Pivot';
-import Spinner from 'hew/Spinner';
 import { Loaded } from 'hew/utils/loadable';
 import { default as MarkdownViewer } from 'markdown-to-jsx';
 import React, { useMemo } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import useResize from 'hooks/useResize';
 import handleError from 'utils/error';
 
 import css from './Markdown.module.scss';
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 interface Props {
   disabled?: boolean;
@@ -56,20 +54,13 @@ const Markdown: React.FC<Props> = ({
       {
         children: (
           <div className={css.noOverflow}>
-            <React.Suspense
-              fallback={
-                <div>
-                  <Spinner spinning tip="Loading text editor..." />
-                </div>
-              }>
-              <CodeEditor
-                file={Loaded(markdown)}
-                files={[{ key: 'input.md' }]}
-                height={`${resize.height - 420}px`}
-                onChange={onChange}
-                onError={handleError}
-              />
-            </React.Suspense>
+            <CodeEditor
+              file={Loaded(markdown)}
+              files={[{ key: 'input.md' }]}
+              height={`${resize.height - 420}px`}
+              onChange={onChange}
+              onError={handleError}
+            />
           </div>
         ),
         key: TabType.Edit,

--- a/webui/react/src/components/Metadata.tsx
+++ b/webui/react/src/components/Metadata.tsx
@@ -1,13 +1,12 @@
 import { Loaded } from 'hew/utils/loadable';
 import React from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import { TrialDetails } from 'types';
 import handleError from 'utils/error';
 
 import css from './Metadata.module.scss';
 import Section from './Section';
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 interface Props {
   trial: TrialDetails;

--- a/webui/react/src/components/UserSettingsModal.tsx
+++ b/webui/react/src/components/UserSettingsModal.tsx
@@ -1,11 +1,11 @@
 import Alert from 'hew/Alert';
-import CodeEditor from 'hew/CodeEditor';
 import { Modal } from 'hew/Modal';
 import { Loadable, Loaded } from 'hew/utils/loadable';
 import { Map } from 'immutable';
 import { useMemoizedObservable } from 'micro-observables';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import useUI, { Mode } from 'components/ThemeProvider';
 import userSettings from 'stores/userSettings';
 import { Json } from 'types';

--- a/webui/react/src/components/WorkspaceCreateModal.tsx
+++ b/webui/react/src/components/WorkspaceCreateModal.tsx
@@ -11,6 +11,7 @@ import yaml from 'js-yaml';
 import { pick } from 'lodash';
 import React, { Fragment, useCallback, useEffect, useId, useMemo } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import { useAsync } from 'hooks/useAsync';
 import usePermissions from 'hooks/usePermissions';
 import { paths } from 'routes/utils';
@@ -53,8 +54,6 @@ interface Props {
   onClose?: () => void;
   workspaceId?: number;
 }
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 const WorkspaceCreateModalComponent: React.FC<Props> = ({ onClose, workspaceId }: Props = {}) => {
   const idPrefix = useId();

--- a/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentCodeViewer.tsx
@@ -5,6 +5,7 @@ import { TreeNode } from 'hew/utils/types';
 import yaml from 'js-yaml';
 import React, { useMemo } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import { useAsync } from 'hooks/useAsync';
 import { paths } from 'routes/utils';
 import { getExperimentFileFromTree, getExperimentFileTree } from 'services/api';
@@ -14,8 +15,6 @@ import handleError, { ErrorType } from 'utils/error';
 import { isSingleTrialExperiment } from 'utils/experiment';
 
 import css from './ExperimentCodeViewer.module.scss';
-
-const CodeEditor = React.lazy(() => import('hew/CodeEditor'));
 
 const configIcon = <Icon name="settings" title="settings" />;
 

--- a/webui/react/src/pages/Templates/TemplateCreateModal.tsx
+++ b/webui/react/src/pages/Templates/TemplateCreateModal.tsx
@@ -1,5 +1,4 @@
 import Alert from 'hew/Alert';
-import CodeEditor from 'hew/CodeEditor';
 import Form from 'hew/Form';
 import Input from 'hew/Input';
 import { Modal } from 'hew/Modal';
@@ -10,6 +9,7 @@ import yaml from 'js-yaml';
 import { useObservable } from 'micro-observables';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import { createTaskTemplate, updateTaskTemplate, updateTaskTemplateName } from 'services/api';
 import workspaceStore from 'stores/workspaces';
 import { Template, Workspace } from 'types';

--- a/webui/react/src/pages/Templates/TemplateViewModal.tsx
+++ b/webui/react/src/pages/Templates/TemplateViewModal.tsx
@@ -1,10 +1,10 @@
 import Avatar from 'hew/Avatar';
-import CodeEditor from 'hew/CodeEditor';
 import { Modal } from 'hew/Modal';
 import { Label } from 'hew/Typography';
 import yaml from 'js-yaml';
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
+import CodeEditor from 'components/CodeEditor';
 import { NavigationItem } from 'components/NavigationSideBar';
 import { paths } from 'routes/utils';
 import { Template, Workspace } from 'types';


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
none


## Description
This fixes an issue where the code editor was being included in the main app bundle. While you can indicate that a component is meant to be split with `React.lazy`, if any code elsewhere imports the code statically the code is unsplit. We wrap the code split component and ban other imports using eslint to prevent this from regressing.




## Test Plan
Frontend bundle size should be reduced. visiting places where the code editor is visible should show a spinner while the code editor is loading



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ