### PR TITLE
chore: removing model_hub references from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ build-%:
 	$(MAKE) -C $(subst -,/,$*) build
 
 .PHONY: build-docs
-build-docs: build-harness build-model_hub build-examples build-helm build-proto build-bindings
+build-docs: build-harness build-examples build-helm build-proto build-bindings
 	$(MAKE) -C docs build
 
 .PHONY: build-bindings
@@ -76,26 +76,26 @@ build: build-master build-agent build-webui build-docs
 clean-%:
 	$(MAKE) -C $(subst -,/,$*) clean
 .PHONY: clean
-clean: clean-tools clean-proto clean-harness clean-model_hub clean-examples clean-docs clean-webui clean-master clean-agent clean-bindings
+clean: clean-tools clean-proto clean-harness clean-examples clean-docs clean-webui clean-master clean-agent clean-bindings
 
 .PHONY: check-%
 check-%:
 	$(MAKE) -C $(subst -,/,$*) check
 .PHONY: check
-check: check-proto check-harness check-model_hub check-e2e_tests check-tools check-master check-webui check-examples check-docs check-schemas
+check: check-proto check-harness check-e2e_tests check-tools check-master check-webui check-examples check-docs check-schemas
 	$(MAKE) check-agent
 
 .PHONY: fmt-%
 fmt-%:
 	$(MAKE) -C $(subst -,/,$*) fmt
 .PHONY: fmt
-fmt: fmt-harness fmt-model_hub fmt-e2e_tests fmt-tools fmt-master fmt-agent fmt-webui fmt-examples fmt-docs fmt-schemas fmt-proto
+fmt: fmt-harness fmt-e2e_tests fmt-tools fmt-master fmt-agent fmt-webui fmt-examples fmt-docs fmt-schemas fmt-proto
 
 .PHONY: test-%
 test-%:
 	$(MAKE) -C $(subst -,/,$*) test
 .PHONY: test
-test: test-harness test-model_hub test-master test-agent test-webui
+test: test-harness test-master test-agent test-webui
 
 # local frontend dev server against current DET_MASTER
 .PHONY: localfrontend


### PR DESCRIPTION
## chore: removing model_hub references from Makefile
Removing some lingering references to a directory we recently removed.

## Description
Just some missed references from the recently work to remove `model_hub`.

## Test Plan
I ran `make clean` to sanity check for syntax problems, etc. Wasn't caught by CI originally because CI doesn't call `make all`.

## Checklist

- [N/A] Changes have been manually QA'd
- [N/A] New features have been approved by the corresponding PM
- [N/A] User-facing API changes have the "User-facing API Change" label
- [N/A] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [N/A] Licenses have been included for new code which was copied and/or modified from any external code