### PR TITLE
fix: do not filter slots for mixed-slot-type pools

### DIFF
--- a/docs/release-notes/unspecified-slots.rst
+++ b/docs/release-notes/unspecified-slots.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**Improvements**
+
+-  WebUI: Change "Compute" slot type to "Unspecified" slot type for resource pools that have no, or
+   more than one slot type.

--- a/docs/release-notes/unspecified-slots.rst
+++ b/docs/release-notes/unspecified-slots.rst
@@ -2,5 +2,5 @@
 
 **Improvements**
 
--  WebUI: Change "Compute" slot type to "Unspecified" slot type for resource pools that have no, or
-   more than one slot type.
+-  WebUI: Change "Compute" slot label to "Unspecified" slot label for resource pools that have no,
+   or more than one slot type.

--- a/docs/release-notes/unspecified-slots.rst
+++ b/docs/release-notes/unspecified-slots.rst
@@ -2,5 +2,6 @@
 
 **Improvements**
 
--  WebUI: Change "Compute" slot label to "Unspecified" slot label for resource pools that have no,
-   or more than one slot type.
+-  WebUI: Change the "Compute Slots Allocated" label to "Unspecified Slots Allocated" for resource
+   pools with no or multiple slot types. Added error logs for zero or multi-slot-type cases, and
+   updated the progress bar to include all agents when the slot type is TYPE_UNSPECIFIED.

--- a/master/internal/rm/agentrm/mock_test.go
+++ b/master/internal/rm/agentrm/mock_test.go
@@ -71,6 +71,7 @@ func MockTaskToAllocateRequest(mockTask *MockTask) *sproto.AllocateRequest {
 
 type MockAgent struct {
 	ID                    string
+	SlotType              string
 	Slots                 int
 	SlotsUsed             int
 	MaxZeroSlotContainers int

--- a/master/internal/rm/agentrm/resource_pool.go
+++ b/master/internal/rm/agentrm/resource_pool.go
@@ -601,7 +601,7 @@ func (rp *resourcePool) GetResourceSummary() resourceSummary {
 	defer func() {
 		rp.agentStatesCache = nil
 	}()
-	return resourceSummaryFromAgentStates(rp.agentStatesCache)
+	return rp.resourceSummaryFromAgentStates(rp.agentStatesCache)
 }
 
 func (rp *resourcePool) CapacityCheck(msg sproto.CapacityCheck) (sproto.CapacityCheckResponse, error) {

--- a/master/internal/rm/agentrm/scheduler_test.go
+++ b/master/internal/rm/agentrm/scheduler_test.go
@@ -468,7 +468,14 @@ func setupSchedulerStates(
 		state.handler = &agent{}
 
 		for i := 0; i < mockAgent.Slots; i++ {
-			state.Devices[device.Device{ID: device.ID(i)}] = nil
+			switch mockAgent.SlotType {
+			case "cuda":
+				state.Devices[device.Device{ID: device.ID(i), Type: device.CUDA}] = nil
+			case "cpu":
+				state.Devices[device.Device{ID: device.ID(i), Type: device.CPU}] = nil
+			default:
+				state.Devices[device.Device{ID: device.ID(i)}] = nil
+			}
 		}
 		agents[aproto.ID(mockAgent.ID)] = state
 	}

--- a/master/internal/rm/agentrm/summaries.go
+++ b/master/internal/rm/agentrm/summaries.go
@@ -24,7 +24,7 @@ type resourceSummary struct {
 	slotType               device.Type
 }
 
-func resourceSummaryFromAgentStates(
+func (rp *resourcePool) resourceSummaryFromAgentStates(
 	agentInfo map[aproto.ID]*agentState,
 ) resourceSummary {
 	summary := resourceSummary{
@@ -48,9 +48,11 @@ func resourceSummaryFromAgentStates(
 		}
 	}
 
-	// If we have homogenous slots, get their type. Otherwise, we default to
-	// `UNSPECIFIED` aka `device.ZeroSlot`, although it may be an error/warning.
-	if len(deviceTypeCount) == 1 {
+	// If we have heterogenous slots, we default to`UNSPECIFIED` aka `device.ZeroSlot`.
+	// We raise an error in the logs.
+	if len(deviceTypeCount) != 1 {
+		rp.syslog.Errorf("resource pool has unspecified slot type with %v total slot types", len(deviceTypeCount))
+	} else {
 		for deviceType := range deviceTypeCount {
 			summary.slotType = deviceType
 		}

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -38,23 +38,6 @@ stages:
 
       # config_file is just a master.yaml
       config_file:
-        resource_manager:
-          type: agent
-          scheduler:
-            type: fair_share
-            fitting_policy: worst
-          default_aux_resource_pool: pool1
-          default_compute_resource_pool: pool1
-        resource_pools:
-          - pool_name: pool1
-            scheduler:
-              type: priority
-              preemption: true
-              fitting_policy: best
-          - pool_name: pool2
-            scheduler:
-              type: priority
-              fitting_policy: worst
         db:
           host: localhost
           port: 5432
@@ -80,41 +63,20 @@ stages:
         # This is important: we have to use the symbolic links in the
         # tools/build directory to run properly.
         root: tools/build
+
   - agent:
-      # Each agent stage should have a unique name for devcluster.
-      name: agent1
       pre:
         - sh: make -C agent build
+      cmdline:
+        - agent/build/determined-agent
+        - run
+        - --config-file
+        - :config
+
+      # config_file is just an agent.yaml
       config_file:
         master_host: 127.0.0.1
         master_port: 8080
-        slot_type: none
-        visible_gpus: 0
-        resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
-        # Often dtrain clusters have multiple gpus per agent.
-        # Each agent needs a unique agent_id.
-        agent_id: agent1
-        # Each agent needs a deconflicting fluent container
-        fluent:
-          port: 24224  # default value is 24224
-          container_name: determined-fluent-1
-  - agent:
-      # Each agent stage should have a unique name for devcluster.
-      name: agent2
-      pre:
-        - sh: make -C agent build
-      config_file:
-        master_host: 127.0.0.1
-        master_port: 8080
-        resource_pool: pool1
-        container_master_host: $DOCKER_LOCALHOST
-        #visible_gpus: 1
-        slot_type: none
-        #artificial_slots: 8
-        # Each agent needs a unique agent_id.
-        agent_id: agent2
-        # Each agent needs a deconflicting fluent container
-        fluent:
-          port: 24225  # default value is 24224
-          container_name: determined-fluent-2
+        log:
+          level: trace

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -93,7 +93,6 @@ stages:
         resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
         # Often dtrain clusters have multiple gpus per agent.
-        artificial_slots: 8
         # Each agent needs a unique agent_id.
         agent_id: agent1
         # Each agent needs a deconflicting fluent container

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -109,8 +109,9 @@ stages:
         master_port: 8080
         resource_pool: pool2
         container_master_host: $DOCKER_LOCALHOST
+        visible_gpus: 1
+        slot_type: cuda
         # Often dtrain clusters have multiple gpus per agent.
-        artificial_slots: 8
         # Each agent needs a unique agent_id.
         agent_id: agent2
         # Each agent needs a deconflicting fluent container

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -38,6 +38,23 @@ stages:
 
       # config_file is just a master.yaml
       config_file:
+        resource_manager:
+          type: agent
+          scheduler:
+            type: fair_share
+            fitting_policy: worst
+          default_aux_resource_pool: pool1
+          default_compute_resource_pool: pool1
+        resource_pools:
+          - pool_name: pool1
+            scheduler:
+              type: priority
+              preemption: true
+              fitting_policy: best
+          - pool_name: pool2
+            scheduler:
+              type: priority
+              fitting_policy: worst
         db:
           host: localhost
           port: 5432
@@ -63,20 +80,41 @@ stages:
         # This is important: we have to use the symbolic links in the
         # tools/build directory to run properly.
         root: tools/build
-
   - agent:
+      # Each agent stage should have a unique name for devcluster.
+      name: agent1
       pre:
         - sh: make -C agent build
-      cmdline:
-        - agent/build/determined-agent
-        - run
-        - --config-file
-        - :config
-
-      # config_file is just an agent.yaml
       config_file:
         master_host: 127.0.0.1
         master_port: 8080
+        slot_type: cuda
+        visible_gpus: 0
+        resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
-        log:
-          level: trace
+        # Often dtrain clusters have multiple gpus per agent.
+        artificial_slots: 8
+        # Each agent needs a unique agent_id.
+        agent_id: agent1
+        # Each agent needs a deconflicting fluent container
+        fluent:
+          port: 24224  # default value is 24224
+          container_name: determined-fluent-1
+  - agent:
+      # Each agent stage should have a unique name for devcluster.
+      name: agent2
+      pre:
+        - sh: make -C agent build
+      config_file:
+        master_host: 127.0.0.1
+        master_port: 8080
+        resource_pool: pool2
+        container_master_host: $DOCKER_LOCALHOST
+        # Often dtrain clusters have multiple gpus per agent.
+        artificial_slots: 8
+        # Each agent needs a unique agent_id.
+        agent_id: agent2
+        # Each agent needs a deconflicting fluent container
+        fluent:
+          port: 24225  # default value is 24224
+          container_name: determined-fluent-2

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -88,7 +88,7 @@ stages:
       config_file:
         master_host: 127.0.0.1
         master_port: 8080
-        slot_type: cuda
+        slot_type: none
         visible_gpus: 0
         resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
@@ -110,8 +110,8 @@ stages:
         resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
         #visible_gpus: 1
-        #slot_type: cuda
-        artificial_slots: 8
+        slot_type: none
+        #artificial_slots: 8
         # Each agent needs a unique agent_id.
         agent_id: agent2
         # Each agent needs a deconflicting fluent container

--- a/tools/devcluster.yaml
+++ b/tools/devcluster.yaml
@@ -107,11 +107,11 @@ stages:
       config_file:
         master_host: 127.0.0.1
         master_port: 8080
-        resource_pool: pool2
+        resource_pool: pool1
         container_master_host: $DOCKER_LOCALHOST
-        visible_gpus: 1
-        slot_type: cuda
-        # Often dtrain clusters have multiple gpus per agent.
+        #visible_gpus: 1
+        #slot_type: cuda
+        artificial_slots: 8
         # Each agent needs a unique agent_id.
         agent_id: agent2
         # Each agent needs a deconflicting fluent container

--- a/webui/react/src/components/SlotAllocationBar.tsx
+++ b/webui/react/src/components/SlotAllocationBar.tsx
@@ -249,7 +249,7 @@ const SlotAllocationBar: React.FC<Props> = ({
     <div className={classes.join(' ')}>
       {!hideHeader && (
         <div className={css.header}>
-          <header>{title || 'Compute'} Slots Allocated</header>
+          <header>{title || 'Unspecified'} Slots Allocated</header>
           {totalSlots === 0 ? (
             <span>0/0</span>
           ) : (
@@ -282,7 +282,7 @@ const SlotAllocationBar: React.FC<Props> = ({
               {`${
                 isAux
                   ? `${footer.auxContainersRunning} Aux Containers Running`
-                  : `${resourceStates.length} ${title || 'Compute'} Slots Allocated`
+                  : `${resourceStates.length} ${title || 'Unspecified'} Slots Allocated`
               }`}
             </header>
           ) : (
@@ -291,7 +291,7 @@ const SlotAllocationBar: React.FC<Props> = ({
                 isAux
                   ? `${footer.auxContainersRunning}/${footer.auxContainerCapacity} Aux Containers Running`
                   : `${resourceStates.length}/${totalSlotsNum} ${
-                      title || 'Compute'
+                      title || 'Unspecified'
                     } Slots Allocated`
               }`}
             </header>

--- a/webui/react/src/utils/cluster.test.ts
+++ b/webui/react/src/utils/cluster.test.ts
@@ -102,7 +102,15 @@ describe('Cluster Utilities', () => {
 
     it('should convert enabled UNSPECIFIED agents into slot container states', () => {
       const result = utils.getSlotContainerStates(AGENTS, Type.ResourceType.UNSPECIFIED);
-      const expected: Type.ResourceState[] = [];
+      const expected: Type.ResourceState[] = [
+        Type.ResourceState.Running,
+        Type.ResourceState.Running,
+        Type.ResourceState.Running,
+        Type.ResourceState.Pulling,
+        Type.ResourceState.Pulling,
+        Type.ResourceState.Pulling,
+        Type.ResourceState.Running,
+      ];
       expect(result).toStrictEqual(expected);
     });
 

--- a/webui/react/src/utils/cluster.ts
+++ b/webui/react/src/utils/cluster.ts
@@ -12,7 +12,11 @@ export const getSlotContainerStates = (
     .flatMap((agent) => {
       const arr: ResourceState[] = Object.entries(agent.slotStats.typeStats ?? {})
         .filter(([type]) => {
-          return resourceType === ResourceType.ALL || type === `TYPE_${resourceType}`;
+          return (
+            resourceType === ResourceType.ALL ||
+            type === `TYPE_${resourceType}` ||
+            resourceType === 'UNSPECIFIED'
+          );
         })
         .flatMap(([, val]) => {
           const tempArr = Object.entries(val.states ?? {}).flatMap(([state, count]) => {

--- a/webui/react/src/utils/cluster.ts
+++ b/webui/react/src/utils/cluster.ts
@@ -14,8 +14,8 @@ export const getSlotContainerStates = (
         .filter(([type]) => {
           return (
             resourceType === ResourceType.ALL ||
-            type === `TYPE_${resourceType}` ||
-            resourceType === 'UNSPECIFIED'
+            resourceType === ResourceType.UNSPECIFIED ||
+            type === `TYPE_${resourceType}`
           );
         })
         .flatMap(([, val]) => {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
fix: do not filter slots for mixed-slot-type pools 
-->
## Ticket
CM-503

## Description
For agent based deployments, if agents of different slot types are assigned to the same resource pool, change the "Compute Slots Allocated" label to "Unspecified Slots Allocated" label to clarify the mixed statusfor the user. 
Additionally, add an error log message in zero slot or multi-slot-type cases. 
Finally, if a resource pool's slot type is of type `TYPE_UNSPECIFIED`, do not filter out any agents from the slot progress bar count.

See new label for slots allocated for pools with multi-slot-type agents (pool1) or zero-slot agents (pool2)

## Test Plan
See unit tests in agent, confirming that the slot type assigned in the resource summary is "zero" or "unspecified" for zero or multiple slot type agents. See screenshots of the changes in the webui in the test cluster

For release party, I really think this should get manually tested -- you must spin up your own aws Ubuntu devcluster (reach out to me for instructions) and configure devcluster to have 1 agent with all the gpus and 1 agent with artificial slots.

You can access my demo cluster webui at http://54.84.91.59:8080/. (Message me for the password) Resource pool `pool1` has multiple slot type agents (CUDA agent1 and CPU agent2). The configuration for these agents  is:
```
  - agent:            
      # Each agent stage should have a unique name for devcluster.    
           name: agent1
      pre:
        - sh: make -C agent build
      config_file:
        master_host: 127.0.0.1
        master_port: 8080
        slot_type: cuda
        resource_pool: pool1
        container_master_host: $DOCKER_LOCALHOST
        # Often dtrain clusters have multiple gpus per agent.
        # Each agent needs a unique agent_id.
        agent_id: agent1
        visible_gpus: 3
  - agent:
      # Each agent stage should have a unique name for devcluster.
      name: agent2
      pre:
        - sh: make -C agent build
      config_file:
        master_host: 127.0.0.1
        master_port: 8080
        resource_pool: pool1
        container_master_host: $DOCKER_LOCALHOST
        artificial_slots: 8
        # Each agent needs a unique agent_id.
        agent_id: agent2
  - agent:
      # Each agent stage should have a unique name for devcluster.
      name: agent3
      pre:
        - sh: make -C agent build
      config_file:
        master_host: 127.0.0.1
        master_port: 8080
        slot_type: cuda
        resource_pool: pool2
        container_master_host: $DOCKER_LOCALHOST
        # Often dtrain clusters have multiple gpus per agent.
        # Each agent needs a unique agent_id.
        agent_id: agent3
        visible_gpus: 0, 1, 2
```

                 
<img width="1482" alt="Screen Shot 2024-09-12 at 10 12 08 AM" src="https://github.com/user-attachments/assets/9f58a08d-cc3c-4ab8-b3cd-01d3c8ed2502">

<img width="1482" alt="Screen Shot 2024-09-12 at 10 20 16 AM" src="https://github.com/user-attachments/assets/764bfc04-2b10-418d-8e27-1858576baa61">

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ