### PR TITLE
fix: GetTrialRemainingLogRetentionDays should take global log retention days into account [CM-518]

### DIFF
--- a/master/internal/api_trials.go
+++ b/master/internal/api_trials.go
@@ -693,6 +693,13 @@ JOIN run_id_task_id as r ON t.task_id = r.task_id
 WHERE r.run_id = ?
 `
 	resp = &apiv1.GetTrialRemainingLogRetentionDaysResponse{}
+	// set trial retention days to global retention days if
+	// trial retention days is unset and global retention days is set
+	if t.LogRetentionDays == nil && a.m.config.RetentionPolicy.LogRetentionDays != nil {
+		t.LogRetentionDays = a.m.config.RetentionPolicy.LogRetentionDays
+	}
+
+	// if neither trial or global retention days is set, default is forever (-1)
 	if t.LogRetentionDays == nil || *t.LogRetentionDays == -1 {
 		days := int32(-1)
 		resp.RemainingDays = &days


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
CM-518


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
GetTrialRemainingLogRetentionDays was not taking global log retention days into account while calculating remaining days. Fixed it by adding a check and an automated test for this scenario.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Added automated test.
For manual testing:

1. Add a global log retention policy to master config:

```
 retention_policy:
         log_retention_days: 90
         schedule: 0 3 * * *
```

3. Start devcluster.
4. Create an experiment and do not specify the log retention days.
5. After a trial under the experiment is completed, the remaining log retention days on the Logs tabs of the trial overview shows accurate value (89 days)
<img width="682" alt="Screen Shot 2024-09-10 at 3 42 07 PM" src="https://github.com/user-attachments/assets/60ae38e5-241c-4261-9235-49014da08998">




## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ