### PR TITLE
chore: create config policies table and add NTSC CRUD operations

### DIFF
--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -1,0 +1,509 @@
+//go:build integration
+// +build integration
+
+package configpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/etc"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetNTSCConfigPolicies(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+	workspaceIDs := []int32{}
+
+	defer func() {
+		if len(workspaceIDs) > 0 {
+			err := db.CleanupMockWorkspace(workspaceIDs)
+			if err != nil {
+				log.Errorf("error when cleaning up mock workspaces")
+			}
+		}
+
+	}()
+
+	tests := []struct {
+		name     string
+		ntscTCPs *model.NTSCTaskConfigPolicies
+		global   bool
+		err      *string
+	}{
+		{
+			"invalid user id",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   -1,
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     DefaultConstraints(),
+			},
+			false,
+			ptrs.Ptr("violates foreign key constraint"),
+		},
+		{
+			"valid config no constraint",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     model.Constraints{},
+			},
+			false,
+			nil,
+		},
+		{
+			"valid constraint no config",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: model.CommandConfig{},
+				Constraints:     DefaultConstraints(),
+			},
+			false,
+			nil,
+		},
+		{
+			"valid constraint valid config",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     DefaultConstraints(),
+			},
+			false,
+			nil,
+		},
+		{
+			"valid config no constraint",
+			&model.NTSCTaskConfigPolicies{
+				WorkspaceID:     nil,
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     model.Constraints{},
+			},
+			false,
+			nil,
+		},
+		{
+			"global valid constraint no config",
+			&model.NTSCTaskConfigPolicies{
+				WorkspaceID:     nil,
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: model.CommandConfig{},
+				Constraints:     DefaultConstraints(),
+			},
+			true,
+			nil,
+		},
+		{
+			"global valid config no constraint",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     model.Constraints{},
+			},
+			true,
+			nil,
+		},
+		{
+			"global valid constraint valid config",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: DefaultCommandConfig(),
+				Constraints:     DefaultConstraints(),
+			},
+			true,
+			nil,
+		},
+		{
+			"global no constraint no config",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.NTSCType,
+				InvariantConfig: model.CommandConfig{},
+				Constraints:     model.Constraints{},
+			},
+			true,
+			nil,
+		},
+		{
+			"experiment workload type for NTCP policies",
+			&model.NTSCTaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				LastUpdatedTime: time.Now().UTC(),
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: model.CommandConfig{},
+				Constraints:     model.Constraints{},
+			},
+			true,
+			ptrs.Ptr("invalid workload type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var w model.Workspace
+			if !test.global {
+				w = model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+				_, err := db.Bun().NewInsert().Model(&w).Exec(ctx)
+				require.NoError(t, err)
+				workspaceIDs = append(workspaceIDs, int32(w.ID))
+				test.ntscTCPs.WorkspaceID = ptrs.Ptr(w.ID)
+			}
+
+			// Test add NTSC task config policies.
+			err := SetNTSCConfigPolicies(ctx, test.ntscTCPs)
+			if test.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, *test.err)
+				return
+			}
+
+			// Test get NTSC task config policies.
+			ntscTCPs, err := GetNTSCConfigPolicies(ctx, test.ntscTCPs.WorkspaceID)
+			require.NoError(t, err)
+			ntscTCPs.LastUpdatedTime = ntscTCPs.LastUpdatedTime.UTC()
+			require.Equal(t, test.ntscTCPs, ntscTCPs)
+
+			// Test update NTSC task config policies.
+			test.ntscTCPs.InvariantConfig.Environment.Image = model.RuntimeItem{
+				CPU: uuid.NewString()}
+			err = SetNTSCConfigPolicies(ctx, test.ntscTCPs)
+			require.NoError(t, err)
+
+			// Test get NTSC task config policies.
+			ntscTCPs, err = GetNTSCConfigPolicies(ctx, test.ntscTCPs.WorkspaceID)
+			require.NoError(t, err)
+			ntscTCPs.LastUpdatedTime = ntscTCPs.LastUpdatedTime.UTC()
+			require.Equal(t, test.ntscTCPs, ntscTCPs)
+		})
+	}
+
+	// Test invalid workspace ID.
+	err := SetNTSCConfigPolicies(ctx, &model.NTSCTaskConfigPolicies{
+		WorkspaceID:     ptrs.Ptr(-1),
+		LastUpdatedBy:   user.ID,
+		WorkloadType:    model.NTSCType,
+		InvariantConfig: DefaultCommandConfig(),
+		Constraints:     DefaultConstraints(),
+	})
+	require.ErrorContains(t, err, "violates foreign key constraint")
+}
+
+// Test the enforcement of the primary key on the task_config_polciies table.
+func TestTaskConfigPoliciesUnique(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+
+	// Global scope.
+	w, _, ntscTCPs := CreateMockTaskConfigPolicies(ctx, t, pgDB, user, true, true, true)
+	ntscTCPs.Constraints = model.Constraints{}
+	expInvariantConfig, err := json.Marshal(ntscTCPs.InvariantConfig)
+	require.NoError(t, err)
+
+	count, err := db.Bun().NewSelect().
+		Table("task_config_policies").
+		Where("workspace_id IS NULL").
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	_, err = db.Bun().NewInsert().Model(ntscTCPs).
+		Where("workspace_id = ?", nil).
+		Where("workspace_type = ?", model.ExperimentType).
+		Value("invariant_config", "?", string(expInvariantConfig)).
+		Exec(ctx)
+	require.ErrorContains(t, err, "duplicate key value violates unique constraint")
+
+	// Workspace-level.
+	w, _, ntscTCPs = CreateMockTaskConfigPolicies(ctx, t, pgDB, user, false, true, true)
+	ntscTCPs.Constraints = model.Constraints{}
+	expInvariantConfig, err = json.Marshal(ntscTCPs.InvariantConfig)
+	require.NoError(t, err)
+
+	count, err = db.Bun().NewSelect().
+		Table("task_config_policies").
+		Where("workspace_id = ?", w.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	_, err = db.Bun().NewInsert().Model(ntscTCPs).
+		Where("workspace_id = ?", w.ID).
+		Where("workspace_type = ?", model.NTSCType).
+		Value("invariant_config", "?", string(expInvariantConfig)).
+		Exec(ctx)
+	require.ErrorContains(t, err, "duplicate key value violates unique constraint")
+}
+
+func TestDeleteConfigPolicies(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+	workspaceIDs := []int32{}
+
+	defer func() {
+		err := db.CleanupMockWorkspace(workspaceIDs)
+		if err != nil {
+			log.Errorf("error when cleaning up mock workspaces")
+		}
+	}()
+
+	tests := []struct {
+		name               string
+		global             bool
+		workloadType       model.WorkloadType
+		hasInvariantConfig bool
+		hasConstraints     bool
+		err                *string
+	}{
+
+		{"ntsc config no constraint", false, model.NTSCType, true, false, nil},
+		{"ntsc config and constraint", false, model.NTSCType, true, true, nil},
+		{"ntsc no config has constraint", false, model.NTSCType, false, true, nil},
+		{
+			"unspecified workload type", false, model.UnknownType, true, true,
+			ptrs.Ptr("invalid workload type"),
+		},
+		{"ntsc no config no constraint", false, model.NTSCType, false, false, nil},
+		{"global ntsc config no constraint", true, model.NTSCType, true, false, nil},
+		{"global ntsc config and constraint", true, model.NTSCType, true, true, nil},
+		{
+			"global unspecified workload type", true, model.UnknownType, true, true,
+			ptrs.Ptr("invalid workload type"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			switch test.workloadType {
+			case model.ExperimentType:
+				w, expTCP, _ := CreateMockTaskConfigPolicies(ctx, t, pgDB, user, test.global,
+					test.hasInvariantConfig, test.hasConstraints)
+				if !test.global {
+					workspaceIDs = append(workspaceIDs, int32(w.ID))
+				}
+
+				err := DeleteConfigPolicies(ctx, expTCP.WorkspaceID, test.workloadType)
+				if test.err == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, *test.err)
+				}
+
+			default:
+				w, _, ntscTCP := CreateMockTaskConfigPolicies(ctx, t, pgDB, user, test.global,
+					test.hasInvariantConfig, test.hasConstraints)
+				if !test.global {
+					workspaceIDs = append(workspaceIDs, int32(w.ID))
+				}
+
+				err := DeleteConfigPolicies(ctx, ntscTCP.WorkspaceID, test.workloadType)
+				if test.err == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, *test.err)
+				}
+			}
+		})
+	}
+
+	// Verify that trying to delete task config policies for a nonexistent scope doesn't error out.
+	err := DeleteConfigPolicies(ctx, ptrs.Ptr(-1), model.ExperimentType)
+	require.NoError(t, err)
+
+	// Verify that trying to delete task config policies for a workspace with no set policies
+	// doesn't error out.
+	w := &model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+	_, err = db.Bun().NewInsert().Model(w).Exec(ctx)
+	require.NoError(t, err)
+	workspaceIDs = append(workspaceIDs, int32(w.ID))
+
+	err = DeleteConfigPolicies(ctx, ptrs.Ptr(w.ID), model.ExperimentType)
+	require.NoError(t, err)
+
+	// Verify that we can create and delete task config policies individually for different
+	// workspaces.
+	w1, _, _ := CreateMockTaskConfigPolicies(ctx, t, pgDB, user, false, true, true)
+	workspaceIDs = append(workspaceIDs, int32(w1.ID))
+	q1 := db.Bun().NewSelect().Table("task_config_policies").Where("workspace_id = ?", w1.ID)
+	count, err := q1.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	w2, _, _ := CreateMockTaskConfigPolicies(ctx, t, pgDB, user, false, true, true)
+	workspaceIDs = append(workspaceIDs, int32(w2.ID))
+	q2 := db.Bun().NewSelect().Table("task_config_policies").Where("workspace_id = ?", w2.ID)
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = DeleteConfigPolicies(ctx, ptrs.Ptr(w1.ID), model.ExperimentType)
+	require.NoError(t, err)
+
+	// Verify that exactly 1 task config policy was deleted from w1.
+	count, err = q1.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// Verify that both task config policies in w2 still exist.
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = DeleteConfigPolicies(ctx, ptrs.Ptr(w2.ID), model.ExperimentType)
+	require.NoError(t, err)
+
+	// Verify that exactly 1 task config policy was deleted from w2.
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = DeleteConfigPolicies(ctx, ptrs.Ptr(w1.ID), model.NTSCType)
+	require.NoError(t, err)
+
+	// Verify that no task config policies exist for w1.
+	count, err = q1.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	err = DeleteConfigPolicies(ctx, ptrs.Ptr(w2.ID), model.NTSCType)
+	require.NoError(t, err)
+
+	// Verify that no task config policies exist for w2.
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	// Test delete cascade on task config policies when a workspace is deleted.
+	w1, _, _ = CreateMockTaskConfigPolicies(ctx, t, pgDB, user, false, true, true)
+	workspaceIDs = append(workspaceIDs, int32(w1.ID))
+	q1 = db.Bun().NewSelect().Table("task_config_policies").Where("workspace_id = ?", w1.ID)
+	count, err = q1.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	w2, _, _ = CreateMockTaskConfigPolicies(ctx, t, pgDB, user, false, true, true)
+	workspaceIDs = append(workspaceIDs, int32(w2.ID))
+	q2 = db.Bun().NewSelect().Table("task_config_policies").Where("workspace_id = ?", w2.ID)
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// Verify that only the task config policies of w1 were deleted when w1 was deleted.
+	_, err = db.Bun().NewDelete().Model(&model.Workspace{}).Where("id = ?", w1.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	count, err = q1.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	// Verify that both task config policies of w2 are deleted when w2 is deleted.
+	_, err = db.Bun().NewDelete().Model(&model.Workspace{}).Where("id = ?", w2.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	count, err = q2.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}
+
+// CreateMockTaskConfigPolicies creates experiment and NTSC invariant configs and constraints as
+// requested for the specified scope.
+func CreateMockTaskConfigPolicies(ctx context.Context, t *testing.T,
+	pgDB *db.PgDB, user model.User, global bool, hasInvariantConfig bool,
+	hasConstraints bool) (*model.Workspace, *model.ExperimentTaskConfigPolicies,
+	*model.NTSCTaskConfigPolicies,
+) {
+	var scope *int
+	var w model.Workspace
+	var ntscConfig model.CommandConfig
+
+	var constraints model.Constraints
+
+	if !global {
+		w = model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+		_, err := db.Bun().NewInsert().Model(&w).Exec(ctx)
+		require.NoError(t, err)
+		scope = ptrs.Ptr(w.ID)
+	}
+	if hasInvariantConfig {
+		ntscConfig = DefaultCommandConfig()
+	}
+	if hasConstraints {
+		constraints = DefaultConstraints()
+	}
+
+	ntscTCP := &model.NTSCTaskConfigPolicies{
+		WorkspaceID:     scope,
+		LastUpdatedBy:   user.ID,
+		WorkloadType:    model.NTSCType,
+		InvariantConfig: ntscConfig,
+		Constraints:     constraints,
+	}
+	err := SetNTSCConfigPolicies(ctx, ntscTCP)
+	require.NoError(t, err)
+
+	return &w, nil, ntscTCP
+}
+
+func DefaultCommandConfig() model.CommandConfig {
+	return model.CommandConfig{
+		Description: "random description",
+		Resources: model.ResourcesConfig{
+			Slots:    4,
+			MaxSlots: ptrs.Ptr(8),
+		},
+	}
+}
+
+func DefaultConstraints() model.Constraints {
+	return model.Constraints{
+		PriorityLimit: ptrs.Ptr[int](10),
+		ResourceConstraints: &model.ResourceConstraints{
+			MaxSlots: ptrs.Ptr(10),
+		},
+	}
+}

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -5,37 +5,22 @@ import (
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
-// ResourceConstraints are non-overridable resource constraints.
-// Submitted workloads that request resource quanities exceeding defined resource constraints in a
-// given scope are rejected.
-type ResourceConstraints struct {
-	MaxSlots *int `json:"max_slots"`
-}
-
-// Constraints are non-overridable workload constraints.
-// Submitted workloads whose config's respective field(s) exceed defined constraints within a given
-// scope are rejected.
-type Constraints struct {
-	ResourceConstraints *ResourceConstraints `json:"resources"`
-	PriorityLimit       *int                 `json:"priority_limit"`
-}
-
-// ExperimentConfigPolicy is the invariant config and constraints for an experiment.
+// ExperimentConfigPolicies is the invariant config and constraints for an experiment.
 // Submitted experiments whose config fields vary from the respective InvariantConfig fields set
 // within a given scope are silently overridden.
 // Submitted experiments whose constraint fields vary from the respective Constraint fields set
 // within a given scope are rejected.
-type ExperimentConfigPolicy struct {
-	InvariantConfig *expconf.ExperimentConfig `json:"invariant_config"`
-	Constraints     *Constraints              `json:"constraints"`
+type ExperimentConfigPolicies struct {
+	InvariantConfig *expconf.ExperimentConfig `json:"config"`
+	Constraints     *model.Constraints        `json:"constraints"`
 }
 
-// NTSCConfigPolicy is the invariant config and constraints for an NTSC task.
+// NTSCConfigPolicies is the invariant config and constraints for an NTSC task.
 // Submitted NTSC tasks whose config fields vary from the respective InvariantConfig fields set
 // within a given scope are silently overridden.
 // Submitted NTSC tasks whose constraint fields vary from the respective Constraint fields set
 // within a given scope are rejected.
-type NTSCConfigPolicy struct {
-	InvariantConfig *model.CommandConfig `json:"invariant_config"`
-	Constraints     *Constraints         `json:"constraints"`
+type NTSCConfigPolicies struct {
+	InvariantConfig *model.CommandConfig `json:"config"`
+	Constraints     *model.Constraints   `json:"constraints"`
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -23,8 +23,8 @@ func ValidWorkloadType(val string) bool {
 }
 
 // UnmarshalExperimentConfigPolicy unpacks a string into ExperimentConfigPolicy struct.
-func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error) {
-	var expConfigPolicy ExperimentConfigPolicy
+func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicies, error) {
+	var expConfigPolicy ExperimentConfigPolicies
 	var err error
 
 	dec := json.NewDecoder(bytes.NewReader([]byte(str)))
@@ -43,8 +43,8 @@ func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicy, error
 }
 
 // UnmarshalNTSCConfigPolicy unpacks a string into NTSCConfigPolicy struct.
-func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicy, error) {
-	var ntscConfigPolicy NTSCConfigPolicy
+func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicies, error) {
+	var ntscConfigPolicy NTSCConfigPolicies
 	var err error
 
 	dec := json.NewDecoder(bytes.NewReader([]byte(str)))

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -57,7 +57,7 @@ var (
 	priorityLimit = 10
 )
 
-var structExperiment = ExperimentConfigPolicy{
+var structExperiment = ExperimentConfigPolicies{
 	InvariantConfig: &expconf.ExperimentConfig{
 		RawDescription: &description,
 		RawResources: &expconf.ResourcesConfig{
@@ -68,8 +68,8 @@ var structExperiment = ExperimentConfigPolicy{
 			RawAddCapabilities: []string{"cap1", "cap2"},
 		},
 	},
-	Constraints: &Constraints{
-		ResourceConstraints: &ResourceConstraints{
+	Constraints: &model.Constraints{
+		ResourceConstraints: &model.ResourceConstraints{
 			MaxSlots: &maxSlots,
 		},
 		PriorityLimit: &priorityLimit,
@@ -86,14 +86,14 @@ func TestUnmarshalYamlExperiment(t *testing.T) {
 		name   string
 		input  string
 		noErr  bool
-		output *ExperimentConfigPolicy
+		output *ExperimentConfigPolicies
 	}{
 		{"valid yaml", yamlExperiment + yamlConstraints, true, &structExperiment},
 		{"just config", yamlExperiment, true, &justConfig},
 		{"just constraints", yamlConstraints, true, &justConstraints},
 		{"extra fields", yamlExperiment + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlExperiment + "  debug true\n", false, nil},
-		{"empty input", "", true, &ExperimentConfigPolicy{}},
+		{"empty input", "", true, &ExperimentConfigPolicies{}},
 		{"null/empty fields", yamlExperiment + "  debug:\n", true, &structExperiment},
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
@@ -121,7 +121,7 @@ invariant_config:
     slots: 1
 `
 
-var structNTSC = NTSCConfigPolicy{
+var structNTSC = NTSCConfigPolicies{
 	InvariantConfig: &model.CommandConfig{
 		Description: "test\nspecial\tchar",
 		Resources: model.ResourcesConfig{
@@ -132,8 +132,8 @@ var structNTSC = NTSCConfigPolicy{
 			AddCapabilities: []string{"cap1", "cap2"},
 		},
 	},
-	Constraints: &Constraints{
-		ResourceConstraints: &ResourceConstraints{
+	Constraints: &model.Constraints{
+		ResourceConstraints: &model.ResourceConstraints{
 			MaxSlots: &maxSlots,
 		},
 		PriorityLimit: &priorityLimit,
@@ -150,14 +150,14 @@ func TestUnmarshalYamlNTSC(t *testing.T) {
 		name   string
 		input  string
 		noErr  bool
-		output *NTSCConfigPolicy
+		output *NTSCConfigPolicies
 	}{
 		{"valid yaml", yamlNTSC + yamlConstraints, true, &structNTSC},
 		{"just config", yamlNTSC, true, &justConfig},
 		{"just constraints", yamlConstraints, true, &justConstraints},
 		{"extra fields", yamlNTSC + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlNTSC + "  debug true\n", false, nil},
-		{"empty input", "", true, &NTSCConfigPolicy{}},
+		{"empty input", "", true, &NTSCConfigPolicies{}},
 		{"null/empty fields", yamlNTSC + "  debug:\n", true, &structNTSC}, // empty fields unmarshal to default value
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
@@ -241,14 +241,14 @@ func TestUnmarshalJSONExperiment(t *testing.T) {
 		name   string
 		input  string
 		noErr  bool
-		output *ExperimentConfigPolicy
+		output *ExperimentConfigPolicies
 	}{
 		{"valid json", `{` + jsonExperiment + `,` + jsonConstraints + `}`, true, &structExperiment},
 		{"just config", `{` + jsonExperiment + `}`, true, &justConfig},
 		{"just constraints", `{` + jsonConstraints + `}`, true, &justConstraints},
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
-		{"empty input", "", true, &ExperimentConfigPolicy{}},
+		{"empty input", "", true, &ExperimentConfigPolicies{}},
 		{"null/empty fields", jsonEmptyField, true, &structExperiment}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}
@@ -287,14 +287,14 @@ func TestUnmarshalJSONNTSC(t *testing.T) {
 		name   string
 		input  string
 		noErr  bool
-		output *NTSCConfigPolicy
+		output *NTSCConfigPolicies
 	}{
 		{"valid json", `{` + jsonNTSC + `,` + jsonConstraints + `}`, true, &structNTSC},
 		{"just config", `{` + jsonNTSC + `}`, true, &justConfig},
 		{"just constraints", `{` + jsonConstraints + `}`, true, &justConstraints},
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
-		{"empty input", "", true, &NTSCConfigPolicy{}},
+		{"empty input", "", true, &NTSCConfigPolicies{}},
 		{"null/empty fields", jsonEmptyField, true, &structNTSC}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}

--- a/master/internal/db/postgres_test_utils.go
+++ b/master/internal/db/postgres_test_utils.go
@@ -581,6 +581,5 @@ func CleanupMockWorkspace(workspaceIDs []int32) error {
 	_, err := Bun().NewDelete().Model(&workspaces).
 		Where("id IN (?)", bun.In(workspaceIDs)).
 		Exec(context.Background())
-
 	return err
 }

--- a/master/pkg/model/task_config_policy.go
+++ b/master/pkg/model/task_config_policy.go
@@ -2,7 +2,11 @@ package model
 
 import (
 	"strings"
+	"time"
 
+	"github.com/uptrace/bun"
+
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 	"github.com/determined-ai/determined/proto/pkg/configpolicyv1"
 )
 
@@ -20,6 +24,43 @@ const (
 	NTSCType WorkloadType = "NTSC"
 )
 
+// ExperimentTaskConfigPolicies is the bun model of a task config policy.
+type ExperimentTaskConfigPolicies struct {
+	bun.BaseModel   `bun:"table:task_config_policies"`
+	WorkspaceID     *int                     `bun:"workspace_id"`
+	LastUpdatedBy   UserID                   `bun:"last_updated_by,notnull"`
+	LastUpdatedTime time.Time                `bun:"last_updated_time,notnull"`
+	WorkloadType    WorkloadType             `bun:"workload_type,notnull"`
+	InvariantConfig expconf.ExperimentConfig `bun:"invariant_config"`
+	Constraints     Constraints              `bun:"constraints"`
+}
+
+// NTSCTaskConfigPolicies is the bun model of a task config policy.
+type NTSCTaskConfigPolicies struct {
+	bun.BaseModel   `bun:"table:task_config_policies"`
+	WorkspaceID     *int          `bun:"workspace_id"`
+	LastUpdatedBy   UserID        `bun:"last_updated_by,notnull"`
+	LastUpdatedTime time.Time     `bun:"last_updated_time,notnull"`
+	WorkloadType    WorkloadType  `bun:"workload_type,notnull"`
+	InvariantConfig CommandConfig `bun:"invariant_config"`
+	Constraints     Constraints   `bun:"constraints"`
+}
+
+// ResourceConstraints are non-overridable resource constraints.
+// Submitted workloads that request resource quanities exceeding defined resource constraints in a
+// given scope are rejected.
+type ResourceConstraints struct {
+	MaxSlots *int `json:"max_slots"`
+}
+
+// Constraints are non-overridable workload constraints.
+// Submitted workloads whose config's respective field(s) exceed defined constraints within a given
+// scope are rejected.
+type Constraints struct {
+	ResourceConstraints *ResourceConstraints `json:"resources"`
+	PriorityLimit       *int                 `json:"priority_limit"`
+}
+
 // WorkloadTypeFromProto maps taskconfigpolicyv1.WorkloadType to WorkloadType.
 func WorkloadTypeFromProto(workloadType configpolicyv1.WorkloadType) WorkloadType {
 	str := workloadType.String()
@@ -30,4 +71,8 @@ func WorkloadTypeFromProto(workloadType configpolicyv1.WorkloadType) WorkloadTyp
 func WorkloadTypeToProto(workloadType WorkloadType) configpolicyv1.WorkloadType {
 	protoWorkloadType := configpolicyv1.WorkloadType_value["WORKLOAD_TYPE_"+string(workloadType)]
 	return configpolicyv1.WorkloadType(protoWorkloadType)
+}
+
+func (w WorkloadType) String() string {
+	return string(w)
 }

--- a/master/pkg/schemas/expconf/experiment_config.go
+++ b/master/pkg/schemas/expconf/experiment_config.go
@@ -83,10 +83,12 @@ func (e *ExperimentConfigV0) Scan(src interface{}) error {
 	if err != nil {
 		return err
 	}
+
+	*e = schemas.WithDefaults(config)
+
 	// This *should* be a copy without any changes, unless perhaps we just shimmed the bytes that
 	// were in the database, but to ensure we never allow any un-defaulted experiments anywhere
 	// inside the system, we call WithDefaults here.
-	*e = schemas.WithDefaults(config)
 	return nil
 }
 

--- a/master/static/migrations/20240829000038_add-task-config-policy-table.tx.up.sql
+++ b/master/static/migrations/20240829000038_add-task-config-policy-table.tx.up.sql
@@ -1,0 +1,21 @@
+CREATE TYPE workload_type AS ENUM ('EXPERIMENT', 'NTSC');
+
+CREATE TABLE IF NOT EXISTS task_config_policies
+(
+    workspace_id integer,  
+    workload_type workload_type NOT NULL,
+    last_updated_by integer NOT NULL,
+    last_updated_time timestamptz NOT NULL DEFAULT current_timestamp,
+    invariant_config jsonb,
+    constraints jsonb,
+
+    CONSTRAINT fk_wksp_id FOREIGN KEY(workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+    CONSTRAINT fk_last_updated_by_user_id FOREIGN KEY(last_updated_by) REFERENCES users(id)
+        ON DELETE CASCADE
+);
+
+
+CREATE UNIQUE INDEX task_config_policies_workload_type_idx ON task_config_policies (workload_type) 
+    WHERE workspace_id IS NULL; 
+CREATE UNIQUE INDEX wksp_id_wkld_type ON task_config_policies (workspace_id, workload_type) 
+WHERE workspace_id IS NOT NULL;


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
[CM-484]



## Description
Create `task_config_policies` table and implement CRUD operations for NTSC task config policies.


## Test Plan
CI passes (automated testing).



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
