### PR TITLE
docs: Replace slack links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 ---
 contact_links:
   - name: 💬 Slack
-    url: https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q
+    url: https://determined-community.slack.com
     about: >
       Ask questions and talk to other Determined.ai users and the maintainers

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -13,7 +13,7 @@ body:
         We have Slack community too.
 
         Feel free to join the community from
-        [here](https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q)
+        [here](https://determined-community.slack.com)
       placeholder: Ex. I have a question about...
     validations:
       required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 If you encounter an issue or would like to request a new feature, please create
 [an issue on GitHub](https://github.com/determined-ai/determined/issues). You can
-also join the [Slack](https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q)
+also join the [Slack](https://determined-community.slack.com)
 to get support and talk with other users and developers in real-time.
 
 ## Contributing Changes
@@ -12,7 +12,7 @@ to get support and talk with other users and developers in real-time.
 We welcome outside contributions. If you'd like to make a contribution, please:
 
 1. Tell us about what you'd like to contribute on
-   [our Slack](https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q)
+   [our Slack](https://determined-community.slack.com)
    or [community mailing list](https://groups.google.com/a/determined.ai/forum/#!forum/community).
    We'd hate for you to duplicate efforts that are already in-flight.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you need help, want to file a bug report, or just want to keep up-to-date
 with the latest news about Determined, please join the Determined community!
 
 - [Slack](https://determined-community.slack.com) is the best place to
-  ask questions about Determined and get support. [Click here to join our Slack](https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q).
+  ask questions about Determined and get support. [Click here to join our Slack](https://determined-community.slack.com).
 - You can also follow us on [YouTube](https://www.youtube.com/@DeterminedAI) and [Twitter](https://www.twitter.com/DeterminedAI).
 - You can also join the [community mailing list](https://groups.google.com/a/determined.ai/forum/#!forum/community)
   to ask questions about the project and receive announcements.

--- a/docs/_templates/article-header-buttons.html
+++ b/docs/_templates/article-header-buttons.html
@@ -7,7 +7,7 @@
 
 <div class="article-header-buttons">
   <a
-    href="https://join.slack.com/t/determined-community/shared_invite/zt-1f4hj60z5-JMHb~wSr2xksLZVBN61g_Q"
+    href="https://determined-community.slack.com"
     target="_blank"
     class="btn btn-sm"
     data-bs-placement="bottom"


### PR DESCRIPTION
## Description

Replace the tracking Slack links with static links, because the tracking links keep expiring after a certain amount of time or number of clicks, and therefore don't work. 