### PR TITLE
chore: fix config policy unmarshal tests CM-502

### DIFF
--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -94,7 +94,7 @@ func TestUnmarshalYamlExperiment(t *testing.T) {
 		{"extra fields", yamlExperiment + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlExperiment + "  debug true\n", false, nil},
 		{"empty input", "", true, &ExperimentConfigPolicy{}},
-		{"null/empty fields", yamlExperiment + "  debug:\n", true, &structExperiment},
+		{"null/empty fields", yamlExperiment + "  debug:\n", true, &justConfig},
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
 
@@ -102,7 +102,7 @@ func TestUnmarshalYamlExperiment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := UnmarshalExperimentConfigPolicy(tt.input)
 			require.Equal(t, tt.noErr, err == nil)
-			if !tt.noErr {
+			if tt.noErr {
 				assert.DeepEqual(t, tt.output, config)
 			}
 		})
@@ -125,7 +125,7 @@ var structNTSC = NTSCConfigPolicy{
 	InvariantConfig: &model.CommandConfig{
 		Description: "test\nspecial\tchar",
 		Resources: model.ResourcesConfig{
-			Slots: 10,
+			Slots: 1,
 		},
 		Environment: model.Environment{
 			ForcePullImage:  false,
@@ -158,7 +158,7 @@ func TestUnmarshalYamlNTSC(t *testing.T) {
 		{"extra fields", yamlNTSC + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlNTSC + "  debug true\n", false, nil},
 		{"empty input", "", true, &NTSCConfigPolicy{}},
-		{"null/empty fields", yamlNTSC + "  debug:\n", true, &structNTSC}, // empty fields unmarshal to default value
+		{"null/empty fields", yamlNTSC + "  debug:\n", true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
 
@@ -166,7 +166,7 @@ func TestUnmarshalYamlNTSC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := UnmarshalNTSCConfigPolicy(tt.input)
 			require.Equal(t, tt.noErr, err == nil)
-			if !tt.noErr {
+			if tt.noErr {
 				assert.DeepEqual(t, tt.output, config)
 			}
 		})
@@ -249,7 +249,7 @@ func TestUnmarshalJSONExperiment(t *testing.T) {
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
 		{"empty input", "", true, &ExperimentConfigPolicy{}},
-		{"null/empty fields", jsonEmptyField, true, &structExperiment}, // empty fields unmarshal to default value
+		{"null/empty fields", jsonEmptyField, true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}
 
@@ -257,7 +257,7 @@ func TestUnmarshalJSONExperiment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := UnmarshalExperimentConfigPolicy(tt.input)
 			require.Equal(t, tt.noErr, err == nil)
-			if !tt.noErr {
+			if tt.noErr {
 				assert.DeepEqual(t, tt.output, config)
 			}
 		})
@@ -295,7 +295,7 @@ func TestUnmarshalJSONNTSC(t *testing.T) {
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
 		{"empty input", "", true, &NTSCConfigPolicy{}},
-		{"null/empty fields", jsonEmptyField, true, &structNTSC}, // empty fields unmarshal to default value
+		{"null/empty fields", jsonEmptyField, true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}
 
@@ -303,7 +303,7 @@ func TestUnmarshalJSONNTSC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := UnmarshalNTSCConfigPolicy(tt.input)
 			require.Equal(t, tt.noErr, err == nil)
-			if !tt.noErr {
+			if tt.noErr {
 				assert.DeepEqual(t, tt.output, config)
 			}
 		})


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-502]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Looking at the tests, I noticed that it was checking contents if `noErr` was `false` and we want to verify contents if `noErr` is `true` (i.e., there are no errors and the contents were unpacked correctly). 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-502]: https://hpe-aiatscale.atlassian.net/browse/CM-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ