### PR TITLE
chore: update test log pattern webhook cache

### DIFF
--- a/e2e_tests/tests/cluster/test_webhooks.py
+++ b/e2e_tests/tests/cluster/test_webhooks.py
@@ -569,14 +569,14 @@ def test_editing_webhook() -> None:
 
 
 @pytest.mark.e2e_cpu
-def test_log_pattern_webhook_cached_url_is_updated() -> None:
+def test_log_pattern_webhook_cache_when_url_is_updated() -> None:
     original_port = 5011
     updated_port = 5012
     original_server = utils.WebhookServer(original_port)
     updated_server = utils.WebhookServer(updated_port)
     sess = api_utils.admin_session()
 
-    regex = r"assert 0 <= self\.metrics_sigma"
+    regex = r"assert not self\.crash_on_startup"
 
     webhook_trigger = bindings.v1Trigger(
         triggerType=bindings.v1TriggerType.TASK_LOG,
@@ -628,7 +628,7 @@ def test_log_pattern_webhook_cached_url_is_updated() -> None:
         sess,
         conf.fixtures_path("no_op/single-medium-train-step.yaml"),
         conf.fixtures_path("no_op"),
-        ["--config", "hyperparameters.metrics_sigma=-1.0"],
+        ["--config", "hyperparameters.crash_on_startup=True"],
     )
     exp.wait_for_experiment_state(sess, exp_id, bindings.experimentv1State.ERROR)
 


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
`metrics_sigma` is no longer a field in single-medium-train-step.yaml. So the test need to be updated.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI Passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ