### PR TITLE
fix: update LogRetentionDays from master config when master starts/upgrades

### DIFF
--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1671,7 +1671,10 @@ Security-related configuration settings.
  ``retention_policy``
 **********************
 
-Specifies configuration settings for the retention of trial logs.
+Specifies configuration settings for the retention of trial logs. Note: If the ``retention_policy``
+is first applied to a long-running cluster, there may be some performance issues as the databse
+cleans up all the relevant task logs. We recommend configuring the retention policy to trigger
+outside the working hours. The retention policy logs can be found at the trace level.
 
 ``log_retention_days``
 ======================

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1671,10 +1671,14 @@ Security-related configuration settings.
  ``retention_policy``
 **********************
 
-Specifies configuration settings for the retention of trial logs. Note: If the ``retention_policy``
-is first applied to a long-running cluster, there may be some performance issues as the databse
-cleans up all the relevant task logs. We recommend configuring the retention policy to trigger
-outside the working hours. The retention policy logs can be found at the trace level.
+Specifies configuration settings for the retention of trial logs.
+
+.. note::
+
+   When applying a retention policy to a long-running cluster for the first time, there may be
+   temporary performance impacts while the database cleans up relevant task logs. For this reason,
+   you should consider configuring the retention policy to trigger outside of peak working hours.
+   Retention policy logs can be found at the trace level.
 
 ``log_retention_days``
 ======================

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -345,14 +345,14 @@ defaults.
 Optional. Defines retention policies for logs related to all trials of a given experiment.
 Parameters include:
 
--  ``log_retention_days``: Optional. Overrides the number of days to retain logs for a trial
-   set in the cluster's task container defaults.
-   Acceptable values range from ``-1`` to ``32767``. If set to ``-1``, logs will be retained
-   indefinitely. If set to ``0``, logs will be deleted during the next cleanup. To modify the
-   retention settings post-completion for a single trial or the entire experiment, you can use the
-   CLI command ``det t set log-retention <trial-id>`` or ``det e set log-retention <exp-id>``. Both
-   commands accept either the argument: ``--days``, which sets the number of days to retain logs
-   from the end time of the task, or ``--forever`` which retains logs indefinitely.
+-  ``log_retention_days``: Optional. Overrides the number of days to retain logs for a trial set in
+   the cluster's task container defaults. Acceptable values range from ``-1`` to ``32767``. If set
+   to ``-1``, logs will be retained indefinitely. If set to ``0``, logs will be deleted during the
+   next cleanup. To modify the retention settings post-completion for a single trial or the entire
+   experiment, you can use the CLI command ``det t set log-retention <trial-id>`` or ``det e set
+   log-retention <exp-id>``. Both commands accept either the argument: ``--days``, which sets the
+   number of days to retain logs from the end time of the task, or ``--forever`` which retains logs
+   indefinitely.
 
    Note: If the cluster's log retention policy/days is upgraded after the experiment is created, the
    new cluster value will override the old experiment value.

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -345,13 +345,17 @@ defaults.
 Optional. Defines retention policies for logs related to all trials of a given experiment.
 Parameters include:
 
--  ``log_retention_days``: Optional. Overrides the number of days to retain logs for a trial.
+-  ``log_retention_days``: Optional. Overrides the number of days to retain logs for a trial
+   set in the cluster's task container defaults.
    Acceptable values range from ``-1`` to ``32767``. If set to ``-1``, logs will be retained
    indefinitely. If set to ``0``, logs will be deleted during the next cleanup. To modify the
    retention settings post-completion for a single trial or the entire experiment, you can use the
    CLI command ``det t set log-retention <trial-id>`` or ``det e set log-retention <exp-id>``. Both
    commands accept either the argument: ``--days``, which sets the number of days to retain logs
    from the end time of the task, or ``--forever`` which retains logs indefinitely.
+
+   Note: If the cluster's log retention policy/days is upgraded after the experiment is created, the
+   new cluster value will override the old experiment value.
 
 Example configuration:
 

--- a/docs/release-notes/fix-master-log-retention-days.rst
+++ b/docs/release-notes/fix-master-log-retention-days.rst
@@ -2,6 +2,6 @@
 
 **Bug Fixes**
 
--  API/Tasks: Fix bug where a master-configured ``log_retention_days`` value is not applied to
-   experiments and tasks. Now, newly created experiments will apply the master-configured value, and
-   all pre-existing experiments will be subjected to the configured ``log_retention_days``.
+-  API/Tasks: Fix a bug where a master-configured ``log_retention_days`` value is not applied to
+   experiments and tasks. Now, the master-configured value is correctly applied to new experiments,
+   and all pre-existing experiments will also follow the specified ``log_retention_days``.

--- a/docs/release-notes/fix-master-log-retention-days.rst
+++ b/docs/release-notes/fix-master-log-retention-days.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+**Bug Fixes**
+
+-  API/Tasks: Fix bug where a master-configured ``log_retention_days`` value is not applied to
+   experiments and tasks. Now, newly created experiments will apply the master-configured value, and
+   all pre-existing experiments will be subjected to the configured ``log_retention_days``.

--- a/master/internal/core.go
+++ b/master/internal/core.go
@@ -1245,6 +1245,7 @@ func (m *Master) Run(ctx context.Context, gRPCLogInitDone chan struct{}) error {
 		SSHRsaSize:            m.config.Security.SSH.RsaKeySize,
 		SegmentEnabled:        m.config.Telemetry.Enabled && m.config.Telemetry.SegmentMasterKey != "",
 		SegmentAPIKey:         m.config.Telemetry.SegmentMasterKey,
+		LogRetentionDays:      m.config.RetentionPolicy.LogRetentionDays,
 	}
 	if m.config.RetentionPolicy.Schedule != nil {
 		if err := logretention.Schedule(m.config.RetentionPolicy); err != nil {

--- a/master/internal/logretention/logretention.go
+++ b/master/internal/logretention/logretention.go
@@ -92,7 +92,6 @@ func DeleteExpiredTaskLogs(ctx context.Context, days *int16) (int64, error) {
 	if days != nil {
 		defaultLogRetentionDays = *days
 	}
-	logrus.Errorf("DEFAULT DAYS %v, %v", defaultLogRetentionDays, *days)
 
 	log.WithField("default-retention-days", defaultLogRetentionDays).Trace("deleting expired task logs")
 	r, err := db.Bun().NewRaw(fmt.Sprintf(`

--- a/master/internal/logretention/logretention.go
+++ b/master/internal/logretention/logretention.go
@@ -92,7 +92,6 @@ func DeleteExpiredTaskLogs(ctx context.Context, days *int16) (int64, error) {
 	if days != nil {
 		defaultLogRetentionDays = *days
 	}
-
 	log.WithField("default-retention-days", defaultLogRetentionDays).Trace("deleting expired task logs")
 	r, err := db.Bun().NewRaw(fmt.Sprintf(`
 		WITH log_retention_tasks AS (

--- a/master/internal/logretention/logretention.go
+++ b/master/internal/logretention/logretention.go
@@ -92,6 +92,8 @@ func DeleteExpiredTaskLogs(ctx context.Context, days *int16) (int64, error) {
 	if days != nil {
 		defaultLogRetentionDays = *days
 	}
+	logrus.Errorf("DEFAULT DAYS %v, %v", defaultLogRetentionDays, *days)
+
 	log.WithField("default-retention-days", defaultLogRetentionDays).Trace("deleting expired task logs")
 	r, err := db.Bun().NewRaw(fmt.Sprintf(`
 		WITH log_retention_tasks AS (


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
fix: update log_retention_days when master starts/upgrades
-->
## Ticket
CM-519



## Description
Fix a bug where the master's task spec container defaults Log Retention Policy wasn't set from the master config or applied to new/past experiments. 
Previously, the master task spec log retention policy remained null, so running `det task cleanup-logs` would not delete any logs, even if the config had that specified. Instead, to affect the task logs with that CLI command, you had to apply a per-experiment retention policy.
Add some documentation to clarify that if master is upgraded/restarted with a new retention policy this will override an experiment's value.


## Test Plan
Manually test (until I can figure out how to configure an e2e master tests with a log retention policy).
Spin up your own, regular devcluster. 
1 . Launch an experiment with a log retention policy specified in its yaml -- suppose the log retention days is 1.
2. Collect some logs.
3. Confirm that the webUI accurately shows your log retention days left.
4. In the DB, run `UPDATE tasks SET end_time = '<some-end-time-a-long-time-age>'`
5. Then, run `det task cleanup-logs`. 
6. Confirm that all task logs for the experiments you created are wiped.

Spin up your own, regular devcluster with a log retention policy set to 5 days.
1. Launch an experiment with _no_ retention policy.
2. Confirm that the webUI/API reports a log retention policy matching the master config.
3. Launch another experiment with a larger/smaller rentention days yaml value.
4. Confirm that the webUI/API reports the experiment's defined retention value.
5. In the DB, run `UPDATE tasks SET end_time = '<some-end-time-a-long-time-age>'`.
6. Run `det task cleanup-logs` and confirm all logs are deleted.
7. Repeat with any combination of log retention days/experiment configs to check that the correct subset of task logs is being removed.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ