### PR TITLE
chore: change log level for log retention policies

### DIFF
--- a/master/internal/logretention/logretention.go
+++ b/master/internal/logretention/logretention.go
@@ -92,7 +92,7 @@ func DeleteExpiredTaskLogs(ctx context.Context, days *int16) (int64, error) {
 	if days != nil {
 		defaultLogRetentionDays = *days
 	}
-	log.WithField("default-retention-days", defaultLogRetentionDays).Trace("deleting expired task logs")
+	log.WithField("default-retention-days", defaultLogRetentionDays).Info("deleting expired task logs")
 	r, err := db.Bun().NewRaw(fmt.Sprintf(`
 		WITH log_retention_tasks AS (
 			SELECT COALESCE(r.log_retention_days, %d) as log_retention_days, t.task_id, t.end_time
@@ -112,6 +112,6 @@ func DeleteExpiredTaskLogs(ctx context.Context, days *int16) (int64, error) {
 		return 0, errors.Wrap(err, "error deleting expired task logs")
 	}
 	rows, err := r.RowsAffected()
-	log.WithFields(logrus.Fields{"rows": rows, "err": err}).Trace("deleted expired task logs")
+	log.WithFields(logrus.Fields{"rows": rows, "err": err}).Info("deleted expired task logs")
 	return rows, err
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
chore: change log level for log retention policies
-->
## Ticket
CM-528



## Description
Change log level of log retention policy logs to "Info" level, not "trace".
```
INFO[2024-09-16T10:36:29-06:00] deleting expired task logs                    component=log-retention default-retention-days=-1
INFO[2024-09-16T10:36:29-06:00] deleted expired task logs                     component=log-retention err="<nil>" rows=123
```



## Test Plan
N/A.
Spin up on your own test cluster to verify, set master config values for log retention policy/days. Then, clean up with `det task cleanup-logs`. You should see these log levels in the Info level.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ