### PR TITLE
chore: refactor and test RBAC config policies work [CM-530]

### DIFF
--- a/master/.mockery.yaml
+++ b/master/.mockery.yaml
@@ -62,6 +62,18 @@ packages:
         config:
           filename: rm_authz_iface.go
           mockname: ResourceManagerAuthZ
+  github.com/determined-ai/determined/master/internal/cluster:
+    interfaces:
+      MiscAuthZ:
+        config:
+          filename: misc_authz_iface.go
+          mockname: MiscAuthZ
+  github.com/determined-ai/determined/master/internal/configpolicy:
+    interfaces:
+      ConfigPolicyAuthZ:
+        config:
+          filename: config_policy_authz_iface.go
+          mockname: ConfigPolicyAuthZ
   github.com/determined-ai/determined/master/internal/task:
     interfaces:
       AllocationService:

--- a/master/.mockery.yaml
+++ b/master/.mockery.yaml
@@ -62,12 +62,6 @@ packages:
         config:
           filename: rm_authz_iface.go
           mockname: ResourceManagerAuthZ
-  github.com/determined-ai/determined/master/internal/cluster:
-    interfaces:
-      MiscAuthZ:
-        config:
-          filename: misc_authz_iface.go
-          mockname: MiscAuthZ
   github.com/determined-ai/determined/master/internal/configpolicy:
     interfaces:
       ConfigPolicyAuthZ:

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -76,7 +76,7 @@ func (a *apiServer) GetWorkspaceConfigPolicies(
 		return nil, err
 	}
 
-	err = workspace.AuthZProvider.Get().CanViewWorkspaceConfigPolicies(ctx, *curUser, w)
+	err = configpolicy.AuthZProvider.Get().CanViewWorkspaceConfigPolicies(ctx, *curUser, w)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -13,7 +13,6 @@ import (
 	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/license"
-	"github.com/determined-ai/determined/master/internal/workspace"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
@@ -166,7 +165,7 @@ func (a *apiServer) DeleteWorkspaceConfigPolicies(
 		return nil, err
 	}
 
-	err = workspace.AuthZProvider.Get().CanModifyWorkspaceConfigPolicies(ctx, *curUser, w)
+	err = configpolicy.AuthZProvider.Get().CanModifyWorkspaceConfigPolicies(ctx, *curUser, w)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 
-	"github.com/determined-ai/determined/master/internal/cluster"
 	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/license"
@@ -197,11 +196,9 @@ func (a *apiServer) DeleteGlobalConfigPolicies(
 		return nil, err
 	}
 
-	permErr, err := cluster.AuthZProvider.Get().CanModifyGlobalConfigPolicies(ctx, curUser)
+	err = configpolicy.AuthZProvider.Get().CanModifyGlobalConfigPolicies(ctx, curUser)
 	if err != nil {
 		return nil, err
-	} else if permErr != nil {
-		return nil, permErr
 	}
 
 	if !configpolicy.ValidWorkloadType(req.WorkloadType) {

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -100,12 +100,11 @@ func (a *apiServer) GetGlobalConfigPolicies(
 		return nil, err
 	}
 
-	permErr, err := cluster.AuthZProvider.Get().CanViewGlobalConfigPolicies(ctx, curUser)
+	err = configpolicy.AuthZProvider.Get().CanViewGlobalConfigPolicies(ctx, curUser)
 	if err != nil {
 		return nil, err
-	} else if permErr != nil {
-		return nil, permErr
 	}
+
 	resp, err := a.getConfigPolicies(ctx, nil, req.WorkloadType)
 	if err != nil {
 		return nil, err

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -358,8 +358,9 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 	testutils.MustLoadLicenseAndKeyFromFilesystem("../../")
 	configPolicyAuthZ := setupConfigPolicyAuthZ()
 
-	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil)
-	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil).Once()
+	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Twice()
 
 	wkspResp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: uuid.New().String()})
 	require.NoError(t, err)
@@ -386,8 +387,6 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkloadType: model.NTSCType,
 		})
 	require.NoError(t, err)
-
-	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil)
 
 	// (Global) Deny with permission access error.
 	expectedErr = fmt.Errorf("canModifyGlobalConfigPoliciesError")

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -373,16 +373,20 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 		mock.Anything).Return(expectedErr).Once()
 
 	_, err = api.DeleteWorkspaceConfigPolicies(ctx,
-		&apiv1.DeleteWorkspaceConfigPoliciesRequest{WorkspaceId: workspaceID,
-			WorkloadType: string(model.NTSCType)})
+		&apiv1.DeleteWorkspaceConfigPoliciesRequest{
+			WorkspaceId:  workspaceID,
+			WorkloadType: model.NTSCType,
+		})
 	require.Equal(t, expectedErr, err)
 
 	// Nil error returns whatever the delete request returned.
 	configPolicyAuthZ.On("CanModifyWorkspaceConfigPolicies", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil).Once()
 	_, err = api.DeleteWorkspaceConfigPolicies(ctx,
-		&apiv1.DeleteWorkspaceConfigPoliciesRequest{WorkspaceId: workspaceID,
-			WorkloadType: model.NTSCType})
+		&apiv1.DeleteWorkspaceConfigPoliciesRequest{
+			WorkspaceId:  workspaceID,
+			WorkloadType: model.NTSCType,
+		})
 	require.NoError(t, err)
 
 	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil)
@@ -393,7 +397,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 		Return(expectedErr, nil).Once()
 
 	_, err = api.DeleteGlobalConfigPolicies(ctx,
-		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: string(model.NTSCType)})
+		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType})
 	require.Equal(t, expectedErr, err)
 
 	// Nil error returns whatever the delete request returned.
@@ -404,8 +408,10 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 	require.NoError(t, err)
 }
 
-var mAuthZ *mocks.MiscAuthZ
-var cpAuthZ *mocks.ConfigPolicyAuthZ
+var (
+	mAuthZ  *mocks.MiscAuthZ
+	cpAuthZ *mocks.ConfigPolicyAuthZ
+)
 
 func setupMiscAuthZ() *mocks.MiscAuthZ {
 	if mAuthZ == nil {

--- a/master/internal/cluster/authz_basic_impl.go
+++ b/master/internal/cluster/authz_basic_impl.go
@@ -68,21 +68,6 @@ func (a *MiscAuthZBasic) CanViewExternalJobs(
 	return nil, nil
 }
 
-// CanModifyGlobalConfigPolicies checks if user has access to modify global task config policies.
-func (a *MiscAuthZBasic) CanModifyGlobalConfigPolicies(ctx context.Context, curUser *model.User,
-) (permErr error, err error) {
-	if !curUser.Admin {
-		return grpcutil.ErrPermissionDenied, nil
-	}
-	return nil, nil
-}
-
-// CanViewGlobalConfigPolicies returns a nil error.
-func (a *MiscAuthZBasic) CanViewGlobalConfigPolicies(ctx context.Context, curUser *model.User,
-) (permErr error, err error) {
-	return nil, nil
-}
-
 func init() {
 	AuthZProvider.Register("basic", &MiscAuthZBasic{})
 }

--- a/master/internal/cluster/authz_iface.go
+++ b/master/internal/cluster/authz_iface.go
@@ -57,15 +57,6 @@ type MiscAuthZ interface {
 	CanViewExternalJobs(
 		ctx context.Context, curUser *model.User,
 	) (permErr error, err error)
-
-	// CanModifyGlobalConfigPolicies returns an error if the user is not authorized to
-	// modify task config policies.
-	CanModifyGlobalConfigPolicies(ctx context.Context, curUser *model.User,
-	) (permErr error, err error)
-
-	// CanViewGlobalConfigPolicies returns a nil error.
-	CanViewGlobalConfigPolicies(ctx context.Context, curUser *model.User,
-	) (permErr error, err error)
 }
 
 // AuthZProvider is the authz registry for Notebooks, Shells, and Commands.

--- a/master/internal/cluster/authz_permissive.go
+++ b/master/internal/cluster/authz_permissive.go
@@ -65,23 +65,6 @@ func (a *MiscAuthZPermissive) CanViewExternalJobs(
 	return (&MiscAuthZBasic{}).CanViewExternalJobs(ctx, curUser)
 }
 
-// CanModifyGlobalConfigPolicies calls the RBAC implementation and returns if
-// the user has access to modfy global task config policies.
-func (a *MiscAuthZPermissive) CanModifyGlobalConfigPolicies(
-	ctx context.Context, curUser *model.User,
-) (permErr error, err error) {
-	_, _ = (&MiscAuthZRBAC{}).CanModifyGlobalConfigPolicies(ctx, curUser)
-	return (&MiscAuthZBasic{}).CanModifyGlobalConfigPolicies(ctx, curUser)
-}
-
-// CanViewGlobalConfigPolicies calls the RBAC implementation but always allows access.
-func (a *MiscAuthZPermissive) CanViewGlobalConfigPolicies(
-	ctx context.Context, curUser *model.User,
-) (permErr error, err error) {
-	_, _ = (&MiscAuthZRBAC{}).CanViewGlobalConfigPolicies(ctx, curUser)
-	return (&MiscAuthZBasic{}).CanViewGlobalConfigPolicies(ctx, curUser)
-}
-
 func init() {
 	AuthZProvider.Register("permissive", &MiscAuthZPermissive{})
 }

--- a/master/internal/configpolicy/authz_basic_impl.go
+++ b/master/internal/configpolicy/authz_basic_impl.go
@@ -1,0 +1,30 @@
+package configpolicy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
+)
+
+// ConfigPolicyAuthZBasic is classic OSS controls.
+type ConfigPolicyAuthZBasic struct{}
+
+// CanModifyWorkspaceConfigPolicies returns a nil error or the user is not an admin
+// or owner of the workspace.
+func (a *ConfigPolicyAuthZBasic) CanModifyWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	if !curUser.Admin && curUser.ID != model.UserID(workspace.UserId) {
+		return fmt.Errorf("only admins may set config policies for workspaces")
+	}
+	return nil
+}
+
+// CanViewWorkspaceConfigPolicies returns a nil error.
+func (a *ConfigPolicyAuthZBasic) CanViewWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	return nil
+}

--- a/master/internal/configpolicy/authz_basic_impl.go
+++ b/master/internal/configpolicy/authz_basic_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
@@ -11,8 +12,7 @@ import (
 // ConfigPolicyAuthZBasic is classic OSS controls.
 type ConfigPolicyAuthZBasic struct{}
 
-// CanModifyWorkspaceConfigPolicies returns a nil error or the user is not an admin
-// or owner of the workspace.
+// CanModifyWorkspaceConfigPolicies requires curUser to be an admin or workspace owner.
 func (a *ConfigPolicyAuthZBasic) CanModifyWorkspaceConfigPolicies(
 	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 ) error {
@@ -25,6 +25,21 @@ func (a *ConfigPolicyAuthZBasic) CanModifyWorkspaceConfigPolicies(
 // CanViewWorkspaceConfigPolicies returns a nil error.
 func (a *ConfigPolicyAuthZBasic) CanViewWorkspaceConfigPolicies(
 	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	return nil
+}
+
+// CanModifyGlobalConfigPolicies requires curUser to be an admin.
+func (a *ConfigPolicyAuthZBasic) CanModifyGlobalConfigPolicies(ctx context.Context, curUser *model.User,
+) error {
+	if !curUser.Admin {
+		return grpcutil.ErrPermissionDenied
+	}
+	return nil
+}
+
+// CanViewGlobalConfigPolicies returns a nil error.
+func (a *ConfigPolicyAuthZBasic) CanViewGlobalConfigPolicies(ctx context.Context, curUser *model.User,
 ) error {
 	return nil
 }

--- a/master/internal/configpolicy/authz_basic_impl.go
+++ b/master/internal/configpolicy/authz_basic_impl.go
@@ -28,3 +28,7 @@ func (a *ConfigPolicyAuthZBasic) CanViewWorkspaceConfigPolicies(
 ) error {
 	return nil
 }
+
+func init() {
+	AuthZProvider.Register("basic", &ConfigPolicyAuthZBasic{})
+}

--- a/master/internal/configpolicy/authz_iface.go
+++ b/master/internal/configpolicy/authz_iface.go
@@ -11,10 +11,21 @@ import (
 // ConfigPolicyAuthZ describes authz methods for config policies.
 type ConfigPolicyAuthZ interface {
 	// PUT /api/v1/config-policies/workspaces/:workspace-id/:type
-	CanModifyWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	CanModifyWorkspaceConfigPolicies(ctx context.Context, curUser model.User,
+		workspace *workspacev1.Workspace,
 	) error
 	// GET /api/v1/config-policies/workspaces/:workspace-id/:type
-	CanViewWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	CanViewWorkspaceConfigPolicies(ctx context.Context, curUser model.User,
+		workspace *workspacev1.Workspace,
+	) error
+
+	// CanModifyGlobalConfigPolicies returns an error if the user is not authorized to
+	// modify task config policies.
+	CanModifyGlobalConfigPolicies(ctx context.Context, curUser *model.User,
+	) error
+
+	// CanViewGlobalConfigPolicies returns a nil error.
+	CanViewGlobalConfigPolicies(ctx context.Context, curUser *model.User,
 	) error
 }
 

--- a/master/internal/configpolicy/authz_iface.go
+++ b/master/internal/configpolicy/authz_iface.go
@@ -1,0 +1,22 @@
+package configpolicy
+
+import (
+	"context"
+
+	"github.com/determined-ai/determined/master/internal/authz"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
+)
+
+// ConfigPolicyAuthZ describes authz methods for config policies.
+type ConfigPolicyAuthZ interface {
+	// PUT /api/v1/config-policies/workspaces/:workspace-id/:type
+	CanModifyWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	) error
+	// GET /api/v1/config-policies/workspaces/:workspace-id/:type
+	CanViewWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+	) error
+}
+
+// AuthZProvider providers WorkspaceAuthZ implementations.
+var AuthZProvider authz.AuthZProviderType[ConfigPolicyAuthZ]

--- a/master/internal/configpolicy/authz_permissive.go
+++ b/master/internal/configpolicy/authz_permissive.go
@@ -1,0 +1,27 @@
+package configpolicy
+
+import (
+	"context"
+
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
+)
+
+// ConfigPolicyAuthZPermissive is the permission implementation.
+type ConfigPolicyAuthZPermissive struct{}
+
+// CanModifyWorkspaceConfigPolicies RBAC authz but enforces basic authz.
+func (p *ConfigPolicyAuthZPermissive) CanModifyWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	_ = (&ConfigPolicyAuthZPermissive{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
+	return (&ConfigPolicyAuthZPermissive{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
+}
+
+// CanViewWorkspaceConfigPolicies RBAC authz but enforces basic authz.
+func (p *ConfigPolicyAuthZPermissive) CanViewWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) error {
+	_ = (&ConfigPolicyAuthZPermissive{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
+	return (&ConfigPolicyAuthZPermissive{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
+}

--- a/master/internal/configpolicy/authz_permissive.go
+++ b/master/internal/configpolicy/authz_permissive.go
@@ -25,3 +25,20 @@ func (p *ConfigPolicyAuthZPermissive) CanViewWorkspaceConfigPolicies(
 	_ = (&ConfigPolicyAuthZRBAC{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
 	return (&ConfigPolicyAuthZBasic{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
 }
+
+// CanModifyGlobalConfigPolicies calls the RBAC implementation and returns if
+// the user has access to modfy global task config policies.
+func (a *ConfigPolicyAuthZPermissive) CanModifyGlobalConfigPolicies(
+	ctx context.Context, curUser *model.User,
+) error {
+	_ = (&ConfigPolicyAuthZRBAC{}).CanModifyGlobalConfigPolicies(ctx, curUser)
+	return (&ConfigPolicyAuthZBasic{}).CanModifyGlobalConfigPolicies(ctx, curUser)
+}
+
+// CanViewGlobalConfigPolicies calls the RBAC implementation but always allows access.
+func (a *ConfigPolicyAuthZPermissive) CanViewGlobalConfigPolicies(
+	ctx context.Context, curUser *model.User,
+) error {
+	_ = (&ConfigPolicyAuthZRBAC{}).CanViewGlobalConfigPolicies(ctx, curUser)
+	return (&ConfigPolicyAuthZBasic{}).CanViewGlobalConfigPolicies(ctx, curUser)
+}

--- a/master/internal/configpolicy/authz_permissive.go
+++ b/master/internal/configpolicy/authz_permissive.go
@@ -28,7 +28,7 @@ func (p *ConfigPolicyAuthZPermissive) CanViewWorkspaceConfigPolicies(
 
 // CanModifyGlobalConfigPolicies calls the RBAC implementation and returns if
 // the user has access to modfy global task config policies.
-func (a *ConfigPolicyAuthZPermissive) CanModifyGlobalConfigPolicies(
+func (p *ConfigPolicyAuthZPermissive) CanModifyGlobalConfigPolicies(
 	ctx context.Context, curUser *model.User,
 ) error {
 	_ = (&ConfigPolicyAuthZRBAC{}).CanModifyGlobalConfigPolicies(ctx, curUser)
@@ -36,7 +36,7 @@ func (a *ConfigPolicyAuthZPermissive) CanModifyGlobalConfigPolicies(
 }
 
 // CanViewGlobalConfigPolicies calls the RBAC implementation but always allows access.
-func (a *ConfigPolicyAuthZPermissive) CanViewGlobalConfigPolicies(
+func (p *ConfigPolicyAuthZPermissive) CanViewGlobalConfigPolicies(
 	ctx context.Context, curUser *model.User,
 ) error {
 	_ = (&ConfigPolicyAuthZRBAC{}).CanViewGlobalConfigPolicies(ctx, curUser)

--- a/master/internal/configpolicy/authz_permissive.go
+++ b/master/internal/configpolicy/authz_permissive.go
@@ -10,18 +10,18 @@ import (
 // ConfigPolicyAuthZPermissive is the permission implementation.
 type ConfigPolicyAuthZPermissive struct{}
 
-// CanModifyWorkspaceConfigPolicies RBAC authz but enforces basic authz.
+// CanModifyWorkspaceConfigPolicies calls RBAC authz but enforces basic authz.
 func (p *ConfigPolicyAuthZPermissive) CanModifyWorkspaceConfigPolicies(
 	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 ) error {
-	_ = (&ConfigPolicyAuthZPermissive{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
-	return (&ConfigPolicyAuthZPermissive{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
+	_ = (&ConfigPolicyAuthZRBAC{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
+	return (&ConfigPolicyAuthZBasic{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
 }
 
-// CanViewWorkspaceConfigPolicies RBAC authz but enforces basic authz.
+// CanViewWorkspaceConfigPolicies calls RBAC authz but enforces basic authz.
 func (p *ConfigPolicyAuthZPermissive) CanViewWorkspaceConfigPolicies(
 	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 ) error {
-	_ = (&ConfigPolicyAuthZPermissive{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
-	return (&ConfigPolicyAuthZPermissive{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
+	_ = (&ConfigPolicyAuthZRBAC{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
+	return (&ConfigPolicyAuthZBasic{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
 }

--- a/master/internal/configpolicy/authz_rbac.go
+++ b/master/internal/configpolicy/authz_rbac.go
@@ -1,0 +1,62 @@
+package configpolicy
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/rbac/audit"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/rbacv1"
+	"github.com/determined-ai/determined/proto/pkg/workspacev1"
+	log "github.com/sirupsen/logrus"
+)
+
+// ConfigPolicyAuthZRBAC is RBAC authorization for config policies.
+type ConfigPolicyAuthZRBAC struct{}
+
+// CanModifyWorkspaceConfigPolicies determines whether a user can modify
+// workspace task config policies.
+func (r *ConfigPolicyAuthZRBAC) CanModifyWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) (err error) {
+	fields := audit.ExtractLogFields(ctx)
+	addConfigPolicyInfo(curUser, workspace, fields, []rbacv1.PermissionType{
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES})
+	defer func() {
+		audit.LogFromErr(fields, err)
+	}()
+
+	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)
+}
+
+// CanViewWorkspaceConfigPolicies determines whether a user can view
+// workspace task config policies.
+func (r *ConfigPolicyAuthZRBAC) CanViewWorkspaceConfigPolicies(
+	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
+) (err error) {
+	fields := audit.ExtractLogFields(ctx)
+	addConfigPolicyInfo(curUser, workspace, fields, []rbacv1.PermissionType{
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES})
+	defer func() {
+		audit.LogFromErr(fields, err)
+	}()
+
+	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
+		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_WORKSPACE_CONFIG_POLICIES)
+}
+
+func addConfigPolicyInfo(curUser model.User,
+	workspace *workspacev1.Workspace,
+	logFields log.Fields,
+	permissions []rbacv1.PermissionType) {
+	logFields["userID"] = curUser.ID
+	logFields["permissionsRequired"] = []audit.PermissionWithSubject{
+		{
+			PermissionTypes: permissions,
+			SubjectType:     "config policy",
+			SubjectIDs:      []string{strconv.Itoa(int(workspace.Id))},
+		},
+	}
+}

--- a/master/internal/configpolicy/authz_rbac.go
+++ b/master/internal/configpolicy/authz_rbac.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"strconv"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/rbac/audit"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/rbacv1"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
-	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	AuthZProvider.Register("rbac", &ConfigPolicyAuthZRBAC{})
+}
 
 // ConfigPolicyAuthZRBAC is RBAC authorization for config policies.
 type ConfigPolicyAuthZRBAC struct{}
@@ -22,7 +27,8 @@ func (r *ConfigPolicyAuthZRBAC) CanModifyWorkspaceConfigPolicies(
 ) (err error) {
 	fields := audit.ExtractLogFields(ctx)
 	addConfigPolicyInfo(curUser, workspace, fields, []rbacv1.PermissionType{
-		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES})
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES,
+	})
 	defer func() {
 		audit.LogFromErr(fields, err)
 	}()
@@ -38,7 +44,8 @@ func (r *ConfigPolicyAuthZRBAC) CanViewWorkspaceConfigPolicies(
 ) (err error) {
 	fields := audit.ExtractLogFields(ctx)
 	addConfigPolicyInfo(curUser, workspace, fields, []rbacv1.PermissionType{
-		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES})
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES,
+	})
 	defer func() {
 		audit.LogFromErr(fields, err)
 	}()
@@ -50,7 +57,8 @@ func (r *ConfigPolicyAuthZRBAC) CanViewWorkspaceConfigPolicies(
 func addConfigPolicyInfo(curUser model.User,
 	workspace *workspacev1.Workspace,
 	logFields log.Fields,
-	permissions []rbacv1.PermissionType) {
+	permissions []rbacv1.PermissionType,
+) {
 	logFields["userID"] = curUser.ID
 	logFields["permissionsRequired"] = []audit.PermissionWithSubject{
 		{

--- a/master/internal/configpolicy/authz_rbac.go
+++ b/master/internal/configpolicy/authz_rbac.go
@@ -57,8 +57,9 @@ func (r *ConfigPolicyAuthZRBAC) CanViewWorkspaceConfigPolicies(
 
 // CanModifyGlobalConfigPolicies checks if the user can modify global
 // task config policies.
-func (a *ConfigPolicyAuthZRBAC) CanModifyGlobalConfigPolicies(
-	ctx context.Context, curUser *model.User) error {
+func (r *ConfigPolicyAuthZRBAC) CanModifyGlobalConfigPolicies(
+	ctx context.Context, curUser *model.User,
+) error {
 	return db.DoesPermissionMatch(
 		ctx,
 		curUser.ID,
@@ -68,7 +69,7 @@ func (a *ConfigPolicyAuthZRBAC) CanModifyGlobalConfigPolicies(
 }
 
 // CanViewGlobalConfigPolicies checks if the user can view global task config policies.
-func (a *ConfigPolicyAuthZRBAC) CanViewGlobalConfigPolicies(
+func (r *ConfigPolicyAuthZRBAC) CanViewGlobalConfigPolicies(
 	ctx context.Context, curUser *model.User,
 ) error {
 	return db.DoesPermissionMatch(

--- a/master/internal/configpolicy/authz_rbac.go
+++ b/master/internal/configpolicy/authz_rbac.go
@@ -9,6 +9,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/rbac/audit"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/rbacv1"
 	"github.com/determined-ai/determined/proto/pkg/workspacev1"
 )
@@ -33,7 +34,7 @@ func (r *ConfigPolicyAuthZRBAC) CanModifyWorkspaceConfigPolicies(
 		audit.LogFromErr(fields, err)
 	}()
 
-	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
+	return db.DoesPermissionMatch(ctx, curUser.ID, ptrs.Ptr(workspace.Id),
 		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)
 }
 
@@ -50,8 +51,32 @@ func (r *ConfigPolicyAuthZRBAC) CanViewWorkspaceConfigPolicies(
 		audit.LogFromErr(fields, err)
 	}()
 
-	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
+	return db.DoesPermissionMatch(ctx, curUser.ID, ptrs.Ptr(workspace.Id),
 		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_WORKSPACE_CONFIG_POLICIES)
+}
+
+// CanModifyGlobalConfigPolicies checks if the user can modify global
+// task config policies.
+func (a *ConfigPolicyAuthZRBAC) CanModifyGlobalConfigPolicies(
+	ctx context.Context, curUser *model.User) error {
+	return db.DoesPermissionMatch(
+		ctx,
+		curUser.ID,
+		nil,
+		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_GLOBAL_CONFIG_POLICIES,
+	)
+}
+
+// CanViewGlobalConfigPolicies checks if the user can view global task config policies.
+func (a *ConfigPolicyAuthZRBAC) CanViewGlobalConfigPolicies(
+	ctx context.Context, curUser *model.User,
+) error {
+	return db.DoesPermissionMatch(
+		ctx,
+		curUser.ID,
+		nil,
+		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_GLOBAL_CONFIG_POLICIES,
+	)
 }
 
 func addConfigPolicyInfo(curUser model.User,

--- a/master/internal/db/postgres_rbac_intg_test.go
+++ b/master/internal/db/postgres_rbac_intg_test.go
@@ -427,7 +427,8 @@ func TestPermissionMatch(t *testing.T) {
 
 		err = DoesPermissionMatch(ctx, userIDWorkspaceAdmin, &workspaceID,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_GLOBAL_CONFIG_POLICIES)
-		require.NoError(t, err)
+		require.IsType(t, authz.PermissionDeniedError{}, err,
+			"user should not have permission to edit global config policies")
 
 		err = DoesPermissionMatch(ctx, userIDWorkspaceAdmin, &workspaceID,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)
@@ -530,7 +531,8 @@ func TestPermissionMatch(t *testing.T) {
 
 		err = DoesPermissionMatchAll(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_GLOBAL_CONFIG_POLICIES, workspaceID)
-		require.NoError(t, err)
+		require.IsType(t, authz.PermissionDeniedError{}, err,
+			"user should not have permission to edit global config policies")
 
 		err = DoesPermissionMatchAll(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES, workspaceID)
@@ -653,7 +655,8 @@ func TestPermissionMatch(t *testing.T) {
 
 		err = DoesPermissionMatchAll(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_GLOBAL_CONFIG_POLICIES, workspaceIDs...)
-		require.NoError(t, err)
+		require.IsType(t, authz.PermissionDeniedError{}, err,
+			"user should not have permission to edit global config policies")
 
 		err = DoesPermissionMatchAll(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES, workspaceIDs...)
@@ -832,7 +835,8 @@ func TestPermissionMatch(t *testing.T) {
 
 		err = DoPermissionsExist(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_GLOBAL_CONFIG_POLICIES)
-		require.NoError(t, err)
+		require.IsType(t, authz.PermissionDeniedError{}, err,
+			"user should not have permission to edit global config policies")
 
 		err = DoPermissionsExist(ctx, userIDWorkspaceAdmin,
 			rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)

--- a/master/internal/workspace/authz_basic_impl.go
+++ b/master/internal/workspace/authz_basic_impl.go
@@ -190,24 +190,6 @@ func (a *WorkspaceAuthZBasic) CanSetWorkspacesDefaultPools(
 	return nil
 }
 
-// CanModifyWorkspaceConfigPolicies returns a nil error or the user is not an admin
-// or owner of the workspace.
-func (a *WorkspaceAuthZBasic) CanModifyWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) error {
-	if !curUser.Admin && curUser.ID != model.UserID(workspace.UserId) {
-		return fmt.Errorf("only admins may set config policies for workspaces")
-	}
-	return nil
-}
-
-// CanViewWorkspaceConfigPolicies returns a nil error.
-func (a *WorkspaceAuthZBasic) CanViewWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) error {
-	return nil
-}
-
 func init() {
 	AuthZProvider.Register("basic", &WorkspaceAuthZBasic{})
 }

--- a/master/internal/workspace/authz_iface.go
+++ b/master/internal/workspace/authz_iface.go
@@ -84,12 +84,6 @@ type WorkspaceAuthZ interface {
 	CanUnpinWorkspace(
 		ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
 	) error
-	// PUT /api/v1/config-policies/workspaces/:workspace-id/:type
-	CanModifyWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-	) error
-	// GET /api/v1/config-policies/workspaces/:workspace-id/:type
-	CanViewWorkspaceConfigPolicies(ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-	) error
 }
 
 // AuthZProvider providers WorkspaceAuthZ implementations.

--- a/master/internal/workspace/authz_permissive.go
+++ b/master/internal/workspace/authz_permissive.go
@@ -179,22 +179,6 @@ func (p *WorkspaceAuthZPermissive) CanViewResourceQuotas(
 	return (&WorkspaceAuthZBasic{}).CanViewResourceQuotas(ctx, curUser)
 }
 
-// CanModifyWorkspaceConfigPolicies RBAC authz but enforces basic authz.
-func (p *WorkspaceAuthZPermissive) CanModifyWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) error {
-	_ = (&WorkspaceAuthZRBAC{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
-	return (&WorkspaceAuthZBasic{}).CanModifyWorkspaceConfigPolicies(ctx, curUser, workspace)
-}
-
-// CanViewWorkspaceConfigPolicies RBAC authz but enforces basic authz.
-func (p *WorkspaceAuthZPermissive) CanViewWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) error {
-	_ = (&WorkspaceAuthZRBAC{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
-	return (&WorkspaceAuthZBasic{}).CanViewWorkspaceConfigPolicies(ctx, curUser, workspace)
-}
-
 func init() {
 	AuthZProvider.Register("permissive", &WorkspaceAuthZPermissive{})
 }

--- a/master/internal/workspace/authz_rbac.go
+++ b/master/internal/workspace/authz_rbac.go
@@ -412,38 +412,6 @@ func (r *WorkspaceAuthZRBAC) CanViewResourceQuotas(ctx context.Context,
 		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_RESOURCE_QUOTAS)
 }
 
-// CanModifyWorkspaceConfigPolicies determines whether a user can modify
-// workspace task config policies.
-func (r *WorkspaceAuthZRBAC) CanModifyWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) (err error) {
-	fields := audit.ExtractLogFields(ctx)
-	addInfoWithoutWorkspace(curUser, fields,
-		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)
-	defer func() {
-		audit.LogFromErr(fields, err)
-	}()
-
-	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
-		rbacv1.PermissionType_PERMISSION_TYPE_MODIFY_WORKSPACE_CONFIG_POLICIES)
-}
-
-// CanViewWorkspaceConfigPolicies determines whether a user can view
-// workspace task config policies.
-func (r *WorkspaceAuthZRBAC) CanViewWorkspaceConfigPolicies(
-	ctx context.Context, curUser model.User, workspace *workspacev1.Workspace,
-) (err error) {
-	fields := audit.ExtractLogFields(ctx)
-	addInfoWithoutWorkspace(curUser, fields,
-		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_WORKSPACE_CONFIG_POLICIES)
-	defer func() {
-		audit.LogFromErr(fields, err)
-	}()
-
-	return db.DoesPermissionMatch(ctx, curUser.ID, nil,
-		rbacv1.PermissionType_PERMISSION_TYPE_VIEW_WORKSPACE_CONFIG_POLICIES)
-}
-
 func hasPermissionOnWorkspace(ctx context.Context, uid model.UserID,
 	workspace *workspacev1.Workspace, permID rbacv1.PermissionType,
 ) error {

--- a/master/static/migrations/20240917113855_modify-tcp-rbac-perms.tx.up.sql
+++ b/master/static/migrations/20240917113855_modify-tcp-rbac-perms.tx.up.sql
@@ -2,4 +2,4 @@
 DELETE FROM permission_assignments WHERE permission_id = 11004 and role_id = 2;
 
 /* Assign global_only to global RBAC permission. */
-UPDATE permissions SET global_only = true WHERE id = 11004 OR id = 11006;
+UPDATE permissions SET global_only = true WHERE id = 11004;

--- a/master/static/migrations/20240917113855_modify-tcp-rbac-perms.tx.up.sql
+++ b/master/static/migrations/20240917113855_modify-tcp-rbac-perms.tx.up.sql
@@ -1,0 +1,5 @@
+/* Remove modify global config policies RBAC permission from WorkspaceAdmin. */
+DELETE FROM permission_assignments WHERE permission_id = 11004 and role_id = 2;
+
+/* Assign global_only to global RBAC permission. */
+UPDATE permissions SET global_only = true WHERE id = 11004 OR id = 11006;


### PR DESCRIPTION
## Ticket
[CM-530]


## Description
- Remove "modify globaly config policies" permission from `WorkspaceAdmin` role
- Classify global config policy permissions as `global_only`
- Add RBAC tests for config policies and refactor existing tests
- Move config policies RBAC work into the `configpolicy` package and add configpolicy-specific logging



## Test Plan
CI passes (automated testing).



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-530]: https://hpe-aiatscale.atlassian.net/browse/CM-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ