### PR TITLE
ci: increase datagrid rightclick timeout/ reduce worker count

### DIFF
--- a/webui/react/playwright.config.ts
+++ b/webui/react/playwright.config.ts
@@ -95,5 +95,5 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
   },
 
-  workers: process.env.CI ? 4 : 1,
+  workers: process.env.CI ? 3 : undefined,
 });

--- a/webui/react/src/e2e/models/common/hew/DataGrid.ts
+++ b/webui/react/src/e2e/models/common/hew/DataGrid.ts
@@ -351,7 +351,7 @@ export class Row<HeadRowType extends HeadRow<Row<HeadRowType>>> extends NamedCom
     await this.parentTable.pwLocator.click({
       button: 'right',
       position: { x: 5, y: this.getY(await this.getIndex()) },
-      timeout: 10_000,
+      timeout: 30_000,
     });
   }
 


### PR DESCRIPTION
## Ticket
ET-678



## Description
This attempts to deflake the datagrid action pause tests by increasing the rightclick timeout. I'm skeptical that this will deflake because the error message on timeout says that it's performing the click action, meaning it's already located the element and it's visible and clickable. 

In addition, we reduce the worker count by one to prevent further timeout issues stemming from the machine throttling.


## Test Plan
No manual testing needed -- ci should be green.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ