### PR TITLE
test: can we apply invariant configs without a refactor?

### DIFF
--- a/master/internal/configpolicy/exp_conf_intg_test.go
+++ b/master/internal/configpolicy/exp_conf_intg_test.go
@@ -3,7 +3,6 @@ package configpolicy
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -47,8 +46,6 @@ func TestExpConfUnmarshal(t *testing.T) {
 	// 3. create user exp conf
 	userExpConf := expconf.ExperimentConfig{}
 	userExpConf = schemas.WithDefaults(userExpConf)
-	fmt.Println("user exp conf:")
-	fmt.Println(*userExpConf.Environment().Image().RawROCM)
 	require.Equal(t, "determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-mpich-0736b6d", *userExpConf.Environment().Image().RawROCM)
 
 	// 4. apply invariant config

--- a/master/internal/configpolicy/exp_conf_intg_test.go
+++ b/master/internal/configpolicy/exp_conf_intg_test.go
@@ -1,0 +1,61 @@
+package configpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/etc"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
+	"github.com/stretchr/testify/require"
+)
+
+// Use a test to find out if we need a refactor of the psudo-interfacce, or not.
+func TestExpConfUnmarshal(t *testing.T) {
+
+	// 0. set up db
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+
+	// 1. add test data to db
+	tcps := model.TaskConfigPolicies{
+		WorkspaceID:     nil,
+		WorkloadType:    model.ExperimentType,
+		LastUpdatedBy:   user.ID,
+		LastUpdatedTime: time.Now().UTC().Truncate(time.Second),
+		InvariantConfig: DefaultInvariantConfigImage(),
+		Constraints:     DefaultConstraints(),
+	}
+
+	err := SetTaskConfigPolicies(ctx, &tcps)
+	require.NoError(t, err)
+
+	// 2. read back test exp conf
+	res, err := GetTaskConfigPolicies(ctx, nil, model.ExperimentType)
+	require.NoError(t, err)
+
+	// 3. create user exp conf
+	userExpConf := expconf.ExperimentConfig{}
+	userExpConf = schemas.WithDefaults(userExpConf)
+	fmt.Println("user exp conf:")
+	fmt.Println(*userExpConf.Environment().Image().RawROCM)
+	require.Equal(t, "determinedai/environments:rocm-5.6-pytorch-1.3-tf-2.10-rocm-mpich-0736b6d", *userExpConf.Environment().Image().RawROCM)
+
+	// 4. apply invariant config
+	err = json.Unmarshal([]byte(*res.InvariantConfig), &userExpConf)
+	require.NoError(t, err)
+
+	// 5. does it work?
+	require.Equal(t, "bogus", *userExpConf.Environment().Image().RawROCM)
+
+}

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -15,7 +15,8 @@ const (
 	wkspIDQuery       = "workspace_id = ?"
 	wkspIDGlobalQuery = "workspace_id IS ?"
 	// DefaultInvariantConfigStr is the default invariant config val used for tests.
-	DefaultInvariantConfigStr = `{"description": "random description", "resources": {"slots": 4, "max_slots": 8}}`
+	DefaultInvariantConfigStr      = `{"description": "random description", "resources": {"slots": 4, "max_slots": 8}}`
+	DefaultInvariantConfigStrImage = `{"description": "random description", "resources": {"slots": 4, "max_slots": 8}, "environment": {"image": {"rocm": "bogus"}}}`
 	// DefaultConstraintsStr is the default constraints val used for tests.
 	DefaultConstraintsStr = `{"priority_limit": 10, "resources": {"max_slots": 8}}`
 )

--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -457,6 +457,10 @@ func DefaultInvariantConfig() *string {
 	return ptrs.Ptr(DefaultInvariantConfigStr)
 }
 
+func DefaultInvariantConfigImage() *string {
+	return ptrs.Ptr(DefaultInvariantConfigStrImage)
+}
+
 func DefaultConstraints() *string {
 	return ptrs.Ptr(DefaultConstraintsStr)
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Will not merge. Illustration / test purposes only.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ