### PR TITLE
feat: add database snapshot functionality to Helm chart

### DIFF
--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -77,6 +77,25 @@
       PersistentVolumes is disabled, users must manually create a PersistentVolume that will match
       the PersistentVolumeClaim.
 
+   -  ``claimSuffix``: Optional configuration that defines the persistent volume claim name for the
+      Determined database. If not undefined, a new PVC is created, with the name
+      ``determined-db-pvc-$releaseName``. If specified, the provided value will be used as the
+      suffix to ``determined-db-pvc-``.
+
+   -  ``snapshotSuffix``: Optional configuration for naming the volume snapshot, which serves as a
+      backup of the Determined database's persistentVolume. If defined, Helm will create a snapshot
+      of the database during the next upgrade, creating a volumeSnapshot named
+      ``determined-db-snapsnot-$snapshotSuffix``. This **must** **not** match the name of an
+      existing persistent volume claim, such as ``determined-db-pvc-$releaseName``, because the
+      ``snapshotSuffix`` will be used to create a new persistent volume claim when restoring.
+
+   -  ``restoreSnapshotSuffix``: Optional configuration of the volumeSnapshot to restore from during
+      an upgrade. If this is set during an upgrade, a new persistentVolume will be created and
+      swapped into Determined's database by creating a new persistent volume claim named
+      ``determined-db-pvc-$restoreSnapshotSuffix``, restoring data from
+      ``determined-db-snapsnot-$restoreSnapshotSuffix``. This **must not** match the name of an
+      existing persistent volume claim (PVC), such as ``$releaseName``.
+
 -  ``checkpointStorage``: Specifies where model checkpoints will be stored. This can be overridden
    on a per-experiment basis in the :ref:`experiment-config-reference`. A checkpoint contains the
    architecture and weights of the model being trained. Determined currently supports several kinds

--- a/docs/release-notes/helm-db-snapshot.rst
+++ b/docs/release-notes/helm-db-snapshot.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+**New Features**
+
+-  Helm: Add support for capturing and restoring snapshots of the database persistent volume. Visit
+   :ref:`helm-config-reference` for more details.

--- a/helm/charts/determined/templates/db-deployment.yaml
+++ b/helm/charts/determined/templates/db-deployment.yaml
@@ -61,6 +61,11 @@ spec:
       volumes:
         - name: determined-db-storage
           persistentVolumeClaim:
-            claimName: determined-db-pvc-{{ .Release.Name }}
+            claimName: 
+              {{ if .Values.db.claimSuffix }}
+              determined-db-pvc-{{ .Values.db.claimSuffix }}
+              {{- else -}}
+              determined-db-pvc-{{ .Release.Name }}
+              {{ end }}
       {{ end }}
-{{ end}}
+{{ end }}

--- a/helm/charts/determined/templates/db-persistent-volume-claim.yaml
+++ b/helm/charts/determined/templates/db-persistent-volume-claim.yaml
@@ -3,7 +3,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: determined-db-pvc-{{ .Release.Name }}
+  name: 
+    {{ if and .Release.IsUpgrade .Values.db.restoreSnapshotSuffix }}
+    determined-db-pvc-{{ .Values.db.restoreSnapshotSuffix }}
+    {{- else -}}
+    determined-db-pvc-{{ .Release.Name }}
+    {{ end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: determined-db-{{ .Release.Name }}
@@ -11,6 +16,12 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if and .Release.IsUpgrade  .Values.db.restoreSnapshotSuffix }}
+  dataSource:
+    name: determined-db-snapshot-{{ .Values.db.restoreSnapshotSuffix }}
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  {{ end }}
   resources:
     requests:
       storage: {{ required  "A valid Values.db.storageSize entry is required!" .Values.db.storageSize }}

--- a/helm/charts/determined/templates/db-volume-snapshot-class.yaml
+++ b/helm/charts/determined/templates/db-volume-snapshot-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: determined-db-snapshot-class
+driver: pd.csi.storage.gke.io
+deletionPolicy: Retain

--- a/helm/charts/determined/templates/db-volume-snapshot.yaml
+++ b/helm/charts/determined/templates/db-volume-snapshot.yaml
@@ -1,0 +1,19 @@
+{{- if and .Release.IsUpgrade .Values.db.snapshotSuffix }}
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: determined-db-snapshot-{{ .Values.db.snapshotSuffix }}
+  namespace: default
+  labels:
+    app: determined-db-{{ .Release.Name }}
+    release: {{ .Release.Name }}
+spec:
+  volumeSnapshotClassName: determined-db-snapshot-class
+  source:
+    persistentVolumeClaimName: 
+      {{ if .Values.db.claimSuffix }}
+      determined-db-pvc-{{ .Values.db.claimSuffix }}
+      {{- else -}}
+      determined-db-pvc-{{ .Release.Name }}
+      {{ end }}
+{{ end }}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -196,6 +196,22 @@ db:
   # resourceType: <secret/configMap>
   # certResourceName: <secret/configMap name>
 
+  # claimSuffix refers to the persistent volume claim name suffix for the database.
+  # If left undefined, a new PVC is created, named "determined-db-pvc-{{ .Release.name }}".
+  # Otherwise, use the PVC provided, given that it exists in the current context.
+  # claimSuffix:
+
+  # snapshotSuffix refers to the volume snapshot name suffix, a backup of Determined's database persistent volume.
+  # If defined, Helm will "snapshot" the DB upon its next upgrade, creating a volumeSnapshot called
+  # `determined-db-snapsnot-{{ .Values.snapshotSuffix}}`. This MUST NOT be the name of a persistent volume claim
+  # that already exists, such as `determined-db-pvc-{{Release.Name}}`.
+  # snapshotSuffix:
+
+  # restoreSnapshotSuffix refers to the volume snapshot name suffix which you wish to restore the database to.
+  # During an upgrade, a new persistent volume & claim will be created, named `determined-db-pvc-{{ .Values.restoreSnapshotSuffix}}`, 
+  # restoring the data from `determined-db-snapsnot-{{ .Values.restoreSnapshotSuffix}}`. MUST NOT be the name 
+  # of a persistent volume claim that already exists, e.g. the {{Release.Name}}.
+  # restoreSnapshotSuffix:
 
 # checkpointStorage controls where checkpoints are stored. Supported types include `shared_fs`,
 # `gcs`, and `s3`.


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
CM-448



## Description
See notes: https://hpe-aiatscale.atlassian.net/wiki/spaces/ENGINEERIN/pages/1748041758/Guide+Release+Party+Database+Backups
TLDR; add Helm values such that you can easily snapshot/backup OR restore a database's persistent volume.

## Test Plan
Manual testing or N/A



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ