### PR TITLE
chore: do not log error for resource pools with zero agents

### DIFF
--- a/master/internal/rm/agentrm/summaries.go
+++ b/master/internal/rm/agentrm/summaries.go
@@ -49,8 +49,8 @@ func (rp *resourcePool) resourceSummaryFromAgentStates(
 	}
 
 	// If we have heterogenous slots, we default to`UNSPECIFIED` aka `device.ZeroSlot`.
-	// We raise an error in the logs.
-	if len(deviceTypeCount) != 1 {
+	// We raise an error in the logs if there is more than one slot type.
+	if len(deviceTypeCount) < 1 {
 		rp.syslog.Errorf("resource pool has unspecified slot type with %v total slot types", len(deviceTypeCount))
 	} else {
 		for deviceType := range deviceTypeCount {

--- a/master/internal/rm/agentrm/summaries.go
+++ b/master/internal/rm/agentrm/summaries.go
@@ -50,7 +50,7 @@ func (rp *resourcePool) resourceSummaryFromAgentStates(
 
 	// If we have heterogenous slots, we default to`UNSPECIFIED` aka `device.ZeroSlot`.
 	// We raise an error in the logs if there is more than one slot type.
-	if len(deviceTypeCount) < 1 {
+	if len(deviceTypeCount) > 1 {
 		rp.syslog.Errorf("resource pool has unspecified slot type with %v total slot types", len(deviceTypeCount))
 	} else {
 		for deviceType := range deviceTypeCount {


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
chore: do not log error for resource pools with zero agents
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
Just fix the log to only print when there a multiple slot types assigned to one pool, ignore in the zero case. This avoids cases where pools _don't_ have any agents assigned and the logs are spammed with this error message.



## Test Plan
N/A



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ