### PR TITLE
fix: fix flaky generic task pause test

### DIFF
--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -232,23 +232,12 @@ def test_pause_and_unpause_generic_task() -> None:
 
     detproc.check_call(sess, command)
 
-    # The task may still be PAUSING, retry a few times.
-    retries = 5
-    for i in range(retries):
-        pause_resp = bindings.get_GetTask(sess, taskId=task_resp.taskId)
-        if pause_resp.task.taskState == bindings.v1GenericTaskState.PAUSED:
-            break
-        time.sleep(1)
-    else:
-        pytest.fail(f"Task {task_resp.taskId} did not reach a PAUSED state after {retries} seconds.")
-
+    task.wait_for_task_state(sess, task_resp.taskId, bindings.v1GenericTaskState.PAUSED)
 
     # Unpause task
     command = ["det", "-m", conf.make_master_url(), "task", "unpause", task_resp.taskId]
 
     detproc.check_call(sess, command)
 
-    unpause_resp = bindings.get_GetTask(sess, taskId=task_resp.taskId)
-    assert unpause_resp.task.taskState == bindings.v1GenericTaskState.ACTIVE
-
+    task.wait_for_task_state(sess, task_resp.taskId, bindings.v1GenericTaskState.ACTIVE)
     task.wait_for_task_state(sess, task_resp.taskId, bindings.v1GenericTaskState.COMPLETED)

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -233,7 +233,7 @@ def test_pause_and_unpause_generic_task() -> None:
     detproc.check_call(sess, command)
 
     # The task may still be PAUSING, retry a few times.
-    retries = 3
+    retries = 5
     for i in range(retries):
         pause_resp = bindings.get_GetTask(sess, taskId=task_resp.taskId)
         if pause_resp.task.taskState == bindings.v1GenericTaskState.PAUSED:

--- a/e2e_tests/tests/task/test_generic_tasks.py
+++ b/e2e_tests/tests/task/test_generic_tasks.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from determined.cli import ntsc
 from determined.common import util


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

test is flaky, race between task going from PAUSING -> PAUSED and test check. so retry a few times.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ