### PR TITLE
feat: add upgrade tests to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,26 @@ jobs:
               jq '. += {"do_nightly_tests": true}' < "<<pipeline.parameters.params_basename>>" > tmpfile
               mv -v tmpfile "<<pipeline.parameters.params_basename>>"
             fi
+      - run:
+          name: Check for scheduled upgrade run.
+          command: |
+            if [[ "scheduled_pipeline" == "<<pipeline.trigger_source>>"
+               && "upgrade_tests" == "<<pipeline.schedule.name>>"
+            ]]
+            then
+              # add the parameter(s) to the temp file
+              jq '. += {"do_upgrade_tests": true}' < "<<pipeline.parameters.params_basename>>" > tmpfile
+              mv -v tmpfile "<<pipeline.parameters.params_basename>>"
+            fi
+      - run:
+          name: Check for labeled upgrade run.
+          command: |
+            if gh pr view --json labels --jq ".labels[].name" \
+               | grep -w "ci-run-upgrade-tests"
+            then
+              jq '. += {"do_upgrade_tests": true}' < "<<pipeline.parameters.params_basename>>" > tmpfile
+              mv -v tmpfile "<<pipeline.parameters.params_basename>>"
+            fi
 
       - run:
           name: Set det-version parameter.

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2027,36 +2027,6 @@ jobs:
       - run: make -C bindings force-gen
       - run: make -C bindings check/python
 
-  find-main-docker-images:
-    docker:
-      - image: <<pipeline.parameters.docker-image>>
-    steps:
-      - setup_remote_docker:
-          version: previous
-      - login-docker:
-          username: ${DOCKER_USER}
-          password: ${DOCKER_PASS}
-      - checkout
-      - add-and-fetch-upstream
-      - run:
-          name: Check for Latest Main Docker Image
-          command: |
-            git fetch origin main && git checkout main
-            export LATEST_MAIN_SHA=$(git rev-parse HEAD)
-            for i in {1..20}; do
-              if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-master/${LATEST_MAIN_SHA}/" > /dev/null; then
-                echo "Master tag '${LATEST_MAIN_SHA}' found."
-                if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-agent/${LATEST_MAIN_SHA}/" > /dev/null; then
-                  echo "Agent tag '${LATEST_MAIN_SHA}' found."
-                  exit 0
-                fi
-              fi
-              echo "Tag '${LATEST_MAIN_SHA}' not found (Attempt $i/20), retrying in 60s..."
-              sleep 60
-            done
-            echo "Tag '${LATEST_MAIN_SHA}' not found after 20 attempts."
-            exit 1
-
   upload-try-now-template:
     docker:
       - image: <<pipeline.parameters.docker-image>>
@@ -3260,7 +3230,6 @@ jobs:
                   - run:
                       name: Start additionalrm minikube
                       command: minikube start --profile additionalrm --kubernetes-version <<parameters.k8s-version>>
-
       - install-devcluster
       - unless:
           condition: <<parameters.managed-devcluster>>
@@ -3272,24 +3241,13 @@ jobs:
       - when:
           condition: <<parameters.upgrade>>
           steps:
-            # Stop devcluster running on the past release.
-            - stop-devcluster
             - reinstall-go
-            - license-gen
             - run: git checkout ${LATEST_MAIN_SHA}
             - run: make -C master build
             - run: make -C agent build
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - "master/build"
-                  - "agent/build"
-
-            # TODO CAROLINA
-            - setup-python-venv:
-                determined: True
-                extra-requirements-file: "e2e_tests/tests/requirements.txt"
-                executor: <<pipeline.parameters.machine-image>>
+            # not persisting to workspace because we still want first run of test to run w/ old branch build
+            # Stop devcluster running on the past release.
+            - stop-devcluster
             - install-devcluster
             - unless:
                 condition: <<parameters.managed-devcluster>>
@@ -3297,7 +3255,6 @@ jobs:
                   - start-devcluster:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
-
 
       - pull-task-images:
           tf2: <<parameters.tf2>>
@@ -4479,6 +4436,9 @@ workflows:
           mark: e2e_cpu_2a
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4490,6 +4450,9 @@ workflows:
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
           target-stage: agent1
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -4501,6 +4464,9 @@ workflows:
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
           target-stage: agent1
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4517,6 +4483,9 @@ workflows:
           # so `compare_stats` cannot get the full logs from `det master logs`.
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4531,6 +4500,9 @@ workflows:
           managed-devcluster: true
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4545,6 +4517,9 @@ workflows:
           devcluster-config: multi-k8s.devcluster.yaml
           run-minikubes: true
           multi-k8s: true
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4557,6 +4532,9 @@ workflows:
           target-stage: master
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4568,6 +4546,9 @@ workflows:
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
           target-stage: agent
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4580,6 +4561,9 @@ workflows:
           mark: e2e_cpu_elastic
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4592,6 +4576,9 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "10"
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4604,6 +4591,9 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "14"
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4618,6 +4608,7 @@ workflows:
           matrix:
             parameters:
               agent-version: ["0.17.10"]
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-agent-connection-loss
@@ -4630,6 +4621,9 @@ workflows:
           wait-for-master: false
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-saml
@@ -4641,6 +4635,9 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
+          matrix:
+            parameters:
+              upgrade: [true, false]
 
       - test-perf:
           name: test-perf
@@ -4801,261 +4798,6 @@ workflows:
                 - main
           requires:
             - package-and-push-system-dev-ee
-
-  test-e2e-release-upgrade:
-    <<: *do-not-run-on-manual-trigger
-    jobs:
-      - build-proto
-      - build-helm
-      - build-react:
-          dev-mode: true
-      - test-e2e-react:
-          name: test-e2e-react-ee
-          ee: true
-          requires:
-            - build-go-ee
-          context:
-            - playwright
-            - github-read
-            - dev-ci-cluster-default-user-credentials
-          filters: *any-upstream
-      - build-docs:
-          requires:
-            - build-helm
-            - build-proto
-      - build-go:
-          name: build-go-ee
-          context: github-read
-      - find-main-docker-images
-      # TODO CAROLINA -- make this weekly 
-
-      - test-e2e:
-          name: test-e2e-rbac
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_cpu_rbac
-          devcluster-config: single-rbac.devcluster.yaml
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-cpu
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 6
-          resource-class: xlarge
-          tf2: true
-          mark: e2e_cpu
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-cpu-double
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 5
-          resource-class: large
-          tf2: true
-          mark: e2e_cpu_2a
-          target-stage: agent2
-          devcluster-config: double-priority.devcluster.yaml
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-cpu-oauth
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          devcluster-config: oauth.devcluster.yaml
-          mark: test_oauth
-          target-stage: agent1
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-cpu-model-registry-rbac
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          devcluster-config: rbac-model-registry.yaml
-          mark: test_model_registry_rbac
-          target-stage: agent1
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-managed-devcluster
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 4
-          resource-class: large
-          tf2: true
-          mark: managed_devcluster
-          managed-devcluster: true
-          # Managed devcluster restarts the master over the course of the tests,
-          # so `compare_stats` cannot get the full logs from `det master logs`.
-          extra-pytest-flags: "--no-compare-stats"
-          collect-det-job-logs: false
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-managed-devcluster-resource-pools
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 4
-          resource-class: large
-          tf2: true
-          mark: managed_devcluster_resource_pools
-          managed-devcluster: true
-          extra-pytest-flags: "--no-compare-stats"
-          collect-det-job-logs: false
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-multi-k8s
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          tf2: true
-          mark: e2e_multi_k8s
-          target-stage: master
-          devcluster-config: multi-k8s.devcluster.yaml
-          run-minikubes: true
-          multi-k8s: true
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-single-k8s
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_single_k8s
-          target-stage: master
-          devcluster-config: single-k8s.devcluster.yaml
-          run-minikubes: true
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-port-registry
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          devcluster-config: port-registry.devcluster.yaml
-          mark: port_registry
-          target-stage: agent
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-cpu-elastic
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          resource-class: large
-          mark: e2e_cpu_elastic
-          devcluster-config: elastic.devcluster.yaml
-          target-stage: agent
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-postgres10-with-ssl
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_cpu_postgres
-          devcluster-config: postgres-with-ssl.devcluster.yaml
-          target-stage: agent
-          postgres-version: "10"
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-postgres14-with-ssl
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_cpu_postgres
-          devcluster-config: postgres-with-ssl.devcluster.yaml
-          target-stage: agent
-          postgres-version: "14"
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-old-agent-versions
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_cpu_postgres
-          devcluster-config: custom-agent-version.devcluster.yaml
-          target-stage: agent
-          matrix:
-            parameters:
-              agent-version: ["0.17.10"]
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-agent-connection-loss
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          mark: e2e_cpu_agent_connection_loss
-          devcluster-config: agent-no-connection.devcluster.yaml
-          target-stage: agent
-          wait-for-master: false
-          extra-pytest-flags: "--no-compare-stats"
-          collect-det-job-logs: false
-          upgrade: true
-
-      - test-e2e:
-          name: test-e2e-saml
-          context:
-            - okta
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-            - find-main-docker-images
-          parallelism: 1
-          devcluster-config: saml.devcluster.yaml
-          mark: e2e_saml
-          upgrade: true
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3198,27 +3198,11 @@ jobs:
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
-            - setup-python-venv:
-                determined: True
-                extra-requirements-file: "e2e_tests/tests/requirements.txt"
-                determined-SHA: $HEAD_COMMIT
-                executor: <<pipeline.parameters.machine-image>>
-            - install-devcluster
-            - unless:
-                condition: <<parameters.managed-devcluster>>
-                steps:
-                  - start-devcluster:
-                      devcluster-config: <<parameters.devcluster-config>>
-                      target-stage: <<parameters.target-stage>>
-            - run: sleep 10
-            - stop-devcluster
-            - checkout
-            - run: make -C master build
-            - run: make -C agent build
 
       - setup-python-venv:
           determined: True
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          determined-SHA: $HEAD_COMMIT
           executor: <<pipeline.parameters.machine-image>>
 
       - when:
@@ -3240,6 +3224,22 @@ jobs:
                   - run:
                       name: Start additionalrm minikube
                       command: minikube start --profile additionalrm --kubernetes-version <<parameters.k8s-version>>
+      - when:
+          condition: <<parameters.upgrade-branch>>
+          steps:
+            - install-devcluster
+            - unless:
+                condition: <<parameters.managed-devcluster>>
+                steps:
+                  - start-devcluster:
+                      devcluster-config: <<parameters.devcluster-config>>
+                      target-stage: <<parameters.target-stage>>
+                  - run: sleep 10
+                  - stop-devcluster
+            - checkout
+            - run: make -C master build
+            - run: make -C agent build
+
       - install-devcluster
       - unless:
           condition: <<parameters.managed-devcluster>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4846,6 +4846,7 @@ workflows:
           name: test-e2e-single-k8s
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4861,6 +4862,7 @@ workflows:
           name: test-e2e-port-registry
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4875,6 +4877,7 @@ workflows:
           name: test-e2e-cpu-elastic
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4890,6 +4893,7 @@ workflows:
           name: test-e2e-postgres10-with-ssl
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4905,6 +4909,7 @@ workflows:
           name: test-e2e-postgres14-with-ssl
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4920,6 +4925,7 @@ workflows:
           name: test-e2e-old-agent-versions
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4933,6 +4939,9 @@ workflows:
 
       - test-e2e:
           name: test-e2e-agent-connection-loss
+          context:
+            - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4951,6 +4960,7 @@ workflows:
           context:
             - okta
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4964,6 +4974,7 @@ workflows:
           name: test-e2e-rbac
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4977,6 +4988,7 @@ workflows:
           name: test-e2e-cpu-model-registry-rbac
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3213,6 +3213,7 @@ jobs:
                 name: Get Determined version branch commits.
                 command: |
                   git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
+            - license-gen
             - run: make -C master build
             - run: make -C agent build
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3196,7 +3196,7 @@ jobs:
             - run: 
                 name: Get Determined version branch commits.
                 command: |
-                  git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
+                  git fetch origin <<parameters.upgrade-branch>> && git checkout <<parameters.upgrade-branch>>
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
@@ -3214,7 +3214,7 @@ jobs:
                       target-stage: <<parameters.target-stage>>
             - run: sleep 10
             - stop-devcluster
-            - run: git checkout $CIRCLE_SHA1
+            - checkout
             - run: make -C master build
             - run: make -C agent build
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4748,7 +4748,7 @@ workflows:
             - package-and-push-system-dev-ee
 
   test-e2e-upgrade:
-    when: << pipeline.parameters.do_upgrade_tests >>
+    #when: << pipeline.parameters.do_upgrade_tests >>
     jobs:
       - build-proto
       - build-helm

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2027,17 +2027,17 @@ jobs:
       - run: make -C bindings force-gen
       - run: make -C bindings check/python
 
-  pull-main-docker-images:
+  find-main-docker-images:
     docker:
       - image: <<pipeline.parameters.docker-image>>
-    steps: # TODO CAROLINA
+    steps:
       - setup_remote_docker:
           version: previous
       - login-docker:
           username: ${DOCKER_USER}
           password: ${DOCKER_PASS}
       - checkout
-      - add-and-fetch-upstream
+      - add-and-fetch-upstreamg
       - run:
           name: Check for Latest Main Docker Image
           command: |
@@ -2267,6 +2267,9 @@ jobs:
       ee:
         type: boolean
         default: true
+      commit_SHA:
+        type: string
+        default: $CIRCLE_SHA1
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -2283,7 +2286,7 @@ jobs:
             - license-gen
       - restore_cache:
           keys:
-            - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+            - det-go-build-<<parameters.commit_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
       - run: make -C master build
       - run: make -C agent build
       - persist_to_workspace:
@@ -2293,7 +2296,7 @@ jobs:
             - "agent/build"
       # Save cache after we build master and agent so we can have our build cache there.
       - save_cache:
-          key: det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+          key: det-go-build-<<parameters.commt_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
           paths:
             - "/home/circleci/go/"
             - "/home/circleci/.cache/go-build/"
@@ -3267,21 +3270,15 @@ jobs:
                 target-stage: <<parameters.target-stage>>
 
       - when:
-          condition: <<parameters.upgrade>>g
+          condition: <<parameters.upgrade>>
           steps:
             # Stop devcluster running on the past release.
             - stop-devcluster
-            - run:
-                name: Install Latest Main Build # TODO CAROLINA -- do I need to checkout branch too?
-                command: |
-                  docker save -o build/master.image determinedai/hpe-mlde-master:${LATEST_MAIN_SHA}
-                  docker save -o build/master-ee.image determinedai/hpe-mlde-master:${LATEST_MAIN_SHA}
-                  docker save -o build/agent.image determinedai/hpe-mlde-agent:${LATEST_MAIN_SHA}
-                  docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${LATEST_MAIN_SHA}
-            - persist_to_workspace: 
-                root: .
-                paths:
-                  - "build/*.image" # TODO CAROLINA -- what images do I need to save and why?
+            - build-go:
+                name: build latest-main Go
+                ee: true
+                commit_SHA: ${LATEST_MAIN_SHA}
+
             # TODO CAROLINA
             - setup-python-venv:
                 determined: True
@@ -4823,7 +4820,7 @@ workflows:
       - build-go:
           name: build-go-ee
           context: github-read
-      - pull-main-docker-images
+      - find-main-docker-images
       # TODO CAROLINA -- make this weekly 
 
       - test-e2e:
@@ -4832,7 +4829,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
@@ -4844,7 +4841,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 6
           resource-class: xlarge
           tf2: true
@@ -4857,7 +4854,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 5
           resource-class: large
           tf2: true
@@ -4872,7 +4869,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
@@ -4885,7 +4882,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
@@ -4898,7 +4895,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4916,7 +4913,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4932,7 +4929,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           tf2: true
           mark: e2e_multi_k8s
@@ -4948,7 +4945,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_single_k8s
           target-stage: master
@@ -4962,7 +4959,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
@@ -4975,7 +4972,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           resource-class: large
           mark: e2e_cpu_elastic
@@ -4989,7 +4986,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -5003,7 +5000,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -5017,7 +5014,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: custom-agent-version.devcluster.yaml
@@ -5031,7 +5028,7 @@ workflows:
           name: test-e2e-agent-connection-loss
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           mark: e2e_cpu_agent_connection_loss
           devcluster-config: agent-no-connection.devcluster.yaml
@@ -5048,7 +5045,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
-            - pull-main-docker-images
+            - find-main-docker-images
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1732,7 +1732,7 @@ jobs:
       - run: docker tag determinedai/hpe-mlde-agent:${CIRCLE_SHA1}-amd64 determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
       - run: docker save -o build/agent.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
       - run: docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
-      - persist_to_workspace: # toDO CAROLINA
+      - persist_to_workspace:
           root: .
           paths:
             - "master/dist/*linux_amd64.deb"
@@ -2026,6 +2026,37 @@ jobs:
           at: .
       - run: make -C bindings force-gen
       - run: make -C bindings check/python
+
+  pull-main-docker-images:
+    docker:
+      - image: <<pipeline.parameters.docker-image>>
+    steps: # TODO CAROLINA
+      - setup_remote_docker:
+          version: previous
+      - login-docker:
+          username: ${DOCKER_USER}
+          password: ${DOCKER_PASS}
+      - run: 
+          name: Fetch & Checkout Latest Main
+          command:  |
+            git fetch origin main && git checkout main
+            export LATEST_MAIN_SHA=$(git rev-parse HEAD)
+      - run:
+          name: Check for Main Docker Image
+          command: |
+            for i in {1..20}; do
+              if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-master/${LATEST_MAIN_SHA}/" > /dev/null; then
+                echo "Master tag '${LATEST_MAIN_SHA}' found."
+                if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-agent/${LATEST_MAIN_SHA}/" > /dev/null; then
+                  echo "Agent tag '${LATEST_MAIN_SHA}' found."
+                  exit 0
+                fi
+              fi
+              echo "Tag '${LATEST_MAIN_SHA}' not found (Attempt $i/20), retrying in 60s..."
+              sleep 60
+            done
+            echo "Tag '${LATEST_MAIN_SHA}' not found after 20 attempts."
+            exit 1
 
   upload-try-now-template:
     docker:
@@ -3240,44 +3271,18 @@ jobs:
           steps:
             # Stop devcluster running on the past release.
             - stop-devcluster
-            - setup_remote_docker:
-                version: previous
-            - login-docker:
-                username: ${DOCKER_USER}
-                password: ${DOCKER_PASS}
-            - run: 
-                name: Fetch & Checkout Latest Main
-                command: git fetch origin main && git checkout main
             - run:
-                name: Check for Main Docker Image
+                name: Install Latest Main Build # TODO CAROLINA -- do I need to checkout branch too?
                 command: |
-                  REPO="determinedai/hpe-mlde-master"
-                  TAG="$1"
-                  for i in {1..20}; do
-                    if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-master/${TAG}/" > /dev/null; then
-                      echo "Master tag '${TAG}' found."
-                      if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-agent/${TAG}/" > /dev/null; then
-                        echo "Agent tag '${TAG}' found."
-                        exit 0
-                      fi
-                    fi
-                    echo "Tag '${TAG}' not found (Attempt $i/20), retrying in 60s..."
-                    sleep 60
-                  done
-
-                  echo "Tag '${TAG}' not found after 20 attempts."
-                  exit 1
-            - run:
-                name: Install New Build
-                command: |
-                  docker save -o build/master.image determinedai/hpe-mlde-master:${CIRCLE_SHA1}
-                  docker save -o build/master-ee.image determinedai/hpe-mlde-master:${CIRCLE_SHA1}
-                  docker save -o build/agent.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
-                  docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
+                  docker save -o build/master.image determinedai/hpe-mlde-master:${LATEST_MAIN_SHA}
+                  docker save -o build/master-ee.image determinedai/hpe-mlde-master:${LATEST_MAIN_SHA}
+                  docker save -o build/agent.image determinedai/hpe-mlde-agent:${LATEST_MAIN_SHA}
+                  docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${LATEST_MAIN_SHA}
             - persist_to_workspace: 
                 root: .
                 paths:
                   - "build/*.image" # TODO CAROLINA -- what images do I need to save and why?
+            # TODO CAROLINA
             - setup-python-venv:
                 determined: True
                 extra-requirements-file: "e2e_tests/tests/requirements.txt"
@@ -4818,6 +4823,8 @@ workflows:
       - build-go:
           name: build-go-ee
           context: github-read
+      - pull-main-docker-images
+      # TODO CAROLINA -- make this weekly 
 
       - test-e2e:
           name: test-e2e-rbac

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -102,8 +102,8 @@ release-dryrun: &release-dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
 release-upgrade: &release-upgrade
-  - "release-0.34.0"
-  - "release-0.35.0"
+  # This value should be updated on every release to capture the updated supported upgrades.
+  - "release-0.37.0"
 
 upstream-feature-branch: &upstream-feature-branch
   branches:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3244,12 +3244,12 @@ jobs:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
             - run-e2e-tests:
-              mark: <<parameters.mark>>
-              master-host: localhost
-              managed-devcluster: <<parameters.managed-devcluster>>
-              extra-pytest-flags: <<parameters.extra-pytest-flags>>
-              wait-for-master: <<parameters.wait-for-master>>
-              collect-det-job-logs: <<parameters.collect-det-job-logs>>
+                mark: <<parameters.mark>>
+                master-host: localhost
+                managed-devcluster: <<parameters.managed-devcluster>>
+                extra-pytest-flags: <<parameters.extra-pytest-flags>>
+                wait-for-master: <<parameters.wait-for-master>>
+                collect-det-job-logs: <<parameters.collect-det-job-logs>>
             - stop-devcluster
             - checkout
             - run: make -C master build

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3196,7 +3196,7 @@ jobs:
             - run: 
                 name: Get Determined version branch commits.
                 command: |
-                  git fetch origin <<parameters.upgrade-branch>> && git checkout <<parameters.upgrade-branch>>
+                  git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2230,21 +2230,9 @@ jobs:
             - license-gen
       - attach_workspace:
           at: .
-      - run:
-          name: Check for latest commit file
-          command: |
-            if [ -f latest_commit.env ]; then
-              echo "Latest commit file found."
-              source latest_commit.env
-              echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> $BASH_ENV
-              git fetch origin $LATEST_MAIN_SHA && git checkout $LATEST_MAIN_SHA
-            else
-              echo "No latest commit file found. Skipping checkout."
-            fi
-
       - restore_cache:
           keys:
-            - det-go-build-${LATEST_MAIN_SHA}-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+            - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
       - run: make -C master build
       - run: make -C agent build
       - persist_to_workspace:
@@ -2254,7 +2242,7 @@ jobs:
             - "agent/build"
       # Save cache after we build master and agent so we can have our build cache there.
       - save_cache:
-          key: det-go-build-${LATEST_MAIN_SHA}-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+          key: det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
           paths:
             - "/home/circleci/go/"
             - "/home/circleci/.cache/go-build/"
@@ -3205,8 +3193,6 @@ jobs:
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
-            - build-go:
-                ee: true
             - setup-python-venv:
                 determined: True
                 extra-requirements-file: "e2e_tests/tests/requirements.txt"
@@ -3218,6 +3204,9 @@ jobs:
                 target-stage: agent1
             - run: sleep 10
             - stop-devcluster
+            - run: git checkout $CIRCLE_SHA1
+            - run: make -C master build
+            - run: make -C agent build
 
       - setup-python-venv:
           determined: True
@@ -4989,7 +4978,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-rbac-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2037,7 +2037,7 @@ jobs:
           username: ${DOCKER_USER}
           password: ${DOCKER_PASS}
       - checkout
-      - add-and-fetch-upstreamg
+      - add-and-fetch-upstream
       - run:
           name: Check for Latest Main Docker Image
           command: |

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -102,7 +102,7 @@ release-dryrun: &release-dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
 release-upgrade: &release-upgrade
-  - "release-0.36.0"
+  - "release-0.34.0"
   - "release-0.35.0"
 
 upstream-feature-branch: &upstream-feature-branch
@@ -404,9 +404,12 @@ commands:
         type: string
       package-commit: 
         type: string
-        default: $CIRCLE_SHA1
+        default: ""
     steps:
-      - run: git checkout <<parameters.package-commit>>
+      - when:
+          condition: <<parameters.package-commit>>
+          steps: 
+            run: git checkout <<parameters.package-commit>>
       - run:
           name: Install <<parameters.package-name>>
           working_directory: <<parameters.package-location>>
@@ -437,7 +440,7 @@ commands:
         default: "3.8.18"
       determined-SHA:
         type: string
-        default: $CIRCLE_SHA1
+        default: ""
     steps:
       - run:
           name: Write cache key
@@ -3188,9 +3191,7 @@ jobs:
       
       - when:
           condition: <<parameters.upgrade-branch>>
-          # Only run this when an upgrade branch parameter is given.
           steps:
-            # Upgrade test portion: downgrade to specified version, start/stop devcluster
             - run: 
                 name: Get Determined version branch commits.
                 command: |

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -98,15 +98,6 @@ release-dryrun: &release-dryrun
       # Tags like: v3.1.3+dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
-release-dryrun: &release-dryrun
-  branches:
-    ignore:
-      - /.*/
-  tags:
-    only:
-      # Tags like: v3.1.3+dryrun
-      - /v\d+\.\d+\.\d+\+dryrun/
-
 release-upgrade: &release-upgrade
   branches:
     only:
@@ -4844,6 +4835,7 @@ workflows:
       - build-go:
           name: build-go-ee
           context: github-read
+
       - start-stop-devcluster:
           context:
             - dev-ci-cluster-default-user-credentials
@@ -4853,6 +4845,19 @@ workflows:
           name: start-stop-devcluster
       - build-go: 
           name: build-upgraded-go
+          context: github-read
+          requires:
+            - start-stop-devcluster          
+
+      - start-stop-devcluster:
+          context:
+            - dev-ci-cluster-default-user-credentials
+            - github-read
+          requires:
+            - build-go-ee
+          name: start-stop-rbac-devcluster
+      - build-go: 
+          name: build-upgraded-rbac-go
           context: github-read
           requires:
             - start-stop-devcluster          
@@ -5031,49 +5036,13 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
-
-  test-e2e-upgrade-rbac:
-    jobs:
-      - build-proto
-      - build-helm
-      - build-react:
-          dev-mode: true
-      - test-e2e-react:
-          name: test-e2e-react-ee
-          ee: true
-          requires:
-            - build-go-ee
-          context:
-            - playwright
-            - github-read
-            - dev-ci-cluster-default-user-credentials
-      - build-docs:
-          requires:
-            - build-helm
-            - build-proto
-      - build-go:
-          name: build-go-ee
-          context: github-read
-      - start-stop-devcluster:
-          context:
-            - dev-ci-cluster-default-user-credentials
-            - github-read
-          requires:
-            - build-go-ee
-          name: start-stop-devcluster
-          devcluster-config: single-rbac.devcluster.yaml
-      - build-go: 
-          name: build-upgraded-go
-          context: github-read
-          requires:
-            - start-stop-devcluster          
-
+      
       - test-e2e:
           name: test-e2e-rbac
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-upgraded-rbac-go
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
@@ -5083,7 +5052,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-upgraded-rbac-go
           parallelism: 1
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3245,7 +3245,6 @@ jobs:
                   - start-devcluster:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
-            - run: sleep 10
             - stop-devcluster
             - checkout
             - run: make -C master build

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1553,7 +1553,7 @@ jobs:
             VERSIONS=$(awk '{ print "  - \"" $0 "\"" }' $INPUT_FILE)
 
             # Replace the existing values under det-versions with the new ones from the text file
-            sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" .
+            sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" $YAML_FILE
             sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE \<<< "$VERSIONS"
 
             echo "Updated real_config.yaml:"

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1548,7 +1548,9 @@ jobs:
           name: Read Versions from supported_versions.txt file
           command: |
             VERSION_FILE="supported_versions.txt"
-            YAML_FILE="real_config.yaml"
+            YAML_FILE=".circleci/real_config.yaml"
+            pwd
+            ls -la
 
             VERSIONS=$(awk '{ print "  - \"" $0 "\"" }' $INPUT_FILE)
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3274,10 +3274,16 @@ jobs:
           steps:
             # Stop devcluster running on the past release.
             - stop-devcluster
-            - build-go:
-                name: build latest-main Go
-                ee: true
-                commit_SHA: ${LATEST_MAIN_SHA}
+            - reinstall-go
+            - license-gen
+            - run: git checkout ${LATEST_MAIN_SHA}
+            - run: make -C master build
+            - run: make -C agent build
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - "master/build"
+                  - "agent/build"
 
             # TODO CAROLINA
             - setup-python-venv:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4894,38 +4894,6 @@ workflows:
               upgrade-from-branch: *release-upgrade
 
       - test-e2e:
-          name: test-e2e-postgres10-with-ssl
-          context:
-            - dev-ci-cluster-default-user-credentials
-            - github-read
-          requires:
-            - build-go-ee
-          parallelism: 1
-          mark: e2e_cpu_postgres
-          devcluster-config: postgres-with-ssl.devcluster.yaml
-          target-stage: agent
-          postgres-version: "10"
-          matrix:
-            parameters:
-              upgrade-from-branch: *release-upgrade
-
-      - test-e2e:
-          name: test-e2e-postgres14-with-ssl
-          context:
-            - dev-ci-cluster-default-user-credentials
-            - github-read
-          requires:
-            - build-go-ee
-          parallelism: 1
-          mark: e2e_cpu_postgres
-          devcluster-config: postgres-with-ssl.devcluster.yaml
-          target-stage: agent
-          postgres-version: "14"
-          matrix:
-            parameters:
-              upgrade-from-branch: *release-upgrade
-
-      - test-e2e:
           name: test-e2e-old-agent-versions
           context:
             - dev-ci-cluster-default-user-credentials

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4788,7 +4788,7 @@ workflows:
     triggers:
       - schedule:
           cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
-          #filters: *release-upgrade  # Only runs on the release branches  
+          filters: *release-upgrade  # Only runs on the release branches  
     jobs:
       - build-proto
       - build-helm

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -101,12 +101,6 @@ release-dryrun: &release-dryrun
       # Tags like: v3.1.3+dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
-release-upgrade: &release-upgrade
-  branches:
-    only:
-      - /v\d+\.\d+\.\d+(rc\d+)?/
-      - carolinac/upgrade-tests
-
 upstream-feature-branch: &upstream-feature-branch
   branches:
     ignore:
@@ -4794,13 +4788,11 @@ workflows:
       - build-helm
       - build-react:
           dev-mode: true
-          filters: *release-upgrade
       - test-e2e-react:
           name: test-e2e-react-ee
           ee: true
           requires:
             - build-go-ee
-          filters: *release-upgrade
           context:
             - playwright
             - github-read
@@ -4809,11 +4801,9 @@ workflows:
           requires:
             - build-helm
             - build-proto
-          filters: *release-upgrade
       - build-go:
           name: build-go-ee
           context: github-read
-          filters: *release-upgrade
 
       - start-stop-devcluster:
           context:
@@ -4822,13 +4812,11 @@ workflows:
           requires:
             - build-go-ee
           name: start-stop-devcluster
-          filters: *release-upgrade
       - build-go: 
           name: build-upgraded-go
           context: github-read
           requires:
             - start-stop-devcluster
-          filters: *release-upgrade          
 
       - start-stop-devcluster:
           context:
@@ -4837,13 +4825,11 @@ workflows:
           requires:
             - build-go-ee
           name: start-stop-rbac-devcluster
-          filters: *release-upgrade
       - build-go: 
           name: build-upgraded-rbac-go
           context: github-read
           requires:
             - start-stop-devcluster 
-          filters: *release-upgrade        
 
       - test-e2e:
           name: test-e2e-cpu
@@ -4855,7 +4841,6 @@ workflows:
           resource-class: xlarge
           tf2: true
           mark: e2e_cpu
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4869,7 +4854,6 @@ workflows:
           mark: e2e_cpu_2a
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4881,7 +4865,6 @@ workflows:
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
           target-stage: agent1
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4898,7 +4881,6 @@ workflows:
           # so `compare_stats` cannot get the full logs from `det master logs`.
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4913,7 +4895,6 @@ workflows:
           managed-devcluster: true
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4928,7 +4909,6 @@ workflows:
           devcluster-config: multi-k8s.devcluster.yaml
           run-minikubes: true
           multi-k8s: true
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4941,7 +4921,6 @@ workflows:
           target-stage: master
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4953,7 +4932,6 @@ workflows:
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
           target-stage: agent
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4966,7 +4944,6 @@ workflows:
           mark: e2e_cpu_elastic
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4979,7 +4956,6 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "10"
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4992,7 +4968,6 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "14"
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -5007,7 +4982,6 @@ workflows:
           matrix:
             parameters:
               agent-version: ["0.17.10"]
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-agent-connection-loss
@@ -5020,7 +4994,6 @@ workflows:
           wait-for-master: false
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-saml
@@ -5032,7 +5005,6 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
-          filters: *release-upgrade
       
       - test-e2e:
           name: test-e2e-rbac
@@ -5043,7 +5015,6 @@ workflows:
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
-          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -5055,7 +5026,6 @@ workflows:
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
           target-stage: agent1
-          filters: *release-upgrade
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2235,8 +2235,6 @@ jobs:
           condition: << parameters.ee >>
           steps:
             - license-gen
-      - attach_workspace:
-          at: .
       - restore_cache:
           keys:
             - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
@@ -3199,6 +3197,8 @@ jobs:
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
+            - run: make -C master build
+            - run: make -C agent build
 
       - setup-python-venv:
           determined: True
@@ -3238,8 +3238,9 @@ jobs:
                   - run: sleep 10
                   - stop-devcluster
             - checkout
-            - run: make -C master build
-            - run: make -C agent build
+            - restore_cache:
+                keys:
+                  - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
 
       - install-devcluster
       - unless:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4781,6 +4781,7 @@ workflows:
           name: test-e2e-cpu
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 6
@@ -4795,6 +4796,7 @@ workflows:
           name: test-e2e-cpu-double
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 5
@@ -4811,6 +4813,7 @@ workflows:
           name: test-e2e-cpu-oauth
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1
@@ -4825,6 +4828,7 @@ workflows:
           name: test-e2e-multi-k8s
           context:
             - dev-ci-cluster-default-user-credentials
+            - github-read
           requires:
             - build-go-ee
           parallelism: 1

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1548,12 +1548,13 @@ jobs:
           name: Read Versions from supported_versions.txt file
           command: |
             VERSION_FILE="supported_versions.txt"
+            YAML_FILE="real_config.yaml"
 
             VERSIONS=$(awk '{ print "  - \"" $0 "\"" }' $INPUT_FILE)
 
             # Replace the existing values under det-versions with the new ones from the text file
             sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" .
-            sed -i "/det-versions: &det-versions/r /dev/stdin" . \<<< "$VERSIONS"
+            sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE \<<< "$VERSIONS"
 
             echo "Updated real_config.yaml:"
             cat $YAML_FILE

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3268,6 +3268,7 @@ jobs:
                 target-stage: <<parameters.target-stage>>
 
       - when:
+          condition: <<parameters.upgrade>>
           steps:
             # Stop devcluster running on the past release.
             - stop-devcluster

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1541,6 +1541,8 @@ commands:
 
 jobs:
   read-supported-versions:
+    docker:
+      - image: <<pipeline.parameters.docker-image>>
     steps:
       - run:
           name: Read Versions from supported_versions.txt file
@@ -1556,7 +1558,7 @@ jobs:
 
             echo "Updated real_config.yaml:"
             cat $YAML_FILE
-            
+
   build-helm:
     docker:
       - image: <<pipeline.parameters.docker-image>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1554,7 +1554,7 @@ jobs:
 
             # Replace the existing values under det-versions with the new ones from the text file
             sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" $YAML_FILE
-            sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE <<< "$VERSIONS"
+            sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE \<<< "$VERSIONS"
 
             echo "Updated real_config.yaml:"
             cat $YAML_FILE

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3184,8 +3184,7 @@ jobs:
       
       - when:
           condition: <<parameters.upgrade-branch>>
-          # Only run this on the main branch when the tests are scheduled.
-          #condition: <<pipeline.parameters.do_upgrade_tests>>
+          # Only run this when an upgrade branch parameter is given.
           steps:
             # Upgrade test portion: downgrade to specified version, start/stop devcluster
             - run: 
@@ -4748,7 +4747,7 @@ workflows:
             - package-and-push-system-dev-ee
 
   test-e2e-upgrade:
-    #when: << pipeline.parameters.do_upgrade_tests >>
+    when: << pipeline.parameters.do_upgrade_tests >>
     jobs:
       - build-proto
       - build-helm
@@ -4774,7 +4773,7 @@ workflows:
           mark: e2e_cpu
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4790,7 +4789,7 @@ workflows:
           devcluster-config: double-priority.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4804,7 +4803,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4823,7 +4822,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4840,7 +4839,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4857,7 +4856,7 @@ workflows:
           multi-k8s: true
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4872,7 +4871,7 @@ workflows:
           run-minikubes: true
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4886,7 +4885,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4901,7 +4900,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4916,7 +4915,7 @@ workflows:
           postgres-version: "10"
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4931,7 +4930,7 @@ workflows:
           postgres-version: "14"
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4945,7 +4944,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
               agent-version: ["0.17.10"]
 
       - test-e2e:
@@ -4961,7 +4960,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-saml
@@ -4975,7 +4974,7 @@ workflows:
           mark: e2e_saml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
       
       - test-e2e:
           name: test-e2e-rbac
@@ -4988,7 +4987,7 @@ workflows:
           devcluster-config: single-rbac.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -5002,7 +5001,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1505,31 +1505,6 @@ commands:
     steps:
       - run: 
           command: pkill -SIGHUP -f "devcluster" && rm -rf /tmp/devcluster/lock
-         
-  make-component:
-    description: "Basic parameterized version of make for building Determined components."
-    parameters:
-      component:
-        type: string
-        default: ""
-      target:
-        type: string
-        default: ""
-      dryrun:
-        type: boolean
-        default: false
-      no_output_timeout:
-        type: string
-        default: "10m"
-    steps:
-      - run:
-          no_output_timeout: <<parameters.no_output_timeout>>
-          command: |
-            if <<parameters.dryrun>>; then
-              make -C <<parameters.component>> <<parameters.target>>
-            else
-              make -C <<parameters.component>> <<parameters.target>>-dryrun
-            fi
 
 jobs:
   start-stop-devcluster:
@@ -4810,10 +4785,10 @@ workflows:
             - package-and-push-system-dev-ee
 
   test-e2e-upgrade:
-    #triggers:
-    #  - schedule:
-    #      cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
-    #      filters: *release-upgrade  # Only runs on the release branches  
+    triggers:
+      - schedule:
+          cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
+          filters: *release-upgrade  # Only runs on the release branches  
     jobs:
       - build-proto
       - build-helm

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3235,12 +3235,13 @@ jobs:
                   - start-devcluster:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
-                  - run: sleep 10
-                  - stop-devcluster
+            - run: sleep 10
+            - stop-devcluster
             - checkout
-            - restore_cache:
-                keys:
-                  - det-go-build-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+            - setup-python-venv:
+                determined: True
+                extra-requirements-file: "e2e_tests/tests/requirements.txt"
+                executor: <<pipeline.parameters.machine-image>>
 
       - install-devcluster
       - unless:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -55,6 +55,9 @@ parameters:
   do_nightly_tests:
     type: boolean
     default: false
+  do_upgrade_tests:
+    type: boolean
+    default: false
   ee:
     type: boolean
     default: false
@@ -4785,20 +4788,19 @@ workflows:
             - package-and-push-system-dev-ee
 
   test-e2e-upgrade:
-    triggers:
-      - schedule:
-          cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
-          filters: *release-upgrade  # Only runs on the release branches  
+    when: << pipeline.parameters.do_upgrade_tests >>
     jobs:
       - build-proto
       - build-helm
       - build-react:
           dev-mode: true
+          filters: *release-upgrade
       - test-e2e-react:
           name: test-e2e-react-ee
           ee: true
           requires:
             - build-go-ee
+          filters: *release-upgrade
           context:
             - playwright
             - github-read
@@ -4807,9 +4809,11 @@ workflows:
           requires:
             - build-helm
             - build-proto
+          filters: *release-upgrade
       - build-go:
           name: build-go-ee
           context: github-read
+          filters: *release-upgrade
 
       - start-stop-devcluster:
           context:
@@ -4818,11 +4822,13 @@ workflows:
           requires:
             - build-go-ee
           name: start-stop-devcluster
+          filters: *release-upgrade
       - build-go: 
           name: build-upgraded-go
           context: github-read
           requires:
-            - start-stop-devcluster          
+            - start-stop-devcluster
+          filters: *release-upgrade          
 
       - start-stop-devcluster:
           context:
@@ -4831,11 +4837,13 @@ workflows:
           requires:
             - build-go-ee
           name: start-stop-rbac-devcluster
+          filters: *release-upgrade
       - build-go: 
           name: build-upgraded-rbac-go
           context: github-read
           requires:
-            - start-stop-devcluster          
+            - start-stop-devcluster 
+          filters: *release-upgrade        
 
       - test-e2e:
           name: test-e2e-cpu
@@ -4847,6 +4855,7 @@ workflows:
           resource-class: xlarge
           tf2: true
           mark: e2e_cpu
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4860,6 +4869,7 @@ workflows:
           mark: e2e_cpu_2a
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4871,6 +4881,7 @@ workflows:
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
           target-stage: agent1
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4887,6 +4898,7 @@ workflows:
           # so `compare_stats` cannot get the full logs from `det master logs`.
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4901,6 +4913,7 @@ workflows:
           managed-devcluster: true
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4915,6 +4928,7 @@ workflows:
           devcluster-config: multi-k8s.devcluster.yaml
           run-minikubes: true
           multi-k8s: true
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4927,6 +4941,7 @@ workflows:
           target-stage: master
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4938,6 +4953,7 @@ workflows:
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
           target-stage: agent
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4950,6 +4966,7 @@ workflows:
           mark: e2e_cpu_elastic
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4962,6 +4979,7 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "10"
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4974,6 +4992,7 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "14"
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4988,6 +5007,7 @@ workflows:
           matrix:
             parameters:
               agent-version: ["0.17.10"]
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-agent-connection-loss
@@ -5000,6 +5020,7 @@ workflows:
           wait-for-master: false
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-saml
@@ -5011,6 +5032,7 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
+          filters: *release-upgrade
       
       - test-e2e:
           name: test-e2e-rbac
@@ -5021,6 +5043,7 @@ workflows:
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
+          filters: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -5032,6 +5055,7 @@ workflows:
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
           target-stage: agent1
+          filters: *release-upgrade
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1548,13 +1548,12 @@ jobs:
           name: Read Versions from supported_versions.txt file
           command: |
             VERSION_FILE="supported_versions.txt"
-            YAML_FILE ="real_config.yaml"
 
             VERSIONS=$(awk '{ print "  - \"" $0 "\"" }' $INPUT_FILE)
 
             # Replace the existing values under det-versions with the new ones from the text file
-            sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" $YAML_FILE
-            sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE \<<< "$VERSIONS"
+            sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" .
+            sed -i "/det-versions: &det-versions/r /dev/stdin" . \<<< "$VERSIONS"
 
             echo "Updated real_config.yaml:"
             cat $YAML_FILE

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -103,10 +103,9 @@ release-dryrun: &release-dryrun
 
 release-upgrade: &release-upgrade
   branches:
-    only:
       - "release-0.35.0"
       - "release-0.32.0"
-      - carolinac/upgrade-tests 
+      - carolinac/upgrade-tests
 
 
 upstream-feature-branch: &upstream-feature-branch

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -107,6 +107,12 @@ release-dryrun: &release-dryrun
       # Tags like: v3.1.3+dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
+release-upgrade: &release-upgrade
+  branches:
+    only:
+      - /v\d+\.\d+\.\d+(rc\d+)?/
+      - carolinac/upgrade-tests
+
 upstream-feature-branch: &upstream-feature-branch
   branches:
     ignore:
@@ -404,7 +410,11 @@ commands:
         type: string
       package-location:
         type: string
+      package-commit: 
+        type: string
+        default: $CIRCLE_SHA1
     steps:
+      - run: git checkout <<parameters.package-commit>>
       - run:
           name: Install <<parameters.package-name>>
           working_directory: <<parameters.package-location>>
@@ -433,6 +443,9 @@ commands:
       python-version:
         type: string
         default: "3.8.18"
+      determined-SHA:
+        type: string
+        default: $CIRCLE_SHA1
     steps:
       - run:
           name: Write cache key
@@ -518,6 +531,7 @@ commands:
             - install-wheel:
                 package-name: determined
                 package-location: ./harness
+                package-commit: <<parameters.determined-SHA>>
       - run:
           name: Install <<parameters.extras-requires>>
           command: |
@@ -635,12 +649,12 @@ commands:
                     ci.workflow_id:${CIRCLE_WORKFLOW_ID},\
                     ci.job_num:${CIRCLE_BUILD_NUM},\
                     ci.username:${CIRCLE_USERNAME},\
-                    git.tag:${CIRCLE_TAG},\
+                    git.tag:${CIRCLE_TAG:-""},\
                     git.commit:${CIRCLE_SHA1},\
                     git.repo:${CIRCLE_PROJECT_REPONAME},\
                     ci.totalNodes:${CIRCLE_NODE_TOTAL},\
                     ci.nodeIdx:${CIRCLE_NODE_INDEX},\
-                    git.pr_num:${CIRCLE_PR_NUMBER}"
+                    git.pr_num:${CIRCLE_PR_NUMBER:-""}"
 
                     sudo mkdir -p /tmp/artifacts/logs
                     sudo chmod -R a+rw /tmp/artifacts/logs
@@ -704,11 +718,11 @@ commands:
             ci.workflow_id:${CIRCLE_WORKFLOW_ID},\
             ci.job_num:${CIRCLE_BUILD_NUM},\
             ci.username:${CIRCLE_USERNAME},\
-            git.tag:${CIRCLE_TAG},\
+            git.tag:${CIRCLE_TAG:-""},\
             git.commit:${CIRCLE_SHA1},\
             ci.totalNodes:${CIRCLE_NODE_TOTAL},\
             ci.nodeIdx:${CIRCLE_NODE_INDEX},\
-            git.pr_num:${CIRCLE_PR_NUMBER}"
+            git.pr_num:${CIRCLE_PR_NUMBER:-""}"
 
             CMD="DD_CIVISIBILITY_AGENTLESS_ENABLED=true \
             DD_TAGS='${tags}' \
@@ -1500,7 +1514,7 @@ commands:
     steps:
       - run: 
           command: pkill -SIGHUP -f "devcluster" && rm -rf /tmp/devcluster/lock
-          
+         
   make-component:
     description: "Basic parameterized version of make for building Determined components."
     parameters:
@@ -1527,6 +1541,48 @@ commands:
             fi
 
 jobs:
+  start-stop-devcluster:
+    parameters:
+      devcluster-config:
+        type: string
+        default: double.devcluster.yaml
+    machine:
+      image: <<pipeline.parameters.machine-image>>
+    resource_class: xlarge
+    environment:
+      DET_POSTGRES_VERSION: 10
+      DET_AGENT_VERSION: ""
+    steps:
+      - checkout
+      - add-and-fetch-upstream
+      - skip-if-only-docs
+      - skip-if-only-github
+      - skip-if-only-webui
+      - attach_workspace:
+          at: .
+
+      - setup-python-venv:
+          determined: True
+          extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          executor: <<pipeline.parameters.machine-image>>
+      - install-devcluster
+      - start-devcluster:
+          devcluster-config: <<parameters.devcluster-config>>
+          target-stage: agent1
+      - run: sleep 10
+      - run:
+          name: Fetch latest commit
+          command: |
+            git fetch origin main
+            LATEST_MAIN_SHA=$(git rev-parse origin/main)
+            echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> latest_commit.env  # Save to a file
+      - persist_to_workspace:
+          root: .
+          paths:
+            - latest_commit.env
+      - stop-devcluster
+
+   
   build-helm:
     docker:
       - image: <<pipeline.parameters.docker-image>>
@@ -2237,9 +2293,6 @@ jobs:
       ee:
         type: boolean
         default: true
-      commit_SHA:
-        type: string
-        default: $CIRCLE_SHA1
     docker:
       - image: <<pipeline.parameters.docker-image>>
         environment:
@@ -2254,9 +2307,23 @@ jobs:
           condition: << parameters.ee >>
           steps:
             - license-gen
+      - attach_workspace:
+          at: .
+      - run:
+          name: Check for latest commit file
+          command: |
+            if [ -f latest_commit.env ]; then
+              echo "Latest commit file found."
+              source latest_commit.env
+              echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> $BASH_ENV
+              git fetch origin $LATEST_MAIN_SHA && git checkout $LATEST_MAIN_SHA
+            else
+              echo "No latest commit file found. Skipping checkout."
+            fi
+
       - restore_cache:
           keys:
-            - det-go-build-<<parameters.commit_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+            - det-go-build-${LATEST_MAIN_SHA}-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
       - run: make -C master build
       - run: make -C agent build
       - persist_to_workspace:
@@ -2266,7 +2333,7 @@ jobs:
             - "agent/build"
       # Save cache after we build master and agent so we can have our build cache there.
       - save_cache:
-          key: det-go-build-<<parameters.commit_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+          key: det-go-build-${LATEST_MAIN_SHA}-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
           paths:
             - "/home/circleci/go/"
             - "/home/circleci/.cache/go-build/"
@@ -3187,9 +3254,6 @@ jobs:
       k8s-version:
         type: string
         default: "1.29.5"
-      upgrade: 
-        type: boolean
-        default: false
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: <<parameters.resource-class>>
@@ -3206,8 +3270,21 @@ jobs:
       - attach_workspace:
           at: .
 
+      - run: 
+          name: Export Latest Main SHA for upgrade tests
+          command: |
+            if [ -f latest_commit.env ]; then
+              echo "Latest commit file found."
+              source latest_commit.env
+              echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> $BASH_ENV
+              git fetch origin $LATEST_MAIN_SHA && git checkout $LATEST_MAIN_SHA
+            else
+              echo "No latest commit file found. Skipping checkout."
+            fi
+
       - setup-python-venv:
           determined: True
+          determined-SHA: $LATEST_MAIN_SHA
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
           executor: <<pipeline.parameters.machine-image>>
 
@@ -3237,24 +3314,6 @@ jobs:
             - start-devcluster:
                 devcluster-config: <<parameters.devcluster-config>>
                 target-stage: <<parameters.target-stage>>
-
-      - when:
-          condition: <<parameters.upgrade>>
-          steps:
-            - reinstall-go
-            - run: git checkout ${LATEST_MAIN_SHA}
-            - run: make -C master build
-            - run: make -C agent build
-            # not persisting to workspace because we still want first run of test to run w/ old branch build
-            # Stop devcluster running on the past release.
-            - stop-devcluster
-            - install-devcluster
-            - unless:
-                condition: <<parameters.managed-devcluster>>
-                steps:
-                  - start-devcluster:
-                      devcluster-config: <<parameters.devcluster-config>>
-                      target-stage: <<parameters.target-stage>>
 
       - pull-task-images:
           tf2: <<parameters.tf2>>
@@ -4436,9 +4495,6 @@ workflows:
           mark: e2e_cpu_2a
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4450,9 +4506,6 @@ workflows:
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
           target-stage: agent1
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -4464,9 +4517,6 @@ workflows:
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
           target-stage: agent1
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4483,9 +4533,6 @@ workflows:
           # so `compare_stats` cannot get the full logs from `det master logs`.
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4500,9 +4547,6 @@ workflows:
           managed-devcluster: true
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4517,9 +4561,6 @@ workflows:
           devcluster-config: multi-k8s.devcluster.yaml
           run-minikubes: true
           multi-k8s: true
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4532,9 +4573,6 @@ workflows:
           target-stage: master
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4546,9 +4584,6 @@ workflows:
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
           target-stage: agent
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4561,9 +4596,6 @@ workflows:
           mark: e2e_cpu_elastic
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4576,9 +4608,6 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "10"
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4591,9 +4620,6 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "14"
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4608,7 +4634,6 @@ workflows:
           matrix:
             parameters:
               agent-version: ["0.17.10"]
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-agent-connection-loss
@@ -4621,9 +4646,6 @@ workflows:
           wait-for-master: false
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-e2e:
           name: test-e2e-saml
@@ -4635,9 +4657,6 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
-          matrix:
-            parameters:
-              upgrade: [true, false]
 
       - test-perf:
           name: test-perf
@@ -4798,6 +4817,277 @@ workflows:
                 - main
           requires:
             - package-and-push-system-dev-ee
+
+  test-e2e-upgrade:
+    #triggers:
+    #  - schedule:
+    #      cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
+    #      filters: *release-upgrade  # Only runs on the release branches  
+    jobs:
+      - build-proto
+      - build-helm
+      - build-react:
+          dev-mode: true
+      - test-e2e-react:
+          name: test-e2e-react-ee
+          ee: true
+          requires:
+            - build-go-ee
+          context:
+            - playwright
+            - github-read
+            - dev-ci-cluster-default-user-credentials
+      - build-docs:
+          requires:
+            - build-helm
+            - build-proto
+      - build-go:
+          name: build-go-ee
+          context: github-read
+      - start-stop-devcluster:
+          context:
+            - dev-ci-cluster-default-user-credentials
+            - github-read
+          requires:
+            - build-go-ee
+          name: start-stop-devcluster
+      - build-go: 
+          name: build-upgraded-go
+          context: github-read
+          requires:
+            - start-stop-devcluster          
+
+      - test-e2e:
+          name: test-e2e-cpu
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 6
+          resource-class: xlarge
+          tf2: true
+          mark: e2e_cpu
+
+      - test-e2e:
+          name: test-e2e-cpu-double
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 5
+          resource-class: large
+          tf2: true
+          mark: e2e_cpu_2a
+          target-stage: agent2
+          devcluster-config: double-priority.devcluster.yaml
+
+      - test-e2e:
+          name: test-e2e-cpu-oauth
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          devcluster-config: oauth.devcluster.yaml
+          mark: test_oauth
+          target-stage: agent1
+
+      - test-e2e:
+          name: test-e2e-managed-devcluster
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 4
+          resource-class: large
+          tf2: true
+          mark: managed_devcluster
+          managed-devcluster: true
+          # Managed devcluster restarts the master over the course of the tests,
+          # so `compare_stats` cannot get the full logs from `det master logs`.
+          extra-pytest-flags: "--no-compare-stats"
+          collect-det-job-logs: false
+
+      - test-e2e:
+          name: test-e2e-managed-devcluster-resource-pools
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 4
+          resource-class: large
+          tf2: true
+          mark: managed_devcluster_resource_pools
+          managed-devcluster: true
+          extra-pytest-flags: "--no-compare-stats"
+          collect-det-job-logs: false
+
+      - test-e2e:
+          name: test-e2e-multi-k8s
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          tf2: true
+          mark: e2e_multi_k8s
+          target-stage: master
+          devcluster-config: multi-k8s.devcluster.yaml
+          run-minikubes: true
+          multi-k8s: true
+
+      - test-e2e:
+          name: test-e2e-single-k8s
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_single_k8s
+          target-stage: master
+          devcluster-config: single-k8s.devcluster.yaml
+          run-minikubes: true
+
+      - test-e2e:
+          name: test-e2e-port-registry
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          devcluster-config: port-registry.devcluster.yaml
+          mark: port_registry
+          target-stage: agent
+
+      - test-e2e:
+          name: test-e2e-cpu-elastic
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          resource-class: large
+          mark: e2e_cpu_elastic
+          devcluster-config: elastic.devcluster.yaml
+          target-stage: agent
+
+      - test-e2e:
+          name: test-e2e-postgres10-with-ssl
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_cpu_postgres
+          devcluster-config: postgres-with-ssl.devcluster.yaml
+          target-stage: agent
+          postgres-version: "10"
+
+      - test-e2e:
+          name: test-e2e-postgres14-with-ssl
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_cpu_postgres
+          devcluster-config: postgres-with-ssl.devcluster.yaml
+          target-stage: agent
+          postgres-version: "14"
+
+      - test-e2e:
+          name: test-e2e-old-agent-versions
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_cpu_postgres
+          devcluster-config: custom-agent-version.devcluster.yaml
+          target-stage: agent
+          matrix:
+            parameters:
+              agent-version: ["0.17.10"]
+
+      - test-e2e:
+          name: test-e2e-agent-connection-loss
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_cpu_agent_connection_loss
+          devcluster-config: agent-no-connection.devcluster.yaml
+          target-stage: agent
+          wait-for-master: false
+          extra-pytest-flags: "--no-compare-stats"
+          collect-det-job-logs: false
+
+      - test-e2e:
+          name: test-e2e-saml
+          context:
+            - okta
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          devcluster-config: saml.devcluster.yaml
+          mark: e2e_saml
+
+  test-e2e-upgrade-rbac:
+    jobs:
+      - build-proto
+      - build-helm
+      - build-react:
+          dev-mode: true
+      - test-e2e-react:
+          name: test-e2e-react-ee
+          ee: true
+          requires:
+            - build-go-ee
+          context:
+            - playwright
+            - github-read
+            - dev-ci-cluster-default-user-credentials
+      - build-docs:
+          requires:
+            - build-helm
+            - build-proto
+      - build-go:
+          name: build-go-ee
+          context: github-read
+      - start-stop-devcluster:
+          context:
+            - dev-ci-cluster-default-user-credentials
+            - github-read
+          requires:
+            - build-go-ee
+          name: start-stop-devcluster
+          devcluster-config: single-rbac.devcluster.yaml
+      - build-go: 
+          name: build-upgraded-go
+          context: github-read
+          requires:
+            - start-stop-devcluster          
+
+      - test-e2e:
+          name: test-e2e-rbac
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          mark: e2e_cpu_rbac
+          devcluster-config: single-rbac.devcluster.yaml
+
+      - test-e2e:
+          name: test-e2e-cpu-model-registry-rbac
+          context:
+            - dev-ci-cluster-default-user-credentials
+          requires:
+            - build-upgraded-go
+          parallelism: 1
+          devcluster-config: rbac-model-registry.yaml
+          mark: test_model_registry_rbac
+          target-stage: agent1
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2036,6 +2036,8 @@ jobs:
       - login-docker:
           username: ${DOCKER_USER}
           password: ${DOCKER_PASS}
+      - checkout
+      - add-and-fetch-upstream
       - run:
           name: Check for Latest Main Docker Image
           command: |

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -101,6 +101,14 @@ release-dryrun: &release-dryrun
       # Tags like: v3.1.3+dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
+release-upgrade: &release-upgrade
+  branches:
+    only:
+      - "release-0.35.0"
+      - "release-0.32.0"
+      - carolinac/upgrade-tests 
+
+
 upstream-feature-branch: &upstream-feature-branch
   branches:
     ignore:
@@ -3190,6 +3198,7 @@ jobs:
             - run: 
                 name: Get Determined version branch commits.
                 command: |
+                  git fetch origin <<parameters.upgrade-branch>> && git checkout <<parameters.upgrade-branch>>
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
@@ -4773,7 +4782,7 @@ workflows:
           mark: e2e_cpu
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4789,7 +4798,7 @@ workflows:
           devcluster-config: double-priority.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4803,7 +4812,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4822,7 +4831,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4839,7 +4848,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4856,7 +4865,7 @@ workflows:
           multi-k8s: true
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4871,7 +4880,7 @@ workflows:
           run-minikubes: true
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4885,7 +4894,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4900,7 +4909,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4915,7 +4924,7 @@ workflows:
           postgres-version: "10"
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4930,7 +4939,7 @@ workflows:
           postgres-version: "14"
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4944,7 +4953,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
               agent-version: ["0.17.10"]
 
       - test-e2e:
@@ -4960,7 +4969,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-saml
@@ -4974,7 +4983,7 @@ workflows:
           mark: e2e_saml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
       
       - test-e2e:
           name: test-e2e-rbac
@@ -4987,7 +4996,7 @@ workflows:
           devcluster-config: single-rbac.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -5001,7 +5010,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: ["carolinac/upgrade-tests", "release-0.32.0", "release-0.35.0"]
+              upgrade-branch: *release-upgrade
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4821,42 +4821,6 @@ workflows:
               upgrade-branch: *release-upgrade
 
       - test-e2e:
-          name: test-e2e-managed-devcluster
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-          parallelism: 4
-          resource-class: large
-          tf2: true
-          mark: managed_devcluster
-          managed-devcluster: true
-          # Managed devcluster restarts the master over the course of the tests,
-          # so `compare_stats` cannot get the full logs from `det master logs`.
-          extra-pytest-flags: "--no-compare-stats"
-          collect-det-job-logs: false
-          matrix:
-            parameters:
-              upgrade-branch: *release-upgrade
-
-      - test-e2e:
-          name: test-e2e-managed-devcluster-resource-pools
-          context:
-            - dev-ci-cluster-default-user-credentials
-          requires:
-            - build-go-ee
-          parallelism: 4
-          resource-class: large
-          tf2: true
-          mark: managed_devcluster_resource_pools
-          managed-devcluster: true
-          extra-pytest-flags: "--no-compare-stats"
-          collect-det-job-logs: false
-          matrix:
-            parameters:
-              upgrade-branch: *release-upgrade
-
-      - test-e2e:
           name: test-e2e-multi-k8s
           context:
             - dev-ci-cluster-default-user-credentials

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4995,7 +4995,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-rbac-go
+            - build-go-ee
           parallelism: 1
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2296,7 +2296,7 @@ jobs:
             - "agent/build"
       # Save cache after we build master and agent so we can have our build cache there.
       - save_cache:
-          key: det-go-build-<<parameters.commt_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
+          key: det-go-build-<<parameters.commit_SHA>>-<<pipeline.parameters.cache-buster>>-{{ checksum  "go.sum" }}
           paths:
             - "/home/circleci/go/"
             - "/home/circleci/.cache/go-build/"

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3213,8 +3213,8 @@ jobs:
                 name: Get Determined version branch commits.
                 command: |
                   git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
-            - run: make -C master build
-            - run: make -C agent build
+            #- run: make -C master build
+            #- run: make -C agent build
 
       - when:
           condition: <<parameters.run-minikubes>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3184,7 +3184,7 @@ jobs:
       
       - when:
           # Only run this on the main branch when the tests are scheduled.
-          condition: <<pipeline.parameters.do_upgrade_tests>>
+          #condition: <<pipeline.parameters.do_upgrade_tests>>
           steps:
             # Upgrade test portion: downgrade to specified version, start/stop devcluster
             - run: 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -62,12 +62,6 @@ parameters:
     type: string
     default: ""
 
-det-versions: &det-versions
-  - "0.34.0"
-  - "0.35.0"
-  - "0.36.0"
-  - <branch-of-unreleased-change>
-
 release-and-rc-filters: &release-and-rc-filters
   branches:
     ignore:
@@ -4868,9 +4862,6 @@ workflows:
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-cpu
@@ -4883,9 +4874,6 @@ workflows:
           tf2: true
           mark: e2e_cpu
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4900,9 +4888,6 @@ workflows:
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4915,9 +4900,6 @@ workflows:
           mark: test_oauth
           target-stage: agent1
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -4930,9 +4912,6 @@ workflows:
           mark: test_model_registry_rbac
           target-stage: agent1
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4950,9 +4929,6 @@ workflows:
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4968,9 +4944,6 @@ workflows:
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4986,9 +4959,6 @@ workflows:
           run-minikubes: true
           multi-k8s: true
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -5002,9 +4972,6 @@ workflows:
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -5017,9 +4984,6 @@ workflows:
           mark: port_registry
           target-stage: agent
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -5033,9 +4997,6 @@ workflows:
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -5049,9 +5010,6 @@ workflows:
           target-stage: agent
           postgres-version: "10"
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -5065,9 +5023,6 @@ workflows:
           target-stage: agent
           postgres-version: "14"
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -5082,7 +5037,6 @@ workflows:
           matrix:
             parameters:
               agent-version: ["0.17.10"]
-              det-version: *det-versions
           upgrade: true
 
       - test-e2e:
@@ -5097,9 +5051,6 @@ workflows:
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
       - test-e2e:
           name: test-e2e-saml
@@ -5112,9 +5063,6 @@ workflows:
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
           upgrade: true
-          matrix:
-            parameters:
-              det-version: *det-versions
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -408,8 +408,8 @@ commands:
           working_directory: <<parameters.package-location>>
           command: |
             make build
-            pip install --find-links dist <<parameters.package-name>>
-            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>
+            pip install --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
+            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
 
   setup-python-venv:
     description: Set up and create Python venv.
@@ -633,12 +633,12 @@ commands:
                     ci.workflow_id:${CIRCLE_WORKFLOW_ID},\
                     ci.job_num:${CIRCLE_BUILD_NUM},\
                     ci.username:${CIRCLE_USERNAME},\
-                    git.tag:${CIRCLE_TAG:-""},\
+                    git.tag:${CIRCLE_TAG},\
                     git.commit:${CIRCLE_SHA1},\
                     git.repo:${CIRCLE_PROJECT_REPONAME},\
                     ci.totalNodes:${CIRCLE_NODE_TOTAL},\
                     ci.nodeIdx:${CIRCLE_NODE_INDEX},\
-                    git.pr_num:${CIRCLE_PR_NUMBER:-""}"
+                    git.pr_num:${CIRCLE_PR_NUMBER}"
 
                     sudo mkdir -p /tmp/artifacts/logs
                     sudo chmod -R a+rw /tmp/artifacts/logs
@@ -702,11 +702,11 @@ commands:
             ci.workflow_id:${CIRCLE_WORKFLOW_ID},\
             ci.job_num:${CIRCLE_BUILD_NUM},\
             ci.username:${CIRCLE_USERNAME},\
-            git.tag:${CIRCLE_TAG:-""},\
+            git.tag:${CIRCLE_TAG},\
             git.commit:${CIRCLE_SHA1},\
             ci.totalNodes:${CIRCLE_NODE_TOTAL},\
             ci.nodeIdx:${CIRCLE_NODE_INDEX},\
-            git.pr_num:${CIRCLE_PR_NUMBER:-""}"
+            git.pr_num:${CIRCLE_PR_NUMBER}"
 
             CMD="DD_CIVISIBILITY_AGENTLESS_ENABLED=true \
             DD_TAGS='${tags}' \

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3183,6 +3183,7 @@ jobs:
           at: .
       
       - when:
+          condition: <<parameters.upgrade-branch>>
           # Only run this on the main branch when the tests are scheduled.
           #condition: <<pipeline.parameters.do_upgrade_tests>>
           steps:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -420,8 +420,8 @@ commands:
           working_directory: <<parameters.package-location>>
           command: |
             make build
-            pip install --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
-            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
+            pip install --find-links dist <<parameters.package-name>>
+            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>
 
   setup-python-venv:
     description: Set up and create Python venv.

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1548,7 +1548,7 @@ jobs:
           name: Read Versions from supported_versions.txt file
           command: |
             VERSION_FILE="supported_versions.txt"
-            YAML_FILE=".circleci/real_config.yaml"
+            YAML_FILE="real_config.yaml"
             pwd
             ls -la
 
@@ -1766,7 +1766,7 @@ jobs:
       - run: docker tag determinedai/hpe-mlde-agent:${CIRCLE_SHA1}-amd64 determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
       - run: docker save -o build/agent.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
       - run: docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
-      - persist_to_workspace:
+      - persist_to_workspace: # toDO CAROLINA
           root: .
           paths:
             - "master/dist/*linux_amd64.deb"
@@ -3233,13 +3233,6 @@ jobs:
       DET_AGENT_VERSION: <<parameters.agent-version>>
     steps:
       - checkout
-      - when:
-          condition: <<parameters.upgrade>>
-          steps:
-            - run: 
-                name: Fetch & Checkout Branch/Commit SHA <<parameters.det-version>>
-                command: git fetch origin <<parameters.det-version>> && git checkout <<parameters.det-version>>
-            # - package-and-push-system-dev TODO CAROLINA
         
       - add-and-fetch-upstream
       - skip-if-only-docs
@@ -3273,23 +3266,6 @@ jobs:
                   - run:
                       name: Start additionalrm minikube
                       command: minikube start --profile additionalrm --kubernetes-version <<parameters.k8s-version>>
-      
-      - when:
-          condition: <<parameters.upgrade>>
-          steps:
-            - install-devcluster
-            - unless:
-                condition: <<parameters.managed-devcluster>>
-                steps:
-                  - start-devcluster:
-                      devcluster-config: <<parameters.devcluster-config>>
-                      target-stage: <<parameters.target-stage>>
-            - stop-devcluster
-            - checkout
-            - setup-python-venv:
-                determined: True
-                extra-requirements-file: "e2e_tests/tests/requirements.txt"
-                executor: <<pipeline.parameters.machine-image>>
 
       - install-devcluster
       - unless:
@@ -3298,6 +3274,61 @@ jobs:
             - start-devcluster:
                 devcluster-config: <<parameters.devcluster-config>>
                 target-stage: <<parameters.target-stage>>
+
+      - when:
+          steps:
+            # Stop devcluster running on the past release.
+            - stop-devcluster
+            - setup_remote_docker:
+                version: previous
+            - login-docker:
+                username: ${DOCKER_USER}
+                password: ${DOCKER_PASS}
+            - run: 
+                name: Fetch & Checkout Latest Main
+                command: git fetch origin main && git checkout main
+            - run:
+                name: Check for Main Docker Image
+                command: |
+                  REPO="determinedai/hpe-mlde-master"
+                  TAG="$1"
+                  for i in {1..20}; do
+                    if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-master/${TAG}/" > /dev/null; then
+                      echo "Master tag '${TAG}' found."
+                      if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-agent/${TAG}/" > /dev/null; then
+                        echo "Agent tag '${TAG}' found."
+                        exit 0
+                      fi
+                    fi
+                    echo "Tag '${TAG}' not found (Attempt $i/20), retrying in 60s..."
+                    sleep 60
+                  done
+
+                  echo "Tag '${TAG}' not found after 20 attempts."
+                  exit 1
+            - run:
+                name: Install New Build
+                command: |
+                  docker save -o build/master.image determinedai/hpe-mlde-master:${CIRCLE_SHA1}
+                  docker save -o build/master-ee.image determinedai/hpe-mlde-master:${CIRCLE_SHA1}
+                  docker save -o build/agent.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
+                  docker save -o build/agent-ee.image determinedai/hpe-mlde-agent:${CIRCLE_SHA1}
+            - persist_to_workspace: 
+                root: .
+                paths:
+                  - "build/*.image" # TODO CAROLINA -- what images do I need to save and why?
+            - setup-python-venv:
+                determined: True
+                extra-requirements-file: "e2e_tests/tests/requirements.txt"
+                executor: <<pipeline.parameters.machine-image>>
+            - install-devcluster
+            - unless:
+                condition: <<parameters.managed-devcluster>>
+                steps:
+                  - start-devcluster:
+                      devcluster-config: <<parameters.devcluster-config>>
+                      target-stage: <<parameters.target-stage>>
+
 
       - pull-task-images:
           tf2: <<parameters.tf2>>
@@ -4826,8 +4857,6 @@ workflows:
       - build-go:
           name: build-go-ee
           context: github-read
-
-      - read-supported-versions
 
       - test-e2e:
           name: test-e2e-rbac

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -104,8 +104,6 @@ release-dryrun: &release-dryrun
 release-upgrade: &release-upgrade
   - "release-0.35.0"
   - "release-0.32.0"
-  - "carolinac/upgrade-tests"
-
 
 upstream-feature-branch: &upstream-feature-branch
   branches:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3196,7 +3196,6 @@ jobs:
       DET_AGENT_VERSION: <<parameters.agent-version>>
     steps:
       - checkout
-        
       - add-and-fetch-upstream
       - skip-if-only-docs
       - skip-if-only-github
@@ -3206,7 +3205,6 @@ jobs:
 
       - setup-python-venv:
           determined: True
-          det-version: <<parameters.det-version>>
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
           executor: <<pipeline.parameters.machine-image>>
 

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3213,8 +3213,8 @@ jobs:
                 name: Get Determined version branch commits.
                 command: |
                   git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
-            #- run: make -C master build
-            #- run: make -C agent build
+            - run: make -C master build
+            - run: make -C agent build
 
       - when:
           condition: <<parameters.run-minikubes>>
@@ -3245,7 +3245,7 @@ jobs:
                   - start-devcluster:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
-            - stop-devcluster
+                  - stop-devcluster
             - checkout
             - run: make -C master build
             - run: make -C agent build

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -102,10 +102,9 @@ release-dryrun: &release-dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
 release-upgrade: &release-upgrade
-  branches:
-      - "release-0.35.0"
-      - "release-0.32.0"
-      - carolinac/upgrade-tests
+  - "release-0.35.0"
+  - "release-0.32.0"
+  - "carolinac/upgrade-tests"
 
 
 upstream-feature-branch: &upstream-feature-branch

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -102,8 +102,8 @@ release-dryrun: &release-dryrun
       - /v\d+\.\d+\.\d+\+dryrun/
 
 release-upgrade: &release-upgrade
+  - "release-0.36.0"
   - "release-0.35.0"
-  - "release-0.32.0"
 
 upstream-feature-branch: &upstream-feature-branch
   branches:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -402,14 +402,7 @@ commands:
         type: string
       package-location:
         type: string
-      package-commit: 
-        type: string
-        default: ""
     steps:
-      - when:
-          condition: <<parameters.package-commit>>
-          steps: 
-            run: git checkout <<parameters.package-commit>>
       - run:
           name: Install <<parameters.package-name>>
           working_directory: <<parameters.package-location>>
@@ -438,9 +431,6 @@ commands:
       python-version:
         type: string
         default: "3.8.18"
-      determined-SHA:
-        type: string
-        default: ""
     steps:
       - run:
           name: Write cache key
@@ -526,7 +516,6 @@ commands:
             - install-wheel:
                 package-name: determined
                 package-location: ./harness
-                package-commit: <<parameters.determined-SHA>>
       - run:
           name: Install <<parameters.extras-requires>>
           command: |
@@ -3211,6 +3200,11 @@ jobs:
       - skip-if-only-webui
       - attach_workspace:
           at: .
+
+      - setup-python-venv:
+          determined: True
+          extra-requirements-file: "e2e_tests/tests/requirements.txt"
+          executor: <<pipeline.parameters.machine-image>>
       
       - when:
           condition: <<parameters.upgrade-branch>>
@@ -3219,17 +3213,8 @@ jobs:
                 name: Get Determined version branch commits.
                 command: |
                   git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
-                  commit=$(git rev-parse "<<parameters.upgrade-branch>>")
-                  echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
-                  echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
             - run: make -C master build
             - run: make -C agent build
-
-      - setup-python-venv:
-          determined: True
-          extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          determined-SHA: $HEAD_COMMIT
-          executor: <<pipeline.parameters.machine-image>>
 
       - when:
           condition: <<parameters.run-minikubes>>
@@ -3263,10 +3248,8 @@ jobs:
             - run: sleep 10
             - stop-devcluster
             - checkout
-            - setup-python-venv:
-                determined: True
-                extra-requirements-file: "e2e_tests/tests/requirements.txt"
-                executor: <<pipeline.parameters.machine-image>>
+            - run: make -C master build
+            - run: make -C agent build
 
       - install-devcluster
       - unless:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2036,14 +2036,11 @@ jobs:
       - login-docker:
           username: ${DOCKER_USER}
           password: ${DOCKER_PASS}
-      - run: 
-          name: Fetch & Checkout Latest Main
-          command:  |
+      - run:
+          name: Check for Latest Main Docker Image
+          command: |
             git fetch origin main && git checkout main
             export LATEST_MAIN_SHA=$(git rev-parse HEAD)
-      - run:
-          name: Check for Main Docker Image
-          command: |
             for i in {1..20}; do
               if curl -fsSL "https://registry.hub.docker.com/repository/determinedai/hpe-mlde-master/${LATEST_MAIN_SHA}/" > /dev/null; then
                 echo "Master tag '${LATEST_MAIN_SHA}' found."
@@ -3268,7 +3265,7 @@ jobs:
                 target-stage: <<parameters.target-stage>>
 
       - when:
-          condition: <<parameters.upgrade>>
+          condition: <<parameters.upgrade>>g
           steps:
             # Stop devcluster running on the past release.
             - stop-devcluster

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3165,7 +3165,7 @@ jobs:
         default: "1.29.5"
       upgrade-branch:
         type: string
-        default: $CIRCLE_SHA1
+        default: ""
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: <<parameters.resource-class>>
@@ -3200,9 +3200,12 @@ jobs:
                 determined-SHA: $HEAD_COMMIT
                 executor: <<pipeline.parameters.machine-image>>
             - install-devcluster
-            - start-devcluster:
-                devcluster-config: <<parameters.devcluster-config>>
-                target-stage: agent1
+            - unless:
+                condition: <<parameters.managed-devcluster>>
+                steps:
+                  - start-devcluster:
+                      devcluster-config: <<parameters.devcluster-config>>
+                      target-stage: <<parameters.target-stage>>
             - run: sleep 10
             - stop-devcluster
             - run: git checkout $CIRCLE_SHA1

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4788,7 +4788,7 @@ workflows:
     triggers:
       - schedule:
           cron: "* * * * *"  # Runs at midnight (UTC) every Monday "0 0 * * 1"
-          filters: *release-upgrade  # Only runs on the release branches  
+          #filters: *release-upgrade  # Only runs on the release branches  
     jobs:
       - build-proto
       - build-helm

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1509,6 +1509,31 @@ commands:
     steps:
       - run: 
           command: pkill -SIGHUP -f "devcluster" && rm -rf /tmp/devcluster/lock
+  
+  make-component:
+    description: "Basic parameterized version of make for building Determined components."
+    parameters:
+      component:
+        type: string
+        default: ""
+      target:
+        type: string
+        default: ""
+      dryrun:
+        type: boolean
+        default: false
+      no_output_timeout:
+        type: string
+        default: "10m"
+    steps:
+      - run:
+          no_output_timeout: <<parameters.no_output_timeout>>
+          command: |
+            if <<parameters.dryrun>>; then
+              make -C <<parameters.component>> <<parameters.target>>
+            else
+              make -C <<parameters.component>> <<parameters.target>>-dryrun
+            fi
 
 jobs:
   build-helm:

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1504,48 +1504,6 @@ commands:
           command: pkill -SIGHUP -f "devcluster" && rm -rf /tmp/devcluster/lock
 
 jobs:
-  start-stop-devcluster:
-    parameters:
-      devcluster-config:
-        type: string
-        default: double.devcluster.yaml
-    machine:
-      image: <<pipeline.parameters.machine-image>>
-    resource_class: xlarge
-    environment:
-      DET_POSTGRES_VERSION: 10
-      DET_AGENT_VERSION: ""
-    steps:
-      - checkout
-      - add-and-fetch-upstream
-      - skip-if-only-docs
-      - skip-if-only-github
-      - skip-if-only-webui
-      - attach_workspace:
-          at: .
-
-      - setup-python-venv:
-          determined: True
-          extra-requirements-file: "e2e_tests/tests/requirements.txt"
-          executor: <<pipeline.parameters.machine-image>>
-      - install-devcluster
-      - start-devcluster:
-          devcluster-config: <<parameters.devcluster-config>>
-          target-stage: agent1
-      - run: sleep 10
-      - run:
-          name: Fetch latest commit
-          command: |
-            git fetch origin main
-            LATEST_MAIN_SHA=$(git rev-parse origin/main)
-            echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> latest_commit.env  # Save to a file
-      - persist_to_workspace:
-          root: .
-          paths:
-            - latest_commit.env
-      - stop-devcluster
-
-   
   build-helm:
     docker:
       - image: <<pipeline.parameters.docker-image>>
@@ -3217,6 +3175,9 @@ jobs:
       k8s-version:
         type: string
         default: "1.29.5"
+      upgrade-branch:
+        type: string
+        default: $CIRCLE_SHA1
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: <<parameters.resource-class>>
@@ -3232,22 +3193,31 @@ jobs:
       - skip-if-only-webui
       - attach_workspace:
           at: .
-
-      - run: 
-          name: Export Latest Main SHA for upgrade tests
-          command: |
-            if [ -f latest_commit.env ]; then
-              echo "Latest commit file found."
-              source latest_commit.env
-              echo "LATEST_MAIN_SHA=$LATEST_MAIN_SHA" >> $BASH_ENV
-              git fetch origin $LATEST_MAIN_SHA && git checkout $LATEST_MAIN_SHA
-            else
-              echo "No latest commit file found. Skipping checkout."
-            fi
+      
+      - when:
+          # Only run this on the main branch when the tests are scheduled.
+          condition: <<pipeline.parameters.do_upgrade_tests>>
+          steps:
+            # Upgrade test portion: downgrade to specified version, start/stop devcluster
+            - run: 
+                name: Get Determined version branch commits.
+                command: |
+                  commit=$(git rev-parse "<<parameters.upgrade-branch>>")
+                  echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
+                  echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
+            - setup-python-venv:
+                determined: True
+                extra-requirements-file: "e2e_tests/tests/requirements.txt"
+                determined-SHA: $HEAD_COMMIT
+            - install-devcluster
+            - start-devcluster:
+                devcluster-config: <<parameters.devcluster-config>>
+                target-stage: agent1
+            - run: sleep 10
+            - stop-devcluster
 
       - setup-python-venv:
           determined: True
-          determined-SHA: $LATEST_MAIN_SHA
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
           executor: <<pipeline.parameters.machine-image>>
 
@@ -4788,15 +4758,6 @@ workflows:
       - build-helm
       - build-react:
           dev-mode: true
-      - test-e2e-react:
-          name: test-e2e-react-ee
-          ee: true
-          requires:
-            - build-go-ee
-          context:
-            - playwright
-            - github-read
-            - dev-ci-cluster-default-user-credentials
       - build-docs:
           requires:
             - build-helm
@@ -4804,32 +4765,6 @@ workflows:
       - build-go:
           name: build-go-ee
           context: github-read
-
-      - start-stop-devcluster:
-          context:
-            - dev-ci-cluster-default-user-credentials
-            - github-read
-          requires:
-            - build-go-ee
-          name: start-stop-devcluster
-      - build-go: 
-          name: build-upgraded-go
-          context: github-read
-          requires:
-            - start-stop-devcluster
-
-      - start-stop-devcluster:
-          context:
-            - dev-ci-cluster-default-user-credentials
-            - github-read
-          requires:
-            - build-go-ee
-          name: start-stop-rbac-devcluster
-      - build-go: 
-          name: build-upgraded-rbac-go
-          context: github-read
-          requires:
-            - start-stop-devcluster 
 
       - test-e2e:
           name: test-e2e-cpu
@@ -4841,6 +4776,9 @@ workflows:
           resource-class: xlarge
           tf2: true
           mark: e2e_cpu
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4854,6 +4792,9 @@ workflows:
           mark: e2e_cpu_2a
           target-stage: agent2
           devcluster-config: double-priority.devcluster.yaml
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4865,6 +4806,9 @@ workflows:
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
           target-stage: agent1
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-managed-devcluster
@@ -4881,6 +4825,9 @@ workflows:
           # so `compare_stats` cannot get the full logs from `det master logs`.
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-managed-devcluster-resource-pools
@@ -4895,6 +4842,9 @@ workflows:
           managed-devcluster: true
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4909,6 +4859,9 @@ workflows:
           devcluster-config: multi-k8s.devcluster.yaml
           run-minikubes: true
           multi-k8s: true
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4921,6 +4874,9 @@ workflows:
           target-stage: master
           devcluster-config: single-k8s.devcluster.yaml
           run-minikubes: true
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4932,6 +4888,9 @@ workflows:
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
           target-stage: agent
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4944,6 +4903,9 @@ workflows:
           mark: e2e_cpu_elastic
           devcluster-config: elastic.devcluster.yaml
           target-stage: agent
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4956,6 +4918,9 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "10"
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4968,6 +4933,9 @@ workflows:
           devcluster-config: postgres-with-ssl.devcluster.yaml
           target-stage: agent
           postgres-version: "14"
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4981,6 +4949,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
               agent-version: ["0.17.10"]
 
       - test-e2e:
@@ -4994,6 +4963,9 @@ workflows:
           wait-for-master: false
           extra-pytest-flags: "--no-compare-stats"
           collect-det-job-logs: false
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-saml
@@ -5005,6 +4977,9 @@ workflows:
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
       
       - test-e2e:
           name: test-e2e-rbac
@@ -5015,6 +4990,9 @@ workflows:
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -5026,6 +5004,9 @@ workflows:
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
           target-stage: agent1
+          matrix:
+            parameters:
+              upgrade-branch: ["carolinac/upgradetests", "release-0.32.0", "release-0.35.0"]
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3209,6 +3209,7 @@ jobs:
                 determined: True
                 extra-requirements-file: "e2e_tests/tests/requirements.txt"
                 determined-SHA: $HEAD_COMMIT
+                executor: <<pipeline.parameters.machine-image>>
             - install-devcluster
             - start-devcluster:
                 devcluster-config: <<parameters.devcluster-config>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4774,7 +4774,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 6
           resource-class: xlarge
           tf2: true
@@ -4788,7 +4788,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 5
           resource-class: large
           tf2: true
@@ -4804,7 +4804,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
@@ -4818,7 +4818,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4837,7 +4837,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4854,7 +4854,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           tf2: true
           mark: e2e_multi_k8s
@@ -4871,7 +4871,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_single_k8s
           target-stage: master
@@ -4886,7 +4886,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
@@ -4900,7 +4900,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           resource-class: large
           mark: e2e_cpu_elastic
@@ -4915,7 +4915,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -4930,7 +4930,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -4945,7 +4945,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: custom-agent-version.devcluster.yaml
@@ -4958,7 +4958,7 @@ workflows:
       - test-e2e:
           name: test-e2e-agent-connection-loss
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           mark: e2e_cpu_agent_connection_loss
           devcluster-config: agent-no-connection.devcluster.yaml
@@ -4976,7 +4976,7 @@ workflows:
             - okta
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-go
+            - build-go-ee
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3205,6 +3205,8 @@ jobs:
                   commit=$(git rev-parse "<<parameters.upgrade-branch>>")
                   echo "Latest commit for <<parameters.upgrade-branch>>: $commit"
                   echo "export HEAD_COMMIT=$commit" >> $BASH_ENV
+            - build-go:
+                ee: true
             - setup-python-venv:
                 determined: True
                 extra-requirements-file: "e2e_tests/tests/requirements.txt"
@@ -4772,7 +4774,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 6
           resource-class: xlarge
           tf2: true
@@ -4786,7 +4788,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 5
           resource-class: large
           tf2: true
@@ -4802,7 +4804,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
@@ -4816,7 +4818,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4835,7 +4837,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4852,7 +4854,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           tf2: true
           mark: e2e_multi_k8s
@@ -4869,7 +4871,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           mark: e2e_single_k8s
           target-stage: master
@@ -4884,7 +4886,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
@@ -4898,7 +4900,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           resource-class: large
           mark: e2e_cpu_elastic
@@ -4913,7 +4915,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -4928,7 +4930,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -4943,7 +4945,7 @@ workflows:
           context:
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: custom-agent-version.devcluster.yaml
@@ -4956,7 +4958,7 @@ workflows:
       - test-e2e:
           name: test-e2e-agent-connection-loss
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           mark: e2e_cpu_agent_connection_loss
           devcluster-config: agent-no-connection.devcluster.yaml
@@ -4974,7 +4976,7 @@ workflows:
             - okta
             - dev-ci-cluster-default-user-credentials
           requires:
-            - build-upgraded-go
+            - build-go
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3182,7 +3182,7 @@ jobs:
       k8s-version:
         type: string
         default: "1.29.5"
-      upgrade-branch:
+      upgrade-from-branch:
         type: string
         default: ""
     machine:
@@ -3205,17 +3205,6 @@ jobs:
           determined: True
           extra-requirements-file: "e2e_tests/tests/requirements.txt"
           executor: <<pipeline.parameters.machine-image>>
-      
-      - when:
-          condition: <<parameters.upgrade-branch>>
-          steps:
-            - run: 
-                name: Get Determined version branch commits.
-                command: |
-                  git fetch origin <<parameters.upgrade-branch>> && git checkout --track origin/<<parameters.upgrade-branch>>
-            - license-gen
-            - run: make -C master build
-            - run: make -C agent build
 
       - when:
           condition: <<parameters.run-minikubes>>
@@ -3236,9 +3225,17 @@ jobs:
                   - run:
                       name: Start additionalrm minikube
                       command: minikube start --profile additionalrm --kubernetes-version <<parameters.k8s-version>>
+
       - when:
-          condition: <<parameters.upgrade-branch>>
+          condition: <<parameters.upgrade-from-branch>>
           steps:
+            - run: 
+                name: Get Determined version branch commits.
+                command: |
+                  git fetch origin <<parameters.upgrade-from-branch>> && git checkout --track origin/<<parameters.upgrade-from-branch>>
+            - license-gen
+            - run: make -C master build
+            - run: make -C agent build
             - install-devcluster
             - unless:
                 condition: <<parameters.managed-devcluster>>
@@ -3246,7 +3243,14 @@ jobs:
                   - start-devcluster:
                       devcluster-config: <<parameters.devcluster-config>>
                       target-stage: <<parameters.target-stage>>
-                  - stop-devcluster
+            - run-e2e-tests:
+              mark: <<parameters.mark>>
+              master-host: localhost
+              managed-devcluster: <<parameters.managed-devcluster>>
+              extra-pytest-flags: <<parameters.extra-pytest-flags>>
+              wait-for-master: <<parameters.wait-for-master>>
+              collect-det-job-logs: <<parameters.collect-det-job-logs>>
+            - stop-devcluster
             - checkout
             - run: make -C master build
             - run: make -C agent build
@@ -4790,7 +4794,7 @@ workflows:
           mark: e2e_cpu
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-double
@@ -4807,7 +4811,7 @@ workflows:
           devcluster-config: double-priority.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-oauth
@@ -4822,7 +4826,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-multi-k8s
@@ -4840,7 +4844,7 @@ workflows:
           multi-k8s: true
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-single-k8s
@@ -4856,7 +4860,7 @@ workflows:
           run-minikubes: true
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-port-registry
@@ -4871,7 +4875,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-elastic
@@ -4887,7 +4891,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres10-with-ssl
@@ -4903,7 +4907,7 @@ workflows:
           postgres-version: "10"
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-postgres14-with-ssl
@@ -4919,7 +4923,7 @@ workflows:
           postgres-version: "14"
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-old-agent-versions
@@ -4934,7 +4938,7 @@ workflows:
           target-stage: agent
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
               agent-version: ["0.17.10"]
 
       - test-e2e:
@@ -4953,7 +4957,7 @@ workflows:
           collect-det-job-logs: false
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-saml
@@ -4968,7 +4972,7 @@ workflows:
           mark: e2e_saml
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
       
       - test-e2e:
           name: test-e2e-rbac
@@ -4982,7 +4986,7 @@ workflows:
           devcluster-config: single-rbac.devcluster.yaml
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
       - test-e2e:
           name: test-e2e-cpu-model-registry-rbac
@@ -4997,7 +5001,7 @@ workflows:
           target-stage: agent1
           matrix:
             parameters:
-              upgrade-branch: *release-upgrade
+              upgrade-from-branch: *release-upgrade
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -404,17 +404,14 @@ commands:
         type: string
       package-location:
         type: string
-      det-version:
-        type: string
-        default: <<pipeline.parameters.det-version>>
     steps:
       - run:
           name: Install <<parameters.package-name>>
           working_directory: <<parameters.package-location>>
           command: |
             make build
-            pip install --find-links dist <<parameters.package-name>>==<<parameters.det-version>>
-            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>==<<parameters.det-version>>
+            pip install --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
+            pip install --no-deps --force-reinstall --find-links dist <<parameters.package-name>>==<< pipeline.parameters.det-version >>
 
   setup-python-venv:
     description: Set up and create Python venv.
@@ -436,9 +433,6 @@ commands:
       python-version:
         type: string
         default: "3.8.18"
-      det-version:
-        type: string
-        default: <<pipeline.parameters.det-version>>
     steps:
       - run:
           name: Write cache key
@@ -522,7 +516,6 @@ commands:
                 name: Install pypa builder
                 command: python3 -m pip install build
             - install-wheel:
-                det-version: <<parameters.det-version>>
                 package-name: determined
                 package-location: ./harness
       - run:
@@ -1534,27 +1527,6 @@ commands:
             fi
 
 jobs:
-  read-supported-versions:
-    docker:
-      - image: <<pipeline.parameters.docker-image>>
-    steps:
-      - run:
-          name: Read Versions from supported_versions.txt file
-          command: |
-            VERSION_FILE="supported_versions.txt"
-            YAML_FILE="real_config.yaml"
-            pwd
-            ls -la
-
-            VERSIONS=$(awk '{ print "  - \"" $0 "\"" }' $INPUT_FILE)
-
-            # Replace the existing values under det-versions with the new ones from the text file
-            sed -i.bak "/det-versions: &det-versions/{n;N;N;d}" $YAML_FILE
-            sed -i "/det-versions: &det-versions/r /dev/stdin" $YAML_FILE \<<< "$VERSIONS"
-
-            echo "Updated real_config.yaml:"
-            cat $YAML_FILE
-
   build-helm:
     docker:
       - image: <<pipeline.parameters.docker-image>>
@@ -3215,9 +3187,6 @@ jobs:
       upgrade: 
         type: boolean
         default: false
-      det-version:
-        type: string
-        default: <<pipeline.parameters.det-version>>
     machine:
       image: <<pipeline.parameters.machine-image>>
     resource_class: <<parameters.resource-class>>

--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -4830,6 +4830,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_cpu_rbac
           devcluster-config: single-rbac.devcluster.yaml
@@ -4841,6 +4842,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 6
           resource-class: xlarge
           tf2: true
@@ -4853,6 +4855,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 5
           resource-class: large
           tf2: true
@@ -4867,6 +4870,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           devcluster-config: oauth.devcluster.yaml
           mark: test_oauth
@@ -4879,6 +4883,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           devcluster-config: rbac-model-registry.yaml
           mark: test_model_registry_rbac
@@ -4891,6 +4896,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4908,6 +4914,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 4
           resource-class: large
           tf2: true
@@ -4923,6 +4930,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           tf2: true
           mark: e2e_multi_k8s
@@ -4938,6 +4946,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_single_k8s
           target-stage: master
@@ -4951,6 +4960,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           devcluster-config: port-registry.devcluster.yaml
           mark: port_registry
@@ -4963,6 +4973,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           resource-class: large
           mark: e2e_cpu_elastic
@@ -4976,6 +4987,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -4989,6 +5001,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: postgres-with-ssl.devcluster.yaml
@@ -5002,6 +5015,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_cpu_postgres
           devcluster-config: custom-agent-version.devcluster.yaml
@@ -5015,6 +5029,7 @@ workflows:
           name: test-e2e-agent-connection-loss
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           mark: e2e_cpu_agent_connection_loss
           devcluster-config: agent-no-connection.devcluster.yaml
@@ -5031,6 +5046,7 @@ workflows:
             - dev-ci-cluster-default-user-credentials
           requires:
             - build-go-ee
+            - pull-main-docker-images
           parallelism: 1
           devcluster-config: saml.devcluster.yaml
           mark: e2e_saml

--- a/.circleci/supported_versions.txt
+++ b/.circleci/supported_versions.txt
@@ -1,3 +1,0 @@
-release-0.34.0
-release-0.35.0
-carolinac/upgrade-tests


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
feat: add upgrade tests to circleCI
-->
## Ticket
CM-449


## Description
Add a new suite of `test-e2e-release-upgrade` tests that:
- start a devcluster on a past Determined version (i.e., 0.34.0, 0.35.0, 0.36.0, etc)
- stop the cluster
- upgrade the cluster to the latest commit SHA on that branch
- start the cluster again
- run a subset of the e2e tests

For this iteration, I chose to omit a subset of the "regular" e2e tests that use SLURM, aws, or gcp -- I can add these back in later, if desired.

## Commentary
Please refer to https://hpe-aiatscale.atlassian.net/wiki/spaces/ENGINEERIN/pages/1716125737/Cookbook+Release+Party#4.-Upgrade-Tests for more context on how these tests are running.


## Test Plan
Observe that CircleCI passes: https://app.circleci.com/pipelines/gh/determined-ai/determined?branch=carolinac%2Fupgrade-tests

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code
