### PR TITLE
ci: remove default arg from utils.run_command()

### DIFF
--- a/e2e_tests/tests/cluster/test_priority_scheduler.py
+++ b/e2e_tests/tests/cluster/test_priority_scheduler.py
@@ -34,15 +34,15 @@ def test_priortity_scheduler_noop_command(
     managed_cluster_priority_scheduler.ensure_agent_ok()
     assert str(conf.MASTER_PORT) == "8082"
     # without slots (and default priority)
-    command_id = utils.run_command(sess, slots=0)
+    command_id = utils.run_command(sess, 0, slots=0)
     utils.wait_for_command_state(sess, command_id, "TERMINATED", 40)
     utils.assert_command_succeeded(sess, command_id)
     # with slots (and default priority)
-    command_id = utils.run_command(sess, slots=1)
+    command_id = utils.run_command(sess, 0, slots=1)
     utils.wait_for_command_state(sess, command_id, "TERMINATED", 60)
     utils.assert_command_succeeded(sess, command_id)
     # explicity priority
-    command_id = utils.run_command_set_priority(sess, slots=0, priority=60)
+    command_id = utils.run_command_set_priority(sess, 0, slots=0, priority=60)
     utils.wait_for_command_state(sess, command_id, "TERMINATED", 60)
     utils.assert_command_succeeded(sess, command_id)
 

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -101,7 +101,7 @@ def num_free_slots(sess: api.Session) -> int:
 
 
 def run_command_set_priority(
-    sess: api.Session, sleep: int = 30, slots: int = 1, priority: int = 0
+    sess: api.Session, sleep: int, slots: int = 1, priority: int = 0
 ) -> str:
     cmd = [
         "det",
@@ -118,7 +118,7 @@ def run_command_set_priority(
     return detproc.check_output(sess, cmd).strip()
 
 
-def run_command(sess: api.Session, sleep: int = 30, slots: int = 1) -> str:
+def run_command(sess: api.Session, sleep: int, slots: int = 1) -> str:
     cmd = [
         "det",
         "command",
@@ -144,7 +144,7 @@ def run_command_args(sess: api.Session, entrypoint: str, args: Optional[List[str
     return detproc.check_output(sess, cmd + [entrypoint]).strip()
 
 
-def run_zero_slot_command(sess: api.Session, sleep: int = 30) -> str:
+def run_zero_slot_command(sess: api.Session, sleep: int) -> str:
     return run_command(sess, sleep=sleep, slots=0)
 
 


### PR DESCRIPTION
The default arg meant a 30(!)-second sleep.

One innocent-looking test was sitting and doing nothing for a full 90 seconds simply by omitting the default arg three times.

This is a good example of why default args are bad; this default saved somebody typing `, 0` and the cost was a test took 90 extra seconds, probably without the author even realizing it.  Better to be clear and explicit, especially with internal APIs (where compatibility and breaking changes are never a concern).