### PR TITLE
fix: fix hf on_save raise exception

### DIFF
--- a/harness/determined/transformers/_hf_callback.py
+++ b/harness/determined/transformers/_hf_callback.py
@@ -92,9 +92,9 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
 
         # If searcher is NOT being updated and preemption signal is received
         # (e.g., by pausing experiment in the WebUI), notify Trainer (via TrainerControl)
-        # to save the checkpoint. After the checkpoint is uploaded to Determined storage,
-        # the process is preempted (see on_save() method for details).
+        # to save the checkpoint and stop training.
         if self.updating_searcher is False and self.core_context.preempt.should_preempt():
+            control.should_training_stop = True
             control.should_save = True
 
     def _get_metrics(self, logs: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
@@ -135,9 +135,6 @@ class DetCallback(transformers.TrainerCallback):  # type: ignore
         self.core_context.checkpoint.upload(
             args.output_dir, metadata=det_checkpoint_metadata, shard=True, selector=selector
         )
-
-        if self.core_context.preempt.should_preempt():
-            pass
 
     def _on_save_user_data(self, save_path: str) -> None:
         """


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
With the previous [fix](https://github.com/determined-ai/determined/pull/9913/files), the training continues after getting a preemption signal. This is the actual fix.



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ