### PR TITLE
chore: implement PUT APIs for task config policies

### DIFF
--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -1,63 +1,193 @@
 package internal
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/ghodss/yaml"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
-	"gopkg.in/yaml.v3"
 
 	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/license"
+	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
 const (
-	noWorkloadErr = "no workload type specified."
+	noWorkloadErr          = "no workload type specified."
+	noPoliciesErr          = "no specified config policies."
+	invalidWorkloadTypeErr = "invalid workload type"
 )
 
-func stubData() (*structpb.Struct, error) {
-	const yamlString = `
-invariant_config:
-  description: "test"
-constraints:
-  resources:
-    max_slots: 4
-  priority_limit: 10
- `
-	// put yaml string into a map
-	var yamlMap map[string]interface{}
-	if err := yaml.Unmarshal([]byte(yamlString), &yamlMap); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal yaml: %w", err)
+func validatePoliciesAndWorkloadType(workloadType, configPolicies string) error {
+	if !configpolicy.ValidWorkloadType(workloadType) {
+		errMessage := fmt.Sprintf(invalidWorkloadTypeErr+": %s.", workloadType)
+		if len(workloadType) == 0 {
+			errMessage = noWorkloadErr
+		}
+		return status.Errorf(codes.InvalidArgument, errMessage)
 	}
 
-	return configpolicy.MarshalConfigPolicy(yamlMap), nil
+	if len(configPolicies) == 0 {
+		return status.Errorf(codes.InvalidArgument, noPoliciesErr)
+	}
+
+	// Validate the input config based on workload type.
+	if workloadType == model.ExperimentType {
+		_, err := configpolicy.UnmarshalExperimentConfigPolicy(configPolicies)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := configpolicy.UnmarshalNTSCConfigPolicy(configPolicies)
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO (request validation): Verify that configs do not violate constraints.
+	return nil
+}
+
+func parseConfigPolicies(configAndConstraints string) (tcps map[string]interface{},
+	invariantConfig *string, constraints *string, err error) {
+	if len(configAndConstraints) == 0 {
+		return nil, nil, nil, status.Error(codes.InvalidArgument, "nothing to parse, empty "+
+			"config and constraints input")
+	}
+	// Standardize to JSON policies file format.
+	configPolicies, err := yaml.YAMLToJSON([]byte(configAndConstraints))
+
+	// Extract individal config and constraints.
+	var policies map[string]interface{}
+	dec := json.NewDecoder(bytes.NewReader(configPolicies))
+	err = dec.Decode(&policies)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error unmarshaling config policies: %s", err.Error())
+	}
+
+	var configPolicy *string
+	if invariantConfig, ok := policies["invariant_config"]; ok {
+		configPolicyBytes, err := json.Marshal(invariantConfig)
+		if err != nil {
+			return nil, nil, nil,
+				fmt.Errorf("error marshaling input invariant config policy: %s", err.Error())
+		}
+		configPolicy = ptrs.Ptr(string(configPolicyBytes))
+
+	}
+
+	var constraintsPolicy *string
+	if constraints, ok := policies["constraints"]; ok {
+		constraintsPolicyBytes, err := json.Marshal(constraints)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("error marshaling input constraints policy: %s",
+				err.Error())
+		}
+		constraintsPolicy = ptrs.Ptr(string(constraintsPolicyBytes))
+	}
+
+	return policies, configPolicy, constraintsPolicy, nil
 }
 
 // Add or update workspace task config policies.
-func (*apiServer) PutWorkspaceConfigPolicies(
+func (a *apiServer) PutWorkspaceConfigPolicies(
 	ctx context.Context, req *apiv1.PutWorkspaceConfigPoliciesRequest,
 ) (*apiv1.PutWorkspaceConfigPoliciesResponse, error) {
-	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
-		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
+	license.RequireLicense("manage config policies")
+
+	// Request Validation
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
 	}
-	data, err := stubData()
-	return &apiv1.PutWorkspaceConfigPoliciesResponse{ConfigPolicies: data}, err
+
+	w, err := a.GetWorkspaceByID(ctx, req.WorkspaceId, *curUser, false)
+	if err != nil {
+		return nil, err
+	}
+
+	err = configpolicy.AuthZProvider.Get().CanModifyWorkspaceConfigPolicies(ctx, *curUser, w)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validatePoliciesAndWorkloadType(req.WorkloadType, req.ConfigPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	configPolicies, invariantConfig, constraints, err := parseConfigPolicies(req.ConfigPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	err = configpolicy.SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+		WorkspaceID:     ptrs.Ptr(int(req.WorkspaceId)),
+		WorkloadType:    req.WorkloadType,
+		LastUpdatedBy:   curUser.ID,
+		LastUpdatedTime: time.Now(),
+		InvariantConfig: invariantConfig,
+		Constraints:     constraints,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setting task config policies: %w", err)
+	}
+
+	return &apiv1.PutWorkspaceConfigPoliciesResponse{
+			ConfigPolicies: configpolicy.MarshalConfigPolicy(configPolicies),
+		},
+		err
 }
 
 // Add or update global task config policies.
-func (*apiServer) PutGlobalConfigPolicies(
+func (a *apiServer) PutGlobalConfigPolicies(
 	ctx context.Context, req *apiv1.PutGlobalConfigPoliciesRequest,
 ) (*apiv1.PutGlobalConfigPoliciesResponse, error) {
-	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
-		return nil, fmt.Errorf("invalid workload type: %s", req.WorkloadType)
+	license.RequireLicense("manage config policies")
+
+	curUser, _, err := grpcutil.GetUser(ctx)
+	if err != nil {
+		return nil, err
 	}
-	data, err := stubData()
-	return &apiv1.PutGlobalConfigPoliciesResponse{ConfigPolicies: data}, err
+
+	err = configpolicy.AuthZProvider.Get().CanModifyGlobalConfigPolicies(ctx, curUser)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validatePoliciesAndWorkloadType(req.WorkloadType, req.ConfigPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	configPolicies, invariantConfig, constraints, err := parseConfigPolicies(req.ConfigPolicies)
+	if err != nil {
+		return nil, err
+	}
+
+	err = configpolicy.SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+		WorkloadType:    req.WorkloadType,
+		LastUpdatedBy:   curUser.ID,
+		LastUpdatedTime: time.Now(),
+		InvariantConfig: invariantConfig,
+		Constraints:     constraints,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error setting task config policies: %w", err)
+	}
+
+	return &apiv1.PutGlobalConfigPoliciesResponse{
+			ConfigPolicies: configpolicy.MarshalConfigPolicy(configPolicies),
+		},
+		err
 }
 
 // Get workspace task config policies.
@@ -117,7 +247,7 @@ func (*apiServer) getConfigPolicies(
 	ctx context.Context, workspaceID *int, workloadType string,
 ) (*structpb.Struct, error) {
 	if !configpolicy.ValidWorkloadType(workloadType) {
-		errMessage := fmt.Sprintf("invalid workload type: %s.", workloadType)
+		errMessage := fmt.Sprintf(invalidWorkloadTypeErr+": %s.", workloadType)
 		if len(workloadType) == 0 {
 			errMessage = noWorkloadErr
 		}
@@ -169,7 +299,7 @@ func (a *apiServer) DeleteWorkspaceConfigPolicies(
 	}
 
 	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
-		errMessage := fmt.Sprintf("invalid workload type: %s.", req.WorkloadType)
+		errMessage := fmt.Sprintf(invalidWorkloadTypeErr+": %s.", req.WorkloadType)
 		if len(req.WorkloadType) == 0 {
 			errMessage = noWorkloadErr
 		}
@@ -201,7 +331,7 @@ func (a *apiServer) DeleteGlobalConfigPolicies(
 	}
 
 	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
-		errMessage := fmt.Sprintf("invalid workload type: %s.", req.WorkloadType)
+		errMessage := fmt.Sprintf(invalidWorkloadTypeErr+": %s.", req.WorkloadType)
 		if len(req.WorkloadType) == 0 {
 			errMessage = noWorkloadErr
 		}

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -91,6 +91,25 @@ invariant_config:
 
 	invalidExperimentConfigPolicyErr = "invalid experiment config policy"
 	invalidNTSCtConfigPolicyErr      = "invalid NTSC config policy"
+
+	updatedExperimentConfigPolicyJSON = `
+	"invariant_config": {
+        "description": "test\nspecial\tchar",
+        "environment": {
+            "force_pull_image": false,
+            "add_capabilities": ["cap1", "cap2"]
+        },
+        "resources": {
+            "slots": 1
+        },
+		"name": "my_experiment_config",
+		"entrypoint": "start from here"
+    }
+`
+
+	entrypointYAML = `
+  entrypoint: "start from here"
+`
 )
 
 func TestDeleteWorkspaceConfigPolicies(t *testing.T) {
@@ -517,8 +536,10 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 	require.Equal(t, expectedErr, err)
 
 	_, err = api.PutGlobalConfigPolicies(ctx,
-		&apiv1.PutGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType,
-			ConfigPolicies: validNTSCConfigPolicyYAML})
+		&apiv1.PutGlobalConfigPoliciesRequest{
+			WorkloadType:   model.NTSCType,
+			ConfigPolicies: validNTSCConfigPolicyYAML,
+		})
 	require.Equal(t, expectedErr, err)
 
 	// (Global) Nil error returns whatever the request returned.
@@ -530,8 +551,10 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = api.PutGlobalConfigPolicies(ctx,
-		&apiv1.PutGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType,
-			ConfigPolicies: validNTSCConfigPolicyYAML})
+		&apiv1.PutGlobalConfigPoliciesRequest{
+			WorkloadType:   model.NTSCType,
+			ConfigPolicies: validNTSCConfigPolicyYAML,
+		})
 	require.NoError(t, err)
 }
 
@@ -545,48 +568,60 @@ func setupConfigPolicyAuthZ() *mocks.ConfigPolicyAuthZ {
 	return cpAuthZ
 }
 
-func TestValidatePoliciesAndWorkloadType(t *testing.T) {
+func TestValidatePoliciesAndWorkloadTypeYAML(t *testing.T) {
 	tests := []struct {
 		name           string
 		workloadType   string
 		configPolicies string
 		err            error
 	}{
-		// YAML tests.
-
-		{"YAML invalid workload type valid config policies", "random", validExperimentConfigPolicyYAML,
-			fmt.Errorf(invalidWorkloadTypeErr)},
-		{"YAML no workload type valid config policies", "", validExperimentConfigPolicyYAML,
-			fmt.Errorf(noWorkloadErr)},
-		{"YAML valid workload type no config policies", model.ExperimentType, "",
-			fmt.Errorf(noPoliciesErr)},
+		{
+			"YAML invalid workload type valid config policies", "random", validExperimentConfigPolicyYAML,
+			fmt.Errorf(invalidWorkloadTypeErr),
+		},
+		{
+			"YAML no workload type valid config policies", "", validExperimentConfigPolicyYAML,
+			fmt.Errorf(noWorkloadErr),
+		},
+		{
+			"YAML valid workload type no config policies", model.ExperimentType, "",
+			fmt.Errorf(noPoliciesErr),
+		},
 
 		// Valid experiment invariant config policies (YAML).
-		{"YAML simple experiment config with description", model.ExperimentType,
+		{
+			"YAML simple experiment config with description", model.ExperimentType,
 			`
 invariant_config:
   description: "test\nspecial\tchar"
-`, nil},
-		{"YAML simple experiment config with resources", model.ExperimentType,
+`, nil,
+		},
+		{
+			"YAML simple experiment config with resources", model.ExperimentType,
 			`
 invariant_config:
   resources:
     slots: 1
-`, nil},
+`, nil,
+		},
 		{"YAML partial experiment config", model.ExperimentType, validExperimentConfigPolicyYAML, nil},
 
 		// Valid NTSC invariant config policies (YAML).
-		{"YAML simple NTSC config with description", model.NTSCType,
+		{
+			"YAML simple NTSC config with description", model.NTSCType,
 			`
 invariant_config:
   description: "test\nspecial\tchar"
-`, nil},
-		{"YAML simple NTSC config with resources", model.NTSCType,
+`, nil,
+		},
+		{
+			"YAML simple NTSC config with resources", model.NTSCType,
 			`
 invariant_config:
   resources:
     slots: 1
-`, nil},
+`, nil,
+		},
 		{"YAML partial NTSC config", model.NTSCType, validNTSCConfigPolicyYAML, nil},
 
 		// Invalid experiment invariant config policies (YAML).
@@ -685,26 +720,30 @@ bad_config_spec:
 		// Valid constraint policies (YAML).
 		{"YAML experiment valid constraints policy", model.ExperimentType, validConstraintsPolicyYAML, nil},
 		{"YAML NTSC valid constraints policy", model.NTSCType, validConstraintsPolicyYAML, nil},
-		{"YAML experiment simple valid constraints policy priority limit", model.ExperimentType,
+		{
+			"YAML experiment simple valid constraints policy priority limit", model.ExperimentType,
 			`
 constraints:
   priority_limit: 10
 `, nil,
 		},
-		{"YAML NTSC simple valid constraints policy priority limit", model.NTSCType,
+		{
+			"YAML NTSC simple valid constraints policy priority limit", model.NTSCType,
 			`
 constraints:
   priority_limit: 10
 `, nil,
 		},
-		{"YAML experiment simple valid constraints policy resources", model.ExperimentType,
+		{
+			"YAML experiment simple valid constraints policy resources", model.ExperimentType,
 			`
 constraints:
   resources:
     max_slots: 4
 `, nil,
 		},
-		{"YAML NTSC simple valid constraints policy resources", model.NTSCType,
+		{
+			"YAML NTSC simple valid constraints policy resources", model.NTSCType,
 			`
 constraints:
   resources:
@@ -713,7 +752,8 @@ constraints:
 		},
 
 		// Invalid experiment constraint policies (YAML).
-		{"experiment constraint with null key", model.ExperimentType,
+		{
+			"experiment constraint with null key", model.ExperimentType,
 			`
 constraints:
  : 10
@@ -752,7 +792,8 @@ constraints:
 		},
 
 		// Invalid NTSC constraint policies (YAML).
-		{"YAML NTSC constraint with null key", model.NTSCType,
+		{
+			"YAML NTSC constraint with null key", model.NTSCType,
 			`
 constraints:
 : 10
@@ -791,16 +832,20 @@ constraints:
 		},
 
 		// Additional experiment combinatory tests (YAML).
-		{"YAML experiment valid config valid constraints", model.ExperimentType,
-			validExperimentConfigPolicyYAML + validConstraintsPolicyYAML, nil},
-		{"YAML experiment valid constraints invalid constraints", model.ExperimentType,
+		{
+			"YAML experiment valid config valid constraints", model.ExperimentType,
+			validExperimentConfigPolicyYAML + validConstraintsPolicyYAML, nil,
+		},
+		{
+			"YAML experiment valid constraints invalid constraints", model.ExperimentType,
 			validExperimentConfigPolicyYAML + `
 constraints:
   resources:
     max_slots: "this should be a number"
 `, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
-		{"YAML experiment invalid config valid constraints", model.ExperimentType,
+		{
+			"YAML experiment invalid config valid constraints", model.ExperimentType,
 			`
 invariant_config:
   resources:
@@ -809,16 +854,20 @@ invariant_config:
 		},
 
 		// Additional NTSC combinatory tests (YAML).
-		{"YAML NTSC valid config valid constraints", model.NTSCType,
-			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, nil},
-		{"YAML NTSC valid constraints invalid constraints", model.NTSCType,
+		{
+			"YAML NTSC valid config valid constraints", model.NTSCType,
+			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, nil,
+		},
+		{
+			"YAML NTSC valid constraints invalid constraints", model.NTSCType,
 			validNTSCConfigPolicyYAML + `
 constraints:
   resources:
     max_slots: "this should be a number"
 `, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
-		{"NTSC invalid config valid constraints", model.NTSCType,
+		{
+			"NTSC invalid config valid constraints", model.NTSCType,
 			`
 invariant_config:
   resources:
@@ -827,75 +876,104 @@ invariant_config:
 		},
 
 		// Experiment-NTSC mismatch test error (YAML).
-		{"YAML valid experiment config with NTSC workload type", model.NTSCType,
+		{
+			"YAML valid experiment config with NTSC workload type", model.NTSCType,
 			validExperimentConfigPolicyYAML, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
-		{"YAML valid NTSC config with experiment workload type", model.ExperimentType,
+		{
+			"YAML valid NTSC config with experiment workload type", model.ExperimentType,
 			validNTSCConfigPolicyYAML, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
+	}
 
-		// JSON tests.
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePoliciesAndWorkloadType(test.workloadType, test.configPolicies)
+			if test.err != nil {
+				require.Error(t, err)
+				require.ErrorContains(t, err, test.err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
+func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		workloadType   string
+		configPolicies string
+		err            error
+	}{
 		// Valid experiment invariant config policies.
-		{"JSON simple experiment config with description", model.ExperimentType,
+		{
+			"JSON simple experiment config with description", model.ExperimentType,
 			`{ "invariant_config": {
-			 	"description": "test\nspecial\tchar"
-				}
-			}`, nil},
-		{"JSON simple experiment config with resources", model.ExperimentType,
+		 "description": "test\nspecial\tchar"
+		}
+	}`, nil,
+		},
+		{
+			"JSON simple experiment config with resources", model.ExperimentType,
 			`{ "invariant_config": {
-			 		"resources": {
-			 			"slots": 1 }
-					}
-			}`, nil},
+			 "resources": {
+				 "slots": 1 }
+			}
+	}`, nil,
+		},
 		{"JSON partial experiment config", model.ExperimentType, "{" +
 			validExperimentConfigPolicyJSON + "}", nil},
 
 		// Valid NTSC invariant config policies (JSON).
-		{"JSON simple NTSC config with description", model.NTSCType,
+		{
+			"JSON simple NTSC config with description", model.NTSCType,
 			`{ "invariant_config": {
-				"description": "test\nspecial\tchar"
-				}
-			}`, nil},
-		{"JSON simple NTSC config with resources", model.NTSCType,
+		"description": "test\nspecial\tchar"
+		}
+	}`, nil,
+		},
+		{
+			"JSON simple NTSC config with resources", model.NTSCType,
 			`{ "invariant_config": {
-					"resources": {
-						"slots": 1
-					}
-				}
-			}`, nil},
+			"resources": {
+				"slots": 1
+			}
+		}
+	}`, nil,
+		},
 		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", nil},
 
 		// Invalid experiment invariant config policies (JSON).
 		{
 			"JSON experiment config with null key", model.ExperimentType,
 			`{ "invariant_config":
-  					: "test\nspecial\tchar"
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+			  : "test\nspecial\tchar"
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment config invalid type for key", model.ExperimentType,
 			`{ "invariant_config:
-  				"resources": {
-					slots: "this should be a number"
-				}
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		  "resources": {
+			slots: "this should be a number"
+		}
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment config nonexistent key", model.ExperimentType,
 			`{ "invariant_config":
-				"nonexistent_description": "test\nspecial\tchar" 
-		}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		"nonexistent_description": "test\nspecial\tchar" 
+}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment config extra nonexistent key", model.ExperimentType,
 			`{ "invariant_config": {
-					"resources": {
-						"slots": 1
-					},
-					"extra_key": 2
-				}
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+			"resources": {
+				"slots": 1
+			},
+			"extra_key": 2
+		}
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment just config", model.ExperimentType,
@@ -904,46 +982,46 @@ invariant_config:
 		{
 			"JSON experiment bad config spec", model.ExperimentType,
 			`{ "bad_config_spec": {
-					"resources": {
-						"slots": 1
-					}				}
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+			"resources": {
+				"slots": 1
+			}				}
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 
 		// Invalid NTSC invariant config policies (JSON).
 		{
 			"JSON NTSC config with null key", model.NTSCType,
 			`{ "invariant_config": {
-   				: "test\nspecial\tchar"
- 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		   : "test\nspecial\tchar"
+	 }`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC config with empty key", model.NTSCType,
 			`{ "invariant_config": {
-   				"": "test\nspecial\tchar"
- 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		   "": "test\nspecial\tchar"
+	 }`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC invalid NTSC type for key", model.NTSCType,
 			`{ "invariant_config":
-				"resources": {
-					"slots": "this should be a number"
-				}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		"resources": {
+			"slots": "this should be a number"
+		}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC nonexistent key", model.NTSCType,
 			`{ "invariant_config": {
-   				"nonexistent_description": "test\nspecial\tchar"
- 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		   "nonexistent_description": "test\nspecial\tchar"
+	 }`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC extra nonexistent key", model.NTSCType,
 			`{ "invariant_config": {
-					"resources": {
-				 		"slots": 1
-  				},
-				"extra_key": 2
-			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+			"resources": {
+				 "slots": 1
+		  },
+		"extra_key": 2
+	}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC just config", model.NTSCType,
@@ -952,76 +1030,83 @@ invariant_config:
 		{
 			"JSON NTSC bad config spec", model.NTSCType,
 			`{ "bad_config_spec": {
-					"resources": {
-						"slots": 1
-					}				
-				}
-			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+			"resources": {
+				"slots": 1
+			}				
+		}
+	}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		// Valid constraint policies (JSON).
-		{"JSON experiment valid constraints policy", model.ExperimentType,
-			"{" + validConstraintsPolicyJSON + "}", nil},
+		{
+			"JSON experiment valid constraints policy", model.ExperimentType,
+			"{" + validConstraintsPolicyJSON + "}", nil,
+		},
 		{"JSON NTSC valid constraints policy", model.NTSCType, "{" + validConstraintsPolicyJSON +
 			"}", nil},
-		{"JSON experiment simple valid constraints policy priority limit", model.ExperimentType,
+		{
+			"JSON experiment simple valid constraints policy priority limit", model.ExperimentType,
 			`{ "constraints": {
-					"priority_limit": 10
-				}
-			}`, nil,
+			"priority_limit": 10
+		}
+	}`, nil,
 		},
-		{"JSON NTSC simple valid constraints policy priority limit", model.NTSCType,
+		{
+			"JSON NTSC simple valid constraints policy priority limit", model.NTSCType,
 			`{ "constraints": {
-					"priority_limit": 10
-				}
-			}`, nil,
+			"priority_limit": 10
+		}
+	}`, nil,
 		},
-		{"JSON experiment simple valid constraints policy resources", model.ExperimentType,
+		{
+			"JSON experiment simple valid constraints policy resources", model.ExperimentType,
 			`{ "constraints": {
-					"resources": {
-						"max_slots": 4
-					}
-				}
-			}`, nil,
+			"resources": {
+				"max_slots": 4
+			}
+		}
+	}`, nil,
 		},
-		{"JSON NTSC simple valid constraints policy resources", model.NTSCType,
+		{
+			"JSON NTSC simple valid constraints policy resources", model.NTSCType,
 			`{ "constraints": {
-					"resources": {
-						"max_slots": 4
-					}
-				}
-			}`, nil,
+			"resources": {
+				"max_slots": 4
+			}
+		}
+	}`, nil,
 		},
 
 		// Invalid experiment constraint policies (JSON).
-		{"JSON experiment constraint with null key", model.ExperimentType,
+		{
+			"JSON experiment constraint with null key", model.ExperimentType,
 			`{ "constraints": {
-				: 10 
-				}
-			}`,
+		: 10 
+		}
+	}`,
 			fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment constraints invalid type for key", model.ExperimentType,
 			`{ "constraints": {
-					"resources": {
-						"max_slots": "this should be a number"
-					}
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+			"resources": {
+				"max_slots": "this should be a number"
+			}
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment constraints nonexistent key", model.ExperimentType,
 			`{ "constraints": {
-				"nonexistent_priority_limit": 10
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		"nonexistent_priority_limit": 10
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment constraints extra nonexistent key", model.ExperimentType,
 			`{ "constraints": {
-					"resources": {
-						"max_slots": 1
-					},
-					"extra_key": 2 
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+			"resources": {
+				"max_slots": 1
+			},
+			"extra_key": 2 
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON experiment just constraints", model.ExperimentType,
@@ -1029,42 +1114,44 @@ invariant_config:
 		},
 
 		// Invalid NTSC constraint policies (JSON).
-		{"JSON NTSC constraint with null key", model.ExperimentType,
+		{
+			"JSON NTSC constraint with null key", model.ExperimentType,
 			`{ "constraints": {
-				: 10 
-				}
-			}`,
+		: 10 
+		}
+	}`,
 			fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
-		{"JSON NTSC constraint with empty key", model.ExperimentType,
+		{
+			"JSON NTSC constraint with empty key", model.ExperimentType,
 			`{ "constraints": {
-				"": 10 
-				}
-			}`,
+		"": 10 
+		}
+	}`,
 			fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 		{
 			"JSON NTSC constraints invalid type for key", model.NTSCType,
 			`"constraints": {
-				"resources": {
-					"max_slots": "this should be a number"
-				}
-			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		"resources": {
+			"max_slots": "this should be a number"
+		}
+	}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC constraints nonexistent key", model.NTSCType,
 			`{ "constraints":
-  					"nonexistent_priority_limit": 10 
-  			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+			  "nonexistent_priority_limit": 10 
+	  }`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC constraints extra nonexistent key", model.NTSCType,
 			`{ "constraints": {
-				"resources": {
-					"max_slots": 1
-				},
-  			"extra_key": 2
-			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		"resources": {
+			"max_slots": 1
+		},
+	  "extra_key": 2
+	}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 		{
 			"JSON NTSC just constraints", model.NTSCType,
@@ -1072,53 +1159,63 @@ invariant_config:
 		},
 
 		// Additional experiment combinatory tests (JSON).
-		{"JSON experiment valid config valid constraints", model.ExperimentType,
-			"{" + validExperimentConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil},
-		{"JSON experiment valid constraints invalid constraints", model.ExperimentType,
+		{
+			"JSON experiment valid config valid constraints", model.ExperimentType,
+			"{" + validExperimentConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil,
+		},
+		{
+			"JSON experiment valid constraints invalid constraints", model.ExperimentType,
 			"{" + validExperimentConfigPolicyJSON + "," +
 				` 
-				"constraints: {
-					"resources": {
-						"max_slots": "this should be a number" 
-					}
-				}
-			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		"constraints: {
+			"resources": {
+				"max_slots": "this should be a number" 
+			}
+		}
+	}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
-		{"JSON experiment invalid config valid constraints", model.ExperimentType,
+		{
+			"JSON experiment invalid config valid constraints", model.ExperimentType,
 			`{ "invariant_config": {
-					"resources": {
-						"slots": "this should be a number"
-					}
-			},` + validConstraintsPolicyJSON + "}", fmt.Errorf(invalidExperimentConfigPolicyErr),
+			"resources": {
+				"slots": "this should be a number"
+			}
+	},` + validConstraintsPolicyJSON + "}", fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 
 		// Additional NTSC combinatory tests (JSON).
-		{"JSON NTSC valid config valid constraints", model.NTSCType,
-			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil},
-		{"JSON NTSC valid constraints invalid constraints", model.NTSCType,
+		{
+			"JSON NTSC valid config valid constraints", model.NTSCType,
+			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil,
+		},
+		{
+			"JSON NTSC valid constraints invalid constraints", model.NTSCType,
 			"{" + validNTSCConfigPolicyJSON + "," +
 				`
-				"constraints": {
-					"resources": {
-						"max_slots": "this should be a number"
-					}
-				}
-			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		"constraints": {
+			"resources": {
+				"max_slots": "this should be a number"
+			}
+		}
+	}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
-		{"JSON NTSC invalid config valid constraints", model.NTSCType,
+		{
+			"JSON NTSC invalid config valid constraints", model.NTSCType,
 			`{ "invariant_config": {
-					"resources": {
-						"slots": "this should be a number"
-					}
-			},
+			"resources": {
+				"slots": "this should be a number"
+			}
+	},
 ` + validConstraintsPolicyJSON + "}", fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
 
 		// Experiment-NTSC mismatch test error (JSON).
-		{"JSON valid experiment config with NTSC workload type", model.NTSCType,
+		{
+			"JSON valid experiment config with NTSC workload type", model.NTSCType,
 			"{" + validExperimentConfigPolicyJSON + "}", fmt.Errorf(invalidNTSCtConfigPolicyErr),
 		},
-		{"JSON valid NTSC config with experiment workload type", model.ExperimentType,
+		{
+			"JSON valid NTSC config with experiment workload type", model.ExperimentType,
 			"{" + validNTSCConfigPolicyJSON + "}", fmt.Errorf(invalidExperimentConfigPolicyErr),
 		},
 	}
@@ -1127,10 +1224,10 @@ invariant_config:
 		t.Run(test.name, func(t *testing.T) {
 			err := validatePoliciesAndWorkloadType(test.workloadType, test.configPolicies)
 			if test.err != nil {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.ErrorContains(t, err, test.err.Error())
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1197,7 +1294,7 @@ work_dir: my/working/directory
 		constraints     map[string]interface{}
 	}{
 		{
-			"valid YAML exp config and constriants", validExperimentConfigPolicyYAML +
+			"valid YAML exp config and constraints", validExperimentConfigPolicyYAML +
 				validConstraintsPolicyYAML,
 			map[string]interface{}{
 				"invariant_config": map[string]interface{}{
@@ -1239,7 +1336,7 @@ work_dir: my/working/directory
 			validExperimentConfigMap, validConstraintsMap,
 		},
 		{
-			"valid YAML NTSC config and constriants", validNTSCConfigPolicyYAML +
+			"valid YAML NTSC config and constraints", validNTSCConfigPolicyYAML +
 				validConstraintsPolicyYAML,
 			map[string]interface{}{
 				"invariant_config": map[string]interface{}{
@@ -1286,7 +1383,8 @@ work_dir: my/working/directory
 					"resources":      map[string]interface{}{"max_slots": float64(4)},
 					"priority_limit": float64(10),
 				},
-			}, nil, validConstraintsMap,
+			},
+			nil, validConstraintsMap,
 		},
 		{
 			"just constraints JSON", validConstraintsJSON, map[string]interface{}{
@@ -1370,7 +1468,8 @@ another_key:
 			map[string]interface{}{
 				"a_key":       "a_value",
 				"another_key": map[string]interface{}{"sub_key": float64(1)},
-			}, nil, nil,
+			},
+			nil, nil,
 		},
 		{
 			"random valid JSON with neither config nor constraint",
@@ -1384,13 +1483,14 @@ another_key:
 			map[string]interface{}{
 				"a_key":       "a_value",
 				"another_key": map[string]interface{}{"sub_key": float64(1)},
-			}, nil, nil,
+			},
+			nil, nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tcps, invariantConfig, constraints, err := parseConfigPolicies(test.configPolicies)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			// Verify invariant config output is correct
 			if test.invariantConfig != nil {
@@ -1426,29 +1526,29 @@ another_key:
 	require.Nil(t, tcps)
 	require.Nil(t, invariantConfig)
 	require.Nil(t, constraints)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "nothing to parse, empty config and constraints input")
 
 	// Test non-JSON and non-YAML formatted strings fail.
-	tcps, invariantConfig, constraints, err = parseConfigPolicies("{\"bad_json\":: 1}")
+	tcps, invariantConfig, constraints, err = parseConfigPolicies("{\"bad_json\",: 1}")
 	require.Nil(t, tcps)
 	require.Nil(t, invariantConfig)
 	require.Nil(t, constraints)
-	require.NotNil(t, err)
-	require.ErrorContains(t, err, "error unmarshaling config policies")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "error parsing config policies")
 
 	tcps, invariantConfig, constraints, err = parseConfigPolicies("bad_yaml:1")
 	require.Nil(t, tcps)
 	require.Nil(t, invariantConfig)
 	require.Nil(t, constraints)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "error unmarshaling config policies")
 
 	tcps, invariantConfig, constraints, err = parseConfigPolicies("random string")
 	require.Nil(t, tcps)
 	require.Nil(t, invariantConfig)
 	require.Nil(t, constraints)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.ErrorContains(t, err, "error unmarshaling config policies")
 }
 
@@ -1463,25 +1563,6 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 			log.Errorf("error when cleaning up mock workspaces")
 		}
 	}()
-
-	entrypointYAML := `
-  entrypoint: "start from here"
-`
-
-	updatedExperimentConfigPolicyJSON := `
-	"invariant_config": {
-        "description": "test\nspecial\tchar",
-        "environment": {
-            "force_pull_image": false,
-            "add_capabilities": ["cap1", "cap2"]
-        },
-        "resources": {
-            "slots": 1
-        },
-		"name": "my_experiment_config",
-		"entrypoint": "start from here"
-    }
-`
 
 	tests := []struct {
 		name                  string
@@ -1503,7 +1584,7 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 			err:                   fmt.Errorf("invalid workload type"),
 		},
 		{
-			name: "emtpy workload type",
+			name: "empty workload type",
 			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
 				ConfigPolicies: validExperimentConfigPolicyYAML,
 			},
@@ -1519,8 +1600,7 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 				ConfigPolicies: validExperimentConfigPolicyYAML,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1537,8 +1617,7 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 				ConfigPolicies: validExperimentConfigPolicyYAML + entrypointYAML,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1560,8 +1639,7 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 				ConfigPolicies: "{" + validExperimentConfigPolicyJSON + "}",
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1578,8 +1656,7 @@ func TestPutWorkspaceConfigPolicies(t *testing.T) {
 				ConfigPolicies: "{" + updatedExperimentConfigPolicyJSON + "}",
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1605,8 +1682,7 @@ invariant_config:
 `,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"name":        "my_experiment_config",
 				},
@@ -1620,8 +1696,7 @@ invariant_config:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "new description!",
 					"name":        "my_experiment_config",
 				},
@@ -1640,8 +1715,7 @@ invariant_config:
 				}`,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"name":        "my_experiment_config",
 				},
@@ -1656,8 +1730,7 @@ invariant_config:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "new description!",
 					"name":        "my_experiment_config",
 				},
@@ -1689,8 +1762,7 @@ constraints:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"constraints": map[string]interface {
-				}{
+				"constraints": map[string]interface{}{
 					"priority_limit": float64(30),
 				},
 			},
@@ -1724,8 +1796,7 @@ constraints:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"constraints": map[string]interface {
-				}{
+				"constraints": map[string]interface{}{
 					"priority_limit": float64(30),
 				},
 			},
@@ -1750,10 +1821,10 @@ constraints:
   resources:
     max_slots: 4
   priority_limit: 10
-`},
+`,
+			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1790,8 +1861,7 @@ constraints:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"add_capabilities": []interface{}{"cap1"},
@@ -1833,10 +1903,10 @@ constraints:
 						},
 						"priority_limit": 10
 					}
-				}`},
+				}`,
+			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -1877,8 +1947,7 @@ constraints:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"add_capabilities": []interface{}{"cap1"},
@@ -1898,6 +1967,37 @@ constraints:
 			},
 			err: nil,
 		},
+		{
+			name: "invalid constraints JSON",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"constraints": {
+						"resources": {
+							"max_slots": a_string_not_int
+						}					
+					}
+				}`,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			name: "invalid NTSC config YAML",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.NTSCType,
+				ConfigPolicies: `
+invariant_config:
+  : "null key"
+`,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
 	}
 
 	for _, test := range tests {
@@ -1915,7 +2015,8 @@ constraints:
 				require.Nil(t, resp)
 				return
 			}
-			require.Nil(t, err)
+			require.NoError(t, err)
+			require.Equal(t, test.configPolicies, resp.ConfigPolicies.AsMap())
 
 			// Verify that we can retrieve the input config policies.
 			getResp, err := api.GetWorkspaceConfigPolicies(ctx,
@@ -1930,7 +2031,8 @@ constraints:
 
 			test.updatedPoliciesReq.WorkspaceId = workspaceID
 			resp, err = api.PutWorkspaceConfigPolicies(ctx, test.updatedPoliciesReq)
-			require.Nil(t, err)
+			require.NoError(t, err)
+			require.Equal(t, test.updatedConfigPolicies, resp.ConfigPolicies.AsMap())
 
 			// Verify that config policies were updated correctly.
 			getResp, err = api.GetWorkspaceConfigPolicies(ctx,
@@ -1960,10 +2062,6 @@ func TestPutGlobalConfigPolicies(t *testing.T) {
 	api, _, ctx := setupAPITest(t, nil)
 	testutils.MustLoadLicenseAndKeyFromFilesystem("../../")
 
-	entrypointYAML := `
-  entrypoint: "start from here"
-`
-
 	updatedExperimentConfigPolicyJSON := `
 	"invariant_config": {
         "description": "test\nspecial\tchar",
@@ -1988,35 +2086,13 @@ func TestPutGlobalConfigPolicies(t *testing.T) {
 		err                   error
 	}{
 		{
-			name: "invalid workload type",
-			req: &apiv1.PutGlobalConfigPoliciesRequest{
-				WorkloadType:   "bad type",
-				ConfigPolicies: validExperimentConfigPolicyYAML,
-			},
-			configPolicies:        nil,
-			updatedPoliciesReq:    nil,
-			updatedConfigPolicies: nil,
-			err:                   fmt.Errorf("invalid workload type"),
-		},
-		{
-			name: "emtpy workload type",
-			req: &apiv1.PutGlobalConfigPoliciesRequest{
-				ConfigPolicies: validExperimentConfigPolicyYAML,
-			},
-			configPolicies:        nil,
-			updatedPoliciesReq:    nil,
-			updatedConfigPolicies: nil,
-			err:                   fmt.Errorf("no workload type"),
-		},
-		{
 			name: "valid experiment invariant config add update YAML",
 			req: &apiv1.PutGlobalConfigPoliciesRequest{
 				WorkloadType:   model.ExperimentType,
 				ConfigPolicies: validExperimentConfigPolicyYAML,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2033,8 +2109,7 @@ func TestPutGlobalConfigPolicies(t *testing.T) {
 				ConfigPolicies: validExperimentConfigPolicyYAML + entrypointYAML,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2056,8 +2131,7 @@ func TestPutGlobalConfigPolicies(t *testing.T) {
 				ConfigPolicies: "{" + validExperimentConfigPolicyJSON + "}",
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2074,8 +2148,7 @@ func TestPutGlobalConfigPolicies(t *testing.T) {
 				ConfigPolicies: "{" + updatedExperimentConfigPolicyJSON + "}",
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2101,8 +2174,7 @@ invariant_config:
 `,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"name":        "my_experiment_config",
 				},
@@ -2116,8 +2188,7 @@ invariant_config:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "new description!",
 					"name":        "my_experiment_config",
 				},
@@ -2136,8 +2207,7 @@ invariant_config:
 				}`,
 			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"name":        "my_experiment_config",
 				},
@@ -2152,8 +2222,7 @@ invariant_config:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "new description!",
 					"name":        "my_experiment_config",
 				},
@@ -2185,8 +2254,7 @@ constraints:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"constraints": map[string]interface {
-				}{
+				"constraints": map[string]interface{}{
 					"priority_limit": float64(30),
 				},
 			},
@@ -2220,8 +2288,7 @@ constraints:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"constraints": map[string]interface {
-				}{
+				"constraints": map[string]interface{}{
 					"priority_limit": float64(30),
 				},
 			},
@@ -2246,10 +2313,10 @@ constraints:
   resources:
     max_slots: 4
   priority_limit: 10
-`},
+`,
+			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2286,8 +2353,7 @@ constraints:
 `,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"add_capabilities": []interface{}{"cap1"},
@@ -2329,10 +2395,10 @@ constraints:
 						},
 						"priority_limit": 10
 					}
-				}`},
+				}`,
+			},
 			configPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"force_pull_image": false,
@@ -2373,8 +2439,7 @@ constraints:
 				}`,
 			},
 			updatedConfigPolicies: map[string]any{
-				"invariant_config": map[string]interface {
-				}{
+				"invariant_config": map[string]interface{}{
 					"description": "test\nspecial\tchar",
 					"environment": map[string]interface{}{
 						"add_capabilities": []interface{}{"cap1"},
@@ -2394,12 +2459,44 @@ constraints:
 			},
 			err: nil,
 		},
+		{
+			name: "invalid constraints JSON",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"constraints": {
+						"resources": {
+							"max_slots": a_string_not_int
+						}					
+					}
+				}`,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			name: "invalid NTSC config YAML",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.NTSCType,
+				ConfigPolicies: `
+invariant_config:
+  : "null key"
+`,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := api.DeleteGlobalConfigPolicies(ctx,
 				&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: test.req.WorkloadType})
+			require.NoError(t, err)
 
 			resp, err := api.PutGlobalConfigPolicies(ctx, test.req)
 			if test.err != nil {
@@ -2407,7 +2504,8 @@ constraints:
 				require.Nil(t, resp)
 				return
 			}
-			require.Nil(t, err)
+			require.NoError(t, err)
+			require.Equal(t, test.configPolicies, resp.ConfigPolicies.AsMap())
 
 			// Verify that we can retrieve the input config policies.
 			getResp, err := api.GetGlobalConfigPolicies(ctx,
@@ -2420,7 +2518,8 @@ constraints:
 			require.Equal(t, test.configPolicies, configPolicies)
 
 			resp, err = api.PutGlobalConfigPolicies(ctx, test.updatedPoliciesReq)
-			require.Nil(t, err)
+			require.NoError(t, err)
+			require.Equal(t, test.updatedConfigPolicies, resp.ConfigPolicies.AsMap())
 
 			// Verify that config policies were updated correctly.
 			getResp, err = api.GetGlobalConfigPolicies(ctx,
@@ -2433,4 +2532,19 @@ constraints:
 			require.Equal(t, test.updatedConfigPolicies, updatedConfigPolicies)
 		})
 	}
+
+	// Test invalid workload type.
+	resp, err := api.PutGlobalConfigPolicies(ctx, &apiv1.PutGlobalConfigPoliciesRequest{
+		WorkloadType:   "bad type",
+		ConfigPolicies: validExperimentConfigPolicyYAML,
+	})
+	require.ErrorContains(t, err, "invalid workload type")
+	require.Nil(t, resp)
+
+	// Test empty workload type.
+	resp, err = api.PutGlobalConfigPolicies(ctx, &apiv1.PutGlobalConfigPoliciesRequest{
+		ConfigPolicies: validExperimentConfigPolicyYAML,
+	})
+	require.ErrorContains(t, err, "no workload type")
+	require.Nil(t, resp)
 }

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -18,6 +20,77 @@ import (
 	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/test/testutils"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+const (
+	validConstraintsPolicyYAML = `
+constraints:
+  resources:
+    max_slots: 4
+  priority_limit: 10
+`
+
+	validExperimentConfigPolicyYAML = `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    force_pull_image: false
+    add_capabilities:
+      - "cap1"
+      - "cap2"
+  resources:
+    slots: 1
+  name: my_experiment_config
+`
+
+	validNTSCConfigPolicyYAML = `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    force_pull_image: false
+    add_capabilities:
+      - "cap1"
+      - "cap2"
+  resources:
+    slots: 1
+  work_dir: my/working/directory
+`
+
+	validConstraintsPolicyJSON = `
+ 	"constraints": {
+        "resources": {
+            "max_slots": 4
+        },
+        "priority_limit": 10
+    }`
+
+	validExperimentConfigPolicyJSON = `
+	"invariant_config": {
+        "description": "test\nspecial\tchar",
+        "environment": {
+            "force_pull_image": false,
+            "add_capabilities": ["cap1", "cap2"]
+        },
+        "resources": {
+            "slots": 1
+        },
+		"name": "my_experiment_config"
+    }`
+	validNTSCConfigPolicyJSON = `
+	"invariant_config": {
+		"description": "test\nspecial\tchar",
+		"environment": {
+			"force_pull_image": false,
+			"add_capabilities": ["cap1", "cap2"]
+		},
+		"resources": {
+			"slots": 1
+		},
+		"work_dir": "my/working/directory"
+	}`
+
+	invalidExperimentConfigPolicyErr = "invalid experiment config policy"
+	invalidNTSCtConfigPolicyErr      = "invalid NTSC config policy"
 )
 
 func TestDeleteWorkspaceConfigPolicies(t *testing.T) {
@@ -208,6 +281,33 @@ func TestBasicRBACConfigPolicyPerms(t *testing.T) {
 			},
 			fmt.Errorf("PermissionDenied"),
 		},
+		{
+			"put workspace config policies",
+			func() error {
+				_, err := api.PutWorkspaceConfigPolicies(ctx,
+					&apiv1.PutWorkspaceConfigPoliciesRequest{
+						WorkspaceId:    wkspID,
+						WorkloadType:   model.NTSCType,
+						ConfigPolicies: validNTSCConfigPolicyYAML + validConstraintsPolicyYAML,
+					},
+				)
+				return err
+			},
+			fmt.Errorf("only admins may set config policies for workspaces"),
+		},
+		{
+			"put global config policies",
+			func() error {
+				_, err := api.PutGlobalConfigPolicies(ctx,
+					&apiv1.PutGlobalConfigPoliciesRequest{
+						WorkloadType:   model.NTSCType,
+						ConfigPolicies: validNTSCConfigPolicyYAML + validConstraintsPolicyYAML,
+					},
+				)
+				return err
+			},
+			fmt.Errorf("PermissionDenied"),
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
@@ -359,17 +459,17 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 	configPolicyAuthZ := setupConfigPolicyAuthZ()
 
 	workspaceAuthZ.On("CanCreateWorkspace", mock.Anything, mock.Anything).Return(nil).Once()
-	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil).Twice()
 
 	wkspResp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{Name: uuid.New().String()})
 	require.NoError(t, err)
 	workspaceID := wkspResp.Workspace.Id
 
 	// (Workspace-level) Deny with permission access error.
+	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Twice()
 	expectedErr := fmt.Errorf("canModifyConfigPoliciesError")
 	configPolicyAuthZ.On("CanModifyWorkspaceConfigPolicies", mock.Anything, mock.Anything,
-		mock.Anything).Return(expectedErr).Once()
+		mock.Anything).Return(expectedErr).Twice()
 
 	_, err = api.DeleteWorkspaceConfigPolicies(ctx,
 		&apiv1.DeleteWorkspaceConfigPoliciesRequest{
@@ -378,9 +478,20 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 		})
 	require.Equal(t, expectedErr, err)
 
-	// Nil error returns whatever the delete request returned.
+	_, err = api.PutWorkspaceConfigPolicies(ctx,
+		&apiv1.PutWorkspaceConfigPoliciesRequest{
+			WorkspaceId:    workspaceID,
+			WorkloadType:   model.NTSCType,
+			ConfigPolicies: validConstraintsPolicyYAML,
+		})
+	require.Equal(t, expectedErr, err)
+
+	// (Workspace-level) Nil error returns whatever the request returned.
+	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Twice()
 	configPolicyAuthZ.On("CanModifyWorkspaceConfigPolicies", mock.Anything, mock.Anything,
-		mock.Anything).Return(nil).Once()
+		mock.Anything).Return(nil).Twice()
+
 	_, err = api.DeleteWorkspaceConfigPolicies(ctx,
 		&apiv1.DeleteWorkspaceConfigPoliciesRequest{
 			WorkspaceId:  workspaceID,
@@ -388,20 +499,39 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 		})
 	require.NoError(t, err)
 
+	_, err = api.PutWorkspaceConfigPolicies(ctx,
+		&apiv1.PutWorkspaceConfigPoliciesRequest{
+			WorkspaceId:    workspaceID,
+			WorkloadType:   model.NTSCType,
+			ConfigPolicies: validConstraintsPolicyYAML,
+		})
+	require.NoError(t, err)
+
 	// (Global) Deny with permission access error.
 	expectedErr = fmt.Errorf("canModifyGlobalConfigPoliciesError")
 	configPolicyAuthZ.On("CanModifyGlobalConfigPolicies", mock.Anything, mock.Anything).
-		Return(expectedErr, nil).Once()
+		Return(expectedErr, nil).Twice()
 
 	_, err = api.DeleteGlobalConfigPolicies(ctx,
 		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType})
 	require.Equal(t, expectedErr, err)
 
-	// Nil error returns whatever the delete request returned.
+	_, err = api.PutGlobalConfigPolicies(ctx,
+		&apiv1.PutGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType,
+			ConfigPolicies: validNTSCConfigPolicyYAML})
+	require.Equal(t, expectedErr, err)
+
+	// (Global) Nil error returns whatever the request returned.
 	configPolicyAuthZ.On("CanModifyGlobalConfigPolicies", mock.Anything, mock.Anything).
-		Return(nil, nil).Once()
+		Return(nil, nil).Twice()
+
 	_, err = api.DeleteGlobalConfigPolicies(ctx,
 		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType})
+	require.NoError(t, err)
+
+	_, err = api.PutGlobalConfigPolicies(ctx,
+		&apiv1.PutGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType,
+			ConfigPolicies: validNTSCConfigPolicyYAML})
 	require.NoError(t, err)
 }
 
@@ -413,4 +543,1894 @@ func setupConfigPolicyAuthZ() *mocks.ConfigPolicyAuthZ {
 		configpolicy.AuthZProvider.Register("mock", cpAuthZ)
 	}
 	return cpAuthZ
+}
+
+func TestValidatePoliciesAndWorkloadType(t *testing.T) {
+	tests := []struct {
+		name           string
+		workloadType   string
+		configPolicies string
+		err            error
+	}{
+		// YAML tests.
+
+		{"YAML invalid workload type valid config policies", "random", validExperimentConfigPolicyYAML,
+			fmt.Errorf(invalidWorkloadTypeErr)},
+		{"YAML no workload type valid config policies", "", validExperimentConfigPolicyYAML,
+			fmt.Errorf(noWorkloadErr)},
+		{"YAML valid workload type no config policies", model.ExperimentType, "",
+			fmt.Errorf(noPoliciesErr)},
+
+		// Valid experiment invariant config policies (YAML).
+		{"YAML simple experiment config with description", model.ExperimentType,
+			`
+invariant_config:
+  description: "test\nspecial\tchar"
+`, nil},
+		{"YAML simple experiment config with resources", model.ExperimentType,
+			`
+invariant_config:
+  resources:
+    slots: 1
+`, nil},
+		{"YAML partial experiment config", model.ExperimentType, validExperimentConfigPolicyYAML, nil},
+
+		// Valid NTSC invariant config policies (YAML).
+		{"YAML simple NTSC config with description", model.NTSCType,
+			`
+invariant_config:
+  description: "test\nspecial\tchar"
+`, nil},
+		{"YAML simple NTSC config with resources", model.NTSCType,
+			`
+invariant_config:
+  resources:
+    slots: 1
+`, nil},
+		{"YAML partial NTSC config", model.NTSCType, validNTSCConfigPolicyYAML, nil},
+
+		// Invalid experiment invariant config policies (YAML).
+		{
+			"YAML experiment config with null key", model.ExperimentType,
+			`
+invariant_config:
+  : "test\nspecial\tchar"
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment config invalid type for key", model.ExperimentType,
+			`
+invariant_config:
+  resources:
+    slots: "this should be a number"
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment config nonexistent key", model.ExperimentType,
+			`
+invariant_config:
+  nonexistent_description: "test\nspecial\tchar"
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment config extra nonexistent key", model.ExperimentType,
+			`
+invariant_config:
+  resources:
+    slots: 1
+  extra_key: 2
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment just config", model.ExperimentType,
+			`
+invariant_config:
+`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+		{
+			"YAML experiment bad config spec", model.ExperimentType,
+			`
+bad_config_spec:
+  resources:
+    slots: 1
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+
+		// Invalid NTSC invariant config policies (YAML).
+		{
+			"YAML NTSC config with null key", model.NTSCType,
+			`
+invariant_config:
+  : "test\nspecial\tchar"
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC invalid NTSC type for key", model.NTSCType,
+			`
+invariant_config:
+  resources:
+    slots: "this should be a number"
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC nonexistent key", model.NTSCType,
+			`
+invariant_config:
+  nonexistent_description: "test\nspecial\tchar"
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC extra nonexistent key", model.NTSCType,
+			`
+invariant_config:
+  resources:
+    slots: 1
+  extra_key: 2
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC just config", model.NTSCType,
+			`
+invariant_config:
+`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+		{
+			"YAML NTSC bad config spec", model.NTSCType,
+			`
+bad_config_spec:
+  resources:
+    slots: 1
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		// Valid constraint policies (YAML).
+		{"YAML experiment valid constraints policy", model.ExperimentType, validConstraintsPolicyYAML, nil},
+		{"YAML NTSC valid constraints policy", model.NTSCType, validConstraintsPolicyYAML, nil},
+		{"YAML experiment simple valid constraints policy priority limit", model.ExperimentType,
+			`
+constraints:
+  priority_limit: 10
+`, nil,
+		},
+		{"YAML NTSC simple valid constraints policy priority limit", model.NTSCType,
+			`
+constraints:
+  priority_limit: 10
+`, nil,
+		},
+		{"YAML experiment simple valid constraints policy resources", model.ExperimentType,
+			`
+constraints:
+  resources:
+    max_slots: 4
+`, nil,
+		},
+		{"YAML NTSC simple valid constraints policy resources", model.NTSCType,
+			`
+constraints:
+  resources:
+    max_slots: 4
+`, nil,
+		},
+
+		// Invalid experiment constraint policies (YAML).
+		{"experiment constraint with null key", model.ExperimentType,
+			`
+constraints:
+ : 10
+`,
+			fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment constraints invalid type for key", model.ExperimentType,
+			`
+constraints:
+  resources:
+    max_slots: "this should be a number"
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment constraints nonexistent key", model.ExperimentType,
+			`
+constraints:
+  nonexistent_priority_limit: 10
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment constraints extra nonexistent key", model.ExperimentType,
+			`
+constraints:
+  resources:
+    max_slots: 1
+  extra_key: 2
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"YAML experiment just constraints", model.ExperimentType,
+			`
+constraints:
+`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+
+		// Invalid NTSC constraint policies (YAML).
+		{"YAML NTSC constraint with null key", model.NTSCType,
+			`
+constraints:
+: 10
+`,
+			fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC constraints invalid type for key", model.NTSCType,
+			`
+constraints:
+  resources:
+    max_slots: "this should be a number"
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC constraints nonexistent key", model.NTSCType,
+			`
+constraints:
+  nonexistent_priority_limit: 10
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC constraints extra nonexistent key", model.NTSCType,
+			`
+constraints:
+  resources:
+    max_slots: 1
+  extra_key: 2
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"YAML NTSC just constraints", model.NTSCType,
+			`
+constraints:
+`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+
+		// Additional experiment combinatory tests (YAML).
+		{"YAML experiment valid config valid constraints", model.ExperimentType,
+			validExperimentConfigPolicyYAML + validConstraintsPolicyYAML, nil},
+		{"YAML experiment valid constraints invalid constraints", model.ExperimentType,
+			validExperimentConfigPolicyYAML + `
+constraints:
+  resources:
+    max_slots: "this should be a number"
+`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{"YAML experiment invalid config valid constraints", model.ExperimentType,
+			`
+invariant_config:
+  resources:
+    slots: "this should be a number"
+` + validConstraintsPolicyYAML, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+
+		// Additional NTSC combinatory tests (YAML).
+		{"YAML NTSC valid config valid constraints", model.NTSCType,
+			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, nil},
+		{"YAML NTSC valid constraints invalid constraints", model.NTSCType,
+			validNTSCConfigPolicyYAML + `
+constraints:
+  resources:
+    max_slots: "this should be a number"
+`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{"NTSC invalid config valid constraints", model.NTSCType,
+			`
+invariant_config:
+  resources:
+    slots: "this should be a number"
+` + validConstraintsPolicyYAML, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+
+		// Experiment-NTSC mismatch test error (YAML).
+		{"YAML valid experiment config with NTSC workload type", model.NTSCType,
+			validExperimentConfigPolicyYAML, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{"YAML valid NTSC config with experiment workload type", model.ExperimentType,
+			validNTSCConfigPolicyYAML, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+
+		// JSON tests.
+
+		// Valid experiment invariant config policies.
+		{"JSON simple experiment config with description", model.ExperimentType,
+			`{ "invariant_config": {
+			 	"description": "test\nspecial\tchar"
+				}
+			}`, nil},
+		{"JSON simple experiment config with resources", model.ExperimentType,
+			`{ "invariant_config": {
+			 		"resources": {
+			 			"slots": 1 }
+					}
+			}`, nil},
+		{"JSON partial experiment config", model.ExperimentType, "{" +
+			validExperimentConfigPolicyJSON + "}", nil},
+
+		// Valid NTSC invariant config policies (JSON).
+		{"JSON simple NTSC config with description", model.NTSCType,
+			`{ "invariant_config": {
+				"description": "test\nspecial\tchar"
+				}
+			}`, nil},
+		{"JSON simple NTSC config with resources", model.NTSCType,
+			`{ "invariant_config": {
+					"resources": {
+						"slots": 1
+					}
+				}
+			}`, nil},
+		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", nil},
+
+		// Invalid experiment invariant config policies (JSON).
+		{
+			"JSON experiment config with null key", model.ExperimentType,
+			`{ "invariant_config":
+  					: "test\nspecial\tchar"
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment config invalid type for key", model.ExperimentType,
+			`{ "invariant_config:
+  				"resources": {
+					slots: "this should be a number"
+				}
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment config nonexistent key", model.ExperimentType,
+			`{ "invariant_config":
+				"nonexistent_description": "test\nspecial\tchar" 
+		}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment config extra nonexistent key", model.ExperimentType,
+			`{ "invariant_config": {
+					"resources": {
+						"slots": 1
+					},
+					"extra_key": 2
+				}
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment just config", model.ExperimentType,
+			`{"invariant_config": }`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+		{
+			"JSON experiment bad config spec", model.ExperimentType,
+			`{ "bad_config_spec": {
+					"resources": {
+						"slots": 1
+					}				}
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+
+		// Invalid NTSC invariant config policies (JSON).
+		{
+			"JSON NTSC config with null key", model.NTSCType,
+			`{ "invariant_config": {
+   				: "test\nspecial\tchar"
+ 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC config with empty key", model.NTSCType,
+			`{ "invariant_config": {
+   				"": "test\nspecial\tchar"
+ 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC invalid NTSC type for key", model.NTSCType,
+			`{ "invariant_config":
+				"resources": {
+					"slots": "this should be a number"
+				}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC nonexistent key", model.NTSCType,
+			`{ "invariant_config": {
+   				"nonexistent_description": "test\nspecial\tchar"
+ 			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC extra nonexistent key", model.NTSCType,
+			`{ "invariant_config": {
+					"resources": {
+				 		"slots": 1
+  				},
+				"extra_key": 2
+			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC just config", model.NTSCType,
+			`{ "invariant_config": }`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+		{
+			"JSON NTSC bad config spec", model.NTSCType,
+			`{ "bad_config_spec": {
+					"resources": {
+						"slots": 1
+					}				
+				}
+			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		// Valid constraint policies (JSON).
+		{"JSON experiment valid constraints policy", model.ExperimentType,
+			"{" + validConstraintsPolicyJSON + "}", nil},
+		{"JSON NTSC valid constraints policy", model.NTSCType, "{" + validConstraintsPolicyJSON +
+			"}", nil},
+		{"JSON experiment simple valid constraints policy priority limit", model.ExperimentType,
+			`{ "constraints": {
+					"priority_limit": 10
+				}
+			}`, nil,
+		},
+		{"JSON NTSC simple valid constraints policy priority limit", model.NTSCType,
+			`{ "constraints": {
+					"priority_limit": 10
+				}
+			}`, nil,
+		},
+		{"JSON experiment simple valid constraints policy resources", model.ExperimentType,
+			`{ "constraints": {
+					"resources": {
+						"max_slots": 4
+					}
+				}
+			}`, nil,
+		},
+		{"JSON NTSC simple valid constraints policy resources", model.NTSCType,
+			`{ "constraints": {
+					"resources": {
+						"max_slots": 4
+					}
+				}
+			}`, nil,
+		},
+
+		// Invalid experiment constraint policies (JSON).
+		{"JSON experiment constraint with null key", model.ExperimentType,
+			`{ "constraints": {
+				: 10 
+				}
+			}`,
+			fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment constraints invalid type for key", model.ExperimentType,
+			`{ "constraints": {
+					"resources": {
+						"max_slots": "this should be a number"
+					}
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment constraints nonexistent key", model.ExperimentType,
+			`{ "constraints": {
+				"nonexistent_priority_limit": 10
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment constraints extra nonexistent key", model.ExperimentType,
+			`{ "constraints": {
+					"resources": {
+						"max_slots": 1
+					},
+					"extra_key": 2 
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON experiment just constraints", model.ExperimentType,
+			`{ "constraints": }`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+
+		// Invalid NTSC constraint policies (JSON).
+		{"JSON NTSC constraint with null key", model.ExperimentType,
+			`{ "constraints": {
+				: 10 
+				}
+			}`,
+			fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{"JSON NTSC constraint with empty key", model.ExperimentType,
+			`{ "constraints": {
+				"": 10 
+				}
+			}`,
+			fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{
+			"JSON NTSC constraints invalid type for key", model.NTSCType,
+			`"constraints": {
+				"resources": {
+					"max_slots": "this should be a number"
+				}
+			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC constraints nonexistent key", model.NTSCType,
+			`{ "constraints":
+  					"nonexistent_priority_limit": 10 
+  			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC constraints extra nonexistent key", model.NTSCType,
+			`{ "constraints": {
+				"resources": {
+					"max_slots": 1
+				},
+  			"extra_key": 2
+			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{
+			"JSON NTSC just constraints", model.NTSCType,
+			`{ "constraints": }`, fmt.Errorf(configpolicy.EmptyInvariantConfigErr),
+		},
+
+		// Additional experiment combinatory tests (JSON).
+		{"JSON experiment valid config valid constraints", model.ExperimentType,
+			"{" + validExperimentConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil},
+		{"JSON experiment valid constraints invalid constraints", model.ExperimentType,
+			"{" + validExperimentConfigPolicyJSON + "," +
+				` 
+				"constraints: {
+					"resources": {
+						"max_slots": "this should be a number" 
+					}
+				}
+			}`, fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+		{"JSON experiment invalid config valid constraints", model.ExperimentType,
+			`{ "invariant_config": {
+					"resources": {
+						"slots": "this should be a number"
+					}
+			},` + validConstraintsPolicyJSON + "}", fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+
+		// Additional NTSC combinatory tests (JSON).
+		{"JSON NTSC valid config valid constraints", model.NTSCType,
+			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil},
+		{"JSON NTSC valid constraints invalid constraints", model.NTSCType,
+			"{" + validNTSCConfigPolicyJSON + "," +
+				`
+				"constraints": {
+					"resources": {
+						"max_slots": "this should be a number"
+					}
+				}
+			}`, fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{"JSON NTSC invalid config valid constraints", model.NTSCType,
+			`{ "invariant_config": {
+					"resources": {
+						"slots": "this should be a number"
+					}
+			},
+` + validConstraintsPolicyJSON + "}", fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+
+		// Experiment-NTSC mismatch test error (JSON).
+		{"JSON valid experiment config with NTSC workload type", model.NTSCType,
+			"{" + validExperimentConfigPolicyJSON + "}", fmt.Errorf(invalidNTSCtConfigPolicyErr),
+		},
+		{"JSON valid NTSC config with experiment workload type", model.ExperimentType,
+			"{" + validNTSCConfigPolicyJSON + "}", fmt.Errorf(invalidExperimentConfigPolicyErr),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePoliciesAndWorkloadType(test.workloadType, test.configPolicies)
+			if test.err != nil {
+				require.NotNil(t, err)
+				require.ErrorContains(t, err, test.err.Error())
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestParseConfigPolicies(t *testing.T) {
+	validExperimentConfigYAML := `
+description: "test\nspecial\tchar"
+environment:
+  force_pull_image: false
+  add_capabilities:
+    - "cap1"
+    - "cap2"
+resources:
+  slots: 1
+name: my_experiment_config
+`
+	validConstraintsYAML := `
+resources:
+  max_slots: 4
+priority_limit: 10
+`
+
+	validNTSCConfigYAML := `
+description: "test\nspecial\tchar"
+environment:
+  force_pull_image: false
+  add_capabilities:
+    - "cap1"
+    - "cap2"
+resources:
+  slots: 1
+work_dir: my/working/directory
+`
+	validExperimentConfigJSON := "{" + validExperimentConfigPolicyJSON + "}"
+	validConstraintsJSON := "{" + validConstraintsPolicyJSON + "}"
+
+	// We create experiment and NTSC config and constraints maps to generate the expected
+	// configuration without replicating the marshaling code used in the parseConfigPolicies
+	// function to generate our expected output. So we compare configuration maps instead of the
+	// directly outputted strings since identical maps imply identical configuration in differently
+	// formatted strings.
+	// This further assures correct function logic since our expected values were derived without
+	// replicating any function logic.
+	var validExperimentConfigMap map[string]interface{}
+	err := yaml.Unmarshal([]byte(validExperimentConfigYAML), &validExperimentConfigMap)
+	require.NoError(t, err)
+
+	var validConstraintsMap map[string]interface{}
+	err = yaml.Unmarshal([]byte(validConstraintsYAML), &validConstraintsMap)
+	require.NoError(t, err)
+
+	var validNTSCConfigMap map[string]interface{}
+	err = yaml.Unmarshal([]byte(validNTSCConfigYAML), &validNTSCConfigMap)
+	require.NoError(t, err)
+
+	// We cast the integers to float64 throughout the tcps maps because yaml.Unmarshal decodes all
+	// objects of numbers type into float64 by default.
+	tests := []struct {
+		name            string
+		configPolicies  string
+		tcps            map[string]interface{}
+		invariantConfig map[string]interface{}
+		constraints     map[string]interface{}
+	}{
+		{
+			"valid YAML exp config and constriants", validExperimentConfigPolicyYAML +
+				validConstraintsPolicyYAML,
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"name":      "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			},
+			validExperimentConfigMap, validConstraintsMap,
+		},
+
+		{
+			"valid JSON experiment config and constraints", "{" + validExperimentConfigPolicyJSON +
+				"," + validConstraintsPolicyJSON + "}",
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"name":      "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			},
+			validExperimentConfigMap, validConstraintsMap,
+		},
+		{
+			"valid YAML NTSC config and constriants", validNTSCConfigPolicyYAML +
+				validConstraintsPolicyYAML,
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"work_dir":  "my/working/directory",
+				},
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			},
+			validNTSCConfigMap, validConstraintsMap,
+		},
+		{
+			"valid JSON NTSC config and constraints", "{" + validNTSCConfigPolicyJSON +
+				"," + validConstraintsPolicyJSON + "}",
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"work_dir":  "my/working/directory",
+				},
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			},
+			validNTSCConfigMap, validConstraintsMap,
+		},
+		{
+			"just constraints YAML", validConstraintsPolicyYAML,
+			map[string]interface{}{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			}, nil, validConstraintsMap,
+		},
+		{
+			"just constraints JSON", validConstraintsJSON, map[string]interface{}{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(4)},
+					"priority_limit": float64(10),
+				},
+			}, nil, validConstraintsMap,
+		},
+		{
+			"just experiment config YAML", validExperimentConfigPolicyYAML,
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"name":      "my_experiment_config",
+				},
+			},
+			validExperimentConfigMap, nil,
+		},
+		{
+			"just experiment config JSON", validExperimentConfigJSON,
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"name":      "my_experiment_config",
+				},
+			},
+			validExperimentConfigMap, nil,
+		},
+		{
+			"just NTSC config YAML", validNTSCConfigPolicyYAML,
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"work_dir":  "my/working/directory",
+				},
+			},
+			validNTSCConfigMap, nil,
+		},
+		{
+			"just NTSC config JSON", "{" + validNTSCConfigPolicyJSON + "}",
+			map[string]interface{}{
+				"invariant_config": map[string]interface{}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+
+					"resources": map[string]interface{}{"slots": float64(1)},
+					"work_dir":  "my/working/directory",
+				},
+			},
+			validNTSCConfigMap, nil,
+		},
+		{
+			"random valid YAML with neither config nor constraint",
+			`
+a_key: "a_value"
+another_key:
+  sub_key: 1
+`,
+			map[string]interface{}{
+				"a_key":       "a_value",
+				"another_key": map[string]interface{}{"sub_key": float64(1)},
+			}, nil, nil,
+		},
+		{
+			"random valid JSON with neither config nor constraint",
+
+			`{
+			"a_key": "a_value",
+			"another_key": {
+				"sub_key": 1
+				}
+			}`,
+			map[string]interface{}{
+				"a_key":       "a_value",
+				"another_key": map[string]interface{}{"sub_key": float64(1)},
+			}, nil, nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tcps, invariantConfig, constraints, err := parseConfigPolicies(test.configPolicies)
+			require.Nil(t, err)
+
+			// Verify invariant config output is correct
+			if test.invariantConfig != nil {
+				require.NotNil(t, invariantConfig)
+
+				var invariantConfigMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(*invariantConfig), &invariantConfigMap)
+				require.NoError(t, err)
+				require.Equal(t, test.invariantConfig, invariantConfigMap)
+			} else {
+				require.Nil(t, invariantConfig)
+			}
+
+			// Verify constraints output is correct.
+			if test.constraints != nil {
+				require.NotNil(t, constraints)
+
+				var constraintsMap map[string]interface{}
+				err = yaml.Unmarshal([]byte(*constraints), &constraintsMap)
+				require.NoError(t, err)
+				require.Equal(t, test.constraints, constraintsMap)
+			} else {
+				require.Nil(t, constraints)
+			}
+
+			// Verify map output is correct.
+			require.Equal(t, test.tcps, tcps)
+		})
+	}
+
+	// Test empty string fails.
+	tcps, invariantConfig, constraints, err := parseConfigPolicies("")
+	require.Nil(t, tcps)
+	require.Nil(t, invariantConfig)
+	require.Nil(t, constraints)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "nothing to parse, empty config and constraints input")
+
+	// Test non-JSON and non-YAML formatted strings fail.
+	tcps, invariantConfig, constraints, err = parseConfigPolicies("{\"bad_json\":: 1}")
+	require.Nil(t, tcps)
+	require.Nil(t, invariantConfig)
+	require.Nil(t, constraints)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "error unmarshaling config policies")
+
+	tcps, invariantConfig, constraints, err = parseConfigPolicies("bad_yaml:1")
+	require.Nil(t, tcps)
+	require.Nil(t, invariantConfig)
+	require.Nil(t, constraints)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "error unmarshaling config policies")
+
+	tcps, invariantConfig, constraints, err = parseConfigPolicies("random string")
+	require.Nil(t, tcps)
+	require.Nil(t, invariantConfig)
+	require.Nil(t, constraints)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "error unmarshaling config policies")
+}
+
+func TestPutWorkspaceConfigPolicies(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+	testutils.MustLoadLicenseAndKeyFromFilesystem("../../")
+
+	workspaceIDs := []int32{}
+	defer func() {
+		err := db.CleanupMockWorkspace(workspaceIDs)
+		if err != nil {
+			log.Errorf("error when cleaning up mock workspaces")
+		}
+	}()
+
+	entrypointYAML := `
+  entrypoint: "start from here"
+`
+
+	updatedExperimentConfigPolicyJSON := `
+	"invariant_config": {
+        "description": "test\nspecial\tchar",
+        "environment": {
+            "force_pull_image": false,
+            "add_capabilities": ["cap1", "cap2"]
+        },
+        "resources": {
+            "slots": 1
+        },
+		"name": "my_experiment_config",
+		"entrypoint": "start from here"
+    }
+`
+
+	tests := []struct {
+		name                  string
+		req                   *apiv1.PutWorkspaceConfigPoliciesRequest
+		configPolicies        map[string]any
+		updatedPoliciesReq    *apiv1.PutWorkspaceConfigPoliciesRequest
+		updatedConfigPolicies map[string]any
+		err                   error
+	}{
+		{
+			name: "invalid workload type",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType:   "bad type",
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf("invalid workload type"),
+		},
+		{
+			name: "emtpy workload type",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf("no workload type"),
+		},
+		{
+			name: "valid experiment invariant config add update YAML",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: validExperimentConfigPolicyYAML + entrypointYAML,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "valid experiment invariant config add update JSON",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: "{" + validExperimentConfigPolicyJSON + "}",
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: "{" + updatedExperimentConfigPolicyJSON + "}",
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment config YAML",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  name: my_experiment_config
+`,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"name":        "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "new description!"
+  name: my_experiment_config
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "new description!",
+					"name":        "my_experiment_config",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment config JSON",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+				"invariant_config": {
+					"description": "test\nspecial\tchar",
+					"name": "my_experiment_config"
+					}
+				}`,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"name":        "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+				"invariant_config": {
+					"description": "new description!",
+					"name": "my_experiment_config"
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "new description!",
+					"name":        "my_experiment_config",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment constraints delete and modify update YAML",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+constraints:
+  resources:
+    max_slots: 10
+  priority_limit: 20
+`,
+			},
+			configPolicies: map[string]any{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(10)},
+					"priority_limit": float64(20),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+constraints:
+  priority_limit: 30
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"constraints": map[string]interface {
+				}{
+					"priority_limit": float64(30),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment constraints delete and modify update JSON",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+					"constraints": {
+						"resources": {
+							"max_slots": 10
+						},
+						"priority_limit": 20
+					}
+			}`,
+			},
+			configPolicies: map[string]any{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(10)},
+					"priority_limit": float64(20),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+					"constraints": {
+						"priority_limit": 30
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"constraints": map[string]interface {
+				}{
+					"priority_limit": float64(30),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "experiment config and constraints YAML",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    force_pull_image: false
+    add_capabilities:
+      - cap1
+      - cap2
+  resources:
+    slots: 1
+  name: my_experiment_config
+constraints:
+  resources:
+    max_slots: 4
+  priority_limit: 10
+`},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(4),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    add_capabilities:
+      - cap1
+  resources:
+    slots: 5
+  name: my_experiment_config
+  entrypoint: "start from here"
+constraints:
+  resources:
+    max_slots: 8
+  priority_limit: 10
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"add_capabilities": []interface{}{"cap1"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(5),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(8),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "experiment config and constraints JSON",
+			req: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"invariant_config": {
+						"description": "test\nspecial\tchar",
+						"environment": {
+							"force_pull_image": false,
+							"add_capabilities": ["cap1", "cap2"]
+						},
+						"resources": {
+							"slots": 1
+						},
+						"name": "my_experiment_config"
+					},
+					"constraints": {
+						"resources": {
+							"max_slots": 4
+						},
+						"priority_limit": 10
+					}
+				}`},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(4),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutWorkspaceConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"invariant_config": {
+						"description": "test\nspecial\tchar",
+						"environment": {
+							"add_capabilities": ["cap1"]
+						},
+						"resources": {
+							"slots": 5
+						},
+						"name": "my_experiment_config",
+						"entrypoint": "start from here",
+					},
+					"constraints": {
+						"resources": {
+							"max_slots": 8
+						},
+						"priority_limit": 10
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"add_capabilities": []interface{}{"cap1"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(5),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(8),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			wkspResp, err := api.PostWorkspace(ctx,
+				&apiv1.PostWorkspaceRequest{Name: uuid.New().String()})
+			workspaceID := wkspResp.Workspace.Id
+			workspaceIDs = append(workspaceIDs, workspaceID)
+			require.NoError(t, err)
+
+			test.req.WorkspaceId = workspaceID
+			resp, err := api.PutWorkspaceConfigPolicies(ctx, test.req)
+			if test.err != nil {
+				require.ErrorContains(t, err, test.err.Error())
+				require.Nil(t, resp)
+				return
+			}
+			require.Nil(t, err)
+
+			// Verify that we can retrieve the input config policies.
+			getResp, err := api.GetWorkspaceConfigPolicies(ctx,
+				&apiv1.GetWorkspaceConfigPoliciesRequest{
+					WorkspaceId:  workspaceID,
+					WorkloadType: test.req.WorkloadType,
+				})
+			require.NoError(t, err)
+
+			configPolicies := getResp.ConfigPolicies.AsMap()
+			require.Equal(t, test.configPolicies, configPolicies)
+
+			test.updatedPoliciesReq.WorkspaceId = workspaceID
+			resp, err = api.PutWorkspaceConfigPolicies(ctx, test.updatedPoliciesReq)
+			require.Nil(t, err)
+
+			// Verify that config policies were updated correctly.
+			getResp, err = api.GetWorkspaceConfigPolicies(ctx,
+				&apiv1.GetWorkspaceConfigPoliciesRequest{
+					WorkspaceId:  workspaceID,
+					WorkloadType: test.req.WorkloadType,
+				})
+			require.NoError(t, err)
+
+			updatedConfigPolicies := getResp.ConfigPolicies.AsMap()
+			require.Equal(t, test.updatedConfigPolicies, updatedConfigPolicies)
+		})
+	}
+
+	// Test invalid workspace ID
+	resp, err := api.PutWorkspaceConfigPolicies(ctx,
+		&apiv1.PutWorkspaceConfigPoliciesRequest{
+			WorkspaceId:    int32(-1),
+			WorkloadType:   model.NTSCType,
+			ConfigPolicies: validExperimentConfigPolicyYAML,
+		})
+	require.Nil(t, resp)
+	require.ErrorContains(t, err, "NotFound")
+}
+
+func TestPutGlobalConfigPolicies(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+	testutils.MustLoadLicenseAndKeyFromFilesystem("../../")
+
+	entrypointYAML := `
+  entrypoint: "start from here"
+`
+
+	updatedExperimentConfigPolicyJSON := `
+	"invariant_config": {
+        "description": "test\nspecial\tchar",
+        "environment": {
+            "force_pull_image": false,
+            "add_capabilities": ["cap1", "cap2"]
+        },
+        "resources": {
+            "slots": 1
+        },
+		"name": "my_experiment_config",
+		"entrypoint": "start from here"
+    }
+`
+
+	tests := []struct {
+		name                  string
+		req                   *apiv1.PutGlobalConfigPoliciesRequest
+		configPolicies        map[string]any
+		updatedPoliciesReq    *apiv1.PutGlobalConfigPoliciesRequest
+		updatedConfigPolicies map[string]any
+		err                   error
+	}{
+		{
+			name: "invalid workload type",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType:   "bad type",
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf("invalid workload type"),
+		},
+		{
+			name: "emtpy workload type",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies:        nil,
+			updatedPoliciesReq:    nil,
+			updatedConfigPolicies: nil,
+			err:                   fmt.Errorf("no workload type"),
+		},
+		{
+			name: "valid experiment invariant config add update YAML",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: validExperimentConfigPolicyYAML,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: validExperimentConfigPolicyYAML + entrypointYAML,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "valid experiment invariant config add update JSON",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: "{" + validExperimentConfigPolicyJSON + "}",
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType:   model.ExperimentType,
+				ConfigPolicies: "{" + updatedExperimentConfigPolicyJSON + "}",
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment config YAML",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  name: my_experiment_config
+`,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"name":        "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "new description!"
+  name: my_experiment_config
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "new description!",
+					"name":        "my_experiment_config",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment config JSON",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+				"invariant_config": {
+					"description": "test\nspecial\tchar",
+					"name": "my_experiment_config"
+					}
+				}`,
+			},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"name":        "my_experiment_config",
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+				"invariant_config": {
+					"description": "new description!",
+					"name": "my_experiment_config"
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "new description!",
+					"name":        "my_experiment_config",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment constraints delete and modify update YAML",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+constraints:
+  resources:
+    max_slots: 10
+  priority_limit: 20
+`,
+			},
+			configPolicies: map[string]any{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(10)},
+					"priority_limit": float64(20),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+constraints:
+  priority_limit: 30
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"constraints": map[string]interface {
+				}{
+					"priority_limit": float64(30),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "simple valid experiment constraints delete and modify update JSON",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+					"constraints": {
+						"resources": {
+							"max_slots": 10
+						},
+						"priority_limit": 20
+					}
+			}`,
+			},
+			configPolicies: map[string]any{
+				"constraints": map[string]interface{}{
+					"resources":      map[string]interface{}{"max_slots": float64(10)},
+					"priority_limit": float64(20),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{ 
+					"constraints": {
+						"priority_limit": 30
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"constraints": map[string]interface {
+				}{
+					"priority_limit": float64(30),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "experiment config and constraints YAML",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    force_pull_image: false
+    add_capabilities:
+      - cap1
+      - cap2
+  resources:
+    slots: 1
+  name: my_experiment_config
+constraints:
+  resources:
+    max_slots: 4
+  priority_limit: 10
+`},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(4),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `
+invariant_config:
+  description: "test\nspecial\tchar"
+  environment:
+    add_capabilities:
+      - cap1
+  resources:
+    slots: 5
+  name: my_experiment_config
+  entrypoint: "start from here"
+constraints:
+  resources:
+    max_slots: 8
+  priority_limit: 10
+`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"add_capabilities": []interface{}{"cap1"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(5),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(8),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "experiment config and constraints JSON",
+			req: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"invariant_config": {
+						"description": "test\nspecial\tchar",
+						"environment": {
+							"force_pull_image": false,
+							"add_capabilities": ["cap1", "cap2"]
+						},
+						"resources": {
+							"slots": 1
+						},
+						"name": "my_experiment_config"
+					},
+					"constraints": {
+						"resources": {
+							"max_slots": 4
+						},
+						"priority_limit": 10
+					}
+				}`},
+			configPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"force_pull_image": false,
+						"add_capabilities": []interface{}{"cap1", "cap2"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(1),
+					},
+					"name": "my_experiment_config",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(4),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			updatedPoliciesReq: &apiv1.PutGlobalConfigPoliciesRequest{
+				WorkloadType: model.ExperimentType,
+				ConfigPolicies: `{
+					"invariant_config": {
+						"description": "test\nspecial\tchar",
+						"environment": {
+							"add_capabilities": ["cap1"]
+						},
+						"resources": {
+							"slots": 5
+						},
+						"name": "my_experiment_config",
+						"entrypoint": "start from here",
+					},
+					"constraints": {
+						"resources": {
+							"max_slots": 8
+						},
+						"priority_limit": 10
+					}
+				}`,
+			},
+			updatedConfigPolicies: map[string]any{
+				"invariant_config": map[string]interface {
+				}{
+					"description": "test\nspecial\tchar",
+					"environment": map[string]interface{}{
+						"add_capabilities": []interface{}{"cap1"},
+					},
+					"resources": map[string]interface{}{
+						"slots": float64(5),
+					},
+					"name":       "my_experiment_config",
+					"entrypoint": "start from here",
+				},
+				"constraints": map[string]interface{}{
+					"resources": map[string]interface{}{
+						"max_slots": float64(8),
+					},
+					"priority_limit": float64(10),
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := api.DeleteGlobalConfigPolicies(ctx,
+				&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: test.req.WorkloadType})
+
+			resp, err := api.PutGlobalConfigPolicies(ctx, test.req)
+			if test.err != nil {
+				require.ErrorContains(t, err, test.err.Error())
+				require.Nil(t, resp)
+				return
+			}
+			require.Nil(t, err)
+
+			// Verify that we can retrieve the input config policies.
+			getResp, err := api.GetGlobalConfigPolicies(ctx,
+				&apiv1.GetGlobalConfigPoliciesRequest{
+					WorkloadType: test.req.WorkloadType,
+				})
+			require.NoError(t, err)
+
+			configPolicies := getResp.ConfigPolicies.AsMap()
+			require.Equal(t, test.configPolicies, configPolicies)
+
+			resp, err = api.PutGlobalConfigPolicies(ctx, test.updatedPoliciesReq)
+			require.Nil(t, err)
+
+			// Verify that config policies were updated correctly.
+			getResp, err = api.GetGlobalConfigPolicies(ctx,
+				&apiv1.GetGlobalConfigPoliciesRequest{
+					WorkloadType: test.req.WorkloadType,
+				})
+			require.NoError(t, err)
+
+			updatedConfigPolicies := getResp.ConfigPolicies.AsMap()
+			require.Equal(t, test.updatedConfigPolicies, updatedConfigPolicies)
+		})
+	}
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -4,12 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/ghodss/yaml"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/protoutils"
+)
+
+const (
+	// EmptyInvariantConfigErr is the error reported when an invariant config is specified with no
+	// fields.
+	EmptyInvariantConfigErr = "empty invariant config"
+	// EmptyConstraintsErr is the error reported when a constraints policy is specified with no
+	// fields.
+	EmptyConstraintsErr = "empty constraints policy"
 )
 
 // ValidWorkloadType checks if the string is an accepted WorkloadType.
@@ -31,15 +41,22 @@ func UnmarshalExperimentConfigPolicy(str string) (*ExperimentConfigPolicies, err
 	dec.DisallowUnknownFields()
 	if err = dec.Decode(&expConfigPolicy); err == nil {
 		// valid JSON input
+		if reflect.DeepEqual(expConfigPolicy, ExperimentConfigPolicies{}) {
+			return nil, fmt.Errorf(EmptyInvariantConfigErr)
+		}
 		return &expConfigPolicy, nil
 	}
 
 	if err = yaml.Unmarshal([]byte(str), &expConfigPolicy, yaml.DisallowUnknownFields); err == nil {
 		// valid Yaml input
+		if reflect.DeepEqual(expConfigPolicy, ExperimentConfigPolicies{}) {
+			return nil, fmt.Errorf(EmptyInvariantConfigErr)
+		}
 		return &expConfigPolicy, nil
 	}
+
 	// invalid JSON & invalid Yaml input
-	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
+	return nil, fmt.Errorf("invalid experiment config policy: %w", err)
 }
 
 // UnmarshalNTSCConfigPolicy unpacks a string into NTSCConfigPolicy struct.
@@ -51,15 +68,22 @@ func UnmarshalNTSCConfigPolicy(str string) (*NTSCConfigPolicies, error) {
 	dec.DisallowUnknownFields()
 	if err = dec.Decode(&ntscConfigPolicy); err == nil {
 		// valid JSON input
+		if reflect.DeepEqual(ntscConfigPolicy, NTSCConfigPolicies{}) {
+			return nil, fmt.Errorf(EmptyInvariantConfigErr)
+		}
 		return &ntscConfigPolicy, nil
 	}
 
 	if err = yaml.Unmarshal([]byte(str), &ntscConfigPolicy, yaml.DisallowUnknownFields); err == nil {
 		// valid Yaml input
+		if reflect.DeepEqual(ntscConfigPolicy, NTSCConfigPolicies{}) {
+			return nil, fmt.Errorf(EmptyInvariantConfigErr)
+		}
 		return &ntscConfigPolicy, nil
 	}
+
 	// invalid JSON & Yaml input
-	return nil, fmt.Errorf("invalid ExperimentConfigPolicy input: %w", err)
+	return nil, fmt.Errorf("invalid NTSC config policy: %w", err)
 }
 
 // MarshalConfigPolicy packs a config policy into a proto struct.

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -93,7 +93,7 @@ func TestUnmarshalYamlExperiment(t *testing.T) {
 		{"just constraints", yamlConstraints, true, &justConstraints},
 		{"extra fields", yamlExperiment + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlExperiment + "  debug true\n", false, nil},
-		{"empty input", "", true, &ExperimentConfigPolicies{}},
+		{"empty input", "", false, nil},
 		{"null/empty fields", yamlExperiment + "  debug:\n", true, &justConfig},
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
@@ -157,7 +157,7 @@ func TestUnmarshalYamlNTSC(t *testing.T) {
 		{"just constraints", yamlConstraints, true, &justConstraints},
 		{"extra fields", yamlNTSC + `  extra_field: "string"` + yamlConstraints, false, nil},
 		{"invalid fields", yamlNTSC + "  debug true\n", false, nil},
-		{"empty input", "", true, &NTSCConfigPolicies{}},
+		{"empty input", "", false, nil},
 		{"null/empty fields", yamlNTSC + "  debug:\n", true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", "invariant_config:\n  debug: 3\n", false, nil},
 	}
@@ -248,7 +248,7 @@ func TestUnmarshalJSONExperiment(t *testing.T) {
 		{"just constraints", `{` + jsonConstraints + `}`, true, &justConstraints},
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
-		{"empty input", "", true, &ExperimentConfigPolicies{}},
+		{"empty input", "", false, nil},
 		{"null/empty fields", jsonEmptyField, true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}
@@ -294,7 +294,7 @@ func TestUnmarshalJSONNTSC(t *testing.T) {
 		{"just constraints", `{` + jsonConstraints + `}`, true, &justConstraints},
 		{"extra fields", jsonExtraField, false, nil},
 		{"invalid fields", jsonInvalidField, false, nil},
-		{"empty input", "", true, &NTSCConfigPolicies{}},
+		{"empty input", "", false, nil},
 		{"null/empty fields", jsonEmptyField, true, &justConfig}, // empty fields unmarshal to default value
 		{"wrong field type", jsonWrongFieldType, false, nil},
 	}


### PR DESCRIPTION
## Ticket
[CM-486], [CM-492]


## Description
Implement PUT APIs for task config policies.



## Test Plan
CI passes (automated testing).


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-486]: https://hpe-aiatscale.atlassian.net/browse/CM-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CM-492]: https://hpe-aiatscale.atlassian.net/browse/CM-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ