### PR TITLE
fix: bring in handleEmptyCell from #9963

### DIFF
--- a/webui/react/src/pages/FlatRuns/columns.ts
+++ b/webui/react/src/pages/FlatRuns/columns.ts
@@ -29,6 +29,7 @@ import { DURATION_UNIT_MEASURES, durationInEnglish, getTimeInEnglish } from 'uti
 import { humanReadableNumber } from 'utils/number';
 import { AnyMouseEvent } from 'utils/routes';
 import { capitalize, floatToPercent, humanReadableBytes } from 'utils/string';
+import { handleEmptyCell } from 'utils/table';
 import { getDisplayName } from 'utils/user';
 
 // order used in ColumnPickerMenu

--- a/webui/react/src/utils/table.test.ts
+++ b/webui/react/src/utils/table.test.ts
@@ -1,0 +1,57 @@
+import { GridCell, GridCellKind } from '@glideapps/glide-data-grid';
+import fc from 'fast-check';
+
+import { EMPTY_CELL, handleEmptyCell } from './table';
+
+const generateGridCell = (value: unknown): GridCell => {
+  return {
+    allowOverlay: false,
+    data: String(value),
+    displayData: String(value),
+    kind: GridCellKind.Text,
+  };
+};
+
+describe('Table Utilities', () => {
+  describe('handleEmptyCell', () => {
+    it('should return passed cell for any string value', () => {
+      fc.assert(
+        fc.property(fc.string(), (value) => {
+          expect(handleEmptyCell(value, (data) => generateGridCell(data))).toEqual(
+            generateGridCell(value),
+          );
+        }),
+      );
+    });
+    it('should return EMPTY_CELL for undefined value', () => {
+      const value = undefined;
+      expect(handleEmptyCell(value, (data) => generateGridCell(data))).not.toEqual(
+        generateGridCell(value),
+      );
+      expect(handleEmptyCell(value, (data) => generateGridCell(data))).toEqual(EMPTY_CELL);
+    });
+    it('should return EMPTY_CELL for null value', () => {
+      const value = null;
+      expect(handleEmptyCell(value, (data) => generateGridCell(data))).not.toEqual(
+        generateGridCell(value),
+      );
+      expect(handleEmptyCell(value, (data) => generateGridCell(data))).toEqual(EMPTY_CELL);
+    });
+    it('should return passed cell for any non-empty string value when allowFalsy is false', () => {
+      fc.assert(
+        fc.property(fc.string({ minLength: 1 }), (value) => {
+          expect(handleEmptyCell(value, (data) => generateGridCell(data))).toEqual(
+            generateGridCell(value),
+          );
+        }),
+      );
+    });
+    it('should return EMPTY_CELL for empty string value when allowFalsy is false', () => {
+      const value = '';
+      expect(handleEmptyCell(value, (data) => generateGridCell(data), false)).not.toEqual(
+        generateGridCell(value),
+      );
+      expect(handleEmptyCell(value, (data) => generateGridCell(data), false)).toEqual(EMPTY_CELL);
+    });
+  });
+});

--- a/webui/react/src/utils/table.ts
+++ b/webui/react/src/utils/table.ts
@@ -1,0 +1,18 @@
+import { GridCell, GridCellKind } from '@glideapps/glide-data-grid';
+
+export const EMPTY_CELL: GridCell = {
+  allowOverlay: false,
+  data: '-',
+  displayData: '-',
+  kind: GridCellKind.Text,
+} as const;
+
+export const handleEmptyCell = <T>(
+  uncertainData: T | undefined,
+  cell: (data: T) => GridCell,
+  allowFalsy = true, // if allowFalsy === false, then falsy values such as 0 or the empty string will be treated as empty
+): GridCell => {
+  if (uncertainData === undefined || uncertainData === null) return EMPTY_CELL;
+  if (allowFalsy === false && !uncertainData) return EMPTY_CELL;
+  return cell(uncertainData);
+};


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-804]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Resolves a dependency on work from ET-749 (not in release).


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
N/A


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-804]: https://hpe-aiatscale.atlassian.net/browse/ET-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ