### PR TITLE
fix: display archived column for runs and searches

### DIFF
--- a/master/internal/api_project.go
+++ b/master/internal/api_project.go
@@ -174,6 +174,12 @@ var defaultRunsTableColumns = []*projectv1.ProjectColumn{
 		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
 		Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
 	},
+	{
+		Column:      "archived",
+		DisplayName: "Archived",
+		Location:    projectv1.LocationType_LOCATION_TYPE_RUN,
+		Type:        projectv1.ColumnType_COLUMN_TYPE_UNSPECIFIED, // no boolean type
+	},
 }
 
 func getRunSummaryMetrics(ctx context.Context, whereClause string, group []int) ([]*projectv1.ProjectColumn, error) {
@@ -403,6 +409,12 @@ func (a *apiServer) getProjectColumnsByID(
 			DisplayName: "External Trial ID",
 			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
 			Type:        projectv1.ColumnType_COLUMN_TYPE_TEXT,
+		},
+		{
+			Column:      "archived",
+			DisplayName: "Archived",
+			Location:    projectv1.LocationType_LOCATION_TYPE_EXPERIMENT,
+			Type:        projectv1.ColumnType_COLUMN_TYPE_UNSPECIFIED, // no boolean type
 		},
 	}
 

--- a/master/internal/api_runs.go
+++ b/master/internal/api_runs.go
@@ -145,7 +145,7 @@ func getRunsColumns(q *bun.SelectQuery) *bun.SelectQuery {
 		Column("r.external_run_id").
 		Column("r.project_id").
 		Column("r.searcher_metric_value").
-		ColumnExpr("r.archived AS archived").
+		ColumnExpr("COALESCE((r.archived OR e.archived), FALSE) AS archived").
 		ColumnExpr("CONCAT(p.key, '-' , r.local_id::text) as local_id").
 		ColumnExpr("extract(epoch FROM coalesce(r.end_time, now()) - r.start_time)::int AS duration").
 		ColumnExpr("CASE WHEN r.hparams='null' THEN NULL ELSE r.hparams END AS hyperparameters").
@@ -209,6 +209,7 @@ func sortRuns(sortString *string, runQuery *bun.SelectQuery) error {
 		"isExpMultitrial":       "(e.config->'searcher'->>'name' != 'single')",
 		"parentArchived":        "(w.archived OR p.archived)",
 		"localId":               "r.local_id",
+		"archived":              "COALESCE((r.archived OR e.archived), FALSE)",
 	}
 	sortParams := strings.Split(*sortString, ",")
 	hasIDSort := false

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -111,7 +111,12 @@ const INITIAL_LOADING_RUNS: Loadable<FlatRun>[] = new Array(PAGE_SIZE).fill(NotL
 
 const STATIC_COLUMNS = [MULTISELECT];
 
-const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal', 'parentArchived', 'isExpMultitrial']);
+const BANNED_FILTER_COLUMNS = new Set([
+  'searcherMetricsVal',
+  'parentArchived',
+  'isExpMultitrial',
+  'archived',
+]);
 const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetricsVal']);
 
 const NO_PINS_WIDTH = 200;

--- a/webui/react/src/pages/FlatRuns/columns.ts
+++ b/webui/react/src/pages/FlatRuns/columns.ts
@@ -61,7 +61,7 @@ const EXCLUDED_SEARCH_DEFAULT_COLUMNS: RunColumn[] = [
 
 export type RunColumn = (typeof runColumns)[number];
 
-export const defaultRunColumns: RunColumn[] = runColumns.slice(0, -1);
+export const defaultRunColumns: RunColumn[] = runColumns.filter((f) => f !== 'archived');
 
 export const defaultSearchRunColumns: RunColumn[] = defaultRunColumns.filter(
   (c) => !EXCLUDED_SEARCH_DEFAULT_COLUMNS?.includes(c),

--- a/webui/react/src/pages/FlatRuns/columns.ts
+++ b/webui/react/src/pages/FlatRuns/columns.ts
@@ -50,6 +50,7 @@ export const runColumns = [
   'externalRunId',
   'isExpMultitrial',
   'parentArchived',
+  'archived',
 ] as const;
 
 const EXCLUDED_SEARCH_DEFAULT_COLUMNS: RunColumn[] = [
@@ -60,9 +61,9 @@ const EXCLUDED_SEARCH_DEFAULT_COLUMNS: RunColumn[] = [
 
 export type RunColumn = (typeof runColumns)[number];
 
-export const defaultRunColumns: RunColumn[] = [...runColumns];
+export const defaultRunColumns: RunColumn[] = runColumns.slice(0, -1);
 
-export const defaultSearchRunColumns: RunColumn[] = runColumns.filter(
+export const defaultSearchRunColumns: RunColumn[] = defaultRunColumns.filter(
   (c) => !EXCLUDED_SEARCH_DEFAULT_COLUMNS?.includes(c),
 );
 
@@ -112,6 +113,18 @@ export const getColumnDefs = ({
   users,
   appTheme,
 }: Params): ColumnDefs<FlatRun> => ({
+  archived: {
+    id: 'archived',
+    renderer: (record: FlatRun) => ({
+      allowOverlay: false,
+      data: String(record.archived),
+      displayData: record.archived ? '📦' : '',
+      kind: GridCellKind.Text,
+    }),
+    title: 'Archived',
+    tooltip: () => undefined,
+    width: columnWidths.archived,
+  },
   checkpointCount: {
     id: 'checkpointCount',
     isNumerical: true,
@@ -521,6 +534,7 @@ export const searcherMetricsValColumn = (
 };
 
 export const defaultColumnWidths: Partial<Record<RunColumn, number>> = {
+  archived: 80,
   checkpointCount: 120,
   checkpointSize: 110,
   duration: 86,


### PR DESCRIPTION
## Ticket
ET-304



## Description
This adds the archived column to the columns api. It also updates the flat runs view to handle showing the archived state of runs and ensures the archived definition matches the show archived behavior.


## Test Plan
When viewing the column list for the new experiment list, the searches view, and the runs view, the user should see the "archived" column in the general tab.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ