### PR TITLE
fix: fix default id search for runs

### DIFF
--- a/webui/react/src/components/FilterForm/components/FilterField.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterField.tsx
@@ -13,7 +13,7 @@ import { useDrag, useDrop } from 'react-dnd';
 import { debounce } from 'throttle-debounce';
 
 import ConjunctionContainer from 'components/FilterForm/components/ConjunctionContainer';
-import { FilterFormStore, getInitField } from 'components/FilterForm/components/FilterFormStore';
+import { FilterFormStore } from 'components/FilterForm/components/FilterFormStore';
 import {
   AvailableOperators,
   Conjunction,
@@ -201,7 +201,10 @@ const FilterField = ({
     (e: React.KeyboardEvent) => {
       // would use isComposing alone but safari has a bug: https://bugs.webkit.org/show_bug.cgi?id=165004
       if (e.key === 'Enter' && !inputOpen && !e.nativeEvent.isComposing && e.keyCode !== 229) {
-        formStore.addChild(parentId, FormKind.Field, { index: index + 1, item: getInitField() });
+        formStore.addChild(parentId, FormKind.Field, {
+          index: index + 1,
+          item: formStore.newField(),
+        });
         // stop panel flashing for selects and dates
         if (
           field.type === 'COLUMN_TYPE_DATE' ||

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.test.ts
@@ -16,7 +16,7 @@ const jsonReplacer = (key: string, value: unknown): unknown => {
   return key === 'id' ? undefined : value;
 };
 
-const initField = JSON.parse(JSON.stringify(getInitField(), jsonReplacer));
+const initField = JSON.parse(JSON.stringify(getInitField(V1LocationType.EXPERIMENT), jsonReplacer));
 
 const ROOT_ID = 'ROOT';
 
@@ -114,12 +114,12 @@ const initData: Readonly<FilterFormSet> = {
 describe('FilterFormStore', () => {
   describe('Init', () => {
     it('should initialize store as NotLoaded', () => {
-      const filterFormStore = new FilterFormStore();
+      const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
       expect(filterFormStore.formset.get()).toEqual(NotLoaded);
     });
 
     it('should have an empty init() fill with default values', () => {
-      const filterFormStore = new FilterFormStore();
+      const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
       filterFormStore.init();
       const loadableFormset = filterFormStore.formset.get();
 
@@ -141,7 +141,7 @@ describe('FilterFormStore', () => {
     });
 
     it('should initialize store with init data', () => {
-      const filterFormStore = new FilterFormStore();
+      const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
       filterFormStore.init(initData);
 
       const loadableFormset = filterFormStore.formset.get();
@@ -151,7 +151,7 @@ describe('FilterFormStore', () => {
     });
 
     it('should deep clone init data to avoid unexpected data overwrite', () => {
-      const filterFormStore = new FilterFormStore();
+      const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
       filterFormStore.init(initData);
       filterFormStore.addChild(ROOT_ID, FormKind.Field);
       const jsonWithId = filterFormStore.formset.get();
@@ -174,14 +174,14 @@ describe('FilterFormStore', () => {
 
     describe('Basic Field and Group Interaction', () => {
       it('should sweep invalid groups and conditions', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init(initData);
         filterFormStore.sweep();
         expect(filterFormStore.fieldCount.get()).toBe(5);
       });
 
       it('should add new fields', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
@@ -211,7 +211,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should add new groups', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 
@@ -266,7 +266,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should add new fields/group comprehensively', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
@@ -319,7 +319,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should remove field', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
@@ -338,7 +338,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should remove empty group', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         let formset = getFormset(filterFormStore);
@@ -353,7 +353,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should remove non-empty group', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
         const loadableFormset = filterFormStore.formset.get();
@@ -367,7 +367,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should clear all (remove ROOT_ID)', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.removeChild(ROOT_ID);
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
@@ -376,7 +376,7 @@ describe('FilterFormStore', () => {
         filterFormStore.removeChild(ROOT_ID);
         expect(filterFormStore.asJsonString.get()).toStrictEqual(JSON.stringify(EMPTY_DATA));
 
-        const filterFormStoreWithInit = new FilterFormStore();
+        const filterFormStoreWithInit = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStoreWithInit.init(initData);
         filterFormStoreWithInit.removeChild(ROOT_ID);
         expect(filterFormStoreWithInit.asJsonString.get()).toStrictEqual(
@@ -385,7 +385,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should change `show archived` value', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.setArchivedValue(true);
         let loadableFormset = filterFormStore.formset.get();
@@ -402,7 +402,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should `show archived` value remain the same after clear all', () => {
-        const filterFormStoreWithInit = new FilterFormStore();
+        const filterFormStoreWithInit = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStoreWithInit.init(initData);
         let loadableFormset = filterFormStoreWithInit.formset.get();
         let formset = Loadable.getOrElse(null, loadableFormset);
@@ -431,7 +431,7 @@ describe('FilterFormStore', () => {
       };
 
       it('should change the field order', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
 
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
@@ -456,7 +456,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should move field into different group', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
 
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
@@ -489,7 +489,7 @@ describe('FilterFormStore', () => {
 
     describe('Field Value Interaction', () => {
       it('should change column name', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
@@ -507,7 +507,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should change operator', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
@@ -519,7 +519,7 @@ describe('FilterFormStore', () => {
       });
 
       it('should change value', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Field);
 
@@ -534,7 +534,7 @@ describe('FilterFormStore', () => {
 
     describe('Group Value Interaction', () => {
       it('should change conjunction', () => {
-        const filterFormStore = new FilterFormStore();
+        const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
         filterFormStore.init();
         filterFormStore.addChild(ROOT_ID, FormKind.Group);
 

--- a/webui/react/src/components/FilterForm/components/FilterFormStore.ts
+++ b/webui/react/src/components/FilterForm/components/FilterFormStore.ts
@@ -33,11 +33,11 @@ const getInitGroup = (): FormGroup => ({
   kind: FormKind.Group,
 });
 
-export const getInitField = (): FormField => ({
+export const getInitField = (location: V1LocationType): FormField => ({
   columnName: 'id',
   id: uuidv4(),
   kind: FormKind.Field,
-  location: V1LocationType.EXPERIMENT,
+  location,
   operator: AvailableOperators[V1ColumnType.NUMBER][0],
   type: V1ColumnType.NUMBER,
   value: null,
@@ -47,6 +47,11 @@ const isNotUndefined = <T>(arg: T): arg is Exclude<T, undefined> => arg !== unde
 
 export class FilterFormStore {
   #formset: WritableObservable<Loadable<FilterFormSet>> = observable(NotLoaded);
+  #defaultLocation: V1LocationType;
+
+  constructor(defaultLocation: V1LocationType) {
+    this.#defaultLocation = defaultLocation;
+  }
 
   public init(data?: Readonly<FilterFormSet>): void {
     this.#formset.update(() => Loaded(structuredClone(data ? data : INIT_FORMSET)));
@@ -265,6 +270,10 @@ export class FilterFormStore {
     return this.#updateField(id, (form) => (form.value === value ? form : { ...form, value }));
   }
 
+  public newField(): FormField {
+    return getInitField(this.#defaultLocation);
+  }
+
   public addChild(
     id: string,
     addType: FormKind,
@@ -275,7 +284,7 @@ export class FilterFormStore {
         ? form.children
             .slice(0, obj.index)
             .concat([structuredClone(obj.item)], form.children.slice(obj.index))
-        : [...form.children, addType === FormKind.Group ? getInitGroup() : getInitField()];
+        : [...form.children, addType === FormKind.Group ? getInitGroup() : this.newField()];
       return {
         ...form,
         children,

--- a/webui/react/src/components/FilterForm/components/FilterGroup.test.tsx
+++ b/webui/react/src/components/FilterForm/components/FilterGroup.test.tsx
@@ -7,11 +7,13 @@ import { useObservable } from 'micro-observables';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 
+import { V1LocationType } from 'services/api-ts-sdk';
+
 import { FilterFormStore, ROOT_ID } from './FilterFormStore';
 import FilterGroup from './FilterGroup';
 import { FormKind } from './type';
 
-const filterFormStore = new FilterFormStore();
+const filterFormStore = new FilterFormStore(V1LocationType.EXPERIMENT);
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
 const Component = ({ filterFormStore }: { filterFormStore: FilterFormStore }): JSX.Element => {

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -117,7 +117,7 @@ const parseSortString = (sortString: string): Sort[] => {
   });
 };
 
-const formStore = new FilterFormStore();
+const formStore = new FilterFormStore(V1LocationType.EXPERIMENT);
 
 export const PAGE_SIZE = 100;
 const INITIAL_LOADING_EXPERIMENTS: Loadable<ExperimentWithTrial>[] = new Array(PAGE_SIZE).fill(

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -130,7 +130,7 @@ const parseSortString = (sortString: string): Sort[] => {
   });
 };
 
-const formStore = new FilterFormStore();
+const formStore = new FilterFormStore(V1LocationType.EXPERIMENT);
 
 export const PAGE_SIZE = 100;
 const INITIAL_LOADING_EXPERIMENTS: Loadable<ExperimentWithTrial>[] = new Array(PAGE_SIZE).fill(

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -116,7 +116,7 @@ const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetricsVal']);
 
 const NO_PINS_WIDTH = 200;
 
-export const formStore = new FilterFormStore();
+export const formStore = new FilterFormStore(V1LocationType.RUN);
 
 interface Props {
   projectId: number;


### PR DESCRIPTION
## Ticket
ET-811

## Description
this fixes an issue where the default search field for global run id would not work properly when interacting with the filter form. the issue is compound:

1) we defaulted new form fields to the `id` column of the experiment location, so when searching runs the column was invalid

2) the form select uses the column name to determine what copy to show in the select label, so the copy looked like it was using the global run id column when it wasn't.

we fix this by specifying the location of all new children in the form field.



## Test Plan
1) on the runs page, open the filters view and reset the view by hitting "clear filters".

2) the filter view should have closed. open it back up and update the filter value to match a run id that's currently in the view

3) the run should show up.

## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
