### PR TITLE
feat: check task config policy constraints before scheduling NTSC wor…

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -115,7 +115,6 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Get the full configuration.
-	// This is for commands. What about notebooks?
 	config := model.DefaultConfig(&taskSpec.TaskContainerDefaults)
 	if req.TemplateName != "" {
 		err := templates.UnmarshalTemplateConfig(ctx, req.TemplateName, aUser, &config, false)

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -151,7 +151,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Check submitted config against task config policies.
-	valid, err := configpolicy.ValidateNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
+	valid, err := configpolicy.CheckNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
 	if !valid {
 		return nil, nil, err
 	}

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -22,6 +22,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/api/apiutils"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/command"
+	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
 	"github.com/determined-ai/determined/master/internal/rbac/audit"
@@ -114,6 +115,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Get the full configuration.
+	// This is for commands. What about notebooks?
 	config := model.DefaultConfig(&taskSpec.TaskContainerDefaults)
 	if req.TemplateName != "" {
 		err := templates.UnmarshalTemplateConfig(ctx, req.TemplateName, aUser, &config, false)
@@ -146,6 +148,12 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	var contextDirectory []byte
 	config.WorkDir, contextDirectory, err = fillContextDir(config.WorkDir, workDirInDefaults, req.Files)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check submitted config against task config policies.
+	valid, err := configpolicy.ValidateConstraintsNTSC(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
+	if !valid {
 		return nil, nil, err
 	}
 

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -151,7 +151,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Check submitted config against task config policies.
-	valid, err := configpolicy.ValidateConstraintsNTSC(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
+	valid, err := configpolicy.ValidateNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
 	if !valid {
 		return nil, nil, err
 	}

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -1833,6 +1833,9 @@ func TestAuthZGetExperimentAndCanDoActions(t *testing.T) {
 				mock.Anything).Return(nil).Once()
 			workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
 				Return(nil).Once()
+			mockRM := MockRM()
+			mockRM.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+			api.m.rm = mockRM
 			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
 				ExperimentIds: []int32{int32(id)},
 			})

--- a/master/internal/api_ntsc_intg_test.go
+++ b/master/internal/api_ntsc_intg_test.go
@@ -318,6 +318,9 @@ func TestAuthZCanCreateNSC(t *testing.T) {
 	).Times(3)
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).Times(3)
+	mockRM := MockRM()
+	mockRM.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+	api.m.rm = mockRM
 	_, err = api.LaunchNotebook(ctx, &apiv1.LaunchNotebookRequest{})
 	require.Equal(t, codes.PermissionDenied, status.Code(err))
 	_, err = api.LaunchCommand(ctx, &apiv1.LaunchCommandRequest{})

--- a/master/internal/api_trials_intg_test.go
+++ b/master/internal/api_trials_intg_test.go
@@ -799,6 +799,9 @@ func TestTrialAuthZ(t *testing.T) {
 				mock.Anything).Return(nil).Once()
 			workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
 				Return(nil).Once()
+			mockRM := MockRM()
+			mockRM.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+			api.m.rm = mockRM
 			_, err := api.LaunchTensorboard(ctx, &apiv1.LaunchTensorboardRequest{
 				TrialIds: []int32{int32(id)},
 			})

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -32,8 +32,8 @@ type NTSCConfigPolicies struct {
 }
 
 var (
-	ErrPriorityConstraintFailure = errors.New("submitted workload failed priority constraint")
-	ErrResourceConstraintFailure = errors.New("submitted workload failed a resource constraint")
+	errPriorityConstraintFailure = errors.New("submitted workload failed priority constraint")
+	errResourceConstraintFailure = errors.New("submitted workload failed a resource constraint")
 )
 
 // CheckNTSCConstraints returns true if the NTSC config passes constraint checks.
@@ -49,12 +49,13 @@ func CheckNTSCConstraints(
 	}
 
 	// For each submitted constraint, check if the workload config is within allowed values.
-	// rm.SmallerValueIsHigherPriority only returns nil if priority is not implemented for that resource manager. In that case, there is no need to check if requested priority is within limits.
+	// rm.SmallerValueIsHigherPriority only returns nil if priority is not implemented for that resource manager.
+	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
 	if err == nil && constraints.PriorityLimit != nil && workloadConfig.Resources.Priority != nil {
 		if !priorityWithinLimit(*workloadConfig.Resources.Priority, *constraints.PriorityLimit, smallerHigher) {
 			return false, fmt.Errorf("requested priority [%d] exceeds limit set by admin [%d]: %w",
-				*constraints.PriorityLimit, *workloadConfig.Resources.Priority, ErrPriorityConstraintFailure)
+				*constraints.PriorityLimit, *workloadConfig.Resources.Priority, errPriorityConstraintFailure)
 		}
 	}
 
@@ -62,7 +63,7 @@ func CheckNTSCConstraints(
 		workloadConfig.Resources.MaxSlots != nil {
 		if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
 			return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]: %w",
-				*constraints.ResourceConstraints.MaxSlots, *workloadConfig.Resources.MaxSlots, ErrResourceConstraintFailure)
+				*constraints.ResourceConstraints.MaxSlots, *workloadConfig.Resources.MaxSlots, errResourceConstraintFailure)
 		}
 	}
 

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -2,8 +2,10 @@ package configpolicy
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
+	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
@@ -28,7 +30,65 @@ type NTSCConfigPolicies struct {
 	Constraints     *model.Constraints   `json:"constraints"`
 }
 
-// PriorityAllowed returns true if the desired priority is within the limit set by task config policies.
+// ValidateNTSCConstraints returns true if the NTSC config passes constraint checks.
+func ValidateConstraintsNTSC(
+	ctx context.Context,
+	workspaceID int,
+	workloadConfig model.CommandConfig,
+	resourceManager rm.ResourceManager,
+) (bool, error) {
+	constraints, err := GetMergedConstraints(ctx, workspaceID, model.NTSCType)
+	if err != nil {
+		return false, err
+	}
+
+	// For each submitted constraint, check if the workload config is within allowed values.
+	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
+	if err == nil && constraints.PriorityLimit != nil && workloadConfig.Resources.Priority != nil {
+		if !priorityWithinLimit(*workloadConfig.Resources.Priority, *constraints.PriorityLimit, smallerHigher) {
+			return false, fmt.Errorf("requested priority [%d] exceeds limit set by admin [%d]",
+				*constraints.PriorityLimit, *workloadConfig.Resources.Priority)
+		}
+	}
+
+	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil && workloadConfig.Resources.MaxSlots != nil {
+		if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
+			return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]",
+				*constraints.ResourceConstraints.MaxSlots, *workloadConfig.Resources.MaxSlots)
+		}
+	}
+
+	return true, nil
+}
+
+// GetMergedConstraints retrieves Workspace and Global constraints and returns a merged result.
+func GetMergedConstraints(ctx context.Context, workspaceID int, workloadType string) (model.Constraints, error) {
+	// Workspace-level constraints should be over-ridden by global contraints, if set.
+	var constraints model.Constraints
+	wkspConfigPolicies, err := GetTaskConfigPolicies(ctx, &workspaceID, workloadType)
+	if err != nil {
+		return constraints, err
+	}
+	if wkspConfigPolicies.Constraints != nil {
+		if err = json.Unmarshal([]byte(*wkspConfigPolicies.Constraints), &constraints); err != nil {
+			return constraints, err
+		}
+	}
+
+	globalConfigPolicies, err := GetTaskConfigPolicies(ctx, nil, workloadType)
+	if err != nil {
+		return constraints, err
+	}
+	if globalConfigPolicies.Constraints != nil {
+		if err = json.Unmarshal([]byte(*globalConfigPolicies.Constraints), &constraints); err != nil {
+			return constraints, err
+		}
+	}
+
+	return constraints, nil
+}
+
+// PriorityAllowed returns true if the desired priority is within the task config policy limit.
 func PriorityAllowed(wkspID int, workloadType string, priority int, smallerHigher bool) (bool, error) {
 	// Check if a priority limit has been set with a constraint policy.
 	// Global policies have highest precedence.

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -31,7 +31,7 @@ type NTSCConfigPolicies struct {
 }
 
 // ValidateNTSCConstraints returns true if the NTSC config passes constraint checks.
-func ValidateConstraintsNTSC(
+func ValidateNTSCConstraints(
 	ctx context.Context,
 	workspaceID int,
 	workloadConfig model.CommandConfig,
@@ -51,7 +51,8 @@ func ValidateConstraintsNTSC(
 		}
 	}
 
-	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil && workloadConfig.Resources.MaxSlots != nil {
+	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil &&
+		workloadConfig.Resources.MaxSlots != nil {
 		if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
 			return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]",
 				*constraints.ResourceConstraints.MaxSlots, *workloadConfig.Resources.MaxSlots)

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -49,7 +49,7 @@ func CheckNTSCConstraints(
 	}
 
 	// For each submitted constraint, check if the workload config is within allowed values.
-	// rm.SmallerValueIsHigherPriority only returns nil if priority is not implemented for that resource manager.
+	// rm.SmallerValueIsHigherPriority only returns an error if task priority is not implemented for that resource manager.
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
 	if err == nil && constraints.PriorityLimit != nil && workloadConfig.Resources.Priority != nil {

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -64,7 +64,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), 1, config, &resourceManager)
+		ok, err := ValidateNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.NoError(t, err)
 		require.True(t, ok)
 	})
@@ -75,7 +75,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		ok, err := ValidateNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.False(t, ok)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "requested priority")
@@ -86,9 +86,10 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
 		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+		require.NoError(t, err)
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		ok, err := ValidateNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.True(t, ok)
 		require.NoError(t, err)
 	})
@@ -97,13 +98,14 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		constraints := DefaultConstraints()
 		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
 		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+		require.NoError(t, err)
 		addConstraints(t, user, &w.ID, *constraints)
 
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		ok, err := ValidateNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.False(t, ok)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "requested resources.max_slots")
@@ -115,7 +117,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		rm1.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil).Once()
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &rm1)
+		ok, err := ValidateNTSCConstraints(context.Background(), w.ID, config, &rm1)
 		require.False(t, ok)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "requested priority")
@@ -123,7 +125,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		// Validate constraints again. This time, the RM does not support priority.
 		rmNoPriority := mocks.ResourceManager{}
 		rmNoPriority.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, fmt.Errorf("not supported")).Once()
-		ok, err = ValidateConstraintsNTSC(context.Background(), w.ID, config, &rmNoPriority)
+		ok, err = ValidateNTSCConstraints(context.Background(), w.ID, config, &rmNoPriority)
 		require.True(t, ok)
 		require.NoError(t, err)
 	})
@@ -136,12 +138,12 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
 		config := defaultConfig()
-		ok, err := ValidateConstraintsNTSC(context.Background(), 1, config, &resourceManager)
+		ok, err := ValidateNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.False(t, ok)
 		require.Error(t, err)
 
 		emptyConfig := model.CommandConfig{}
-		ok, err = ValidateConstraintsNTSC(context.Background(), 1, emptyConfig, &resourceManager)
+		ok, err = ValidateNTSCConstraints(context.Background(), 1, emptyConfig, &resourceManager)
 		require.True(t, ok)
 		require.NoError(t, err)
 	})
@@ -208,7 +210,6 @@ func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.W
 func addConstraints(t *testing.T, user model.User, wkspID *int, constraints string) {
 	ctx := context.Background()
 
-	fmt.Printf("adding constraints to wksp=%d, %s\n", wkspID, constraints)
 	input := model.TaskConfigPolicies{
 		WorkloadType:  model.NTSCType,
 		WorkspaceID:   wkspID,

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -79,7 +79,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		config := defaultConfig()
 		_, err := CheckNTSCConstraints(ctx, w.ID, config, &resourceManager)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrPriorityConstraintFailure)
+		require.ErrorIs(t, err, errPriorityConstraintFailure)
 	})
 
 	t.Run("running in wksp without constraints - ok", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		config := defaultConfig()
 		_, err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrResourceConstraintFailure)
+		require.ErrorIs(t, err, errResourceConstraintFailure)
 	})
 
 	t.Run("rm priority not supported - ok", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		config := defaultConfig()
 		_, err := CheckNTSCConstraints(context.Background(), w.ID, config, &rm1)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrPriorityConstraintFailure)
+		require.ErrorIs(t, err, errPriorityConstraintFailure)
 
 		// Validate constraints again. This time, the RM does not support priority.
 		rmNoPriority := mocks.ResourceManager{}

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 )
@@ -26,7 +28,7 @@ func TestPriorityAllowed(t *testing.T) {
 
 	wkspLimit := 50
 	user := db.RequireMockUser(t, pgDB)
-	w := addWorkspacePriorityLimit(t, pgDB, user, wkspLimit)
+	w := addWorkspacePriorityLimit(t, user, wkspLimit)
 
 	// Priority is outside workspace limit.
 	smallerValueIsHigherPriority := true
@@ -35,7 +37,7 @@ func TestPriorityAllowed(t *testing.T) {
 	require.False(t, ok)
 
 	globalLimit := 42
-	addGlobalPriorityLimit(t, pgDB, user, globalLimit)
+	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit))
 
 	// Priority is within global limit.
 	ok, err = PriorityAllowed(w.ID, model.NTSCType, wkspLimit-1, true)
@@ -48,7 +50,141 @@ func TestPriorityAllowed(t *testing.T) {
 	require.False(t, ok)
 }
 
-func addWorkspacePriorityLimit(t *testing.T, pgDB *db.PgDB, user model.User, limit int) model.Workspace {
+func TestValidateNTSCConstraints(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	wkspPriorityLimit := 7
+	user := db.RequireMockUser(t, pgDB)
+
+	t.Run("no constraints set - ok", func(t *testing.T) {
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), 1, config, &resourceManager)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("running in wksp with constraints - not ok", func(t *testing.T) {
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit)
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		require.False(t, ok)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested priority")
+	})
+
+	t.Run("running in wksp without constraints - ok", func(t *testing.T) {
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("exceeds max slots - not ok", func(t *testing.T) {
+		constraints := DefaultConstraints()
+		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+		addConstraints(t, user, &w.ID, *constraints)
+
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &resourceManager)
+		require.False(t, ok)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested resources.max_slots")
+	})
+
+	t.Run("rm priority not supported - ok", func(t *testing.T) {
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit)
+		rm1 := mocks.ResourceManager{}
+		rm1.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil).Once()
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), w.ID, config, &rm1)
+		require.False(t, ok)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "requested priority")
+
+		// Validate constraints again. This time, the RM does not support priority.
+		rmNoPriority := mocks.ResourceManager{}
+		rmNoPriority.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, fmt.Errorf("not supported")).Once()
+		ok, err = ValidateConstraintsNTSC(context.Background(), w.ID, config, &rmNoPriority)
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("no config set - ok", func(t *testing.T) {
+		constraints := DefaultConstraints()
+		addConstraints(t, user, nil, *constraints) // add global constraints
+
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+
+		config := defaultConfig()
+		ok, err := ValidateConstraintsNTSC(context.Background(), 1, config, &resourceManager)
+		require.False(t, ok)
+		require.Error(t, err)
+
+		emptyConfig := model.CommandConfig{}
+		ok, err = ValidateConstraintsNTSC(context.Background(), 1, emptyConfig, &resourceManager)
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+}
+
+func TestGetMergedConstraints(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	// When no constraints present, all values are nil.
+	constraints, err := GetMergedConstraints(context.Background(), 0, model.NTSCType)
+	require.NoError(t, err)
+	require.Nil(t, constraints.PriorityLimit)
+	require.Nil(t, constraints.ResourceConstraints)
+
+	// Workspace priority limit set.
+	wkspLimit := 42
+	user := db.RequireMockUser(t, pgDB)
+	w := addWorkspacePriorityLimit(t, user, wkspLimit)
+	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
+	require.NoError(t, err)
+	require.Nil(t, constraints.ResourceConstraints)
+	require.Equal(t, wkspLimit, *constraints.PriorityLimit)
+
+	// Global limit overrides workspace limit.
+	globalLimit := 25
+	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit))
+	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
+	require.NoError(t, err)
+	require.Nil(t, constraints.ResourceConstraints)
+	require.Equal(t, globalLimit, *constraints.PriorityLimit)
+
+	// Workspace max slots set.
+	addConstraints(t, user, &w.ID, *DefaultConstraints())
+	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
+	require.NoError(t, err)
+	require.Equal(t, 8, *constraints.ResourceConstraints.MaxSlots) // defined in DefaultConstraintsStr
+	require.Equal(t, globalLimit, *constraints.PriorityLimit)      // global constraint overrides workspace value
+}
+
+func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.Workspace {
 	ctx := context.Background()
 
 	// add a workspace to use
@@ -57,6 +193,7 @@ func addWorkspacePriorityLimit(t *testing.T, pgDB *db.PgDB, user model.User, lim
 	require.NoError(t, err)
 
 	constraints := fmt.Sprintf(`{"priority_limit": %d}`, limit)
+	fmt.Printf("adding constraints to wksp=%d, %s\n", w.ID, constraints)
 	input := model.TaskConfigPolicies{
 		WorkloadType:  model.NTSCType,
 		WorkspaceID:   &w.ID,
@@ -69,16 +206,27 @@ func addWorkspacePriorityLimit(t *testing.T, pgDB *db.PgDB, user model.User, lim
 	return w
 }
 
-func addGlobalPriorityLimit(t *testing.T, pgDB *db.PgDB, user model.User, limit int) {
+func addConstraints(t *testing.T, user model.User, wkspID *int, constraints string) {
 	ctx := context.Background()
 
-	constraints := fmt.Sprintf(`{"priority_limit": %d}`, limit)
+	fmt.Printf("adding constraints to wksp=%d, %s\n", wkspID, constraints)
 	input := model.TaskConfigPolicies{
 		WorkloadType:  model.NTSCType,
-		WorkspaceID:   nil,
+		WorkspaceID:   wkspID,
 		Constraints:   &constraints,
 		LastUpdatedBy: user.ID,
 	}
 	err := SetTaskConfigPolicies(ctx, &input)
 	require.NoError(t, err)
+}
+
+func defaultConfig() model.CommandConfig {
+	config := model.DefaultConfig(nil)
+
+	configPriority := 50
+	configMaxSlots := 12
+	config.Resources.Priority = &configPriority
+	config.Resources.MaxSlots = &configMaxSlots
+
+	return config
 }

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -193,7 +193,6 @@ func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.W
 	require.NoError(t, err)
 
 	constraints := fmt.Sprintf(`{"priority_limit": %d}`, limit)
-	fmt.Printf("adding constraints to wksp=%d, %s\n", w.ID, constraints)
 	input := model.TaskConfigPolicies{
 		WorkloadType:  model.NTSCType,
 		WorkspaceID:   &w.ID,


### PR DESCRIPTION
…kloads

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-489]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Before scheduling NTSC workloads, check if the user-submitted config violates any constraints from task config policies. If the workload request does violate constraints, the workload will not be scheduled.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Covered by unit and integration tests.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CM-489]: https://hpe-aiatscale.atlassian.net/browse/CM-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ