### PR TITLE
test: add e2e experiment list pagination test

### DIFF
--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -414,20 +414,29 @@ test.describe('Experiment List', () => {
       });
     });
     test('Pagination', async () => {
-      const expectPageNumber = async (pageParam: string | null) => {
-        await projectDetailsPage._page.waitForResponse((res) => {
+      const pollWatch = () =>
+        projectDetailsPage._page.waitForResponse((res) => {
           return res.url().endsWith('experiments-search');
         });
+      const expectPageNumber = (pageParam: string | null) => {
         const params = new URL(projectDetailsPage._page.url()).searchParams;
         expect(params.get('page')).toBe(pageParam);
       };
       // table is virtualized so row counts are not reliable.
+      const nextPageUpdate = pollWatch();
       await projectDetailsPage.f_experimentList.pagination.next.pwLocator.click();
-      await expectPageNumber('1');
+      await nextPageUpdate;
+      expectPageNumber('1');
+
+      const buttonPageUpdate = pollWatch();
       await projectDetailsPage.f_experimentList.pagination.pageButtonLocator(3).click();
-      await expectPageNumber('2');
+      await buttonPageUpdate;
+      expectPageNumber('2');
+
+      const perPageUpdate = pollWatch();
       await projectDetailsPage.f_experimentList.pagination.perPage.selectMenuOption('80 / page');
-      await expectPageNumber(null);
+      await perPageUpdate;
+      expectPageNumber(null);
     });
   });
 });


### PR DESCRIPTION

## Ticket
ET-754


## Description
This adds a pagination test to the e2e experiment list test suite. We check page url parameter after interacting with the pagination element. Because the table rows are virtualized, we cannot directly check the row count based on what is in the html dom.



## Test Plan
React-e2e tests should pass



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ