### PR TITLE
fix: run centric api deprecated bindings (ET-694)

### DIFF
--- a/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
+++ b/webui/react/src/pages/TrialDetails/TrialDetailsLogs.tsx
@@ -168,7 +168,7 @@ const TrialDetailsLogs: React.FC<Props> = ({ experiment, trial }: Props) => {
     canceler.current = newCanceler;
 
     readStream(
-      detApi.StreamingExperiments.trialLogsFields(trial.id, true, { signal: fieldCanceler.signal }),
+      detApi.StreamingInternal.trialLogsFields(trial.id, true, { signal: fieldCanceler.signal }),
       (event) => setFilterOptions(event as Filters),
     );
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -955,7 +955,7 @@ export const getExpValidationHistory: DetApi<
     }));
   },
   request: (params, options) => {
-    return detApi.Experiments.getExperimentValidationHistory(params.id, options);
+    return detApi.Internal.getExperimentValidationHistory(params.id, options);
   },
 };
 
@@ -1067,7 +1067,7 @@ export const timeSeries: DetApi<
     return response.trials.map(decoder.decodeTrialSummary);
   },
   request: (params: Service.TimeSeriesParams) => {
-    return detApi.Experiments.compareTrials(
+    return detApi.Internal.compareTrials(
       params.trialIds,
       params.maxDatapoints,
       undefined,
@@ -1088,7 +1088,7 @@ export const getExperimentFileTree: DetApi<
   name: 'getModelDefTree',
   postProcess: (response) => response.files || [],
   request: (params) => {
-    return detApi.Experiments.getModelDefTree(params.experimentId);
+    return detApi.Internal.getModelDefTree(params.experimentId);
   },
 };
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-694]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Switches clients over to the correct paths after reclassifying endpoints as internal in #9933 


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
N/A


## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-694]: https://hpe-aiatscale.atlassian.net/browse/ET-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ