### PR TITLE
feat: Config Policies UI, Workspaces Experiments [CM-521]

### DIFF
--- a/webui/react/src/components/ConfigPolicies.tsx
+++ b/webui/react/src/components/ConfigPolicies.tsx
@@ -9,6 +9,7 @@ import { useToast } from 'hew/Toast';
 import useConfirm from 'hew/useConfirm';
 import { Loadable, NotLoaded } from 'hew/utils/loadable';
 import yaml from 'js-yaml';
+import { isEmpty } from 'lodash';
 import { useState } from 'react';
 
 import { useAsync } from 'hooks/useAsync';
@@ -75,6 +76,7 @@ const ConfigPolicies: React.FC<Props> = ({ workspaceId }: Props) => {
         workloadType: 'NTSC',
         workspaceId,
       });
+      if (isEmpty(response.configPolicies)) return undefined;
       return response.configPolicies;
     }
     return NotLoaded;

--- a/webui/react/src/components/ConfigPolicies.tsx
+++ b/webui/react/src/components/ConfigPolicies.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 
 import { useAsync } from 'hooks/useAsync';
 import usePermissions from 'hooks/usePermissions';
-import { getWorkspaceConfigPolicies, updateWorkspaceConfigPolicies } from 'services/api';
+import { deleteWorkspaceConfigPolicies, getWorkspaceConfigPolicies, updateWorkspaceConfigPolicies } from 'services/api';
 import handleError from 'utils/error';
 
 interface Props {
@@ -76,18 +76,32 @@ const ConfigPoliciesTab: React.FC<TabProps> = ({ workspaceId, type }: TabProps) 
 
   const APPLY_MESSAGE = "You're about to apply these config policies to this workspace.";
   const VIEW_MESSAGE = 'An admin applied these config policies to this workspace.';
+  const CONFIRMATION_MESSAGE = 'Config policies updated';
 
   const updatePolicies = async () => {
     if (workspaceId) {
-      try {
-        await updateWorkspaceConfigPolicies({
-          configPolicies: form.getFieldValue('configPolicies'),
-          workloadType: ConfigPoliciesValues[type].workloadType,
-          workspaceId,
-        });
-        openToast({ title: 'Config policies updated' });
-      } catch (error) {
-        handleError(error);
+      const configPolicies = form.getFieldValue('configPolicies');
+      if (configPolicies.length) {
+        try {
+          await updateWorkspaceConfigPolicies({
+            configPolicies,
+            workloadType: ConfigPoliciesValues[type].workloadType,
+            workspaceId,
+          });
+          openToast({ title: CONFIRMATION_MESSAGE });
+        } catch (error) {
+          handleError(error);
+        }
+      } else {
+        try {
+          await deleteWorkspaceConfigPolicies({
+            workloadType: ConfigPoliciesValues[type].workloadType,
+            workspaceId,
+          });
+          openToast({ title: CONFIRMATION_MESSAGE });
+        } catch (error) {
+          handleError(error);
+        }
       }
     }
   };

--- a/webui/react/src/components/ConfigPolicies.tsx
+++ b/webui/react/src/components/ConfigPolicies.tsx
@@ -194,6 +194,7 @@ const ConfigPoliciesTab: React.FC<TabProps> = ({ workspaceId, type }: TabProps) 
               <CodeEditor
                 file={initialConfigPoliciesYAML}
                 files={[{ key: type, title: `${type}-config-policies.yaml` }]}
+                readonly={!canModifyWorkspaceConfigPolicies}
                 onError={(error) => {
                   handleError(error);
                 }}

--- a/webui/react/src/components/ConfigPolicies.tsx
+++ b/webui/react/src/components/ConfigPolicies.tsx
@@ -15,7 +15,11 @@ import { useState } from 'react';
 
 import { useAsync } from 'hooks/useAsync';
 import usePermissions from 'hooks/usePermissions';
-import { deleteWorkspaceConfigPolicies, getWorkspaceConfigPolicies, updateWorkspaceConfigPolicies } from 'services/api';
+import {
+  deleteWorkspaceConfigPolicies,
+  getWorkspaceConfigPolicies,
+  updateWorkspaceConfigPolicies,
+} from 'services/api';
 import handleError from 'utils/error';
 
 interface Props {
@@ -140,7 +144,9 @@ const ConfigPoliciesTab: React.FC<TabProps> = ({ workspaceId, type }: TabProps) 
   const initialConfigPoliciesYAML = yaml.dump(loadableConfigPolicies.getOrElse(undefined));
 
   const handleChange = () => {
-    setDisabled(hasErrors(form) || form.getFieldValue('configPolicies') === initialConfigPoliciesYAML);
+    setDisabled(
+      hasErrors(form) || form.getFieldValue('configPolicies') === initialConfigPoliciesYAML,
+    );
   };
 
   if (rbacLoading) return <Spinner spinning />;

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -1006,3 +1006,9 @@ export const updateWorkspaceConfigPolicies = generateDetApi<
   Api.V1PutWorkspaceConfigPoliciesResponse,
   Api.V1PutWorkspaceConfigPoliciesResponse
 >(Config.updateWorkspaceConfigPolicies);
+
+export const deleteWorkspaceConfigPolicies = generateDetApi<
+  Service.DeleteWorkspaceConfigPolicies,
+  Api.V1DeleteWorkspaceConfigPoliciesResponse,
+  Api.V1DeleteWorkspaceConfigPoliciesResponse
+>(Config.deleteWorkspaceConfigPolicies);

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -2192,6 +2192,17 @@ export const getWorkspaceConfigPolicies: DetApi<
     detApi.Alpha.getWorkspaceConfigPolicies(params.workspaceId, params.workloadType, options),
 };
 
+export const deleteWorkspaceConfigPolicies: DetApi<
+  Service.DeleteWorkspaceConfigPolicies,
+  Api.V1DeleteWorkspaceConfigPoliciesResponse,
+  Api.V1DeleteWorkspaceConfigPoliciesResponse
+> = {
+  name: 'deleteWorkspaceConfigPolicies',
+  postProcess: identity,
+  request: (params: Service.DeleteWorkspaceConfigPolicies, options) =>
+    detApi.Alpha.deleteWorkspaceConfigPolicies(params.workspaceId, params.workloadType, options),
+};
+
 export const updateWorkspaceConfigPolicies: DetApi<
   Service.UpdateWorkspaceConfigPolicies,
   Api.V1PutWorkspaceConfigPoliciesResponse,

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -574,3 +574,8 @@ export interface UpdateWorkspaceConfigPolicies {
   workloadType: 'NTSC' | 'EXPERIMENT';
   configPolicies: string;
 }
+
+export interface DeleteWorkspaceConfigPolicies {
+  workspaceId: number;
+  workloadType: 'NTSC' | 'EXPERIMENT';
+}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
CM-521


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add secondary tabs for "Experiments" and "Tasks" to "Config Policies" tab on Workspace Details page. Also made changes to 
* call delete endpoint when saving an empty document 
* Not display JSON brackets when loading with empty config policies object
* display CodeEditor in read-only mode when user does not have permissions to modify

<img width="1022" alt="Screenshot 2024-10-02 at 12 26 31 PM" src="https://github.com/user-attachments/assets/f6c663a3-d3df-4623-80fe-28b65a3e3300">
<img width="1014" alt="Screenshot 2024-10-02 at 12 26 49 PM" src="https://github.com/user-attachments/assets/329e7715-623c-4955-812f-2eff523d7897">
<img width="1019" alt="Screenshot 2024-10-02 at 12 27 05 PM" src="https://github.com/user-attachments/assets/05c659d8-e437-468d-8655-88ec36951557">
<img width="1020" alt="Screenshot 2024-10-02 at 12 27 12 PM" src="https://github.com/user-attachments/assets/57ca577b-25ae-4b8b-a3b4-50d38c842d61">


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
Only in EE:
"Config Policies" tab on Workspace Details page should display secondary tabs for "Experiments" and "Tasks"
Non-admin should not see Apply button, and should see CodeEditor in read-only mode.
Admin should be able to Apply (with valid YAML syntax that modifies what's fetched).
Should be able to remove all YAML and Apply without error.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ