### PR TITLE
fix: use UID not username to set HOME dir

### DIFF
--- a/master/static/srv/generic-task-entrypoint.sh
+++ b/master/static/srv/generic-task-entrypoint.sh
@@ -5,25 +5,6 @@ source /run/determined/task-setup.sh
 set -e
 
 STARTUP_HOOK="startup-hook.sh"
-export PATH="/run/determined/pythonuserbase/bin:$PATH"
-
-# If HOME is not explicitly set for a container, libcontainer (Docker) will
-# try to guess it by reading /etc/password directly, which will not work with
-# our libnss_determined plugin (or any user-defined NSS plugin in a container).
-# The default is "/", but HOME must be a writable location for distributed
-# training, so we try to query the user system for a valid HOME, or default to
-# the working directory otherwise.
-if [ "$HOME" = "/" ]; then
-    HOME="$(
-        set -o pipefail
-        getent passwd "$(whoami)" | cut -d: -f6
-    )" || HOME="$PWD"
-    export HOME
-fi
-
-if [ -z "$DET_PYTHON_EXECUTABLE" ]; then
-    export DET_PYTHON_EXECUTABLE="python3"
-fi
 
 # In order to be able to use a proxy when running a generic task, Python must be
 # available in the container, and the "determined*.whl" must be installed,

--- a/master/static/srv/task-setup.sh
+++ b/master/static/srv/task-setup.sh
@@ -49,7 +49,7 @@ fi
 if [ "$HOME" = "/" ]; then
     HOME="$(
         set -o pipefail
-        getent passwd "$(whoami)" | cut -d: -f6
+        getent passwd "$UID" | cut -d: -f6
     )" || HOME="$PWD"
     export HOME
 fi


### PR DESCRIPTION
When a task's uid setting is nonzero but username is still "root", we will accidentally set the HOME directory to /root.

This happens because we start the container based on the UID, then we look up the username (uid->username lookup) and we find that we are called "root", then we do a username->HOME lookup to arrive at /root.