### PR TITLE
chore: Revoke Access Tokens when a User is Deactivated

### DIFF
--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -131,6 +131,13 @@ func Update(
 				Where("id = ?", updated.ID).Exec(ctx); err != nil {
 				return fmt.Errorf("error setting active status of %q: %s", updated.Username, err)
 			}
+			// Revoke all access tokens of a user when it is deactivated.
+			if !updated.Active {
+				err := revokeUserAccessTokens(ctx, tx, updated.ID)
+				if err != nil {
+					return fmt.Errorf("error revoking active access token of %q: %s", updated.Username, err)
+				}
+			}
 		}
 
 		if slices.Contains(toUpdate, "password_hash") {
@@ -153,6 +160,19 @@ func Update(
 
 		return nil
 	})
+}
+
+// Revoke all access tokens of a user when it is deactivated.
+func revokeUserAccessTokens(ctx context.Context, tx bun.Tx, userID model.UserID) error {
+	_, err := tx.NewUpdate().
+		Table("user_sessions").
+		Set("revoked = ?", true).
+		Where("user_id = ?", userID).
+		Exec(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetActive changes multiple users' activation status.

--- a/master/internal/user/postgres_users.go
+++ b/master/internal/user/postgres_users.go
@@ -168,11 +168,9 @@ func revokeUserAccessTokens(ctx context.Context, tx bun.Tx, userID model.UserID)
 		Table("user_sessions").
 		Set("revoked = ?", true).
 		Where("user_id = ?", userID).
+		Where("token_type = ?", model.TokenTypeAccessToken).
 		Exec(ctx)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // SetActive changes multiple users' activation status.


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10404](https://hpe-aiatscale.atlassian.net/browse/DET-10404)


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10404]: https://hpe-aiatscale.atlassian.net/browse/DET-10404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ