### PR TITLE
fix: correct expToWebhookConfig cache locking

### DIFF
--- a/master/internal/webhooks/postgres_webhook.go
+++ b/master/internal/webhooks/postgres_webhook.go
@@ -148,8 +148,8 @@ func (l *WebhookManager) getWebhookConfig(ctx context.Context, expID *int) (*exp
 		return nil, nil
 	}
 
-	l.mu.RLock()
-	defer l.mu.RUnlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
 	if config, ok := l.expToWebhookConfig[*expID]; ok {
 		return config, nil


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
CM-527



## Description
There is a write under a read lock, causing the master to crash in integration tests with `fatal error: concurrent map writes`.


## Test Plan
Change is a test fix.


<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ