### PR TITLE
chore: check task config policies against slots and max_slots

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -153,7 +153,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	// Check submitted config against task config policies.
 	valid, err := configpolicy.CheckNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
 	if !valid {
-		return nil, nil, err
+		return nil, nil, status.Errorf(codes.InvalidArgument, "failed constraint check: %w", err)
 	}
 
 	token, err := getTaskSessionToken(ctx, userModel)

--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -153,7 +153,7 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	// Check submitted config against task config policies.
 	valid, err := configpolicy.CheckNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
 	if !valid {
-		return nil, nil, status.Errorf(codes.InvalidArgument, "failed constraint check: %w", err)
+		return nil, nil, status.Errorf(codes.InvalidArgument, "failed constraint check: %v", err)
 	}
 
 	token, err := getTaskSessionToken(ctx, userModel)

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -55,15 +55,20 @@ func CheckNTSCConstraints(
 	if err == nil && constraints.PriorityLimit != nil && workloadConfig.Resources.Priority != nil {
 		if !priorityWithinLimit(*workloadConfig.Resources.Priority, *constraints.PriorityLimit, smallerHigher) {
 			return false, fmt.Errorf("requested priority [%d] exceeds limit set by admin [%d]: %w",
-				*constraints.PriorityLimit, *workloadConfig.Resources.Priority, errPriorityConstraintFailure)
+				*workloadConfig.Resources.Priority, *constraints.PriorityLimit, errPriorityConstraintFailure)
 		}
 	}
 
-	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil &&
-		workloadConfig.Resources.MaxSlots != nil {
-		if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
-			return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]: %w",
-				*constraints.ResourceConstraints.MaxSlots, *workloadConfig.Resources.MaxSlots, errResourceConstraintFailure)
+	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
+		if workloadConfig.Resources.MaxSlots != nil {
+			if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
+				return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]: %w",
+					*workloadConfig.Resources.MaxSlots, *constraints.ResourceConstraints.MaxSlots, errResourceConstraintFailure)
+			}
+		}
+		if *constraints.ResourceConstraints.MaxSlots < workloadConfig.Resources.Slots {
+			return false, fmt.Errorf("requested resources.slots [%d] exceeds limit set by admin [%d]: %w",
+				workloadConfig.Resources.Slots, *constraints.ResourceConstraints.MaxSlots, errResourceConstraintFailure)
 		}
 	}
 
@@ -94,6 +99,8 @@ func GetMergedConstraints(ctx context.Context, workspaceID int, workloadType str
 			return nil, fmt.Errorf("unable to merge workspace and global constraints: %w", err)
 		}
 	}
+
+	fmt.Printf("merged constraints: %v\n", constraints)
 
 	return &constraints, nil
 }

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -100,8 +100,6 @@ func GetMergedConstraints(ctx context.Context, workspaceID int, workloadType str
 		}
 	}
 
-	fmt.Printf("merged constraints: %v\n", constraints)
-
 	return &constraints, nil
 }
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-551]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Need to check both `resources.max_slots` and `resources.slots` when checking if a NTSC workload requests is within constraints.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Covered by automated tests.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CM-551]: https://hpe-aiatscale.atlassian.net/browse/CM-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ