### PR TITLE
chore: check experiment constraints

### DIFF
--- a/master/internal/api_command.go
+++ b/master/internal/api_command.go
@@ -151,8 +151,8 @@ func (a *apiServer) getCommandLaunchParams(ctx context.Context, req *protoComman
 	}
 
 	// Check submitted config against task config policies.
-	valid, err := configpolicy.CheckNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
-	if !valid {
+	err = configpolicy.CheckNTSCConstraints(ctx, int(cmdSpec.Metadata.WorkspaceID), config, a.m.rm)
+	if err != nil {
 		return nil, nil, status.Errorf(codes.InvalidArgument, "failed constraint check: %v", err)
 	}
 

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1688,7 +1688,6 @@ func (a *apiServer) CreateExperiment(
 	}
 	if len(wkspIDs) != 1 {
 		return nil, status.Error(codes.InvalidArgument, "expected exactly one workspace")
-
 	}
 	err = configpolicy.CheckExperimentConstraints(ctx, int(wkspIDs[0]), activeConfig, a.m.rm)
 	if err != nil {

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
+	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/db/bunutils"
 	"github.com/determined-ai/determined/master/internal/experiment"
@@ -1679,6 +1680,19 @@ func (a *apiServer) CreateExperiment(
 
 	if err = experiment.AuthZProvider.Get().CanCreateExperiment(ctx, *user, p); err != nil {
 		return nil, status.Errorf(codes.PermissionDenied, err.Error())
+	}
+
+	wkspIDs, err := workspace.WorkspaceIDsFromNames(ctx, []string{taskSpec.Workspace})
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+	if len(wkspIDs) != 1 {
+		return nil, status.Error(codes.InvalidArgument, "expected exactly one workspace")
+
+	}
+	err = configpolicy.CheckExperimentConstraints(ctx, int(wkspIDs[0]), activeConfig, a.m.rm)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	if req.ValidateOnly {

--- a/master/internal/api_logretention_intg_test.go
+++ b/master/internal/api_logretention_intg_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 
@@ -108,6 +109,9 @@ searcher:
 	}
 
 	// No checkpoint specified anywhere.
+	mockRM := MockRM()
+	api.m.rm = mockRM
+	mockRM.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 	resp, err := api.CreateExperiment(ctx, createReq)
 	require.NoError(t, err)
 	require.Empty(t, resp.Warnings)

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -59,10 +59,9 @@ func CheckNTSCConstraints(
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
 	if err != nil {
-		return nil
-	}
-	if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources.Priority); err != nil {
-		return err
+		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources.Priority); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -36,7 +36,7 @@ var (
 	errResourceConstraintFailure = errors.New("submitted workload failed a resource constraint")
 )
 
-// CheckNTSCConstraints returns true if the NTSC config passes constraint checks.
+// CheckNTSCConstraints returns an error if the NTSC config fails constraint checks.
 func CheckNTSCConstraints(
 	ctx context.Context,
 	workspaceID int,
@@ -68,7 +68,7 @@ func CheckNTSCConstraints(
 	return nil
 }
 
-// CheckExperimentConstraints returns true if the NTSC config passes constraint checks.
+// CheckExperimentConstraints returns an error if the NTSC config fails constraint checks.
 func CheckExperimentConstraints(
 	ctx context.Context,
 	workspaceID int,

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -59,7 +59,7 @@ func CheckNTSCConstraints(
 	// rm.SmallerValueIsHigherPriority only returns an error if task priority is not implemented for that resource manager.
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
-	if err != nil {
+	if err == nil {
 		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit,
 			workloadConfig.Resources.Priority); err != nil {
 			return err
@@ -94,7 +94,7 @@ func CheckExperimentConstraints(
 	// rm.SmallerValueIsHigherPriority only returns an error if task priority is not implemented for that resource manager.
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
-	if err != nil {
+	if err == nil {
 		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit,
 			workloadConfig.Resources().Priority()); err != nil {
 			return err

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -49,7 +49,8 @@ func CheckNTSCConstraints(
 	}
 
 	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
-		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, workloadConfig.Resources.Slots, workloadConfig.Resources.MaxSlots); err != nil {
+		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, workloadConfig.Resources.Slots,
+			workloadConfig.Resources.MaxSlots); err != nil {
 			return err
 		}
 	}
@@ -59,7 +60,8 @@ func CheckNTSCConstraints(
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
 	if err != nil {
-		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources.Priority); err != nil {
+		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit,
+			workloadConfig.Resources.Priority); err != nil {
 			return err
 		}
 	}
@@ -82,7 +84,8 @@ func CheckExperimentConstraints(
 	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
 		// users cannot specify number of slots for an experiment
 		slotsRequest := 0
-		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, slotsRequest, workloadConfig.Resources().MaxSlots()); err != nil {
+		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, slotsRequest,
+			workloadConfig.Resources().MaxSlots()); err != nil {
 			return err
 		}
 	}
@@ -92,10 +95,10 @@ func CheckExperimentConstraints(
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
 	if err != nil {
-		return nil
-	}
-	if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources().Priority()); err != nil {
-		return err
+		if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit,
+			workloadConfig.Resources().Priority()); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -42,37 +42,92 @@ func CheckNTSCConstraints(
 	workspaceID int,
 	workloadConfig model.CommandConfig,
 	resourceManager rm.ResourceManager,
-) (bool, error) {
+) error {
 	constraints, err := GetMergedConstraints(ctx, workspaceID, model.NTSCType)
 	if err != nil {
-		return false, err
+		return err
+	}
+
+	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
+		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, workloadConfig.Resources.Slots, workloadConfig.Resources.MaxSlots); err != nil {
+			return err
+		}
 	}
 
 	// For each submitted constraint, check if the workload config is within allowed values.
 	// rm.SmallerValueIsHigherPriority only returns an error if task priority is not implemented for that resource manager.
 	// In that case, there is no need to check if requested priority is within limits.
 	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
-	if err == nil && constraints.PriorityLimit != nil && workloadConfig.Resources.Priority != nil {
-		if !priorityWithinLimit(*workloadConfig.Resources.Priority, *constraints.PriorityLimit, smallerHigher) {
-			return false, fmt.Errorf("requested priority [%d] exceeds limit set by admin [%d]: %w",
-				*workloadConfig.Resources.Priority, *constraints.PriorityLimit, errPriorityConstraintFailure)
-		}
+	if err != nil {
+		return nil
+	}
+	if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources.Priority); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CheckExperimentConstraints returns true if the NTSC config passes constraint checks.
+func CheckExperimentConstraints(
+	ctx context.Context,
+	workspaceID int,
+	workloadConfig expconf.ExperimentConfigV0,
+	resourceManager rm.ResourceManager,
+) error {
+	constraints, err := GetMergedConstraints(ctx, workspaceID, model.ExperimentType)
+	if err != nil {
+		return err
 	}
 
 	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
-		if workloadConfig.Resources.MaxSlots != nil {
-			if *constraints.ResourceConstraints.MaxSlots < *workloadConfig.Resources.MaxSlots {
-				return false, fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]: %w",
-					*workloadConfig.Resources.MaxSlots, *constraints.ResourceConstraints.MaxSlots, errResourceConstraintFailure)
-			}
-		}
-		if *constraints.ResourceConstraints.MaxSlots < workloadConfig.Resources.Slots {
-			return false, fmt.Errorf("requested resources.slots [%d] exceeds limit set by admin [%d]: %w",
-				workloadConfig.Resources.Slots, *constraints.ResourceConstraints.MaxSlots, errResourceConstraintFailure)
+		// users cannot specify number of slots for an experiment
+		slotsRequest := 0
+		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, slotsRequest, workloadConfig.Resources().MaxSlots()); err != nil {
+			return err
 		}
 	}
 
-	return true, nil
+	// For each submitted constraint, check if the workload config is within allowed values.
+	// rm.SmallerValueIsHigherPriority only returns an error if task priority is not implemented for that resource manager.
+	// In that case, there is no need to check if requested priority is within limits.
+	smallerHigher, err := resourceManager.SmallerValueIsHigherPriority()
+	if err != nil {
+		return nil
+	}
+	if err = checkPriorityConstraint(smallerHigher, constraints.PriorityLimit, workloadConfig.Resources().Priority()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkPriorityConstraint(smallerHigher bool, priorityLimit *int, priorityRequest *int) error {
+	if priorityLimit == nil || priorityRequest == nil {
+		return nil
+	}
+
+	if !priorityWithinLimit(*priorityRequest, *priorityLimit, smallerHigher) {
+		return fmt.Errorf("requested priority [%d] exceeds limit set by admin [%d]: %w",
+			*priorityRequest, *priorityLimit, errPriorityConstraintFailure)
+	}
+	return nil
+}
+
+func checkSlotsConstraint(slotsLimit int, slotsRequest int, maxSlotsRequest *int) error {
+	if slotsLimit < slotsRequest {
+		return fmt.Errorf("requested resources.slots [%d] exceeds limit set by admin [%d]: %w",
+			slotsRequest, slotsLimit, errResourceConstraintFailure)
+	}
+
+	if maxSlotsRequest != nil {
+		if slotsLimit < *maxSlotsRequest {
+			return fmt.Errorf("requested resources.max_slots [%d] exceeds limit set by admin [%d]: %w",
+				*maxSlotsRequest, slotsLimit, errResourceConstraintFailure)
+		}
+	}
+
+	return nil
 }
 
 // GetMergedConstraints retrieves Workspace and Global constraints and returns a merged result.

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -64,9 +64,8 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 
 		config := defaultConfig()
-		ok, err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
+		err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.NoError(t, err)
-		require.True(t, ok)
 	})
 
 	t.Run("running in wksp with constraints - not ok", func(t *testing.T) {
@@ -77,7 +76,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		config := defaultConfig()
-		_, err := CheckNTSCConstraints(ctx, w.ID, config, &resourceManager)
+		err := CheckNTSCConstraints(ctx, w.ID, config, &resourceManager)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errPriorityConstraintFailure)
 	})
@@ -90,8 +89,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		require.NoError(t, err)
 
 		config := defaultConfig()
-		ok, err := CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
-		require.True(t, ok)
+		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.NoError(t, err)
 	})
 
@@ -106,7 +104,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
 		config := defaultConfig()
-		_, err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
+		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errResourceConstraintFailure)
 	})
@@ -124,7 +122,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		config := defaultConfig()
 		config.Resources.Slots = *config.Resources.MaxSlots
 		config.Resources.MaxSlots = nil // ensure only slots is set
-		_, err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
+		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errResourceConstraintFailure)
 	})
@@ -135,15 +133,14 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		rm1.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil).Once()
 
 		config := defaultConfig()
-		_, err := CheckNTSCConstraints(context.Background(), w.ID, config, &rm1)
+		err := CheckNTSCConstraints(context.Background(), w.ID, config, &rm1)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errPriorityConstraintFailure)
 
 		// Validate constraints again. This time, the RM does not support priority.
 		rmNoPriority := mocks.ResourceManager{}
 		rmNoPriority.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, fmt.Errorf("not supported")).Once()
-		ok, err := CheckNTSCConstraints(context.Background(), w.ID, config, &rmNoPriority)
-		require.True(t, ok)
+		err = CheckNTSCConstraints(context.Background(), w.ID, config, &rmNoPriority)
 		require.NoError(t, err)
 	})
 
@@ -155,13 +152,11 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
 		config := defaultConfig()
-		ok, err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
-		require.False(t, ok)
+		err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.Error(t, err)
 
 		emptyConfig := model.CommandConfig{}
-		ok, err = CheckNTSCConstraints(context.Background(), 1, emptyConfig, &resourceManager)
-		require.True(t, ok)
+		err = CheckNTSCConstraints(context.Background(), 1, emptyConfig, &resourceManager)
 		require.NoError(t, err)
 	})
 }

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/mocks"
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
 
 func TestPriorityAllowed(t *testing.T) {
@@ -28,7 +29,7 @@ func TestPriorityAllowed(t *testing.T) {
 
 	wkspLimit := 50
 	user := db.RequireMockUser(t, pgDB)
-	w := addWorkspacePriorityLimit(t, user, wkspLimit)
+	w := addWorkspacePriorityLimit(t, user, wkspLimit, model.NTSCType)
 
 	// Priority is outside workspace limit.
 	smallerValueIsHigherPriority := true
@@ -37,7 +38,7 @@ func TestPriorityAllowed(t *testing.T) {
 	require.False(t, ok)
 
 	globalLimit := 42
-	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit))
+	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit), model.NTSCType)
 
 	// Priority is within global limit.
 	ok, err = PriorityAllowed(w.ID, model.NTSCType, wkspLimit-1, true)
@@ -50,7 +51,7 @@ func TestPriorityAllowed(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestValidateNTSCConstraints(t *testing.T) {
+func TestCheckNTSCConstraints(t *testing.T) {
 	require.NoError(t, etc.SetRootPath(db.RootFromDB))
 	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
 	defer cleanup()
@@ -63,19 +64,19 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.NoError(t, err)
 	})
 
 	t.Run("running in wksp with constraints - not ok", func(t *testing.T) {
-		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit)
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit, model.NTSCType)
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err := CheckNTSCConstraints(ctx, w.ID, config, &resourceManager)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errPriorityConstraintFailure)
@@ -88,7 +89,7 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
 		require.NoError(t, err)
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.NoError(t, err)
 	})
@@ -98,12 +99,12 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
 		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
 		require.NoError(t, err)
-		addConstraints(t, user, &w.ID, *constraints)
+		addConstraints(t, user, &w.ID, *constraints, model.NTSCType)
 
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errResourceConstraintFailure)
@@ -114,12 +115,12 @@ func TestValidateNTSCConstraints(t *testing.T) {
 		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
 		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
 		require.NoError(t, err)
-		addConstraints(t, user, &w.ID, *constraints)
+		addConstraints(t, user, &w.ID, *constraints, model.NTSCType)
 
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		config.Resources.Slots = *config.Resources.MaxSlots
 		config.Resources.MaxSlots = nil // ensure only slots is set
 		err = CheckNTSCConstraints(context.Background(), w.ID, config, &resourceManager)
@@ -128,11 +129,11 @@ func TestValidateNTSCConstraints(t *testing.T) {
 	})
 
 	t.Run("rm priority not supported - ok", func(t *testing.T) {
-		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit)
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit, model.NTSCType)
 		rm1 := mocks.ResourceManager{}
 		rm1.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil).Once()
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err := CheckNTSCConstraints(context.Background(), w.ID, config, &rm1)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errPriorityConstraintFailure)
@@ -146,17 +147,112 @@ func TestValidateNTSCConstraints(t *testing.T) {
 
 	t.Run("no config set - ok", func(t *testing.T) {
 		constraints := DefaultConstraints()
-		addConstraints(t, user, nil, *constraints) // add global constraints
+		addConstraints(t, user, nil, *constraints, model.NTSCType) // add global constraints
 
 		resourceManager := mocks.ResourceManager{}
 		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
 
-		config := defaultConfig()
+		config := defaultNTSCConfig()
 		err := CheckNTSCConstraints(context.Background(), 1, config, &resourceManager)
 		require.Error(t, err)
 
 		emptyConfig := model.CommandConfig{}
 		err = CheckNTSCConstraints(context.Background(), 1, emptyConfig, &resourceManager)
+		require.NoError(t, err)
+	})
+}
+
+func TestCheckExperimentConstraints(t *testing.T) {
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	wkspPriorityLimit := 7
+	user := db.RequireMockUser(t, pgDB)
+
+	t.Run("no constraints set - ok", func(t *testing.T) {
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+
+		config := defaultExperimentConfig()
+		err := CheckExperimentConstraints(context.Background(), 1, config, &resourceManager)
+		require.NoError(t, err)
+	})
+
+	t.Run("running in wksp with constraints - not ok", func(t *testing.T) {
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit, model.ExperimentType)
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		config := defaultExperimentConfig()
+		err := CheckExperimentConstraints(ctx, w.ID, config, &resourceManager)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errPriorityConstraintFailure)
+	})
+
+	t.Run("running in wksp without constraints - ok", func(t *testing.T) {
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil)
+		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+		require.NoError(t, err)
+
+		config := defaultExperimentConfig()
+		err = CheckExperimentConstraints(context.Background(), w.ID, config, &resourceManager)
+		require.NoError(t, err)
+	})
+
+	t.Run("exceeds max slots - not ok", func(t *testing.T) {
+		constraints := DefaultConstraints()
+		w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+		_, err := db.Bun().NewInsert().Model(&w).Exec(context.Background())
+		require.NoError(t, err)
+		addConstraints(t, user, &w.ID, *constraints, model.ExperimentType)
+
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+
+		config := defaultExperimentConfig()
+		err = CheckExperimentConstraints(context.Background(), w.ID, config, &resourceManager)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errResourceConstraintFailure)
+	})
+
+	t.Run("rm priority not supported - ok", func(t *testing.T) {
+		w := addWorkspacePriorityLimit(t, user, wkspPriorityLimit, model.ExperimentType)
+		rm1 := mocks.ResourceManager{}
+		rm1.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, nil).Once()
+
+		config := defaultExperimentConfig()
+		err := CheckExperimentConstraints(context.Background(), w.ID, config, &rm1)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errPriorityConstraintFailure)
+
+		// Validate constraints again. This time, the RM does not support priority.
+		rmNoPriority := mocks.ResourceManager{}
+		rmNoPriority.On("SmallerValueIsHigherPriority", mock.Anything).Return(false, fmt.Errorf("not supported")).Once()
+		err = CheckExperimentConstraints(context.Background(), w.ID, config, &rmNoPriority)
+		require.NoError(t, err)
+	})
+
+	t.Run("no config set - ok", func(t *testing.T) {
+		constraints := DefaultConstraints()
+		addConstraints(t, user, nil, *constraints, model.ExperimentType) // add global constraints
+
+		resourceManager := mocks.ResourceManager{}
+		resourceManager.On("SmallerValueIsHigherPriority", mock.Anything).Return(true, nil)
+
+		config := defaultExperimentConfig()
+		err := CheckExperimentConstraints(context.Background(), 1, config, &resourceManager)
+		require.Error(t, err)
+
+		emptyResources := expconf.ResourcesConfigV0{}
+		emptyConfig := expconf.ExperimentConfigV0{}
+		emptyConfig.SetResources(emptyResources)
+		err = CheckExperimentConstraints(context.Background(), 1, emptyConfig, &resourceManager)
 		require.NoError(t, err)
 	})
 }
@@ -176,7 +272,7 @@ func TestGetMergedConstraints(t *testing.T) {
 	// Workspace priority limit set.
 	wkspLimit := 42
 	user := db.RequireMockUser(t, pgDB)
-	w := addWorkspacePriorityLimit(t, user, wkspLimit)
+	w := addWorkspacePriorityLimit(t, user, wkspLimit, model.NTSCType)
 	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
 	require.NoError(t, err)
 	require.Nil(t, constraints.ResourceConstraints)
@@ -184,21 +280,21 @@ func TestGetMergedConstraints(t *testing.T) {
 
 	// Global limit overrides workspace limit.
 	globalLimit := 25
-	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit))
+	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit), model.NTSCType)
 	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
 	require.NoError(t, err)
 	require.Nil(t, constraints.ResourceConstraints)
 	require.Equal(t, globalLimit, *constraints.PriorityLimit)
 
 	// Workspace max slots set.
-	addConstraints(t, user, &w.ID, *DefaultConstraints())
+	addConstraints(t, user, &w.ID, *DefaultConstraints(), model.NTSCType)
 	constraints, err = GetMergedConstraints(context.Background(), w.ID, model.NTSCType)
 	require.NoError(t, err)
 	require.Equal(t, 8, *constraints.ResourceConstraints.MaxSlots) // defined in DefaultConstraintsStr
 	require.Equal(t, globalLimit, *constraints.PriorityLimit)      // global constraint overrides workspace value
 }
 
-func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.Workspace {
+func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int, workloadType string) model.Workspace {
 	ctx := context.Background()
 
 	// add a workspace to use
@@ -208,7 +304,7 @@ func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.W
 
 	constraints := fmt.Sprintf(`{"priority_limit": %d}`, limit)
 	input := model.TaskConfigPolicies{
-		WorkloadType:  model.NTSCType,
+		WorkloadType:  workloadType,
 		WorkspaceID:   &w.ID,
 		Constraints:   &constraints,
 		LastUpdatedBy: user.ID,
@@ -219,11 +315,11 @@ func addWorkspacePriorityLimit(t *testing.T, user model.User, limit int) model.W
 	return w
 }
 
-func addConstraints(t *testing.T, user model.User, wkspID *int, constraints string) {
+func addConstraints(t *testing.T, user model.User, wkspID *int, constraints string, workloadType string) {
 	ctx := context.Background()
 
 	input := model.TaskConfigPolicies{
-		WorkloadType:  model.NTSCType,
+		WorkloadType:  workloadType,
 		WorkspaceID:   wkspID,
 		Constraints:   &constraints,
 		LastUpdatedBy: user.ID,
@@ -232,13 +328,27 @@ func addConstraints(t *testing.T, user model.User, wkspID *int, constraints stri
 	require.NoError(t, err)
 }
 
-func defaultConfig() model.CommandConfig {
+func defaultNTSCConfig() model.CommandConfig {
 	config := model.DefaultConfig(nil)
 
 	configPriority := 50
 	configMaxSlots := 12
 	config.Resources.Priority = &configPriority
 	config.Resources.MaxSlots = &configMaxSlots
+
+	return config
+}
+
+func defaultExperimentConfig() expconf.ExperimentConfigV0 {
+	config := expconf.ExperimentConfigV0{}
+
+	configPriority := 50
+	configMaxSlots := 12
+	resources := expconf.ResourcesConfigV0{
+		RawMaxSlots: &configMaxSlots,
+		RawPriority: &configPriority,
+	}
+	config.SetResources(resources)
 
 	return config
 }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-491]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Check if experiment config passes any constraints defined in task config policies.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

Covered by unit tests.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CM-491]: https://hpe-aiatscale.atlassian.net/browse/CM-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ