### PR TITLE
chore: exp invariant config silent override during add or update

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1469,6 +1469,21 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 			fmt.Sprintf("override config must have single searcher type got '%s' instead", overrideName))
 	}
 
+	ctx := context.TODO()
+	w, err := workspace.WorkspaceByName(ctx, activeConfig.Workspace())
+	if err != nil {
+		return nil, false,
+			fmt.Errorf("error getting workspace %s: %w", activeConfig.Workspace(), err)
+	}
+
+	// Merge the config with the optionally specified invariant config specified by task config
+	// policies.
+	err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, w.ID, &mergedConfig)
+	if err != nil {
+		return nil, false,
+			fmt.Errorf("error merging invariant experiment configs: %w", err)
+	}
+
 	bytes, err := mergedConfig.Value()
 	if err != nil {
 		return nil, false, fmt.Errorf("getting value of merged config: %w", err)

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1471,17 +1471,17 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 
 	ctx := context.TODO()
 	w, err := workspace.WorkspaceByName(ctx, activeConfig.Workspace())
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows && err != db.ErrNotFound {
 		return nil, false,
 			fmt.Errorf("error getting workspace %s: %w", activeConfig.Workspace(), err)
-	}
-
-	// Merge the config with the optionally specified invariant config specified by task config
-	// policies.
-	err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, w.ID, &mergedConfig)
-	if err != nil {
-		return nil, false,
-			fmt.Errorf("error merging invariant experiment configs: %w", err)
+	} else if w != nil {
+		// Merge the config with the optionally specified invariant config specified by task config
+		// policies.
+		err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, w.ID, &mergedConfig)
+		if err != nil {
+			return nil, false,
+				fmt.Errorf("error merging invariant experiment configs: %w", err)
+		}
 	}
 
 	bytes, err := mergedConfig.Value()

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1465,20 +1465,20 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 	}
 	mergedConfig := schemas.Merge(providedConfig, activeConfig)
 	if overrideName := mergedConfig.Searcher().AsLegacy().Name; isSingle && overrideName != "single" {
-		return nil, false, status.Errorf(codes.InvalidArgument,
+		return nil, false, status.Errorf(codes.Internal,
 			fmt.Sprintf("override config must have single searcher type got '%s' instead", overrideName))
 	}
 
 	// Determine which workspace the experiment is in.
 	wkspName := activeConfig.Workspace()
 	if wkspName == "" {
-		wkspName = "Uncategorized"
+		wkspName = model.DefaultWorkspaceName
 	}
 	ctx := context.TODO()
 	w, err := workspace.WorkspaceByName(ctx, wkspName)
 	if err != nil {
-		return nil, false,
-			fmt.Errorf("error getting workspace %s: %w", activeConfig.Workspace(), err)
+		return nil, false, status.Errorf(codes.Internal,
+			fmt.Sprintf("failed to get workspace %s", activeConfig.Workspace()))
 	}
 	// Merge the config with the optionally specified invariant config specified by task config
 	// policies.
@@ -1486,7 +1486,7 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 		w.ID, mergedConfig)
 	if err != nil {
 		return nil, false,
-			fmt.Errorf("error merging invariant experiment configs: %w", err)
+			fmt.Errorf("failed to merge invariant experiment configs: %w", err)
 	}
 	mergedConfig = *configWithInvariantDefaults
 

--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1469,20 +1469,26 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 			fmt.Sprintf("override config must have single searcher type got '%s' instead", overrideName))
 	}
 
+	// Determine which workspace the experiment is in.
+	wkspName := activeConfig.Workspace()
+	if wkspName == "" {
+		wkspName = "Uncategorized"
+	}
 	ctx := context.TODO()
-	w, err := workspace.WorkspaceByName(ctx, activeConfig.Workspace())
-	if err != nil && err != sql.ErrNoRows && err != db.ErrNotFound {
+	w, err := workspace.WorkspaceByName(ctx, wkspName)
+	if err != nil {
 		return nil, false,
 			fmt.Errorf("error getting workspace %s: %w", activeConfig.Workspace(), err)
-	} else if w != nil {
-		// Merge the config with the optionally specified invariant config specified by task config
-		// policies.
-		err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, w.ID, &mergedConfig)
-		if err != nil {
-			return nil, false,
-				fmt.Errorf("error merging invariant experiment configs: %w", err)
-		}
 	}
+	// Merge the config with the optionally specified invariant config specified by task config
+	// policies.
+	configWithInvariantDefaults, err := configpolicy.MergeWithInvariantExperimentConfigs(ctx,
+		w.ID, mergedConfig)
+	if err != nil {
+		return nil, false,
+			fmt.Errorf("error merging invariant experiment configs: %w", err)
+	}
+	mergedConfig = *configWithInvariantDefaults
 
 	bytes, err := mergedConfig.Value()
 	if err != nil {

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -18,7 +18,15 @@ const (
 	wkspIDQuery       = "workspace_id = ?"
 	wkspIDGlobalQuery = "workspace_id IS ?"
 	// DefaultInvariantConfigStr is the default invariant config val used for tests.
-	DefaultInvariantConfigStr = `{"description": "random description", "resources": {"slots": 4, "max_slots": 8}}`
+	DefaultInvariantConfigStr = `{
+	"description": "random description", 
+	"resources": {"slots": 4, "max_slots": 8},
+	"log_policies": [
+		{
+		  "pattern": "nonrepeat"
+		}
+	]
+	}`
 	// DefaultConstraintsStr is the default constraints val used for tests.
 	DefaultConstraintsStr = `{"priority_limit": 10, "resources": {"max_slots": 8}}`
 )

--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -572,12 +572,12 @@ func CreateMockTaskConfigPolicies(ctx context.Context, t *testing.T,
 	return &w, nil, ntscTCP
 }
 
-// DefaultInvaraintConfig has slots 4 and max_slots 8
+// DefaultInvaraintConfig has slots 4 and max_slots 8.
 func DefaultInvariantConfig() *string {
 	return ptrs.Ptr(DefaultInvariantConfigStr)
 }
 
-// DefaultConstraints has priority_limit 10 and max_slots 8
+// DefaultConstraints has priority_limit 10 and max_slots 8.
 func DefaultConstraints() *string {
 	return ptrs.Ptr(DefaultConstraintsStr)
 }

--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -572,10 +572,12 @@ func CreateMockTaskConfigPolicies(ctx context.Context, t *testing.T,
 	return &w, nil, ntscTCP
 }
 
+// DefaultInvaraintConfig has slots 4 and max_slots 8
 func DefaultInvariantConfig() *string {
 	return ptrs.Ptr(DefaultInvariantConfigStr)
 }
 
+// DefaultConstraints has priority_limit 10 and max_slots 8
 func DefaultConstraints() *string {
 	return ptrs.Ptr(DefaultConstraintsStr)
 }

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/labstack/gommon/log"
+
 	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
-	"github.com/labstack/gommon/log"
 )
 
 // ExperimentConfigPolicies is the invariant config and constraints for an experiment.

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -196,8 +196,9 @@ func MergeWithInvariantExperimentConfigs(ctx context.Context, workspaceID int,
 	if wkspOverride {
 		if globalOverride {
 			scope += "workspace and global"
+		} else {
+			scope += "workspace"
 		}
-		scope += "workspace"
 	} else if globalOverride {
 		scope += "global"
 	}

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -192,7 +192,7 @@ func MergeWithInvariantExperimentConfigs(ctx context.Context, workspaceID int,
 	}
 	if globalConfigPolicies.InvariantConfig != nil {
 		var tempConfig expconf.ExperimentConfigV0
-		err = json.Unmarshal([]byte(*globalConfigPolicies.InvariantConfig), &config)
+		err = json.Unmarshal([]byte(*globalConfigPolicies.InvariantConfig), &tempConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshaling global invariant config: %w", err)
 		}

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -526,14 +526,12 @@ func TestMergeWithInvariantExperimentConfigs(t *testing.T) {
 			expconf.ExperimentConfigV0{})
 		require.NoError(t, err)
 		require.Equal(t, wkspConfigNoDefaults, *conf)
-
 	})
 
 	t.Run("test invalid workspace id", func(t *testing.T) {
 		conf, err := MergeWithInvariantExperimentConfigs(context.Background(), -1, defaultConfig)
 		require.NoError(t, err)
 		require.Equal(t, defaultConfig, *conf)
-
 	})
 
 	testMergeSlicesAndMaps(t)
@@ -557,8 +555,8 @@ func testMergeSlicesAndMaps(t *testing.T) {
 		"slots": 5,
 		"devices": [
 		  {
-			"host_path": "random/path/wksp",
-			"container_path": "random/container/path/wksp",
+			"host_path": "random/path",
+			"container_path": "random/container/path",
 			"mode": "slow"
 		  }
 		]
@@ -566,8 +564,8 @@ func testMergeSlicesAndMaps(t *testing.T) {
 	  "preemption_timeout": 2000,
 	  "bind_mounts": [
 		{
-		  "host_path": "random/path/wksp",
-		  "container_path": "random/container/path/wksp",
+		  "host_path": "random/path",
+		  "container_path": "random/container/path",
 		  "read_only": true,
 		  "propagation": "cluster-wide"
 		}
@@ -604,15 +602,15 @@ func testMergeSlicesAndMaps(t *testing.T) {
 	  "resources": {
 		"devices": [
 		  {
-			"host_path": "random/path",
-			"container_path": "random/container/path",
+			"host_path": "random/path/wksp",
+			"container_path": "random/container/path/wksp",
 			"mode": "fast"
 		  } ]
 		}, 
 	  "bind_mounts": [
 		{
-		  "host_path": "random/path",
-		  "container_path": "random/container/path",
+		  "host_path": "random/path/wksp",
+		  "container_path": "random/container/path/wksp",
 		  "read_only": true,
 		  "propagation": "cluster-wide"
 		}
@@ -647,14 +645,14 @@ func testMergeSlicesAndMaps(t *testing.T) {
 	  "resources": {
 		"slots": 5,
 		"devices": [
-		  {
-			"host_path": "random/path",
-			"container_path": "random/container/path",
+		 {
+			"host_path": "random/path/wksp",
+			"container_path": "random/container/path/wksp",
 			"mode": "fast"
 		  },
 		  {
-			"host_path": "random/path/wksp",
-			"container_path": "random/container/path/wksp",
+			"host_path": "random/path",
+			"container_path": "random/container/path",
 			"mode": "slow"
 		  }
 		]
@@ -662,14 +660,14 @@ func testMergeSlicesAndMaps(t *testing.T) {
 	  "preemption_timeout": 2000,
 	  "bind_mounts": [
 		{
-		  "host_path": "random/path",
-		  "container_path": "random/container/path",
+		  "host_path": "random/path/wksp",
+		  "container_path": "random/container/path/wksp",
 		  "read_only": true,
 		  "propagation": "cluster-wide"
 		},
 		 {
-		  "host_path": "random/path/wksp",
-		  "container_path": "random/container/path/wksp",
+		  "host_path": "random/path",
+		  "container_path": "random/container/path",
 		  "read_only": true,
 		  "propagation": "cluster-wide"
 		}
@@ -707,6 +705,134 @@ func testMergeSlicesAndMaps(t *testing.T) {
 	  ]
 	}
 	`
+
+		globalPartialConfig := `{
+	  "raw_data": { "3" : "data point 3" },
+	  "resources": {
+		"devices": [
+		  {
+			"host_path": "random/path/global",
+			"container_path": "random/container/path/global",
+			"mode": "fast"
+		  } ]
+		}, 
+	  "bind_mounts": [
+		{
+		  "host_path": "random/path/global",
+		  "container_path": "random/container/path/global",
+		  "read_only": true,
+		  "propagation": "cluster-wide"
+		}
+	  ],
+	  "environment": {
+		"environment_variables": {
+		  "cpu": [
+			"cpu3:cpuval3"
+		  ],
+		  "proxy_ports": [
+			{
+			  "proxy_port": 10195,
+			  "proxy_tcp": true
+			}
+		  ]
+		}
+	  },
+	  "log_policies": [
+		{
+		  "pattern": "gloablrepeat"
+		}
+	  ]
+	}`
+
+		mergedGlobalConfig := `
+	{
+	  "raw_data": { 
+			  "1" : "data point 1",
+			 "2" : "data point 2",
+			 "3" : "data point 3"
+		},
+	  "description": "random description workspace",
+	  "resources": {
+		"slots": 5,
+		"devices": [
+		{
+			"host_path": "random/path/global",
+			"container_path": "random/container/path/global",
+			"mode": "fast"
+		  },
+		 {
+			"host_path": "random/path/wksp",
+			"container_path": "random/container/path/wksp",
+			"mode": "fast"
+		  },
+		  {
+			"host_path": "random/path",
+			"container_path": "random/container/path",
+			"mode": "slow"
+		  }
+		]
+	  },
+	  "preemption_timeout": 2000,
+	  "bind_mounts": [
+	   {
+		  "host_path": "random/path/global",
+		  "container_path": "random/container/path/global",
+		  "read_only": true,
+		  "propagation": "cluster-wide"
+		},
+		{
+		  "host_path": "random/path/wksp",
+		  "container_path": "random/container/path/wksp",
+		  "read_only": true,
+		  "propagation": "cluster-wide"
+		},
+		 {
+		  "host_path": "random/path",
+		  "container_path": "random/container/path",
+		  "read_only": true,
+		  "propagation": "cluster-wide"
+		}
+	  ],
+	  "environment": {
+		"environment_variables": {
+		  "cpu": [
+			"cpu1:cpuval1", "cpu2:cpuval2", "cpu3:cpuval3"
+		  ],
+		   "cuda": [
+			"cuda1:cudaval"
+		  ],
+		   "rocm": [
+			"rocm1:rocmval1"
+		  ],
+		  "proxy_ports": [
+			{
+			  "proxy_port": 9195,
+			  "proxy_tcp": true
+			},
+			{
+			  "proxy_port": 91950,
+			  "proxy_tcp": true
+			},
+			{
+			  "proxy_port": 10195,
+			  "proxy_tcp": true
+			}
+		  ]
+		}
+	  },
+	  "log_policies": [
+		{
+		  "pattern": "nonrepeat"
+		},
+		{
+		  "pattern": "repeat"    
+		},
+		{
+		  "pattern": "gloablrepeat"
+		}
+	  ]
+	}
+	`
 		var adminPartialInvariantConfig expconf.ExperimentConfigV0
 		err := json.Unmarshal([]byte(adminPartialConfig), &adminPartialInvariantConfig)
 		require.NoError(t, err)
@@ -721,10 +847,11 @@ func testMergeSlicesAndMaps(t *testing.T) {
 		userPartialInvariantConfig.RawName = defaultConfig.RawName
 		userPartialInvariantConfig = schemas.WithDefaults(userPartialInvariantConfig)
 
-		var mergedInvariantConfig expconf.ExperimentConfigV0
-		err = json.Unmarshal([]byte(mergedWkspConfig), &mergedInvariantConfig)
+		var mergedWkspInvariantConfig expconf.ExperimentConfigV0
+		err = json.Unmarshal([]byte(mergedWkspConfig), &mergedWkspInvariantConfig)
 		require.NoError(t, err)
 
+		// Test merging user-submitted config with workspace config policies only.
 		setConfigPolicies(ctx, t, &w.ID, &model.TaskConfigPolicies{
 			WorkspaceID:     &w.ID,
 			WorkloadType:    model.ExperimentType,
@@ -732,13 +859,42 @@ func testMergeSlicesAndMaps(t *testing.T) {
 			InvariantConfig: &adminPartialConfig,
 		}, nil)
 
-		mergedInvariantConfig.RawName = adminPartialInvariantConfig.RawName
-		mergedInvariantConfig = schemas.WithDefaults(mergedInvariantConfig)
+		mergedWkspInvariantConfig.RawName = adminPartialInvariantConfig.RawName
+		mergedWkspInvariantConfig = schemas.WithDefaults(mergedWkspInvariantConfig)
 		res, err := MergeWithInvariantExperimentConfigs(context.Background(), w.ID,
 			userPartialInvariantConfig)
 
 		require.NoError(t, err)
-		require.EqualValues(t, mergedInvariantConfig, *res)
+		require.Equal(t, mergedWkspInvariantConfig, *res)
+
+		// Merge user-submitted config with workspace and global config policies.
+		setConfigPolicies(ctx, t, &w.ID, &model.TaskConfigPolicies{
+			WorkspaceID:     &w.ID,
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   w.UserID,
+			InvariantConfig: &adminPartialConfig,
+		}, &model.TaskConfigPolicies{
+			WorkspaceID:     nil,
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   w.UserID,
+			InvariantConfig: &globalPartialConfig,
+		})
+
+		var globalInvariantConfig expconf.ExperimentConfigV0
+		err = json.Unmarshal([]byte(globalPartialConfig), &globalInvariantConfig)
+		require.NoError(t, err)
+
+		var mergedGlobalInvariantConfig expconf.ExperimentConfigV0
+		err = json.Unmarshal([]byte(mergedGlobalConfig), &mergedGlobalInvariantConfig)
+		require.NoError(t, err)
+
+		mergedGlobalInvariantConfig.RawName = defaultConfig.RawName
+		mergedGlobalInvariantConfig = schemas.WithDefaults(mergedGlobalInvariantConfig)
+		res, err = MergeWithInvariantExperimentConfigs(context.Background(), w.ID,
+			userPartialInvariantConfig)
+
+		require.NoError(t, err)
+		require.Equal(t, mergedGlobalInvariantConfig, *res)
 	})
 }
 

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -358,12 +358,14 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 
 	// Merge the config with the optionally specified invariant config specified by task config
 	// policies.
-	err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, workspaceID, &config)
+	configWithInvariantOverrides, err := configpolicy.MergeWithInvariantExperimentConfigs(ctx,
+		workspaceID, config)
 	if err != nil {
 		return nil, nil, config, nil, nil,
 			fmt.Errorf("error merging invariant experiment configs: %w", err)
 	}
 
+	config = *configWithInvariantOverrides
 	// Disallow EOL searchers.
 	if err = config.Searcher().AssertCurrent(); err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/authz"
 	"github.com/determined-ai/determined/master/internal/checkpoints"
+	"github.com/determined-ai/determined/master/internal/configpolicy"
 	detContext "github.com/determined-ai/determined/master/internal/context"
 	"github.com/determined-ai/determined/master/internal/db"
 	expauth "github.com/determined-ai/determined/master/internal/experiment"
@@ -227,6 +228,7 @@ func getCreateExperimentsProject(
 	m *Master, req *apiv1.CreateExperimentRequest, user *model.User, config expconf.ExperimentConfig,
 ) (*projectv1.Project, error) {
 	// Place experiment in Uncategorized, unless project set in request params or config.
+	// Request params supersede the project specified in the config.
 	var err error
 	projectID := model.DefaultProjectID
 	errProjectNotFound := api.NotFoundErrs("project", strconv.Itoa(projectID), true)
@@ -263,7 +265,8 @@ func getCreateExperimentsProject(
 	return p, nil
 }
 
-func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExperimentRequest, owner *model.User) (
+func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExperimentRequest,
+	owner *model.User) (
 	*model.Experiment, []byte, expconf.ExperimentConfig, *projectv1.Project, *tasks.TaskSpec, error,
 ) {
 	// Read the config as the user provided it.
@@ -271,6 +274,7 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	if err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
 	}
+
 	if config.RawResources != nil && config.RawResources.Slots() != nil {
 		return nil, nil, config, nil, nil, fmt.Errorf("<config>.resources: additionalProperties \"slots\" not allowed")
 	}
@@ -350,6 +354,14 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	// Make sure the experiment config has all eventuallyRequired fields.
 	if err = schemas.IsComplete(config); err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
+	}
+
+	// Merge the config with the optionally specified invariant config specified by task config
+	// policies.
+	err = configpolicy.MergeWithInvariantExperimentConfigs(ctx, workspaceID, &config)
+	if err != nil {
+		return nil, nil, config, nil, nil,
+			fmt.Errorf("error merging invariant experiment configs: %w", err)
 	}
 
 	// Disallow EOL searchers.


### PR DESCRIPTION
## Ticket
[CM-494]


## Description
Implement experiment invariant config silent override when adding or updating an experiment.



## Test Plan
CI passes (automated testing).


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-494]: https://hpe-aiatscale.atlassian.net/browse/CM-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ