### PR TITLE
docs: add k8s RP example to the helm `values.yaml`.

### DIFF
--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -374,6 +374,35 @@ telemetry:
 ## Configure the resource pools in the Determined cluster.
 resourcePools:
   - pool_name: default
+## To set up multiple resource pools for Determined on your Kubernetes cluster
+## with custom pod spec or node selectors:
+# resourcePools:
+#   - pool_name: prod_pool
+#     kubernetes_namespace: default
+#     task_container_defaults:
+#       gpu_pod_spec:
+#         apiVersion: v1
+#         kind: Pod
+#         spec:
+#           tolerations:
+#             - key: "pool_taint"
+#               operator: "Equal"
+#               value: "prod"
+#               effect: "NoSchedule"
+#             affinity:
+#             # Define an example node selector label.
+#                nodeSelectorTerms:
+#                   kubernetes.io/hostname: "foo"
+#             # Define an example node affinity.
+#                nodeAffinity:
+#                requiredDuringSchedulingIgnoredDuringExecution:
+#                   nodeSelectorTerms:
+#                      - matchExpressions:
+#                      - key: topology.kubernetes.io/zone
+#                         operator: In
+#                         values:
+#                         - antarctica-west1
+#                         - antarctica-east1
 # defaultAuxResourcePool: default
 # defaultComputeResourcePool: default
 


### PR DESCRIPTION
## Description

helm chart was missing an example from the docs on how to configure multiple resource pools.

https://determined-community.slack.com/archives/CV3MTNZ6U/p1728335445008509

## Test Plan

n/a


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
