### PR TITLE
chore: wait_for_task_state shows logs on failure

### DIFF
--- a/e2e_tests/tests/cluster/test_agent_disable.py
+++ b/e2e_tests/tests/cluster/test_agent_disable.py
@@ -85,7 +85,6 @@ def test_disable_agent_experiment_resume() -> None:
     assert len(slots) == 1
     agent_id = slots[0]["agent_id"]
 
-    # Make the experiment preemptible.
     exp_ref = noop.create_experiment(sess, [noop.Sleep(100)], config={"max_restarts": 0})
     exp.wait_for_experiment_state(
         sess,

--- a/e2e_tests/tests/cluster/utils.py
+++ b/e2e_tests/tests/cluster/utils.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import http.server
-import subprocess
+import sys
 import threading
 import time
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -179,7 +179,9 @@ def wait_for_task_state(
             return
         time.sleep(1)
 
-    print(subprocess.check_output(["det", "-m", conf.make_master_url(), "task", "logs", task_id]))
+    print("== begin task logs ==", file=sys.stderr)
+    print(detproc.check_output(sess, ["det", "task", "logs", task_id]), file=sys.stderr)
+    print("== end task logs ==", file=sys.stderr)
     pytest.fail(f"{task_type} expected {state} state got {gotten_state} instead after {ticks} secs")
 
 


### PR DESCRIPTION
Before, it wasn't using the session to fetch logs.