### PR TITLE
docs: revise postgres permission setup instructions.

### DIFF
--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -123,7 +123,8 @@ Install PostgreSQL using ``apt`` or ``yum``
       postgres=# CREATE DATABASE determined;
       postgres=# CREATE USER determined WITH ENCRYPTED PASSWORD 'determined-password';
       postgres=# GRANT ALL PRIVILEGES ON DATABASE determined TO determined;
-      postgres=# GRANT ALL ON SCHEMA public TO determined;
+      postgres=# \c determined
+      determined=> GRANT ALL ON SCHEMA public TO determined;
 
 ************
  Next Steps

--- a/docs/setup-cluster/checklists/postgresql.rst
+++ b/docs/setup-cluster/checklists/postgresql.rst
@@ -123,6 +123,7 @@ Install PostgreSQL using ``apt`` or ``yum``
       postgres=# CREATE DATABASE determined;
       postgres=# CREATE USER determined WITH ENCRYPTED PASSWORD 'determined-password';
       postgres=# GRANT ALL PRIVILEGES ON DATABASE determined TO determined;
+      postgres=# GRANT ALL ON SCHEMA public TO determined;
 
 ************
  Next Steps

--- a/docs/setup-cluster/on-prem/options/linux-packages.rst
+++ b/docs/setup-cluster/on-prem/options/linux-packages.rst
@@ -113,7 +113,8 @@ Install PostgreSQL using ``apt`` or ``yum``
       postgres=# CREATE DATABASE determined;
       postgres=# CREATE USER determined WITH ENCRYPTED PASSWORD 'determined-password';
       postgres=# GRANT ALL PRIVILEGES ON DATABASE determined TO determined;
-      postgres=# GRANT ALL ON SCHEMA public TO determined;
+      postgres=# \c determined
+      determined=> GRANT ALL ON SCHEMA public TO determined;
 
 Install the Determined Master and Agent
 =======================================

--- a/docs/setup-cluster/on-prem/options/linux-packages.rst
+++ b/docs/setup-cluster/on-prem/options/linux-packages.rst
@@ -113,6 +113,7 @@ Install PostgreSQL using ``apt`` or ``yum``
       postgres=# CREATE DATABASE determined;
       postgres=# CREATE USER determined WITH ENCRYPTED PASSWORD 'determined-password';
       postgres=# GRANT ALL PRIVILEGES ON DATABASE determined TO determined;
+      postgres=# GRANT ALL ON SCHEMA public TO determined;
 
 Install the Determined Master and Agent
 =======================================


### PR DESCRIPTION
## Description

Since pg15, you need to explicitly grant access on public schema.
I remember some people hit the same issue in older postgres versions as well when using external/custom postgres installations with special permissions.

https://determined-community.slack.com/archives/CV3MTNZ6U/p1728583301953569?thread_ts=1728510027.402639&cid=CV3MTNZ6U

## Test Plan
N/A


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ