### PR TITLE
fix: apply config policy constraints to PATCH /experiments/:id

### DIFF
--- a/master/internal/experiment_job_service.go
+++ b/master/internal/experiment_job_service.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strconv"
 
@@ -10,9 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/determined-ai/determined/master/internal/config"
-	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/workspace"
-	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/jobv1"
 )
 
@@ -57,29 +54,7 @@ func (e *internalExperiment) SetJobPriority(priority int) error {
 		return fmt.Errorf("priority must be between 1 and 99")
 	}
 
-	workspaceModel, err := workspace.WorkspaceByProjectID(context.TODO(), e.ProjectID)
-	if err != nil && errors.Cause(err) != sql.ErrNoRows {
-		return err
-	}
-	wkspID := resolveWorkspaceID(workspaceModel)
-
-	// Returns an error if RM does not implement priority.
-	if smallerHigher, err := e.rm.SmallerValueIsHigherPriority(); err == nil {
-		ok, err := configpolicy.PriorityUpdateAllowed(
-			wkspID,
-			model.ExperimentType,
-			priority,
-			smallerHigher,
-		)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("priority exceeds task config policy's priority_limit")
-		}
-	}
-
-	err = e.setPriority(&priority, true)
+	err := e.setPriority(&priority, true)
 	if err != nil {
 		e.syslog.WithError(err).Info("setting experiment job priority")
 	}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
CM-564


## Description
Pushing this check down a level makes sure it applies for `PATCH /api/v1/experiments/:id` calls, too.


## Test Plan
TBD.
