### PR TITLE
feat: add metadata column type badge

### DIFF
--- a/webui/react/src/components/Searches/columns.ts
+++ b/webui/react/src/components/Searches/columns.ts
@@ -130,7 +130,6 @@ export const getColumnDefs = ({
   },
   checkpointCount: {
     id: 'checkpointCount',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       data: Number(record.experiment.checkpoints),
@@ -143,7 +142,6 @@ export const getColumnDefs = ({
   },
   checkpointSize: {
     id: 'checkpointSize',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) =>
       handleEmptyCell(record.experiment.checkpointSize, (data) => ({
         allowOverlay: false,
@@ -174,7 +172,6 @@ export const getColumnDefs = ({
   },
   duration: {
     id: 'duration',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) =>
       handleEmptyCell(record.experiment.duration, () => ({
         allowOverlay: false,
@@ -297,7 +294,6 @@ export const getColumnDefs = ({
   },
   numTrials: {
     id: 'numTrials',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       data: record.experiment.numTrials,
@@ -335,7 +331,6 @@ export const getColumnDefs = ({
   },
   searcherMetric: {
     id: 'searcherMetric',
-    isNumerical: false,
     renderer: (record: ExperimentWithTrial) =>
       handleEmptyCell(record.experiment.searcherMetric, (data) => ({
         allowOverlay: false,
@@ -361,7 +356,6 @@ export const getColumnDefs = ({
   },
   startTime: {
     id: 'startTime',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: getTimeInEnglish(new Date(record.experiment.startTime)),
@@ -440,7 +434,6 @@ export const getColumnDefs = ({
 export const searcherMetricsValColumn = (columnWidth?: number): ColumnDef<ExperimentWithTrial> => {
   return {
     id: 'searcherMetricsVal',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) =>
       handleEmptyCell(record.bestTrial?.searcherMetricsVal, (data) => ({
         allowOverlay: false,

--- a/webui/react/src/pages/F_ExpList/expListColumns.ts
+++ b/webui/react/src/pages/F_ExpList/expListColumns.ts
@@ -136,7 +136,6 @@ export const getColumnDefs = ({
   },
   checkpointCount: {
     id: 'checkpointCount',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       data: Number(record.experiment.checkpoints),
@@ -149,7 +148,6 @@ export const getColumnDefs = ({
   },
   checkpointSize: {
     id: 'checkpointSize',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: record.experiment.checkpointSize
@@ -176,7 +174,6 @@ export const getColumnDefs = ({
   },
   duration: {
     id: 'duration',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: getDurationInEnglish(record.experiment),
@@ -305,7 +302,6 @@ export const getColumnDefs = ({
   },
   numTrials: {
     id: 'numTrials',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       data: record.experiment.numTrials,
@@ -346,7 +342,6 @@ export const getColumnDefs = ({
   },
   searcherMetric: {
     id: 'searcherMetric',
-    isNumerical: false,
     renderer: (record: ExperimentWithTrial) => {
       const sMetric = record.experiment.searcherMetric ?? '';
       return {
@@ -374,7 +369,6 @@ export const getColumnDefs = ({
   },
   startTime: {
     id: 'startTime',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => ({
       allowOverlay: false,
       copyData: getTimeInEnglish(new Date(record.experiment.startTime)),
@@ -456,7 +450,6 @@ export const searcherMetricsValColumn = (
 ): ColumnDef<ExperimentWithTrial> => {
   return {
     id: 'searcherMetricsVal',
-    isNumerical: true,
     renderer: (record: ExperimentWithTrial) => {
       const sMetricValue = record.bestTrial?.searcherMetricsVal;
 

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -75,6 +75,7 @@ import userSettings from 'stores/userSettings';
 import { DetailedUser, FlatRun, FlatRunAction, ProjectColumn, RunState } from 'types';
 import handleError from 'utils/error';
 import { combine } from 'utils/filterFormSet';
+import { formatColumnKey } from 'utils/flatRun';
 import { eagerSubscribe } from 'utils/observable';
 import { pluralizer } from 'utils/string';
 
@@ -295,7 +296,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
     const projectColumnsMap: Loadable<Record<string, ProjectColumn>> = Loadable.map(
       projectColumns,
       (columns) => {
-        return columns.reduce((acc, col) => ({ ...acc, [col.column]: col }), {});
+        return columns.reduce((acc, col) => ({ ...acc, [formatColumnKey(col)]: col }), {});
       },
     );
     const columnDefs = getColumnDefs({
@@ -333,6 +334,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
           };
 
         let dataPath: string | undefined = undefined;
+        const columnDefKey = formatColumnKey(currentColumn);
         switch (currentColumn.location) {
           case V1LocationType.EXPERIMENT:
             dataPath = `experiment.${currentColumn.column}`;
@@ -373,11 +375,11 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
               settings.heatmapOn &&
               !settings.heatmapSkipped.includes(currentColumn.column)
             ) {
-              columnDefs[currentColumn.column] = defaultNumberColumn(
-                currentColumn.column,
+              columnDefs[columnDefKey] = defaultNumberColumn(
+                columnDefKey,
                 currentColumn.displayName || currentColumn.column,
-                settings.columnWidths[currentColumn.column] ??
-                  defaultColumnWidths[currentColumn.column as RunColumn] ??
+                settings.columnWidths[columnDefKey] ??
+                  defaultColumnWidths[columnDefKey as RunColumn] ??
                   MIN_COLUMN_WIDTH,
                 dataPath,
                 {
@@ -386,33 +388,34 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
                 },
               );
             } else {
-              columnDefs[currentColumn.column] = defaultNumberColumn(
-                currentColumn.column,
+              columnDefs[columnDefKey] = defaultNumberColumn(
+                columnDefKey,
                 currentColumn.displayName || currentColumn.column,
-                settings.columnWidths[currentColumn.column] ??
-                  defaultColumnWidths[currentColumn.column as RunColumn] ??
+                settings.columnWidths[columnDefKey] ??
+                  defaultColumnWidths[columnDefKey as RunColumn] ??
                   MIN_COLUMN_WIDTH,
                 dataPath,
+                undefined,
               );
             }
             break;
           }
           case V1ColumnType.DATE:
-            columnDefs[currentColumn.column] = defaultDateColumn(
-              currentColumn.column,
+            columnDefs[columnDefKey] = defaultDateColumn(
+              columnDefKey,
               currentColumn.displayName || currentColumn.column,
-              settings.columnWidths[currentColumn.column] ??
-                defaultColumnWidths[currentColumn.column as RunColumn] ??
+              settings.columnWidths[columnDefKey] ??
+                defaultColumnWidths[columnDefKey as RunColumn] ??
                 MIN_COLUMN_WIDTH,
               dataPath,
             );
             break;
           case V1ColumnType.ARRAY:
-            columnDefs[currentColumn.column] = defaultArrayColumn(
-              currentColumn.column,
+            columnDefs[columnDefKey] = defaultArrayColumn(
+              columnDefKey,
               currentColumn.displayName || currentColumn.column,
-              settings.columnWidths[currentColumn.column] ??
-                defaultColumnWidths[currentColumn.column as RunColumn] ??
+              settings.columnWidths[columnDefKey] ??
+                defaultColumnWidths[columnDefKey as RunColumn] ??
                 MIN_COLUMN_WIDTH,
               dataPath,
             );
@@ -420,11 +423,11 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
           case V1ColumnType.TEXT:
           case V1ColumnType.UNSPECIFIED:
           default:
-            columnDefs[currentColumn.column] = defaultTextColumn(
-              currentColumn.column,
+            columnDefs[columnDefKey] = defaultTextColumn(
+              columnDefKey,
               currentColumn.displayName || currentColumn.column,
-              settings.columnWidths[currentColumn.column] ??
-                defaultColumnWidths[currentColumn.column as RunColumn] ??
+              settings.columnWidths[columnDefKey] ??
+                defaultColumnWidths[columnDefKey as RunColumn] ??
                 MIN_COLUMN_WIDTH,
               dataPath,
             );
@@ -434,7 +437,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             .getOrElse([])
             .find((h) => h.metricsName === currentColumn.column);
 
-          columnDefs[currentColumn.column] = searcherMetricsValColumn(
+          columnDefs[columnDefKey] = searcherMetricsValColumn(
             settings.columnWidths[currentColumn.column],
             heatmap && settings.heatmapOn && !settings.heatmapSkipped.includes(currentColumn.column)
               ? {
@@ -444,7 +447,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
               : undefined,
           );
         }
-        return columnDefs[currentColumn.column];
+        return columnDefs[columnDefKey];
       })
       .flatMap((col) => (col ? [col] : []));
     return gridColumns;

--- a/webui/react/src/pages/FlatRuns/columns.ts
+++ b/webui/react/src/pages/FlatRuns/columns.ts
@@ -127,7 +127,6 @@ export const getColumnDefs = ({
   },
   checkpointCount: {
     id: 'checkpointCount',
-    isNumerical: true,
     renderer: (record: FlatRun) => ({
       allowOverlay: false,
       data: Number(record.checkpointCount),
@@ -140,7 +139,6 @@ export const getColumnDefs = ({
   },
   checkpointSize: {
     id: 'checkpointSize',
-    isNumerical: true,
     renderer: (record: FlatRun) => ({
       allowOverlay: false,
       copyData: humanReadableBytes(record.checkpointSize),
@@ -153,7 +151,6 @@ export const getColumnDefs = ({
   },
   duration: {
     id: 'duration',
-    isNumerical: true,
     renderer: (record: FlatRun) =>
       handleEmptyCell(record.duration, (data) => ({
         allowOverlay: false,
@@ -394,7 +391,6 @@ export const getColumnDefs = ({
   },
   searcherMetric: {
     id: 'searcherMetric',
-    isNumerical: false,
     renderer: (record: FlatRun) =>
       handleEmptyCell(record.experiment?.searcherMetric, (data) => ({
         allowOverlay: false,
@@ -421,7 +417,6 @@ export const getColumnDefs = ({
   },
   startTime: {
     id: 'startTime',
-    isNumerical: true,
     renderer: (record: FlatRun) => ({
       allowOverlay: false,
       copyData: getTimeInEnglish(new Date(record.startTime)),
@@ -505,7 +500,6 @@ export const searcherMetricsValColumn = (
 ): ColumnDef<FlatRun> => {
   return {
     id: 'searcherMetricsVal',
-    isNumerical: true,
     renderer: (record: FlatRun) => {
       const sMetricValue = record.searcherMetricValue;
 

--- a/webui/react/src/utils/flatRun.ts
+++ b/webui/react/src/utils/flatRun.ts
@@ -6,7 +6,8 @@ import {
   terminalRunStates,
 } from 'constants/states';
 import { PermissionsHook } from 'hooks/usePermissions';
-import { FlatRun, FlatRunAction, RunState, SelectionType } from 'types';
+import { V1ColumnType, V1LocationType } from 'services/api-ts-sdk';
+import { FlatRun, FlatRunAction, ProjectColumn, RunState, SelectionType } from 'types';
 
 import { combine } from './filterFormSet';
 
@@ -115,4 +116,17 @@ export const getIdsFilter = (
     ...filterFormSet,
     filterGroup,
   };
+};
+
+export const removeColumnTypePrefix = (columnName: V1ColumnType): string => {
+  return columnName.replace('COLUMN_TYPE_', '');
+};
+
+/// wanna know why this separator is used? see https://hpe-aiatscale.atlassian.net/browse/ET-785
+export const METADATA_SEPARATOR = '\u241F' as const; // TODO: unify after merging PR 10052
+
+export const formatColumnKey = (col: ProjectColumn, required = false): string => {
+  if (required || col.location === V1LocationType.RUNMETADATA)
+    return `${col.type}${METADATA_SEPARATOR}${col.column}`;
+  return col.column;
 };


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->

[ET-791](https://hpe-aiatscale.atlassian.net/browse/ET-791)



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Right now, if we have multiple metadata columns with the same name, there's no quick way of knowing of which type each one is while selecting it. This PR intends to add a descriptive badge next to duplicate entries for the metadata columns.



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

- make sure that you have at least one metadata column that is duplicated and of a different type
- go to a experiment list
  - make sure that the grid visualization is enabled
- open the column picker
- verify that the duplicates has a `<column_name> <column_type_tag>` format

<img width="1480" alt="Screenshot 2024-10-14 at 16 58 13" src="https://github.com/user-attachments/assets/94b28e84-718b-400b-a587-cf839c4c0577">

<img width="1481" alt="Screenshot 2024-10-14 at 16 59 27" src="https://github.com/user-attachments/assets/8a003186-8649-4b67-abd4-3f914474689e">

![Screenshot 2024-10-21 at 11 12 49](https://github.com/user-attachments/assets/02a0f643-1e8c-41ee-bb04-0710373755fa)

![Screenshot 2024-10-21 at 11 12 42](https://github.com/user-attachments/assets/1d417d54-6010-4d67-bc4a-d879e9b5a5ff)

![Screenshot 2024-10-21 at 11 13 43](https://github.com/user-attachments/assets/7e33d63a-116a-47dc-98e1-ef2622845b36)

![Screenshot 2024-10-18 at 17 44 26](https://github.com/user-attachments/assets/e398c1d5-300c-4761-992e-0e64a89a887c)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-790]: https://hpe-aiatscale.atlassian.net/browse/ET-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ET-791]: https://hpe-aiatscale.atlassian.net/browse/ET-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ