### PR TITLE
chore: experiment config slots to comply with constraint max slots

### DIFF
--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -861,7 +861,7 @@ invariant_config:
 		// Additional NTSC combinatory tests (YAML).
 		{
 			"YAML NTSC valid config valid constraints", model.NTSCType,
-			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, fmt.Errorf("invalid ntsc config policy"),
+			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, nil,
 		},
 		{
 			"YAML NTSC valid constraints invalid constraints", model.NTSCType,
@@ -1192,8 +1192,8 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 
 		// Additional NTSC combinatory tests (JSON).
 		{
-			"JSON NTSC valid config invalid constraints", model.NTSCType,
-			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", fmt.Errorf("invalid ntsc config policy"),
+			"JSON NTSC valid config valid constraints", model.NTSCType,
+			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", nil,
 		},
 		{
 			"JSON NTSC valid constraints invalid constraints", model.NTSCType,

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -88,10 +88,15 @@ func CheckExperimentConstraints(
 
 	if constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
 		// users cannot specify number of slots for an experiment
-		slotsRequest := *constraints.ResourceConstraints.MaxSlots
-		if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots, slotsRequest,
-			workloadConfig.Resources().MaxSlots()); err != nil {
-			return err
+		if workloadConfig.RawResources != nil {
+			slotsRequest := workloadConfig.RawResources.RawSlotsPerTrial
+			if slotsRequest != nil {
+				if err = checkSlotsConstraint(*constraints.ResourceConstraints.MaxSlots,
+					*slotsRequest,
+					workloadConfig.Resources().MaxSlots()); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -159,9 +159,9 @@ func checkConstraintConflicts(constraints *model.Constraints, maxSlots, slots, p
 	if maxSlots != nil && *constraints.ResourceConstraints.MaxSlots != *maxSlots {
 		return fmt.Errorf("invariant config & constraints are trying to set the max slots")
 	}
-	if slots != nil && *constraints.ResourceConstraints.MaxSlots > *slots {
-		return fmt.Errorf("invariant config & constraints are attempting to set an invalid max slot123: %v vs %v",
-			*constraints.ResourceConstraints.MaxSlots, *slots)
+	if slots != nil && *constraints.ResourceConstraints.MaxSlots < *slots {
+		return fmt.Errorf("invariant config has %v slots per trial. violates constraints max slots of %v",
+			*slots, *constraints.ResourceConstraints.MaxSlots)
 	}
 
 	return nil


### PR DESCRIPTION
## Ticket

[CM-569]



## Description
Experiment config slots to comply with constraint max slots. 


## Test Plan
CI Passes.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-569]: https://hpe-aiatscale.atlassian.net/browse/CM-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ