### PR TITLE
chore: ntsc config not supported

### DIFF
--- a/e2e_tests/tests/cluster/test_config_policies.py
+++ b/e2e_tests/tests/cluster/test_config_policies.py
@@ -37,22 +37,22 @@ def test_set_config_policies() -> None:
     print(data)
     assert data.rstrip() == stdout.rstrip()
 
-    # valid path with ntsc type
+    # valid path with experiment type
     stdout = detproc.check_output(
         sess,
         [
             "det",
             "config-policies",
             "set",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/ntscvalid.yaml"),
+            conf.fixtures_path("config_policies/valid.yaml"),
         ],
     )
 
-    with open(conf.fixtures_path("config_policies/ntscvalid.yaml"), "r") as f:
+    with open(conf.fixtures_path("config_policies/valid.yaml"), "r") as f:
         data = f.read()
     assert data.rstrip() == stdout.rstrip()
 
@@ -79,7 +79,7 @@ def test_set_config_policies() -> None:
             "det",
             "config-policies",
             "set",
-            "ntsc",
+            "experiment",
             "--config-file",
             conf.fixtures_path("config_policies/valid.yaml"),
         ],
@@ -93,7 +93,7 @@ def test_set_config_policies() -> None:
             "det",
             "config-policies",
             "set",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
         ],
@@ -116,11 +116,11 @@ def test_describe_config_policies() -> None:
             "det",
             "config-policies",
             "set",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/ntscvalid.yaml"),
+            conf.fixtures_path("config_policies/valid.yaml"),
         ],
     )
 
@@ -131,12 +131,12 @@ def test_describe_config_policies() -> None:
             "det",
             "config-policies",
             "describe",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
         ],
     )
-    with open(conf.fixtures_path("config_policies/ntscvalid.yaml"), "r") as f:
+    with open(conf.fixtures_path("config_policies/valid.yaml"), "r") as f:
         data = f.read()
     assert data.rstrip() == stdout.rstrip()
 
@@ -147,7 +147,7 @@ def test_describe_config_policies() -> None:
             "det",
             "config-policies",
             "describe",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
             "--yaml",
@@ -164,7 +164,7 @@ def test_describe_config_policies() -> None:
             "det",
             "config-policies",
             "describe",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
             "--json",
@@ -183,7 +183,7 @@ def test_describe_config_policies() -> None:
             "det",
             "config-policies",
             "describe",
-            "ntsc",
+            "experiment",
         ],
         "the following arguments are required: --workspace",
     )
@@ -204,11 +204,11 @@ def test_delete_config_policies() -> None:
             "det",
             "config-policies",
             "set",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/ntscvalid.yaml"),
+            conf.fixtures_path("config_policies/valid.yaml"),
         ],
     )
 
@@ -218,7 +218,7 @@ def test_delete_config_policies() -> None:
             "det",
             "config-policies",
             "delete",
-            "ntsc",
+            "experiment",
             "--workspace",
             workspace_name,
         ],
@@ -232,7 +232,7 @@ def test_delete_config_policies() -> None:
             "det",
             "config-policies",
             "delete",
-            "ntsc",
+            "experiment",
         ],
         "the following arguments are required: --workspace",
     )

--- a/e2e_tests/tests/cluster/test_config_policies.py
+++ b/e2e_tests/tests/cluster/test_config_policies.py
@@ -52,7 +52,7 @@ def test_set_config_policies() -> None:
         ],
     )
 
-    with open(conf.fixtures_path("config_policies/valid.yaml"), "r") as f:
+    with open(conf.fixtures_path("config_policies/ntscvalid.yaml"), "r") as f:
         data = f.read()
     assert data.rstrip() == stdout.rstrip()
 
@@ -136,7 +136,7 @@ def test_describe_config_policies() -> None:
             workspace_name,
         ],
     )
-    with open(conf.fixtures_path("config_policies/valid.yaml"), "r") as f:
+    with open(conf.fixtures_path("config_policies/ntscvalid.yaml"), "r") as f:
         data = f.read()
     assert data.rstrip() == stdout.rstrip()
 

--- a/e2e_tests/tests/cluster/test_config_policies.py
+++ b/e2e_tests/tests/cluster/test_config_policies.py
@@ -48,7 +48,7 @@ def test_set_config_policies() -> None:
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/valid.yaml"),
+            conf.fixtures_path("config_policies/ntscvalid.yaml"),
         ],
     )
 
@@ -120,7 +120,7 @@ def test_describe_config_policies() -> None:
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/valid.yaml"),
+            conf.fixtures_path("config_policies/ntscvalid.yaml"),
         ],
     )
 
@@ -208,7 +208,7 @@ def test_delete_config_policies() -> None:
             "--workspace",
             workspace_name,
             "--config-file",
-            conf.fixtures_path("config_policies/valid.yaml"),
+            conf.fixtures_path("config_policies/ntscvalid.yaml"),
         ],
     )
 

--- a/e2e_tests/tests/fixtures/config_policies/ntscvalid.yaml
+++ b/e2e_tests/tests/fixtures/config_policies/ntscvalid.yaml
@@ -1,4 +1,0 @@
-constraints:
-  priority_limit: 10
-  resources:
-    max_slots: 4

--- a/e2e_tests/tests/fixtures/config_policies/ntscvalid.yaml
+++ b/e2e_tests/tests/fixtures/config_policies/ntscvalid.yaml
@@ -1,0 +1,4 @@
+constraints:
+  priority_limit: 10
+  resources:
+    max_slots: 4

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -950,8 +950,10 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 		}
 	}`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
-		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}",
-			fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr)},
+		{
+			"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}",
+			fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
+		},
 
 		// Invalid experiment invariant config policies (JSON).
 		{

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -564,7 +564,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkloadType:   model.NTSCType,
 			ConfigPolicies: validNTSCConfigPolicyYAML,
 		})
-	require.NoError(t, err)
+	require.Error(t, err)
 }
 
 var cpAuthZ *mocks.ConfigPolicyAuthZ
@@ -623,7 +623,7 @@ invariant_config:
 			`
 invariant_config:
   description: "test\nspecial\tchar"
-`, nil,
+`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 		{
 			"YAML simple NTSC config with resources", model.NTSCType,
@@ -631,10 +631,11 @@ invariant_config:
 invariant_config:
   resources:
     slots: 1
-`, nil,
+`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 		{
-			"YAML partial NTSC config", model.NTSCType, validNTSCConfigPolicyYAML, nil,
+			"YAML partial NTSC config", model.NTSCType, validNTSCConfigPolicyYAML,
+			fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 
 		// Invalid experiment invariant config policies (YAML).
@@ -861,7 +862,7 @@ invariant_config:
 		// Additional NTSC combinatory tests (YAML).
 		{
 			"YAML NTSC valid config valid constraints", model.NTSCType,
-			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, fmt.Errorf("invalid ntsc config policy"),
+			validNTSCConfigPolicyYAML + validConstraintsPolicyYAML, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 		{
 			"YAML NTSC valid constraints invalid constraints", model.NTSCType,
@@ -938,7 +939,7 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 			`{ "invariant_config": {
 		"description": "test\nspecial\tchar"
 		}
-	}`, nil,
+	}`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 		{
 			"JSON simple NTSC config with resources", model.NTSCType,
@@ -947,7 +948,7 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 				"slots": 1
 			}
 		}
-	}`, nil,
+	}`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
 		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", nil},
 

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -950,7 +950,8 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 		}
 	}`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
-		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr)},
+		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}",
+			fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr)},
 
 		// Invalid experiment invariant config policies (JSON).
 		{

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -950,7 +950,7 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 		}
 	}`, fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr),
 		},
-		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", nil},
+		{"JSON partial NTSC config", model.NTSCType, "{" + validNTSCConfigPolicyJSON + "}", fmt.Errorf(configpolicy.NotSupportedConfigPolicyErr)},
 
 		// Invalid experiment invariant config policies (JSON).
 		{
@@ -1194,7 +1194,7 @@ func TestValidatePoliciesAndWorkloadTypeJSON(t *testing.T) {
 		// Additional NTSC combinatory tests (JSON).
 		{
 			"JSON NTSC valid config invalid constraints", model.NTSCType,
-			"{" + validNTSCConfigPolicyJSON + "," + validConstraintsPolicyJSON + "}", fmt.Errorf("invalid ntsc config policy"),
+			"{" + validConstraintsPolicyJSON + "}", nil,
 		},
 		{
 			"JSON NTSC valid constraints invalid constraints", model.NTSCType,

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -24,7 +24,8 @@ const (
 	// InvalidExperimentConfigPolicyErr is the error reported by an invalid experiment config policy.
 	InvalidExperimentConfigPolicyErr = "invalid experiment config policy"
 	// InvalidNTSCConfigPolicyErr is the error reported by an invalid NTSC config policy.
-	InvalidNTSCConfigPolicyErr = "invalid ntsc config policy"
+	InvalidNTSCConfigPolicyErr  = "invalid ntsc config policy"
+	NotSupportedConfigPolicyErr = "not supported"
 )
 
 // ConfigPolicyWarning logs a warning for the configuration policy component.
@@ -114,8 +115,9 @@ func ValidateNTSCConfig(
 		return err // Handle error for nil cp or unmarshalling error.
 	}
 	if cp.InvariantConfig != nil {
-		return fmt.Errorf(`not supported: invariant config policies for tasks is not yet supported, 
-		please remove "invariant_config" section and try again`)
+		msg := `invariant config policies for tasks is not yet supported, 
+		  please remove "invariant_config" section and try again`
+		return status.Errorf(codes.InvalidArgument, fmt.Sprintf(NotSupportedConfigPolicyErr+": %s.", msg))
 	}
 	if globalConfigPolicies != nil {
 		checkAgainstGlobalConfig[model.Constraints](globalConfigPolicies.Constraints, cp.Constraints, "invalid constraints")

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -114,7 +114,8 @@ func ValidateNTSCConfig(
 		return err // Handle error for nil cp or unmarshalling error.
 	}
 	if cp.InvariantConfig != nil {
-		return fmt.Errorf("not supported: invariant config policies for tasks is not yet supported; please remove `invariant_config` section and try again")
+		return fmt.Errorf(`not supported: invariant config policies for tasks is not yet supported, 
+		please remove "invariant_config" section and try again`)
 	}
 	if globalConfigPolicies != nil {
 		checkAgainstGlobalConfig[model.Constraints](globalConfigPolicies.Constraints, cp.Constraints, "invalid constraints")

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -24,7 +24,8 @@ const (
 	// InvalidExperimentConfigPolicyErr is the error reported by an invalid experiment config policy.
 	InvalidExperimentConfigPolicyErr = "invalid experiment config policy"
 	// InvalidNTSCConfigPolicyErr is the error reported by an invalid NTSC config policy.
-	InvalidNTSCConfigPolicyErr  = "invalid ntsc config policy"
+	InvalidNTSCConfigPolicyErr = "invalid ntsc config policy"
+	// NotSupportedConfigPolicyErr is the error reported when admins attempt to set NTSC invariant config.
 	NotSupportedConfigPolicyErr = "not supported"
 )
 

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -172,8 +172,8 @@ func checkConstraintConflicts(constraints *model.Constraints, maxSlots, slots, p
 	}
 	if slots != nil && constraints.ResourceConstraints != nil && constraints.ResourceConstraints.MaxSlots != nil {
 		if *constraints.ResourceConstraints.MaxSlots < *slots {
-      return fmt.Errorf("invariant config has %v slots per trial. violates constraints max slots of %v",
-        *slots, *constraints.ResourceConstraints.MaxSlots)
+			return fmt.Errorf("invariant config has %v slots per trial. violates constraints max slots of %v",
+				*slots, *constraints.ResourceConstraints.MaxSlots)
 		}
 	}
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[CM-559]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Returns an error if admins set invariant config for NTSC. Also fixes some nil pointer issues and refines error message when there's a conflict between global and workspace config policies.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-559]: https://hpe-aiatscale.atlassian.net/browse/CM-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ