### PR TITLE
test: add experiment list test for stop row action

### DIFF
--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -322,6 +322,7 @@ test.describe('Experiment List', () => {
       await waitTableStable();
       await expect.soft((await row.getCellByColumnName('Name')).pwLocator).toHaveText(editedValue);
     });
+
     // await test.step('Stop', async () => {
     //   // what happens if the experiment is already stopped?
     // });
@@ -339,6 +340,39 @@ test.describe('Experiment List', () => {
     //   // await authedPage.waitForURL(;
     // });
     // await test.step('Hyperparameter Search', async () => {});
+  });
+
+  test('DataGrid Action Stop', async ({ testExperiments }) => {
+    const [expId] = await testExperiments(1, {
+      configFile: 'examples/tutorials/mnist_pytorch/adaptive.yaml',
+      paused: true,
+    });
+    await test.step('filter to experiment', async () => {
+      const tableFilter =
+        await projectDetailsPage.f_experimentList.tableActionBar.tableFilter.open();
+      await tableFilter.filterForm.filter.filterFields.columnName.selectMenuOption('ID');
+      await tableFilter.filterForm.filter.filterFields.operator.selectMenuOption('=');
+      await tableFilter.filterForm.filter.filterFields.valueNumber.pwLocator.fill(expId);
+
+      await expect(projectDetailsPage.f_experimentList.tableActionBar.count.pwLocator).toHaveText(
+        /^1 /,
+      );
+      await tableFilter.close();
+    });
+    await test.step('stop experiment', async () => {
+      const row = projectDetailsPage.f_experimentList.dataGrid.getRowByIndex(0);
+      await row.experimentActionDropdown.open();
+      await row.experimentActionDropdown.pwLocator.getByRole('menuitem', { name: 'Stop' }).click();
+      await expect((await row.getCellByColumnName('State')).pwLocator).toHaveText('canceled');
+    });
+    await test.step('stop menu item should be gone', async () => {
+      const row = projectDetailsPage.f_experimentList.dataGrid.getRowByIndex(0);
+      await row.experimentActionDropdown.open();
+      await expect(row.experimentActionDropdown.pwLocator).toBeVisible();
+      await expect(
+        row.experimentActionDropdown.pwLocator.getByRole('menuitem', { name: 'Stop' }),
+      ).toHaveCount(0);
+    });
   });
 
   test('DataGrid Action Pause', async () => {

--- a/webui/react/src/e2e/utils/detCLI.ts
+++ b/webui/react/src/e2e/utils/detCLI.ts
@@ -1,7 +1,10 @@
-import { execSync } from 'child_process';
+import { exec as execCallback, execSync } from 'child_process';
 import path from 'path';
+import { promisify } from 'util';
 
 import { detMasterURL, detPath, password, username } from './envVars';
+
+const exec = promisify(execCallback);
 
 const baseDir = execSync('git rev-parse --show-toplevel').toString().trim();
 
@@ -29,3 +32,24 @@ export function detExecSync(detCommand: string): string {
     }
   }
 }
+
+export const detExec = async (command: string): Promise<string> => {
+  try {
+    const child = await exec(`${detPath()} ${command}`, {
+      env: {
+        ...process.env,
+        DET_MASTER: detMasterURL(),
+        DET_PASS: password(),
+        DET_USER: username(),
+      },
+      timeout: 10_000,
+    });
+    return child.stdout;
+  } catch (e: unknown) {
+    if (e && typeof e === 'object' && 'stderr' in e && typeof e.stderr === 'string') {
+      throw new Error(`detExec error: ${e.stderr}`);
+    } else {
+      throw e;
+    }
+  }
+};


### PR DESCRIPTION



## Ticket
ET-661



## Description

This adds an experiment list test for the stop action. it also introduces a new test fixture to allow for creating new experiments to be cleaned up afterwards on the fly.


## Test Plan
Tests should pass



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
