### PR TITLE
chore: remove max length from pytorch trials

### DIFF
--- a/docs/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-pytorch-ug.rst
@@ -879,6 +879,7 @@ To run Trainer API solely on-cluster, the code is much simpler:
            trial_inst = model.MNistTrial(train_context)
            trainer = det.pytorch.Trainer(trial_inst, train_context)
            trainer.fit(
+               max_length=pytorch.Epoch(11),
                checkpoint_period=pytorch.Batch(100),
                validation_period=pytorch.Batch(100),
                latest_checkpoint=det.get_cluster_info().latest_checkpoint,

--- a/examples/tutorials/mnist_pytorch/adaptive.yaml
+++ b/examples/tutorials/mnist_pytorch/adaptive.yaml
@@ -25,6 +25,6 @@ searcher:
   metric: validation_loss
   smaller_is_better: true
   max_trials: 16
-  time_metric: batch
+  time_metric: batches
   max_time: 937  # 60,000 training images with batch size 64
 entrypoint: python3 train.py --epochs 1

--- a/examples/tutorials/mnist_pytorch/train.py
+++ b/examples/tutorials/mnist_pytorch/train.py
@@ -80,7 +80,6 @@ class MNistTrial(pytorch.PyTorchTrial):
         return {
             "validation_loss": validation_loss,
             "accuracy": accuracy,
-            "batch": self.context.current_train_batch(),
         }
 
 
@@ -115,7 +114,11 @@ def run(max_length, local: bool = False):
     with pytorch.init() as train_context:
         trial = MNistTrial(train_context, hparams=hparams)
         trainer = pytorch.Trainer(trial, train_context)
-        trainer.fit(max_length=max_length, latest_checkpoint=latest_checkpoint)
+        trainer.fit(
+            max_length=max_length,
+            latest_checkpoint=latest_checkpoint,
+            validation_period=pytorch.Batch(100),
+        )
 
 
 if __name__ == "__main__":

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -84,7 +84,7 @@ type trial struct {
 	// state is the current state of the trial. It's patched by experiment changes and kill trial.
 	state model.State
 	// searcher encapsulates the searcher state of the trial.
-	searcher experiment.TrialSearcherState
+	searcher experiment.RunSearcherState
 	// restarts is a failure count, it increments when the trial fails and we retry it.
 	restarts int
 	// runID is a count of how many times the task container(s) have stopped and restarted, which
@@ -110,7 +110,7 @@ func newTrial(
 	jobSubmissionTime time.Time,
 	experimentID int,
 	initialState model.State,
-	searcher experiment.TrialSearcherState,
+	searcher experiment.RunSearcherState,
 	rm rm.ResourceManager,
 	pgDB db.DB,
 	config expconf.ExperimentConfig,
@@ -224,7 +224,7 @@ func (t *trial) PatchState(req model.StateWithReason) error {
 	return t.patchState(req)
 }
 
-func (t *trial) PatchSearcherState(req experiment.TrialSearcherState) error {
+func (t *trial) PatchSearcherState(req experiment.RunSearcherState) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -269,7 +269,7 @@ func (t *trial) PatchRP(rp string) {
 	}
 }
 
-func (t *trial) SetUserInitiatedEarlyExit(req experiment.UserInitiatedEarlyTrialExit) error {
+func (t *trial) SetUserInitiatedEarlyExit(req experiment.UserInitiatedEarlyRunExit) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -307,7 +307,7 @@ func (t *trial) create() error {
 		t.experimentID,
 		model.JSONObj(t.searcher.Create.Hparams),
 		t.warmStartCheckpoint,
-		int64(t.searcher.Create.TrialSeed),
+		int64(t.searcher.Create.RunSeed),
 		t.taskSpec.LogRetentionDays,
 	)
 
@@ -546,7 +546,7 @@ func (t *trial) buildTaskSpecifier() (*tasks.TrialSpec, error) {
 		TrialRunID:       t.runID,
 		ExperimentConfig: schemas.Copy(t.config),
 		HParams:          t.searcher.Create.Hparams,
-		TrialSeed:        t.searcher.Create.TrialSeed,
+		TrialSeed:        t.searcher.Create.RunSeed,
 		StepsCompleted:   stepsCompleted,
 		LatestCheckpoint: latestCheckpoint,
 

--- a/master/internal/trial.go
+++ b/master/internal/trial.go
@@ -84,7 +84,7 @@ type trial struct {
 	// state is the current state of the trial. It's patched by experiment changes and kill trial.
 	state model.State
 	// searcher encapsulates the searcher state of the trial.
-	searcher experiment.RunSearcherState
+	searcher experiment.TrialSearcherState
 	// restarts is a failure count, it increments when the trial fails and we retry it.
 	restarts int
 	// runID is a count of how many times the task container(s) have stopped and restarted, which
@@ -110,7 +110,7 @@ func newTrial(
 	jobSubmissionTime time.Time,
 	experimentID int,
 	initialState model.State,
-	searcher experiment.RunSearcherState,
+	searcher experiment.TrialSearcherState,
 	rm rm.ResourceManager,
 	pgDB db.DB,
 	config expconf.ExperimentConfig,
@@ -224,7 +224,7 @@ func (t *trial) PatchState(req model.StateWithReason) error {
 	return t.patchState(req)
 }
 
-func (t *trial) PatchSearcherState(req experiment.RunSearcherState) error {
+func (t *trial) PatchSearcherState(req experiment.TrialSearcherState) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -269,7 +269,7 @@ func (t *trial) PatchRP(rp string) {
 	}
 }
 
-func (t *trial) SetUserInitiatedEarlyExit(req experiment.UserInitiatedEarlyRunExit) error {
+func (t *trial) SetUserInitiatedEarlyExit(req experiment.UserInitiatedEarlyTrialExit) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -307,7 +307,7 @@ func (t *trial) create() error {
 		t.experimentID,
 		model.JSONObj(t.searcher.Create.Hparams),
 		t.warmStartCheckpoint,
-		int64(t.searcher.Create.RunSeed),
+		int64(t.searcher.Create.TrialSeed),
 		t.taskSpec.LogRetentionDays,
 	)
 
@@ -546,7 +546,7 @@ func (t *trial) buildTaskSpecifier() (*tasks.TrialSpec, error) {
 		TrialRunID:       t.runID,
 		ExperimentConfig: schemas.Copy(t.config),
 		HParams:          t.searcher.Create.Hparams,
-		TrialSeed:        t.searcher.Create.RunSeed,
+		TrialSeed:        t.searcher.Create.TrialSeed,
 		StepsCompleted:   stepsCompleted,
 		LatestCheckpoint: latestCheckpoint,
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

remove max_length from pytorch trials/trainer


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ