### PR TITLE
fix: nil deref in usage of incomplete experiment config policies

### DIFF
--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -257,8 +257,8 @@ func findAllowedPriority(scope *int, workloadType string) (limit int, exists boo
 			if err != nil {
 				return 0, false, fmt.Errorf("unable to unmarshal task config policies: %w", err)
 			}
-			if configs.Resources().Priority() != nil {
-				adminPriority := *configs.Resources().Priority()
+			if configs.RawResources != nil && configs.RawResources.RawPriority != nil {
+				adminPriority := *configs.RawResources.RawPriority
 				return adminPriority, false,
 					fmt.Errorf("priority set by invariant config: %w", errPriorityImmutable)
 			}


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
CM-572


## Description
Fix a call to `cfg.Resources().Priority()` on an experiment config without `schemas.WithDefaults`. I didn't call with defaults because the config is intentionally incomplete (we need to know what the user set, without any defaulting).


## Test Plan
Manually tested.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ