### PR TITLE
chore: remove redundant rm.ExternalPreemptionPending interface

### DIFF
--- a/master/internal/rm/agentrm/agent_resource_manager.go
+++ b/master/internal/rm/agentrm/agent_resource_manager.go
@@ -230,11 +230,6 @@ func (a *ResourceManager) CheckMaxSlotsExceeded(v *sproto.ValidateResourcesReque
 	return resp.CapacityExceeded, nil
 }
 
-// ExternalPreemptionPending implements rm.ResourceManager.
-func (*ResourceManager) ExternalPreemptionPending(sproto.PendingPreemption) error {
-	return rmerrors.ErrNotSupported
-}
-
 // GetAgent implements rm.ResourceManager.
 func (a *ResourceManager) GetAgent(msg *apiv1.GetAgentRequest) (*apiv1.GetAgentResponse, error) {
 	agent, ok := a.agentService.get(aproto.ID(msg.AgentId))

--- a/master/internal/rm/dispatcherrm/dispatcher_resource_manager.go
+++ b/master/internal/rm/dispatcherrm/dispatcher_resource_manager.go
@@ -243,26 +243,6 @@ func (m *DispatcherResourceManager) DeleteJob(
 	return sproto.EmptyDeleteJobResponse(), nil
 }
 
-// ExternalPreemptionPending notifies a task of a preemption from the underlying resource manager.
-func (m *DispatcherResourceManager) ExternalPreemptionPending(msg sproto.PendingPreemption) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.syslog.WithField("allocation-id", msg.AllocationID).
-		Info("pending preemption of allocation, terminating")
-	allocReq, ok := m.reqList.TaskByID(msg.AllocationID)
-	if ok {
-		rmevents.Publish(allocReq.AllocationID, &sproto.ReleaseResources{
-			Reason:          "preempted by the scheduler",
-			ForcePreemption: true,
-		})
-	} else {
-		m.syslog.WithField("allocation-id", msg.AllocationID).
-			Errorf("unable to find allocation actor for allocation")
-	}
-	return nil
-}
-
 // HealthCheck tries to call launcher and check if it is reachable.
 func (m *DispatcherResourceManager) HealthCheck() []model.ResourceManagerHealth {
 	status := model.Healthy

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -173,11 +173,6 @@ func (ResourceManager) DeleteJob(sproto.DeleteJob) (sproto.DeleteJobResponse, er
 	return sproto.EmptyDeleteJobResponse(), nil
 }
 
-// ExternalPreemptionPending implements rm.ResourceManager.
-func (ResourceManager) ExternalPreemptionPending(sproto.PendingPreemption) error {
-	return rmerrors.ErrNotSupported
-}
-
 // HealthCheck tries to call the KubeAPI.
 func (k *ResourceManager) HealthCheck() []model.ResourceManagerHealth {
 	return []model.ResourceManagerHealth{

--- a/master/internal/rm/multirm/multirm.go
+++ b/master/internal/rm/multirm/multirm.go
@@ -131,13 +131,6 @@ func (m *MultiRMRouter) SetGroupPriority(req sproto.SetGroupPriority) error {
 	return m.rms[resolvedRMName].SetGroupPriority(req)
 }
 
-// ExternalPreemptionPending routes an ExternalPreemptionPending request to the specified resource manager.
-func (m *MultiRMRouter) ExternalPreemptionPending(sproto.PendingPreemption) error {
-	// MultiRM is currently only implemented for Kubernetes, which doesn't support this.
-	m.syslog.WithError(fmt.Errorf("ExternalPreemptionPending is not implemented for agent, kubernetes, or multi-rm"))
-	return rmerrors.ErrNotSupported
-}
-
 // IsReattachableOnlyAfterStarted routes a IsReattachableOnlyAfterStarted call to a specified resource manager/pool.
 func (m *MultiRMRouter) IsReattachableOnlyAfterStarted() bool {
 	resolvedRMName, err := m.getRMName("")

--- a/master/internal/rm/multirm/multirm_intg_test.go
+++ b/master/internal/rm/multirm/multirm_intg_test.go
@@ -209,22 +209,6 @@ func TestSetGroupPriority(t *testing.T) {
 	}
 }
 
-func TestExternalPreemptionPending(t *testing.T) {
-	cases := []struct {
-		name string
-		req  sproto.PendingPreemption
-		err  error
-	}{
-		{"MultiRM doesn't implement ExternalPreemptionPending", sproto.PendingPreemption{}, rmerrors.ErrNotSupported},
-	}
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			err := testMultiRM.ExternalPreemptionPending(tt.req)
-			require.Equal(t, tt.err, err)
-		})
-	}
-}
-
 func TestIsReattachable(t *testing.T) {
 	val := testMultiRM.IsReattachableOnlyAfterStarted()
 	require.True(t, val)

--- a/master/internal/rm/resource_manager_iface.go
+++ b/master/internal/rm/resource_manager_iface.go
@@ -24,7 +24,6 @@ type ResourceManager interface {
 	SetGroupMaxSlots(sproto.SetGroupMaxSlots)
 	SetGroupWeight(sproto.SetGroupWeight) error
 	SetGroupPriority(sproto.SetGroupPriority) error
-	ExternalPreemptionPending(sproto.PendingPreemption) error
 	IsReattachableOnlyAfterStarted() bool
 	SmallerValueIsHigherPriority() (bool, error)
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
The `ExternalPreemptionPending` method always essentially called `allocation.Signal`, but through 2/3 pointless other calls/message passes. This just cuts out a few middlemen.

I did it now because it stood in the way of a test @rb-determined-ai was trying to remove.


## Test Plan
This is code removal, needs no testing. It even swaps to tested code instead!


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ