### PR TITLE
docs: fix internal link in multi-rm docs page.

### DIFF
--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -25,8 +25,7 @@ Any requests to resource pools not defined in the master configuration are route
 resource manager. Such requests are not routed to additional resource managers, if defined.
 
 To enable use of Determined tasks that rely on Determined proxies in the external-to-master
-clusters, set up a gateway as described in the docs :doc:Internal Task Gateway here :doc:`Internal
-Task Gateway here <internal-task-gateway>`.
+clusters, set up a gateway as described in the :doc:`internal-task-gateway`.
 
 *********************************************
  How to Configure Multiple Resource Managers


### PR DESCRIPTION
## Description

Fix a bad link markup.

## Test Plan

Look at multi-rm docs page.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ