### PR TITLE
chore: return error if workspace config violates global constraints

### DIFF
--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -50,9 +50,11 @@ func (a *apiServer) validatePoliciesAndWorkloadType(
 	_, priorityEnabledErr := a.m.rm.SmallerValueIsHigherPriority()
 	switch workloadType {
 	case model.ExperimentType:
-		return configpolicy.ValidateExperimentConfig(globalConfigPolicies, configPolicies, priorityEnabledErr)
+		return configpolicy.ValidateExperimentConfig(globalConfigPolicies, configPolicies,
+			priorityEnabledErr)
 	case model.NTSCType:
-		return configpolicy.ValidateNTSCConfig(globalConfigPolicies, configPolicies, priorityEnabledErr)
+		return configpolicy.ValidateNTSCConfig(globalConfigPolicies, configPolicies,
+			priorityEnabledErr)
 	default:
 		return status.Errorf(codes.InvalidArgument, fmt.Sprintf(invalidWorkloadTypeErr+": %s.", workloadType))
 	}
@@ -127,7 +129,8 @@ func (a *apiServer) PutWorkspaceConfigPolicies(
 		return nil, err
 	}
 
-	err = a.validatePoliciesAndWorkloadType(globalConfigPolicies, req.WorkloadType, req.ConfigPolicies)
+	err = a.validatePoliciesAndWorkloadType(globalConfigPolicies, req.WorkloadType,
+		req.ConfigPolicies)
 	if err != nil {
 		return nil, err
 	}

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -47,9 +47,8 @@ func SetTaskConfigPoliciesTx(ctx context.Context, tx *bun.Tx,
 ) error {
 	q := db.Bun().NewInsert().Model(tcp)
 
-	q = q.Set("last_updated_by = ?, last_updated_time = ?", tcp.LastUpdatedBy, tcp.LastUpdatedTime)
-	q = q.Set("invariant_config = ?", tcp.InvariantConfig)
-	q = q.Set("constraints = ?", tcp.Constraints)
+	q = q.Set("last_updated_by = ?, last_updated_time = ?, invariant_config = ?, constraints = ?",
+		tcp.LastUpdatedBy, tcp.LastUpdatedTime, tcp.InvariantConfig, tcp.Constraints)
 
 	if tcp.WorkspaceID == nil {
 		q = q.On("CONFLICT (workload_type) WHERE workspace_id IS NULL DO UPDATE")

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -44,37 +44,39 @@ func ValidWorkloadType(val string) bool {
 	}
 }
 
-func UnmarshalConfigPolicies[T any](errMsg string, constraints,
-	invariantConfig *string) (*model.Constraints, *T,
+// UnmarshalConfigPolicies unmarshals optionally specified invariant config and constraint
+// configurations presented as YAML or JSON strings.
+func UnmarshalConfigPolicies[T any](errMsg string, constraintsStr,
+	configStr *string) (*model.Constraints, *T,
 	error,
 ) {
-	var globalConstraints *model.Constraints
-	var globalConfig *T
+	var constraints *model.Constraints
+	var config *T
 
-	if constraints != nil {
+	if constraintsStr != nil {
 		unmarshaledConstraints, err := UnmarshalConfigPolicy[model.Constraints](
-			*constraints,
+			*constraintsStr,
 			errMsg,
 		)
 		if err != nil {
 			ConfigPolicyWarning(err.Error())
 			return nil, nil, err
 		}
-		globalConstraints = unmarshaledConstraints
+		constraints = unmarshaledConstraints
 	}
 
-	if invariantConfig != nil {
+	if configStr != nil {
 		unmarshaledConfig, err := UnmarshalConfigPolicy[T](
-			*invariantConfig,
+			*configStr,
 			errMsg,
 		)
 		if err != nil {
 			ConfigPolicyWarning(err.Error())
 			return nil, nil, err
 		}
-		globalConfig = unmarshaledConfig
+		config = unmarshaledConfig
 	}
-	return globalConstraints, globalConfig, nil
+	return constraints, config, nil
 }
 
 // UnmarshalConfigPolicy is a generic helper function to unmarshal both JSON and YAML strings.

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -425,7 +425,7 @@ resources:
 			`
 invariant_config:
   resources:
-max_slots: 15
+    max_slots: 15
 `, nil,
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
## Ticket
[CM-575]



## Description
Return error if workspace invariant config violates global constraints


## Test Plan
CI passes (automated testing)



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-575]: https://hpe-aiatscale.atlassian.net/browse/CM-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ