### PR TITLE
chore: INFENG-922: use correct gh_team tag for infrastructure

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -2742,7 +2742,7 @@ jobs:
             sudo apt-get install gettext
             sudo apt-get install iproute2
             yes yes | PATH=$HOME/.local/bin:$PATH make slurmcluster \
-              FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\\\"determined_ci\\\", gh_team=\\\"machine-user\\\"}'" \
+              FLAGS="-c <<parameters.container-run-type>> -w <<parameters.workload-manager>> -l '{owner=\\\"determined_ci\\\", gh_team=\\\"machine-users\\\"}'" \
               TF_LOCK=false | tee output.log || circleci-agent step halt
           background: true
 


### PR DESCRIPTION
## Ticket

INFENG-922

## Description

This changeset fixes a tag/label value in the CircleCI config; `gh_team: machine-user` should be `gh_team: machine-users` (plural). This fixes some inconsistencies in cost tracking.


## Test Plan

Probably unnecessary, although getting the `test-e2e-hpc-gcp` job to run would guarantee that the correct label is being applied. But unless label application isn't working at all, this only updates the value that's already being set.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code