### PR TITLE
chore: fix update invariant config and constraints

### DIFF
--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -6,6 +6,7 @@ package configpolicy
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"testing"
 	"time"
 
@@ -204,6 +205,169 @@ func TestSetTaskConfigPolicies(t *testing.T) {
 		Constraints:     DefaultConstraints(),
 	})
 	require.ErrorContains(t, err, "violates foreign key constraint")
+}
+
+func TestUpdateTaskConfigPolicies(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+
+	workspaceIDs := []int32{}
+
+	defer func() {
+		if len(workspaceIDs) > 0 {
+			err := db.CleanupMockWorkspace(workspaceIDs)
+			if err != nil {
+				log.Errorf("error when cleaning up mock workspaces")
+			}
+		}
+	}()
+
+	config1 := `
+{ 
+	"resources": {
+  		"priority": 99
+	}
+	"max_restarts": 20,
+}
+`
+	config2 := `
+{ 
+	"resources": {
+  		"priority": 100
+	}
+	"max_restarts": 25,
+}
+`
+
+	constraints1 := `
+{
+	"resources": {
+		"max_slots": 50
+	}
+	"priority_limit": 99,
+}
+`
+	constraints2 := `
+{
+	"resources": {
+		"max_slots": 80
+	}
+	"priority_limit": 100,
+}
+`
+	tests := []struct {
+		name        string
+		tcps        *model.TaskConfigPolicies
+		tcpsUpdated *model.TaskConfigPolicies
+	}{
+		{
+			"config to config and constraints", &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config1,
+			}, &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config2,
+				Constraints:     &constraints2,
+			},
+		},
+		{
+			"constraints to config and constraints", &model.TaskConfigPolicies{
+				LastUpdatedBy: user.ID,
+				WorkloadType:  model.ExperimentType,
+				Constraints:   &constraints1,
+			}, &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config2,
+				Constraints:     &constraints2,
+			},
+		},
+		{
+			"config and constraints to config and constraints", &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config1,
+				Constraints:     &constraints1,
+			}, &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config2,
+				Constraints:     &constraints2,
+			},
+		},
+		{
+			"config and constraints to only config", &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config1,
+				Constraints:     &constraints1,
+			}, &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config2,
+			},
+		},
+		{
+			"config and constraints to only constraints", &model.TaskConfigPolicies{
+				LastUpdatedBy:   user.ID,
+				WorkloadType:    model.ExperimentType,
+				InvariantConfig: &config1,
+				Constraints:     &constraints1,
+			}, &model.TaskConfigPolicies{
+				LastUpdatedBy: user.ID,
+				WorkloadType:  model.ExperimentType,
+				Constraints:   &constraints2,
+			},
+		},
+	}
+
+	whitespace := regexp.MustCompile(`[\s]`)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+			_, err := db.Bun().NewInsert().Model(&w).Exec(ctx)
+			require.NoError(t, err)
+			workspaceIDs = append(workspaceIDs, int32(w.ID))
+
+			test.tcps.WorkspaceID = &w.ID
+			test.tcpsUpdated.WorkspaceID = &w.ID
+
+			// Set config policies.
+			err = SetTaskConfigPolicies(ctx, test.tcps)
+			require.NoError(t, err)
+
+			// Update config policies.
+			err = SetTaskConfigPolicies(ctx, test.tcpsUpdated)
+			require.NoError(t, err)
+
+			// Verify config policies are updated properly.
+			tcps, err := GetTaskConfigPolicies(ctx, &w.ID, test.tcps.WorkloadType)
+			require.NoError(t, err)
+
+			if test.tcpsUpdated.InvariantConfig != nil {
+				expectedInvariantConfig := whitespace.ReplaceAllString(
+					*test.tcpsUpdated.InvariantConfig,
+					"")
+				require.NotNil(t, tcps.InvariantConfig)
+				require.Equal(t, expectedInvariantConfig,
+					*tcps.InvariantConfig)
+			}
+			if test.tcpsUpdated.Constraints != nil {
+				expectedConstraints := whitespace.ReplaceAllString(*test.tcpsUpdated.Constraints,
+					"")
+				require.NotNil(t, tcps.Constraints)
+				require.Equal(t, expectedConstraints, *tcps.Constraints)
+			}
+		})
+	}
 }
 
 // Test the enforcement of the primary key on the task_config_polciies table.


### PR DESCRIPTION
## Ticket

[CM-573]



## Description

When configs and constraints are both set for a given scope, updating the config policies to only use policy (config or constraints) doesn't work (the deleted config policy remains enforced).



## Test Plan
CI passes (automated testing).



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
