### PR TITLE
fix: Tensorboard broken on unified install [CM-578]

### DIFF
--- a/master/internal/api_tensorboard.go
+++ b/master/internal/api_tensorboard.go
@@ -286,6 +286,10 @@ func (a *apiServer) LaunchTensorboard(
 	if err != nil {
 		return nil, err
 	}
+
+	if launchReq.Spec.Base.ExtraEnvVars == nil {
+		launchReq.Spec.Base.ExtraEnvVars = map[string]string{}
+	}
 	maps.Copy(launchReq.Spec.Base.ExtraEnvVars, oidcPachydermEnvVars)
 
 	if launchReq.Spec.Config.Debug {


### PR DESCRIPTION
I think this was just missed in: https://github.com/determined-ai/determined/pull/8700

## Description
- Fix nil map.

## Test Plan
- Launch a Tensorboard on a unified install.
