### PR TITLE
feat: add actual select all to glide tables [ET-238]

### DIFF
--- a/webui/react/src/components/ComparisonView.test.mock.tsx
+++ b/webui/react/src/components/ComparisonView.test.mock.tsx
@@ -1,11 +1,14 @@
+import { useObservable } from 'micro-observables';
 import React from 'react';
 
 import { useGlasbey } from 'hooks/useGlasbey';
 import { RunMetricData } from 'hooks/useMetrics';
+import { V1LocationType } from 'services/api-ts-sdk';
 import { ExperimentWithTrial, Scale } from 'types';
 import { generateTestRunData } from 'utils/tests/generateTestData';
 
 import ComparisonView from './ComparisonView';
+import { FilterFormStore } from './FilterForm/components/FilterFormStore';
 
 export const METRIC_DATA: RunMetricData = {
   data: {
@@ -245,6 +248,7 @@ export const ExperimentComparisonViewWithMocks: React.FC<Props> = ({
   onWidthChange,
   open,
 }: Props): JSX.Element => {
+  const tableFilters = useObservable(new FilterFormStore(V1LocationType.EXPERIMENT).asJsonString);
   const colorMap = useGlasbey(SELECTED_EXPERIMENTS.map((exp) => exp.experiment.id));
   return (
     <ComparisonView
@@ -258,6 +262,7 @@ export const ExperimentComparisonViewWithMocks: React.FC<Props> = ({
       initialWidth={200}
       open={open}
       projectId={1}
+      tableFilters={tableFilters}
       onWidthChange={onWidthChange}>
       {children}
     </ComparisonView>
@@ -270,6 +275,7 @@ export const RunComparisonViewWithMocks: React.FC<Props> = ({
   onWidthChange,
   open,
 }: Props): JSX.Element => {
+  const tableFilters = useObservable(new FilterFormStore(V1LocationType.RUN).asJsonString);
   const colorMap = useGlasbey(SELECTED_RUNS.map((run) => run.id));
   return (
     <ComparisonView
@@ -283,6 +289,7 @@ export const RunComparisonViewWithMocks: React.FC<Props> = ({
           ? { selections: [], type: 'ONLY_IN' }
           : { selections: SELECTED_RUNS.map((run) => run.id), type: 'ONLY_IN' }
       }
+      tableFilters={tableFilters}
       onWidthChange={onWidthChange}>
       {children}
     </ComparisonView>

--- a/webui/react/src/components/ComparisonView.test.mock.tsx
+++ b/webui/react/src/components/ComparisonView.test.mock.tsx
@@ -1,14 +1,11 @@
-import { useObservable } from 'micro-observables';
 import React from 'react';
 
 import { useGlasbey } from 'hooks/useGlasbey';
 import { RunMetricData } from 'hooks/useMetrics';
-import { V1LocationType } from 'services/api-ts-sdk';
 import { ExperimentWithTrial, Scale } from 'types';
 import { generateTestRunData } from 'utils/tests/generateTestData';
 
 import ComparisonView from './ComparisonView';
-import { FilterFormStore } from './FilterForm/components/FilterFormStore';
 
 export const METRIC_DATA: RunMetricData = {
   data: {
@@ -248,7 +245,6 @@ export const ExperimentComparisonViewWithMocks: React.FC<Props> = ({
   onWidthChange,
   open,
 }: Props): JSX.Element => {
-  const tableFilters = useObservable(new FilterFormStore(V1LocationType.EXPERIMENT).asJsonString);
   const colorMap = useGlasbey(SELECTED_EXPERIMENTS.map((exp) => exp.experiment.id));
   return (
     <ComparisonView
@@ -262,7 +258,6 @@ export const ExperimentComparisonViewWithMocks: React.FC<Props> = ({
       initialWidth={200}
       open={open}
       projectId={1}
-      tableFilters={tableFilters}
       onWidthChange={onWidthChange}>
       {children}
     </ComparisonView>
@@ -275,7 +270,6 @@ export const RunComparisonViewWithMocks: React.FC<Props> = ({
   onWidthChange,
   open,
 }: Props): JSX.Element => {
-  const tableFilters = useObservable(new FilterFormStore(V1LocationType.RUN).asJsonString);
   const colorMap = useGlasbey(SELECTED_RUNS.map((run) => run.id));
   return (
     <ComparisonView
@@ -289,7 +283,6 @@ export const RunComparisonViewWithMocks: React.FC<Props> = ({
           ? { selections: [], type: 'ONLY_IN' }
           : { selections: SELECTED_RUNS.map((run) => run.id), type: 'ONLY_IN' }
       }
-      tableFilters={tableFilters}
       onWidthChange={onWidthChange}>
       {children}
     </ComparisonView>

--- a/webui/react/src/components/ComparisonView.tsx
+++ b/webui/react/src/components/ComparisonView.tsx
@@ -155,12 +155,11 @@ const ComparisonView: React.FC<Props> = ({
       return NotLoaded;
     }
     try {
-      const filters = JSON.parse(tableFilters) as FilterFormSet;
-      const filterFormSet = INIT_FORMSET;
+      const filterFormSet =
+        experimentSelection.type === 'ALL_EXCEPT'
+          ? (JSON.parse(tableFilters) as FilterFormSet)
+          : INIT_FORMSET;
       const filter = getExperimentIdsFilter(filterFormSet, experimentSelection);
-      if (experimentSelection.type === 'ALL_EXCEPT') {
-        filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
-      }
       const response = await searchExperiments({
         filter: JSON.stringify(filter),
         limit: SELECTION_LIMIT,
@@ -183,9 +182,11 @@ const ComparisonView: React.FC<Props> = ({
     ) {
       return NotLoaded;
     }
-    const filterFormSet = INIT_FORMSET;
+    const filterFormSet =
+      runSelection.type === 'ALL_EXCEPT'
+        ? (JSON.parse(tableFilters) as FilterFormSet)
+        : INIT_FORMSET;
     try {
-      const filters = JSON.parse(tableFilters) as FilterFormSet;
       const filter = getRunIdsFilter(filterFormSet, runSelection);
       if (searchId) {
         // only display trials for search
@@ -198,9 +199,6 @@ const ComparisonView: React.FC<Props> = ({
           value: searchId,
         };
         filter.filterGroup = combine(filter.filterGroup, 'and', searchFilter);
-      }
-      if (runSelection.type === 'ALL_EXCEPT') {
-        filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
       }
       const response = await searchRuns({
         filter: JSON.stringify(filter),

--- a/webui/react/src/components/ComparisonView.tsx
+++ b/webui/react/src/components/ComparisonView.tsx
@@ -24,7 +24,7 @@ import { getIdsFilter as getRunIdsFilter } from 'utils/flatRun';
 
 import CompareMetrics from './CompareMetrics';
 import { INIT_FORMSET } from './FilterForm/components/FilterFormStore';
-import { Operator } from './FilterForm/components/type';
+import { FilterFormSet, Operator } from './FilterForm/components/type';
 
 export const EMPTY_MESSAGE = 'No items selected.';
 
@@ -37,6 +37,7 @@ interface BaseProps {
   fixedColumnsCount: number;
   projectId: number;
   searchId?: number;
+  tableFilters: string;
 }
 
 type Props = XOR<{ experimentSelection: SelectionType }, { runSelection: SelectionType }> &
@@ -137,6 +138,7 @@ const ComparisonView: React.FC<Props> = ({
   experimentSelection,
   runSelection,
   searchId,
+  tableFilters,
 }) => {
   const scrollbarWidth = useScrollbarWidth();
   const hasPinnedColumns = fixedColumnsCount > 1;
@@ -153,8 +155,12 @@ const ComparisonView: React.FC<Props> = ({
       return NotLoaded;
     }
     try {
+      const filters = JSON.parse(tableFilters) as FilterFormSet;
       const filterFormSet = INIT_FORMSET;
       const filter = getExperimentIdsFilter(filterFormSet, experimentSelection);
+      if (experimentSelection.type === 'ALL_EXCEPT') {
+        filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
+      }
       const response = await searchExperiments({
         filter: JSON.stringify(filter),
         limit: SELECTION_LIMIT,
@@ -167,7 +173,7 @@ const ComparisonView: React.FC<Props> = ({
       handleError(e, { publicSubject: 'Unable to fetch experiments for comparison' });
       return NotLoaded;
     }
-  }, [experimentSelection, open]);
+  }, [experimentSelection, open, tableFilters]);
 
   const loadableSelectedRuns = useAsync(async () => {
     if (
@@ -179,6 +185,7 @@ const ComparisonView: React.FC<Props> = ({
     }
     const filterFormSet = INIT_FORMSET;
     try {
+      const filters = JSON.parse(tableFilters) as FilterFormSet;
       const filter = getRunIdsFilter(filterFormSet, runSelection);
       if (searchId) {
         // only display trials for search
@@ -191,6 +198,9 @@ const ComparisonView: React.FC<Props> = ({
           value: searchId,
         };
         filter.filterGroup = combine(filter.filterGroup, 'and', searchFilter);
+      }
+      if (runSelection.type === 'ALL_EXCEPT') {
+        filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
       }
       const response = await searchRuns({
         filter: JSON.stringify(filter),
@@ -205,7 +215,7 @@ const ComparisonView: React.FC<Props> = ({
       handleError(e, { publicSubject: 'Unable to fetch runs for comparison' });
       return NotLoaded;
     }
-  }, [open, projectId, runSelection, searchId]);
+  }, [open, projectId, runSelection, searchId, tableFilters]);
 
   const minWidths: [number, number] = useMemo(() => {
     return [fixedColumnsCount * MIN_COLUMN_WIDTH + scrollbarWidth, 100];
@@ -218,17 +228,27 @@ const ComparisonView: React.FC<Props> = ({
       children
     );
 
-  const rightPane = useMemo(() => {
-    const selection = experimentSelection ?? runSelection;
-    if (selection.type === 'ONLY_IN' && selection.selections.length === 0) {
-      return (
-        <Alert description="Select records you would like to compare." message={EMPTY_MESSAGE} />
-      );
+  const getRightPaneContent = () => {
+    if (experimentSelection) {
+      if (experimentSelection.type === 'ONLY_IN' && experimentSelection.selections.length === 0) {
+        return (
+          <Alert description="Select records you would like to compare." message={EMPTY_MESSAGE} />
+        );
+      }
+      if (loadableSelectedExperiments.isNotLoaded) {
+        return <Spinner spinning />;
+      }
     }
-    if (loadableSelectedExperiments.isNotLoaded && loadableSelectedRuns.isNotLoaded) {
-      return <Spinner spinning />;
+    if (runSelection) {
+      if (runSelection.type === 'ONLY_IN' && runSelection.selections.length === 0) {
+        return (
+          <Alert description="Select records you would like to compare." message={EMPTY_MESSAGE} />
+        );
+      }
+      if (loadableSelectedRuns.isNotLoaded) {
+        return <Spinner spinning />;
+      }
     }
-
     return (
       <>
         {isSelectionLimitReached && (
@@ -242,15 +262,7 @@ const ComparisonView: React.FC<Props> = ({
         />
       </>
     );
-  }, [
-    colorMap,
-    experimentSelection,
-    isSelectionLimitReached,
-    loadableSelectedExperiments,
-    loadableSelectedRuns,
-    projectId,
-    runSelection,
-  ]);
+  };
 
   return (
     <SplitPane
@@ -258,7 +270,7 @@ const ComparisonView: React.FC<Props> = ({
       initialWidth={initialWidth}
       leftPane={leftPane}
       minimumWidths={{ left: minWidths[0], right: minWidths[1] }}
-      rightPane={rightPane}
+      rightPane={getRightPaneContent()}
       onChange={onWidthChange}
     />
   );

--- a/webui/react/src/components/ExperimentActionDropdown.tsx
+++ b/webui/react/src/components/ExperimentActionDropdown.tsx
@@ -353,6 +353,7 @@ const ExperimentActionDropdown: React.FC<Props> = ({
       />
       <ExperimentMoveModal.Component
         experimentIds={[experiment.id]}
+        selectionSize={1}
         sourceProjectId={experiment.projectId}
         sourceWorkspaceId={experiment.workspaceId}
         onSubmit={handleMoveComplete}

--- a/webui/react/src/components/ExperimentCreateModal.test.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 
 import ExperimentCreateModalComponent, {
   CreateExperimentType,
+  RunActionCopyMap,
 } from 'components/ExperimentCreateModal';
 import { ThemeProvider } from 'components/ThemeProvider';
 import { createExperiment as mockCreateExperiment } from 'services/api';
@@ -66,7 +67,9 @@ describe('Create Experiment Modal', () => {
   it('submits a valid create experiment request', async () => {
     await setup();
 
-    await user.click(screen.getByRole('button', { name: CreateExperimentType.Fork }));
+    await user.click(
+      screen.getByRole('button', { name: RunActionCopyMap[CreateExperimentType.Fork] }),
+    );
     expect(mockCreateExperiment).toHaveBeenCalled();
   });
 });

--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -361,7 +361,7 @@ const ExperimentCreateModalComponent = ({
         form: idPrefix + FORM_ID,
         handleError,
         handler: handleSubmit,
-        text: type,
+        text: ExperimentActionCopyMap[type],
       }}
       title={titleLabel}
       onClose={handleModalClose}>

--- a/webui/react/src/components/ExperimentCreateModal.tsx
+++ b/webui/react/src/components/ExperimentCreateModal.tsx
@@ -51,7 +51,7 @@ const ExperimentEntityCopyMap = {
   trial: 'trial',
 };
 
-const RunActionCopyMap = {
+export const RunActionCopyMap = {
   [CreateExperimentType.ContinueTrial]: 'Continue Run',
   [CreateExperimentType.Fork]: 'Fork',
 };

--- a/webui/react/src/components/ExperimentMoveModal.tsx
+++ b/webui/react/src/components/ExperimentMoveModal.tsx
@@ -21,7 +21,6 @@ import workspaceStore from 'stores/workspaces';
 import { Project, SelectionType, XOR } from 'types';
 import handleError from 'utils/error';
 import { getIdsFilter as getExperimentIdsFilter } from 'utils/experiment';
-import { combine } from 'utils/filterFormSet';
 import { capitalize, pluralizer } from 'utils/string';
 
 import { INIT_FORMSET } from './FilterForm/components/FilterFormStore';
@@ -97,12 +96,11 @@ const ExperimentMoveModalComponent: React.FC<Props> = ({
     };
 
     if (tableFilters !== undefined) {
-      const filters = JSON.parse(tableFilters) as FilterFormSet;
-      const filterFormSet = INIT_FORMSET;
+      const filterFormSet =
+        selection.type === 'ALL_EXCEPT'
+          ? (JSON.parse(tableFilters) as FilterFormSet)
+          : INIT_FORMSET;
       const filter = getExperimentIdsFilter(filterFormSet, selection);
-      if (selection.type === 'ALL_EXCEPT') {
-        filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
-      }
       moveSearchesArgs.filter = JSON.stringify(filter);
     } else {
       moveSearchesArgs.searchIds = experimentIds;

--- a/webui/react/src/components/LoadableCount.tsx
+++ b/webui/react/src/components/LoadableCount.tsx
@@ -12,6 +12,7 @@ interface Props {
   labelSingular: string;
   labelPlural: string;
   onActualSelectAll?: () => void;
+  onClearSelect?: () => void;
   pageSize?: number;
   selectedCount: number;
 }
@@ -21,6 +22,7 @@ const LoadableCount: React.FC<Props> = ({
   labelPlural,
   labelSingular,
   onActualSelectAll,
+  onClearSelect,
   pageSize = 20,
   selectedCount,
 }: Props) => {
@@ -48,7 +50,7 @@ const LoadableCount: React.FC<Props> = ({
 
   const actualSelectAll = useMemo(() => {
     return Loadable.match(total, {
-      Failed: () => null,
+      _: () => null,
       Loaded: (loadedTotal) => {
         if (onActualSelectAll && selectedCount >= pageSize && selectedCount < loadedTotal) {
           return (
@@ -56,13 +58,18 @@ const LoadableCount: React.FC<Props> = ({
               Select all {labelPlural} in table
             </Button>
           );
+        } else if (onClearSelect && selectedCount >= pageSize) {
+          return (
+            <Button type="text" onClick={onClearSelect}>
+              Clear Selection
+            </Button>
+          );
         }
 
         return null;
       },
-      NotLoaded: () => null,
     });
-  }, [labelPlural, onActualSelectAll, pageSize, selectedCount, total]);
+  }, [labelPlural, onActualSelectAll, onClearSelect, pageSize, selectedCount, total]);
 
   if (!isMobile) {
     return (

--- a/webui/react/src/components/LoadableCount.tsx
+++ b/webui/react/src/components/LoadableCount.tsx
@@ -1,3 +1,4 @@
+import Button from 'hew/Button';
 import { Loadable } from 'hew/utils/loadable';
 import { useMemo } from 'react';
 
@@ -10,6 +11,8 @@ interface Props {
   total: Loadable<number>;
   labelSingular: string;
   labelPlural: string;
+  onActualSelectAll?: () => void;
+  pageSize?: number;
   selectedCount: number;
 }
 
@@ -17,6 +20,8 @@ const LoadableCount: React.FC<Props> = ({
   total,
   labelPlural,
   labelSingular,
+  onActualSelectAll,
+  pageSize = 20,
   selectedCount,
 }: Props) => {
   const isMobile = useMobile();
@@ -41,11 +46,32 @@ const LoadableCount: React.FC<Props> = ({
     });
   }, [labelPlural, labelSingular, total, selectedCount]);
 
+  const actualSelectAll = useMemo(() => {
+    return Loadable.match(total, {
+      Failed: () => null,
+      Loaded: (loadedTotal) => {
+        if (onActualSelectAll && selectedCount >= pageSize && selectedCount < loadedTotal) {
+          return (
+            <Button type="text" onClick={onActualSelectAll}>
+              Select all {labelPlural} in table
+            </Button>
+          );
+        }
+
+        return null;
+      },
+      NotLoaded: () => null,
+    });
+  }, [labelPlural, onActualSelectAll, pageSize, selectedCount, total]);
+
   if (!isMobile) {
     return (
-      <span className={css.base} data-test="count">
-        {selectionLabel}
-      </span>
+      <>
+        <span className={css.base} data-test="count">
+          {selectionLabel}
+        </span>
+        {actualSelectAll}
+      </>
     );
   } else {
     return null;

--- a/webui/react/src/components/LoadableCount.tsx
+++ b/webui/react/src/components/LoadableCount.tsx
@@ -54,13 +54,13 @@ const LoadableCount: React.FC<Props> = ({
       Loaded: (loadedTotal) => {
         if (onActualSelectAll && selectedCount >= pageSize && selectedCount < loadedTotal) {
           return (
-            <Button type="text" onClick={onActualSelectAll}>
+            <Button data-test="select-all" type="text" onClick={onActualSelectAll}>
               Select all {labelPlural} in table
             </Button>
           );
-        } else if (onClearSelect && selectedCount >= pageSize) {
+        } else if (onClearSelect && (selectedCount >= pageSize || selectedCount === loadedTotal)) {
           return (
-            <Button type="text" onClick={onClearSelect}>
+            <Button data-test="clear-selection" type="text" onClick={onClearSelect}>
               Clear Selection
             </Button>
           );

--- a/webui/react/src/components/RunActionDropdown.tsx
+++ b/webui/react/src/components/RunActionDropdown.tsx
@@ -207,7 +207,8 @@ const RunActionDropdown: React.FC<Props> = ({
 
   const shared = (
     <FlatRunMoveComponentModal
-      flatRuns={[run]}
+      selection={{ selections: [run.id], type: 'ONLY_IN' }}
+      selectionSize={1}
       sourceProjectId={projectId}
       sourceWorkspaceId={run.workspaceId}
       onSubmit={() => onComplete?.(FlatRunAction.Move, run.id)}

--- a/webui/react/src/components/RunActionDropdown.tsx
+++ b/webui/react/src/components/RunActionDropdown.tsx
@@ -207,7 +207,7 @@ const RunActionDropdown: React.FC<Props> = ({
 
   const shared = (
     <FlatRunMoveComponentModal
-      selection={{ selections: [run.id], type: 'ONLY_IN' }}
+      runIds={[run.id]}
       selectionSize={1}
       sourceProjectId={projectId}
       sourceWorkspaceId={run.workspaceId}

--- a/webui/react/src/components/RunFilterInterstitialModalComponent.test.tsx
+++ b/webui/react/src/components/RunFilterInterstitialModalComponent.test.tsx
@@ -111,7 +111,7 @@ describe('RunFilterInterstitialModalComponent', () => {
 
     // TODO: is there a better way to test these expectations?
     expect(filterFormSet.showArchived).toBeTruthy();
-    const [, , idFilter] = filterFormSet.filterGroup.children;
+    const [, idFilter] = filterFormSet.filterGroup.children;
     for (const child of expectedFilterGroup.children) {
       expect(filterFormSet.filterGroup.children).toContainEqual(child);
     }
@@ -148,7 +148,7 @@ describe('RunFilterInterstitialModalComponent', () => {
     const filterFormSet = JSON.parse(filterFormSetString || '');
 
     expect(filterFormSet.showArchived).toBe(false);
-    const idFilters = filterFormSet.filterGroup.children || [];
+    const idFilters = filterFormSet.filterGroup.children[0].children || [];
     expect(idFilters.every((f: FormField) => f.operator === '=')).toBe(true);
     expect(idFilters.map((f: FormField) => f.value)).toEqual(expectedSelection);
   });

--- a/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
+++ b/webui/react/src/components/RunFilterInterstitialModalComponent.tsx
@@ -1,5 +1,5 @@
 import { useModal } from 'hew/Modal';
-import { Failed, NotLoaded } from 'hew/utils/loadable';
+import { Failed, Loadable, NotLoaded } from 'hew/utils/loadable';
 import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 
 import { FilterFormSetWithoutId } from 'components/FilterForm/components/type';
@@ -74,11 +74,13 @@ export const RunFilterInterstitialModalComponent = forwardRef<ControlledModalRef
 
     useImperativeHandle(ref, () => ({ close, open }));
 
-    const selectionHasSearchRuns = useAsync(
+    const selectionHasSearchRuns: Loadable<boolean> = useAsync(
       async (canceler) => {
         if (!isOpen) return NotLoaded;
         const mergedCanceler = mergeAbortControllers(canceler, closeController.current);
-        const filterWithSingleFilter = combine(filterFormSet.filterGroup, 'and', {
+
+        const filter: FilterFormSetWithoutId = getIdsFilter(filterFormSet, selection);
+        filter.filterGroup = combine(filter.filterGroup, 'and', {
           columnName: 'searcherType',
           kind: 'field',
           location: 'LOCATION_TYPE_RUN',
@@ -86,13 +88,6 @@ export const RunFilterInterstitialModalComponent = forwardRef<ControlledModalRef
           type: 'COLUMN_TYPE_TEXT',
           value: 'single',
         });
-        const filter: FilterFormSetWithoutId = getIdsFilter(
-          {
-            ...filterFormSet,
-            filterGroup: filterWithSingleFilter,
-          },
-          selection,
-        );
 
         try {
           const results = await searchRuns(

--- a/webui/react/src/components/SearchTensorBoardModal.tsx
+++ b/webui/react/src/components/SearchTensorBoardModal.tsx
@@ -1,29 +1,24 @@
 import { Modal } from 'hew/Modal';
 
 import { UNMANAGED_EXPERIMENT_ANNOTATION_MESSAGE } from 'constant';
-import { openOrCreateTensorBoard } from 'services/api';
-import { V1BulkExperimentFilters } from 'services/api-ts-sdk';
+import { openOrCreateTensorBoardSearches } from 'services/api';
 import { ProjectExperiment } from 'types';
 import handleError from 'utils/error';
 import { openCommandResponse } from 'utils/wait';
 
 interface Props {
-  selectedExperiments: ProjectExperiment[];
-  filters?: V1BulkExperimentFilters;
+  selectedSearches: ProjectExperiment[];
   workspaceId?: number;
 }
 
-const ExperimentTensorBoardModal = ({
-  workspaceId,
-  selectedExperiments,
-  filters,
-}: Props): JSX.Element => {
+const SearchTensorBoardModal = ({ workspaceId, selectedSearches }: Props): JSX.Element => {
   const handleSubmit = async () => {
-    const managedExperimentIds = selectedExperiments
-      .filter((exp) => !exp.unmanaged)
-      .map((exp) => exp.id);
+    const managedSearchIds = selectedSearches.filter((exp) => !exp.unmanaged).map((exp) => exp.id);
     openCommandResponse(
-      await openOrCreateTensorBoard({ experimentIds: managedExperimentIds, filters, workspaceId }),
+      await openOrCreateTensorBoardSearches({
+        searchIds: managedSearchIds,
+        workspaceId,
+      }),
     );
   };
 
@@ -42,4 +37,4 @@ const ExperimentTensorBoardModal = ({
   );
 };
 
-export default ExperimentTensorBoardModal;
+export default SearchTensorBoardModal;

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -88,8 +88,6 @@ interface Props {
   project: Project;
 }
 
-type ExperimentWithIndex = { index: number; experiment: BulkExperimentItem };
-
 const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal']);
 const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetricsVal']);
 
@@ -248,23 +246,22 @@ const Searches: React.FC<Props> = ({ project }) => {
     return [];
   }, [settings.selection]);
 
-  const loadedSelectedExperimentIds = useMemo(() => {
-    const selectedMap = new Map<number, ExperimentWithIndex>();
+  const loadedExperimentIdMap = useMemo(() => {
+    const experimentMap = new Map<number, { experiment: ExperimentWithTrial; index: number }>();
+
     if (isLoadingSettings) {
-      return selectedMap;
+      return experimentMap;
     }
-    const selectedIdSet = new Set(allSelectedExperimentIds);
+
     experiments.forEach((e, index) => {
-      Loadable.forEach(e, ({ experiment }) => {
-        if (selectedIdSet.has(experiment.id)) {
-          selectedMap.set(experiment.id, { experiment, index });
-        }
+      Loadable.forEach(e, (experiment) => {
+        experimentMap.set(experiment.experiment.id, { experiment, index });
       });
     });
-    return selectedMap;
-  }, [isLoadingSettings, allSelectedExperimentIds, experiments]);
+    return experimentMap;
+  }, [experiments, isLoadingSettings]);
 
-  const colorMap = useGlasbey([...loadedSelectedExperimentIds.keys()]);
+  const colorMap = useGlasbey([...loadedExperimentIdMap.keys()]);
 
   const experimentFilters = useMemo(() => {
     const filters: V1BulkExperimentFilters = {

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -641,6 +641,10 @@ const Searches: React.FC<Props> = ({ project }) => {
     handleSelectionChange?.('add-all');
   }, [handleSelectionChange]);
 
+  const handleClearSelect = useCallback(() => {
+    handleSelectionChange?.('remove-all');
+  }, [handleSelectionChange]);
+
   const handleHeaderClick = useCallback(
     (columnId: string): void => {
       if (columnId === MULTISELECT) {
@@ -800,6 +804,7 @@ const Searches: React.FC<Props> = ({ project }) => {
         onActionComplete={handleActionComplete}
         onActionSuccess={handleActionSuccess}
         onActualSelectAll={handleActualSelectAll}
+        onClearSelect={handleClearSelect}
         onIsOpenFilterChange={handleIsOpenFilterChange}
         onRowHeightChange={handleRowHeightChange}
         onSortChange={handleSortChange}

--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -174,12 +174,14 @@ const Searches: React.FC<Props> = ({ project }) => {
   const isMobile = useMobile();
   const { openToast } = useToast();
 
-  const { selectionSize, dataGridSelection, handleSelectionChange, rowRangeToIds } = useSelection({
-    records: experiments.map((loadable) => loadable.map((exp) => exp.experiment)),
-    selection: settings.selection,
-    total,
-    updateSettings,
-  });
+  const { selectionSize, dataGridSelection, handleSelectionChange, isRangeSelected } = useSelection(
+    {
+      records: experiments.map((loadable) => loadable.map((exp) => exp.experiment)),
+      selection: settings.selection,
+      total,
+      updateSettings,
+    },
+  );
 
   const handlePinnedColumnsCountChange = useCallback(
     (newCount: number) => updateSettings({ pinnedColumnsCount: newCount }),
@@ -641,20 +643,6 @@ const Searches: React.FC<Props> = ({ project }) => {
   const handleActualSelectAll = useCallback(() => {
     handleSelectionChange?.('add-all');
   }, [handleSelectionChange]);
-
-  const isRangeSelected = useCallback(
-    (range: [number, number]): boolean => {
-      if (settings.selection.type === 'ONLY_IN') {
-        const includedSet = new Set(settings.selection.selections);
-        return rowRangeToIds(range).every((id) => includedSet.has(id));
-      } else if (settings.selection.type === 'ALL_EXCEPT') {
-        const excludedSet = new Set(settings.selection.exclusions);
-        return rowRangeToIds(range).every((id) => !excludedSet.has(id));
-      }
-      return false; // should never be reached
-    },
-    [rowRangeToIds, settings.selection],
-  );
 
   const handleHeaderClick = useCallback(
     (columnId: string): void => {

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -93,6 +93,7 @@ interface Props {
   isOpenFilter: boolean;
   onActionComplete?: () => Promise<void>;
   onActionSuccess?: (action: BatchAction, successfulIds: number[]) => void;
+  onActualSelectAll?: () => void;
   onComparisonViewToggle?: () => void;
   onHeatmapToggle?: (heatmapOn: boolean) => void;
   onIsOpenFilterChange?: (value: boolean) => void;
@@ -100,6 +101,7 @@ interface Props {
   onSortChange?: (sorts: Sort[]) => void;
   onVisibleColumnChange?: (newColumns: string[], pinnedCount?: number) => void;
   onHeatmapSelectionRemove?: (id: string) => void;
+  pageSize?: number;
   project: Project;
   projectColumns: Loadable<ProjectColumn[]>;
   rowHeight: RowHeight;
@@ -124,6 +126,7 @@ const TableActionBar: React.FC<Props> = ({
   isOpenFilter,
   onActionComplete,
   onActionSuccess,
+  onActualSelectAll,
   onComparisonViewToggle,
   onHeatmapToggle,
   onIsOpenFilterChange,
@@ -131,6 +134,7 @@ const TableActionBar: React.FC<Props> = ({
   onSortChange,
   onHeatmapSelectionRemove,
   onVisibleColumnChange,
+  pageSize,
   project,
   projectColumns,
   rowHeight,
@@ -423,8 +427,10 @@ const TableActionBar: React.FC<Props> = ({
             <LoadableCount
               labelPlural={labelPlural}
               labelSingular={labelSingular}
+              pageSize={pageSize}
               selectedCount={selectedExperimentIds.length}
               total={total}
+              onActualSelectAll={onActualSelectAll}
             />
           </Row>
         </Column>

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -107,6 +107,7 @@ interface Props {
   projectColumns: Loadable<ProjectColumn[]>;
   rowHeight: RowHeight;
   selectedExperimentIds: number[];
+  selectionSize: number;
   sorts: Sort[];
   pinnedColumnsCount?: number;
   total: Loadable<number>;
@@ -150,6 +151,7 @@ const TableActionBar: React.FC<Props> = ({
   bannedFilterColumns,
   bannedSortColumns,
   entityCopy,
+  selectionSize,
 }) => {
   const permissions = usePermissions();
   const [batchAction, setBatchAction] = useState<BatchAction>();
@@ -382,8 +384,6 @@ const TableActionBar: React.FC<Props> = ({
     }, [] as MenuItem[]);
   }, [availableBatchActions]);
 
-  const handleAction = useCallback((key: string) => handleBatchAction(key), [handleBatchAction]);
-
   return (
     <div className={css.base} data-test-component="tableActionBar">
       <Row>
@@ -420,7 +420,7 @@ const TableActionBar: React.FC<Props> = ({
             />
             <OptionsMenu rowHeight={rowHeight} onRowHeightChange={onRowHeightChange} />
             {selectedExperimentIds.length > 0 && (
-              <Dropdown menu={editMenuItems} onClick={handleAction}>
+              <Dropdown menu={editMenuItems} onClick={handleBatchAction}>
                 <Button data-test="actionsDropdown" hideChildren={isMobile}>
                   Actions
                 </Button>
@@ -430,7 +430,7 @@ const TableActionBar: React.FC<Props> = ({
               labelPlural={labelPlural}
               labelSingular={labelSingular}
               pageSize={pageSize}
-              selectedCount={selectedExperimentIds.length}
+              selectedCount={selectionSize}
               total={total}
               onActualSelectAll={onActualSelectAll}
               onClearSelect={onClearSelect}

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -94,6 +94,7 @@ interface Props {
   onActionComplete?: () => Promise<void>;
   onActionSuccess?: (action: BatchAction, successfulIds: number[]) => void;
   onActualSelectAll?: () => void;
+  onClearSelect?: () => void;
   onComparisonViewToggle?: () => void;
   onHeatmapToggle?: (heatmapOn: boolean) => void;
   onIsOpenFilterChange?: (value: boolean) => void;
@@ -127,6 +128,7 @@ const TableActionBar: React.FC<Props> = ({
   onActionComplete,
   onActionSuccess,
   onActualSelectAll,
+  onClearSelect,
   onComparisonViewToggle,
   onHeatmapToggle,
   onIsOpenFilterChange,
@@ -431,6 +433,7 @@ const TableActionBar: React.FC<Props> = ({
               selectedCount={selectedExperimentIds.length}
               total={total}
               onActualSelectAll={onActualSelectAll}
+              onClearSelect={onClearSelect}
             />
           </Row>
         </Column>

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -500,13 +500,11 @@ const TableActionBar: React.FC<Props> = ({
         />
       )}
       <ExperimentMoveModal.Component
-        experimentIds={selectedExperimentIds.filter(
-          (id) =>
-            canActionExperiment(ExperimentAction.Move, experimentMap[id]) &&
-            permissions.canMoveExperiment({ experiment: experimentMap[id] }),
-        )}
+        selection={selection}
+        selectionSize={selectionSize}
         sourceProjectId={project.id}
         sourceWorkspaceId={project.workspaceId}
+        tableFilters={tableFilterString}
         onSubmit={handleSubmitMove}
       />
       <ExperimentRetainLogsModal.Component

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -273,7 +273,6 @@ const TableActionBar: React.FC<Props> = ({
         case ExperimentAction.Archive:
           return await archiveSearches(params);
         case ExperimentAction.Cancel:
-          if (params.searchIds === undefined) break;
           return await cancelSearches(params);
         case ExperimentAction.Kill:
           return await killSearches(params);

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -218,7 +218,7 @@ const TableActionBar: React.FC<Props> = ({
   const availableBatchActions = useMemo(() => {
     switch (selection.type) {
       case 'ONLY_IN': {
-        const experiments = selectedExperimentIds.map((id) => experimentMap[id]) ?? [];
+        const experiments = selection.selections.map((id) => experimentMap[id]) ?? [];
         return getActionsForExperimentsUnion(experiments, [...batchActions], permissions); // Spreading batchActions is so TypeScript doesn't complain that it's readonly.
       }
       case 'ALL_EXCEPT':
@@ -227,7 +227,7 @@ const TableActionBar: React.FC<Props> = ({
             action !== ExperimentAction.OpenTensorBoard && action !== ExperimentAction.Cancel,
         );
     }
-  }, [selection.type, selectedExperimentIds, permissions, experimentMap]);
+  }, [selection, permissions, experimentMap]);
 
   const sendBatchActions = useCallback(
     async (action: BatchAction): Promise<BulkActionResult | void> => {

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -16,7 +16,7 @@ import ColumnPickerMenu from 'components/ColumnPickerMenu';
 import ExperimentMoveModalComponent from 'components/ExperimentMoveModal';
 import ExperimentRetainLogsModalComponent from 'components/ExperimentRetainLogsModal';
 import ExperimentTensorBoardModal from 'components/ExperimentTensorBoardModal';
-import { FilterFormStore } from 'components/FilterForm/components/FilterFormStore';
+import { FilterFormStore, INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 import TableFilter from 'components/FilterForm/TableFilter';
 import MultiSortMenu from 'components/MultiSortMenu';
 import { OptionsMenu, RowHeight } from 'components/OptionsMenu';
@@ -56,6 +56,7 @@ import {
 import { capitalizeWord } from 'utils/string';
 import { openCommandResponse } from 'utils/wait';
 
+import { FilterFormSet } from './FilterForm/components/type';
 import LoadableCount from './LoadableCount';
 import css from './TableActionBar.module.scss';
 
@@ -241,8 +242,11 @@ const TableActionBar: React.FC<Props> = ({
           break;
         }
         case 'ALL_EXCEPT': {
-          const filters = JSON.parse(tableFilterString);
-          params.filter = JSON.stringify(getIdsFilter(filters, selection));
+          const filterFormSet =
+            selection.type === 'ALL_EXCEPT'
+              ? (JSON.parse(tableFilterString) as FilterFormSet)
+              : INIT_FORMSET;
+          params.filter = JSON.stringify(getIdsFilter(filterFormSet, selection));
           break;
         }
       }

--- a/webui/react/src/components/TableActionBar.tsx
+++ b/webui/react/src/components/TableActionBar.tsx
@@ -16,7 +16,7 @@ import ColumnPickerMenu from 'components/ColumnPickerMenu';
 import ExperimentMoveModalComponent from 'components/ExperimentMoveModal';
 import ExperimentRetainLogsModalComponent from 'components/ExperimentRetainLogsModal';
 import ExperimentTensorBoardModal from 'components/ExperimentTensorBoardModal';
-import { FilterFormStore, INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
+import { FilterFormStore } from 'components/FilterForm/components/FilterFormStore';
 import TableFilter from 'components/FilterForm/TableFilter';
 import MultiSortMenu from 'components/MultiSortMenu';
 import { OptionsMenu, RowHeight } from 'components/OptionsMenu';
@@ -242,10 +242,7 @@ const TableActionBar: React.FC<Props> = ({
           break;
         }
         case 'ALL_EXCEPT': {
-          const filterFormSet =
-            selection.type === 'ALL_EXCEPT'
-              ? (JSON.parse(tableFilterString) as FilterFormSet)
-              : INIT_FORMSET;
+          const filterFormSet = JSON.parse(tableFilterString) as FilterFormSet;
           params.filter = JSON.stringify(getIdsFilter(filterFormSet, selection));
           break;
         }

--- a/webui/react/src/e2e/models/common/hew/DataGrid.ts
+++ b/webui/react/src/e2e/models/common/hew/DataGrid.ts
@@ -5,7 +5,6 @@ import {
 } from 'playwright-page-model-base/BaseComponent';
 
 import { expect } from 'e2e/fixtures/global-fixtures';
-import { DropdownMenu } from 'e2e/models/common/hew/Dropdown';
 import { printMap } from 'e2e/utils/debug';
 
 class IndexNotFoundError extends Error {}
@@ -396,14 +395,6 @@ export class HeadRow<RowType extends Row<HeadRow<RowType>>> extends NamedCompone
     parent: this,
     selector: 'th',
   });
-  readonly selectDropdown = new HeaderDropdown({
-    clickThisComponentToOpen: new BaseComponent({
-      parent: this,
-      selector: `[${DataGrid.columnIndexAttribute}="1"]`,
-    }),
-    openMethod: this.clickSelectDropdown.bind(this),
-    root: this.root,
-  });
 
   #columnDefs = new Map<string, number>();
 
@@ -473,18 +464,8 @@ export class HeadRow<RowType extends Row<HeadRow<RowType>>> extends NamedCompone
   /**
    * Clicks the head row's select button
    */
-  async clickSelectDropdown(): Promise<void> {
+  async clickSelectHeader(): Promise<void> {
     // magic numbers for the select button
     await this.parentTable.pwLocator.click({ position: { x: 5, y: 5 } });
   }
-}
-
-/**
- * Represents the HeaderDropdown from the DataGrid component
- */
-class HeaderDropdown extends DropdownMenu {
-  readonly select5 = this.menuItem('select-5');
-  readonly select10 = this.menuItem('select-10');
-  readonly select25 = this.menuItem('select-25');
-  readonly selectAll = this.menuItem('select-all');
 }

--- a/webui/react/src/e2e/models/components/TableActionBar.ts
+++ b/webui/react/src/e2e/models/components/TableActionBar.ts
@@ -25,6 +25,7 @@ export class TableActionBar extends NamedComponent {
   count = new BaseComponent({ parent: this, selector: '[data-test="count"]' });
   heatmapToggle = new BaseComponent({ parent: this, selector: '[data-test="heatmapToggle"]' });
   compare = new BaseComponent({ parent: this, selector: '[data-test="compare"]' });
+  clearSelection = new BaseComponent({ parent: this, selector: '[data-test="clear-selection"]' });
   // TODO a bunch of modals
 }
 

--- a/webui/react/src/e2e/models/pages/ProjectDetails.ts
+++ b/webui/react/src/e2e/models/pages/ProjectDetails.ts
@@ -5,7 +5,7 @@ import { F_ExperimentList } from 'e2e/models/components/F_ExperimentList';
 import { PageComponent } from 'e2e/models/components/Page';
 
 /**
- * Represents the SignIn page from src/pages/ProjectDetails.tsx
+ * Represents the ProjectDetails page from src/pages/ProjectDetails.tsx
  */
 export class ProjectDetails extends DeterminedPage {
   readonly title = /Uncategorized Experiments|Project Details/;
@@ -34,6 +34,8 @@ export class ProjectDetails extends DeterminedPage {
     if (matches === null) throw new Error('No ID found in the URL');
     return Number(matches[1]);
   }
+
+  // async getRowsSelected(): Promise<{ selected: number; total?: number }> {}
 
   readonly pageComponent = new PageComponent({ parent: this });
   readonly dynamicTabs = new DynamicTabs({ parent: this.pageComponent });

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -56,10 +56,10 @@ test.describe('Experiment List', () => {
       timeout: 10_000,
     });
     await test.step('Deselect', async () => {
-      let count = await getCount();
-      while (count !== 0) {
+      const count = await getCount();
+      if (count !== 0) {
         await grid.headRow.clickSelectHeader();
-        count = await getCount();
+        await projectDetailsPage.f_experimentList.tableActionBar.clearSelection.pwLocator.click();
       }
     });
     await test.step('Reset Columns', async () => {

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -13,7 +13,7 @@ test.describe('Experiment List', () => {
   const getCount = async () => {
     const count =
       await projectDetailsPage.f_experimentList.tableActionBar.count.pwLocator.textContent();
-    if (count === null) throw new Error('Count is null');
+    if (count === null) return 0;
     return parseInt(count);
   };
 
@@ -56,11 +56,10 @@ test.describe('Experiment List', () => {
       timeout: 10_000,
     });
     await test.step('Deselect', async () => {
-      try {
-        await grid.headRow.selectDropdown.menuItem('select-none').select({ timeout: 1_000 });
-      } catch (e) {
-        // close the dropdown by clicking elsewhere
-        await projectDetailsPage.f_experimentList.tableActionBar.count.pwLocator.click();
+      let count = await getCount();
+      while (count !== 0) {
+        await grid.headRow.clickSelectHeader();
+        count = await getCount();
       }
     });
     await test.step('Reset Columns', async () => {
@@ -295,11 +294,6 @@ test.describe('Experiment List', () => {
     });
     await test.step('Read Cell Value', async () => {
       await expect.soft((await row.getCellByColumnName('ID')).pwLocator).toHaveText(/\d+/);
-    });
-    await test.step('Select 5', async () => {
-      await (
-        await projectDetailsPage.f_experimentList.dataGrid.headRow.selectDropdown.open()
-      ).select5.pwLocator.click();
     });
     await test.step('Experiment Overview Navigation', async () => {
       await projectDetailsPage.f_experimentList.dataGrid.scrollLeft();

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -59,7 +59,11 @@ test.describe('Experiment List', () => {
       const count = await getCount();
       if (count !== 0) {
         await grid.headRow.clickSelectHeader();
-        await projectDetailsPage.f_experimentList.tableActionBar.clearSelection.pwLocator.click();
+        const isClearSelectionVisible =
+          await projectDetailsPage.f_experimentList.tableActionBar.clearSelection.pwLocator.isVisible();
+        if (isClearSelectionVisible) {
+          await projectDetailsPage.f_experimentList.tableActionBar.clearSelection.pwLocator.click();
+        }
       }
     });
     await test.step('Reset Columns', async () => {

--- a/webui/react/src/hooks/useSelection.ts
+++ b/webui/react/src/hooks/useSelection.ts
@@ -1,0 +1,193 @@
+import { CompactSelection, GridSelection } from '@glideapps/glide-data-grid';
+import {
+  HandleSelectionChangeType,
+  RangelessSelectionType,
+  SelectionType,
+} from 'hew/DataGrid/DataGrid';
+import { Loadable } from 'hew/utils/loadable';
+import * as t from 'io-ts';
+import { useCallback, useMemo } from 'react';
+
+import { RegularSelectionType, SelectionType as SelectionState } from 'types';
+
+export const DEFAULT_SELECTION: t.TypeOf<typeof RegularSelectionType> = {
+  selections: [],
+  type: 'ONLY_IN',
+};
+
+interface HasId {
+  id: number;
+}
+
+interface SelectionConfig<T> {
+  records: Loadable<T>[];
+  selection: SelectionState;
+  total: Loadable<number>;
+  updateSettings: (p: Record<string, unknown>) => void;
+}
+
+interface UseSelectionReturn<T> {
+  selectionSize: number;
+  dataGridSelection: GridSelection;
+  handleSelectionChange: HandleSelectionChangeType;
+  rowRangeToIds: (range: [number, number]) => number[];
+  loadedSelectedRecords: T[];
+  isRangeSelected: (range: [number, number]) => boolean;
+}
+
+const useSelection = <T extends HasId>(config: SelectionConfig<T>): UseSelectionReturn<T> => {
+  const loadedRecordIdMap = useMemo(() => {
+    const recordMap = new Map<number, { record: T; index: number }>();
+
+    config.records.forEach((r, index) => {
+      Loadable.forEach(r, (record) => {
+        recordMap.set(record.id, { index, record });
+      });
+    });
+    return recordMap;
+  }, [config.records]);
+
+  const selectedRecordIdSet = useMemo(() => {
+    if (config.selection.type === 'ONLY_IN') {
+      return new Set(config.selection.selections);
+    } else if (config.selection.type === 'ALL_EXCEPT') {
+      const excludedSet = new Set(config.selection.exclusions);
+      return new Set(
+        Loadable.filterNotLoaded(config.records, (record) => !excludedSet.has(record.id)).map(
+          (record) => record.id,
+        ),
+      );
+    }
+    return new Set<number>(); // should never be reached
+  }, [config.records, config.selection]);
+
+  const dataGridSelection = useMemo<GridSelection>(() => {
+    let rows = CompactSelection.empty();
+    if (config.selection.type === 'ONLY_IN') {
+      config.selection.selections.forEach((id) => {
+        const incIndex = loadedRecordIdMap.get(id)?.index;
+        if (incIndex !== undefined) {
+          rows = rows.add(incIndex);
+        }
+      });
+    } else if (config.selection.type === 'ALL_EXCEPT') {
+      rows = rows.add([0, config.total.getOrElse(1) - 1]);
+      console.log(config.selection.exclusions);
+      console.log(loadedRecordIdMap);
+      config.selection.exclusions.forEach((exc) => {
+        const excIndex = loadedRecordIdMap.get(exc)?.index;
+        console.log(excIndex);
+        if (excIndex !== undefined) {
+          rows = rows.remove(excIndex);
+        }
+      });
+    }
+    console.log(rows);
+    return {
+      columns: CompactSelection.empty(),
+      rows,
+    };
+  }, [loadedRecordIdMap, config.selection, config.total]);
+
+  const loadedSelectedRecords: T[] = useMemo(() => {
+    return Loadable.filterNotLoaded(config.records, (record) => selectedRecordIdSet.has(record.id));
+  }, [config.records, selectedRecordIdSet]);
+
+  const selectionSize = useMemo(() => {
+    if (config.selection.type === 'ONLY_IN') {
+      return config.selection.selections.length;
+    } else if (config.selection.type === 'ALL_EXCEPT') {
+      return config.total.getOrElse(0) - config.selection.exclusions.length;
+    }
+    return 0;
+  }, [config.selection, config.total]);
+
+  const rowRangeToIds = useCallback(
+    (range: [number, number]) => {
+      const slice = config.records.slice(range[0], range[1]);
+      return Loadable.filterNotLoaded(slice).map((run) => run.id);
+    },
+    [config.records],
+  );
+
+  const handleSelectionChange: HandleSelectionChangeType = useCallback(
+    (selectionType: SelectionType | RangelessSelectionType, range?: [number, number]) => {
+      let newSettings: SelectionState = { ...config.selection };
+
+      switch (selectionType) {
+        case 'add':
+          if (!range) return;
+          if (newSettings.type === 'ALL_EXCEPT') {
+            const excludedSet = new Set(newSettings.exclusions);
+            rowRangeToIds(range).forEach((id) => excludedSet.delete(id));
+            newSettings.exclusions = Array.from(excludedSet);
+          } else {
+            const includedSet = new Set(newSettings.selections);
+            rowRangeToIds(range).forEach((id) => includedSet.add(id));
+            newSettings.selections = Array.from(includedSet);
+          }
+
+          break;
+        case 'add-all':
+          newSettings = {
+            exclusions: [],
+            type: 'ALL_EXCEPT',
+          };
+
+          break;
+        case 'remove':
+          if (!range) return;
+          if (newSettings.type === 'ALL_EXCEPT') {
+            const excludedSet = new Set(newSettings.exclusions);
+            rowRangeToIds(range).forEach((id) => excludedSet.add(id));
+            newSettings.exclusions = Array.from(excludedSet);
+          } else {
+            const includedSet = new Set(newSettings.selections);
+            rowRangeToIds(range).forEach((id) => includedSet.delete(id));
+            newSettings.selections = Array.from(includedSet);
+          }
+
+          break;
+        case 'remove-all':
+          newSettings = DEFAULT_SELECTION;
+
+          break;
+        case 'set':
+          if (!range) return;
+          newSettings = {
+            ...DEFAULT_SELECTION,
+            selections: Array.from(rowRangeToIds(range)),
+          };
+
+          break;
+      }
+      config.updateSettings({ selection: newSettings });
+    },
+    [config, rowRangeToIds],
+  );
+
+  const isRangeSelected = useCallback(
+    (range: [number, number]): boolean => {
+      if (config.selection.type === 'ONLY_IN') {
+        const includedSet = new Set(config.selection.selections);
+        return rowRangeToIds(range).every((id) => includedSet.has(id));
+      } else if (config.selection.type === 'ALL_EXCEPT') {
+        const excludedSet = new Set(config.selection.exclusions);
+        return rowRangeToIds(range).every((id) => !excludedSet.has(id));
+      }
+      return false; // should never be reached
+    },
+    [rowRangeToIds, config.selection],
+  );
+
+  return {
+    dataGridSelection,
+    handleSelectionChange,
+    isRangeSelected,
+    loadedSelectedRecords,
+    rowRangeToIds,
+    selectionSize,
+  };
+};
+
+export default useSelection;

--- a/webui/react/src/hooks/useSelection.ts
+++ b/webui/react/src/hooks/useSelection.ts
@@ -32,6 +32,7 @@ interface UseSelectionReturn<T> {
   handleSelectionChange: HandleSelectionChangeType;
   rowRangeToIds: (range: [number, number]) => number[];
   loadedSelectedRecords: T[];
+  loadedSelectedRecordIds: number[];
   isRangeSelected: (range: [number, number]) => boolean;
 }
 
@@ -72,17 +73,13 @@ const useSelection = <T extends HasId>(config: SelectionConfig<T>): UseSelection
       });
     } else if (config.selection.type === 'ALL_EXCEPT') {
       rows = rows.add([0, config.total.getOrElse(1) - 1]);
-      console.log(config.selection.exclusions);
-      console.log(loadedRecordIdMap);
       config.selection.exclusions.forEach((exc) => {
         const excIndex = loadedRecordIdMap.get(exc)?.index;
-        console.log(excIndex);
         if (excIndex !== undefined) {
           rows = rows.remove(excIndex);
         }
       });
     }
-    console.log(rows);
     return {
       columns: CompactSelection.empty(),
       rows,
@@ -92,6 +89,10 @@ const useSelection = <T extends HasId>(config: SelectionConfig<T>): UseSelection
   const loadedSelectedRecords: T[] = useMemo(() => {
     return Loadable.filterNotLoaded(config.records, (record) => selectedRecordIdSet.has(record.id));
   }, [config.records, selectedRecordIdSet]);
+
+  const loadedSelectedRecordIds: number[] = useMemo(() => {
+    return loadedSelectedRecords.map((record) => record.id);
+  }, [loadedSelectedRecords]);
 
   const selectionSize = useMemo(() => {
     if (config.selection.type === 'ONLY_IN') {
@@ -184,6 +185,7 @@ const useSelection = <T extends HasId>(config: SelectionConfig<T>): UseSelection
     dataGridSelection,
     handleSelectionChange,
     isRangeSelected,
+    loadedSelectedRecordIds,
     loadedSelectedRecords,
     rowRangeToIds,
     selectionSize,

--- a/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
+++ b/webui/react/src/pages/ExperimentDetails/ExperimentDetailsHeader.tsx
@@ -785,6 +785,7 @@ const ExperimentDetailsHeader: React.FC<Props> = ({
       <ExperimentDeleteModal.Component experiment={experiment} />
       <ExperimentMoveModal.Component
         experimentIds={isMovable ? [experiment.id] : []}
+        selectionSize={1}
         sourceProjectId={experiment.projectId}
         sourceWorkspaceId={experiment.workspaceId}
         onSubmit={handleModalClose}

--- a/webui/react/src/pages/ExperimentList.tsx
+++ b/webui/react/src/pages/ExperimentList.tsx
@@ -1045,6 +1045,7 @@ const ExperimentList: React.FC<Props> = ({ project }) => {
       />
       <ExperimentMoveModal.Component
         experimentIds={batchMovingExperimentIds ?? []}
+        selectionSize={batchMovingExperimentIds?.length ?? 0}
         sourceProjectId={project.id}
         sourceWorkspaceId={project.workspaceId}
         onSubmit={handleActionComplete}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -1130,6 +1130,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               initialWidth={comparisonViewTableWidth}
               open={settings.compare}
               projectId={project.id}
+              tableFilters={filtersString}
               onWidthChange={handleCompareWidthChange}>
               <DataGrid<ExperimentWithTrial, ExperimentAction, BulkExperimentItem>
                 columns={columns}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -487,6 +487,14 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
     [handleSelectionChange, openToast],
   );
 
+  const handleActualSelectAll = useCallback(() => {
+    handleSelectionChange?.('add-all');
+  }, [handleSelectionChange]);
+
+  const handleClearSelect = useCallback(() => {
+    handleSelectionChange?.('remove-all');
+  }, [handleSelectionChange]);
+
   const handleContextMenuComplete = useCallback(
     (action: ExperimentAction, id: number, data?: Partial<BulkExperimentItem>) =>
       handleActionSuccess(action, [id], data),
@@ -997,6 +1005,8 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
         total={total}
         onActionComplete={handleActionComplete}
         onActionSuccess={handleActionSuccess}
+        onActualSelectAll={handleActualSelectAll}
+        onClearSelect={handleClearSelect}
         onComparisonViewToggle={handleToggleComparisonView}
         onHeatmapSelectionRemove={(id) => {
           const newSelection = settings.heatmapSkipped.filter((s) => s !== id);

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -1026,6 +1026,7 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               initialWidth={comparisonViewTableWidth}
               open={settings.compare}
               projectId={project.id}
+              tableFilters={filtersString}
               onWidthChange={handleCompareWidthChange}>
               <DataGrid<ExperimentWithTrial, ExperimentAction, BulkExperimentItem>
                 columns={columns}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -1026,7 +1026,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
               initialWidth={comparisonViewTableWidth}
               open={settings.compare}
               projectId={project.id}
-              tableFilters={filtersString}
               onWidthChange={handleCompareWidthChange}>
               <DataGrid<ExperimentWithTrial, ExperimentAction, BulkExperimentItem>
                 columns={columns}

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -255,10 +255,6 @@ const F_ExperimentList: React.FC<Props> = ({ project }) => {
   const [error] = useState(false);
   const [canceler] = useState(new AbortController());
 
-  // const allSelectedExperimentIds = useMemo(() => {
-  //   return settings.selection.type === 'ONLY_IN' ? settings.selection.selections : [];
-  // }, [settings.selection]);
-
   const colorMap = useGlasbey(loadedSelectedExperimentIds);
   const { width: containerWidth } = useResize(contentRef);
 

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
@@ -29,6 +29,7 @@ const setup = (selectedFlatRuns: ReadonlyArray<Readonly<FlatRun>>) => {
         projectId={1}
         selectedRuns={selectedFlatRuns}
         selection={{ selections: selectedFlatRuns.map((run) => run.id), type: 'ONLY_IN' }}
+        selectionSize={selectedFlatRuns.length}
         tableFilterString=""
         workspaceId={1}
         onActionComplete={onActionComplete}

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
@@ -28,6 +28,8 @@ const setup = (selectedFlatRuns: ReadonlyArray<Readonly<FlatRun>>) => {
         isMobile={false}
         projectId={1}
         selectedRuns={selectedFlatRuns}
+        selection={{ selections: selectedFlatRuns.map((run) => run.id), type: 'ONLY_IN' }}
+        tableFilterString=""
         workspaceId={1}
         onActionComplete={onActionComplete}
         onActionSuccess={onActionSuccess}

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.test.tsx
@@ -25,12 +25,12 @@ const setup = (selectedFlatRuns: ReadonlyArray<Readonly<FlatRun>>) => {
   render(
     <UIProvider theme={DefaultTheme.Light}>
       <FlatRunActionButton
+        filter="{}"
         isMobile={false}
         projectId={1}
         selectedRuns={selectedFlatRuns}
         selection={{ selections: selectedFlatRuns.map((run) => run.id), type: 'ONLY_IN' }}
         selectionSize={selectedFlatRuns.length}
-        tableFilterString=""
         workspaceId={1}
         onActionComplete={onActionComplete}
         onActionSuccess={onActionSuccess}

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -61,6 +61,7 @@ interface Props {
   onActionSuccess?: (action: BatchAction, successfulIds: number[]) => void;
   onActionComplete?: () => void | Promise<void>;
   selection: SelectionType;
+  selectionSize: number;
 }
 
 const FlatRunActionButton = ({
@@ -69,6 +70,7 @@ const FlatRunActionButton = ({
   selectedRuns,
   projectId,
   selection,
+  selectionSize,
   workspaceId,
   onActionSuccess,
   onActionComplete,
@@ -254,7 +256,7 @@ const FlatRunActionButton = ({
 
   return (
     <>
-      {selectedRuns.length > 0 && (
+      {selectionSize > 0 && (
         <Dropdown menu={editMenuItems} onClick={handleBatchAction}>
           <Button hideChildren={isMobile} icon={<Icon decorative name="pencil" />}>
             Actions

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -62,6 +62,7 @@ interface Props {
   onActionComplete?: () => void | Promise<void>;
   selection: SelectionType;
   selectionSize: number;
+  searchId?: number;
 }
 
 const FlatRunActionButton = ({
@@ -72,6 +73,7 @@ const FlatRunActionButton = ({
   selection,
   selectionSize,
   workspaceId,
+  searchId,
   onActionSuccess,
   onActionComplete,
 }: Props): JSX.Element => {
@@ -98,6 +100,23 @@ const FlatRunActionButton = ({
         }
         case 'ALL_EXCEPT': {
           const filters = JSON.parse(tableFilterString);
+          if (searchId) {
+            // only display trials for search
+            const existingFilterGroup = { ...filters.filterGroup };
+            const searchFilter = {
+              columnName: 'experimentId',
+              kind: 'field',
+              location: 'LOCATION_TYPE_RUN',
+              operator: '=',
+              type: 'COLUMN_TYPE_NUMBER',
+              value: searchId,
+            };
+            filters.filterGroup = {
+              children: [existingFilterGroup, searchFilter],
+              conjunction: 'and',
+              kind: 'group',
+            };
+          }
           params.filter = JSON.stringify(getIdsFilter(filters, selection));
           break;
         }
@@ -120,7 +139,7 @@ const FlatRunActionButton = ({
           return await resumeRuns(params);
       }
     },
-    [flatRunMoveModalOpen, projectId, selectedRuns, selection, tableFilterString],
+    [flatRunMoveModalOpen, projectId, searchId, selectedRuns, selection, tableFilterString],
   );
 
   const submitBatchAction = useCallback(

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -281,6 +281,7 @@ const FlatRunActionButton = ({
         selectionSize={selectionSize}
         sourceProjectId={projectId}
         sourceWorkspaceId={workspaceId}
+        tableFilters={tableFilterString}
         onSubmit={onSubmitMove}
       />
     </>

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -88,14 +88,19 @@ const FlatRunActionButton = ({
   const sendBatchActions = useCallback(
     async (action: BatchAction): Promise<BulkActionResult | void> => {
       const params: RunBulkActionParams = { projectId };
-      if (selection.type === 'ONLY_IN') {
-        const validRunIds = selectedRuns
-          .filter((run) => canActionFlatRun(action, run))
-          .map((run) => run.id);
-        params.runIds = validRunIds;
-      } else if (selection.type === 'ALL_EXCEPT') {
-        const filters = JSON.parse(tableFilterString);
-        params.filter = JSON.stringify(getIdsFilter(filters, selection));
+      switch (selection.type) {
+        case 'ONLY_IN': {
+          const validRunIds = selectedRuns
+            .filter((run) => canActionFlatRun(action, run))
+            .map((run) => run.id);
+          params.runIds = validRunIds;
+          break;
+        }
+        case 'ALL_EXCEPT': {
+          const filters = JSON.parse(tableFilterString);
+          params.filter = JSON.stringify(getIdsFilter(filters, selection));
+          break;
+        }
       }
       switch (action) {
         case ExperimentAction.Move:
@@ -185,12 +190,12 @@ const FlatRunActionButton = ({
   );
 
   const availableBatchActions = useMemo(() => {
-    if (selection.type === 'ONLY_IN') {
-      return getActionsForFlatRunsUnion(selectedRuns, [...BATCH_ACTIONS], permissions);
-    } else if (selection.type === 'ALL_EXCEPT') {
-      return BATCH_ACTIONS;
+    switch (selection.type) {
+      case 'ONLY_IN':
+        return getActionsForFlatRunsUnion(selectedRuns, [...BATCH_ACTIONS], permissions);
+      case 'ALL_EXCEPT':
+        return BATCH_ACTIONS;
     }
-    return [];
   }, [selection.type, selectedRuns, permissions]);
 
   const editMenuItems = useMemo(() => {

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -154,8 +154,7 @@ const FlatRunActionButton = ({
         } else {
           openToast({
             closeable: true,
-            description: `${action} succeeded for ${numSuccesses} out of ${numFailures + numSuccesses}{' '}
-            ${pluralizer(numFailures + numSuccesses, 'run')}`,
+            description: `${action} succeeded for ${numSuccesses} out of ${numFailures + numSuccesses} ${pluralizer(numFailures + numSuccesses, 'run')}`,
             severity: 'Warning',
             title: `Partial ${action} Failure`,
           });

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -217,7 +217,7 @@ const FlatRunActionButton = ({
     }, []);
   }, [availableBatchActions]);
 
-  const onSubmit = useCallback(
+  const onSubmitMove = useCallback(
     async (results: BulkActionResult, destinationProjectId: number) => {
       const numSuccesses = results?.successful.length ?? 0;
       const numFailures = results?.failed.length ?? 0;
@@ -277,10 +277,11 @@ const FlatRunActionButton = ({
         />
       )}
       <FlatRunMoveComponentModal
-        flatRuns={[...selectedRuns]}
+        selection={selection}
+        selectionSize={selectionSize}
         sourceProjectId={projectId}
         sourceWorkspaceId={workspaceId}
-        onSubmit={onSubmit}
+        onSubmit={onSubmitMove}
       />
     </>
   );

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -9,7 +9,7 @@ import { useObservable } from 'micro-observables';
 import { useCallback, useMemo, useState } from 'react';
 
 import BatchActionConfirmModalComponent from 'components/BatchActionConfirmModal';
-import { FilterFormSetWithoutId, Operator } from 'components/FilterForm/components/type';
+import { FilterFormSetWithoutId } from 'components/FilterForm/components/type';
 import Link from 'components/Link';
 import usePermissions from 'hooks/usePermissions';
 import FlatRunMoveModalComponent from 'pages/FlatRuns/FlatRunMoveModal';
@@ -22,12 +22,10 @@ import {
   resumeRuns,
   unarchiveRuns,
 } from 'services/api';
-import { V1ColumnType, V1LocationType } from 'services/api-ts-sdk';
 import { RunBulkActionParams } from 'services/types';
 import projectStore from 'stores/projects';
 import { BulkActionResult, ExperimentAction, FlatRun, Project, SelectionType } from 'types';
 import handleError from 'utils/error';
-import { combine } from 'utils/filterFormSet';
 import { canActionFlatRun, getActionsForFlatRunsUnion, getIdsFilter } from 'utils/flatRun';
 import { capitalizeWord, pluralizer } from 'utils/string';
 
@@ -56,7 +54,7 @@ const ACTION_ICONS: Record<BatchAction, IconName> = {
 const LABEL_PLURAL = 'runs';
 
 interface Props {
-  tableFilterString: string;
+  filter: string;
   isMobile: boolean;
   selectedRuns: ReadonlyArray<Readonly<FlatRun>>;
   projectId: number;
@@ -65,18 +63,16 @@ interface Props {
   onActionComplete?: () => void | Promise<void>;
   selection: SelectionType;
   selectionSize: number;
-  searchId?: number;
 }
 
 const FlatRunActionButton = ({
-  tableFilterString,
+  filter,
   isMobile,
   selectedRuns,
   projectId,
   selection,
   selectionSize,
   workspaceId,
-  searchId,
   onActionSuccess,
   onActionComplete,
 }: Props): JSX.Element => {
@@ -102,19 +98,7 @@ const FlatRunActionButton = ({
           break;
         }
         case 'ALL_EXCEPT': {
-          const filterFormSet = JSON.parse(tableFilterString) as FilterFormSetWithoutId;
-          if (searchId) {
-            // only display trials for search
-            const searchFilter = {
-              columnName: 'experimentId',
-              kind: 'field' as const,
-              location: V1LocationType.RUN,
-              operator: Operator.Eq,
-              type: V1ColumnType.NUMBER,
-              value: searchId,
-            };
-            filterFormSet.filterGroup = combine(filterFormSet.filterGroup, 'and', searchFilter);
-          }
+          const filterFormSet = JSON.parse(filter) as FilterFormSetWithoutId;
           params.filter = JSON.stringify(getIdsFilter(filterFormSet, selection));
           break;
         }
@@ -137,7 +121,7 @@ const FlatRunActionButton = ({
           return await resumeRuns(params);
       }
     },
-    [flatRunMoveModalOpen, projectId, searchId, selectedRuns, selection, tableFilterString],
+    [flatRunMoveModalOpen, projectId, selectedRuns, selection, filter],
   );
 
   const submitBatchAction = useCallback(
@@ -297,7 +281,7 @@ const FlatRunActionButton = ({
         selectionSize={selectionSize}
         sourceProjectId={projectId}
         sourceWorkspaceId={workspaceId}
-        tableFilters={tableFilterString}
+        tableFilters={filter}
         onSubmit={onSubmitMove}
       />
     </>

--- a/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunActionButton.tsx
@@ -9,8 +9,7 @@ import { useObservable } from 'micro-observables';
 import { useCallback, useMemo, useState } from 'react';
 
 import BatchActionConfirmModalComponent from 'components/BatchActionConfirmModal';
-import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
-import { FilterFormSet, Operator } from 'components/FilterForm/components/type';
+import { FilterFormSetWithoutId, Operator } from 'components/FilterForm/components/type';
 import Link from 'components/Link';
 import usePermissions from 'hooks/usePermissions';
 import FlatRunMoveModalComponent from 'pages/FlatRuns/FlatRunMoveModal';
@@ -103,10 +102,7 @@ const FlatRunActionButton = ({
           break;
         }
         case 'ALL_EXCEPT': {
-          const filterFormSet =
-            selection.type === 'ALL_EXCEPT'
-              ? (JSON.parse(tableFilterString) as FilterFormSet)
-              : INIT_FORMSET;
+          const filterFormSet = JSON.parse(tableFilterString) as FilterFormSetWithoutId;
           if (searchId) {
             // only display trials for search
             const searchFilter = {
@@ -117,7 +113,7 @@ const FlatRunActionButton = ({
               type: V1ColumnType.NUMBER,
               value: searchId,
             };
-            combine(filterFormSet.filterGroup, 'and', searchFilter);
+            filterFormSet.filterGroup = combine(filterFormSet.filterGroup, 'and', searchFilter);
           }
           params.filter = JSON.stringify(getIdsFilter(filterFormSet, selection));
           break;

--- a/webui/react/src/pages/FlatRuns/FlatRunMoveModal.test.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunMoveModal.test.tsx
@@ -1,14 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import dayjs from 'dayjs';
 import Button from 'hew/Button';
 import { useModal } from 'hew/Modal';
 import UIProvider, { DefaultTheme } from 'hew/Theme';
-import { useMemo } from 'react';
 
 import FlatRunMoveModalComponent from 'pages/FlatRuns/FlatRunMoveModal';
 import { V1MoveRunsRequest } from 'services/api-ts-sdk';
-import { BulkActionResult, FlatRun, RunState } from 'types';
+import { BulkActionResult, SelectionType } from 'types';
 
 const OPEN_MODAL_TEXT = 'Open Modal';
 
@@ -32,23 +30,7 @@ const Container = ({
 }: {
   onSubmit?: (results: BulkActionResult, destinationProjectId: number) => void;
 }): JSX.Element => {
-  const BASE_FLAT_RUNS: FlatRun[] = useMemo(() => {
-    return [
-      {
-        archived: false,
-        checkpointCount: 0,
-        checkpointSize: 0,
-        id: 1,
-        parentArchived: false,
-        projectId: 1,
-        projectName: 'test',
-        startTime: dayjs('2024-05-24T23:03:45.415603Z').toDate(),
-        state: RunState.Active,
-        workspaceId: 1,
-        workspaceName: 'test',
-      },
-    ];
-  }, []);
+  const SELECTION: SelectionType = { selections: [1, 2, 3], type: 'ONLY_IN' };
 
   const flatRunMoveModal = useModal(FlatRunMoveModalComponent);
 
@@ -56,7 +38,8 @@ const Container = ({
     <div>
       <Button onClick={flatRunMoveModal.open}>{OPEN_MODAL_TEXT}</Button>
       <flatRunMoveModal.Component
-        flatRuns={BASE_FLAT_RUNS}
+        selection={SELECTION}
+        selectionSize={SELECTION.selections.length}
         sourceProjectId={1}
         onSubmit={onSubmit}
       />

--- a/webui/react/src/pages/FlatRuns/FlatRunMoveModal.test.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunMoveModal.test.tsx
@@ -6,7 +6,7 @@ import UIProvider, { DefaultTheme } from 'hew/Theme';
 
 import FlatRunMoveModalComponent from 'pages/FlatRuns/FlatRunMoveModal';
 import { V1MoveRunsRequest } from 'services/api-ts-sdk';
-import { BulkActionResult, SelectionType } from 'types';
+import { BulkActionResult } from 'types';
 
 const OPEN_MODAL_TEXT = 'Open Modal';
 
@@ -30,16 +30,14 @@ const Container = ({
 }: {
   onSubmit?: (results: BulkActionResult, destinationProjectId: number) => void;
 }): JSX.Element => {
-  const SELECTION: SelectionType = { selections: [1, 2, 3], type: 'ONLY_IN' };
-
   const flatRunMoveModal = useModal(FlatRunMoveModalComponent);
 
   return (
     <div>
       <Button onClick={flatRunMoveModal.open}>{OPEN_MODAL_TEXT}</Button>
       <flatRunMoveModal.Component
-        selection={SELECTION}
-        selectionSize={SELECTION.selections.length}
+        runIds={[1]}
+        selectionSize={1}
         sourceProjectId={1}
         onSubmit={onSubmit}
       />

--- a/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
@@ -10,6 +10,7 @@ import { List } from 'immutable';
 import { useObservable } from 'micro-observables';
 import React, { Ref, useCallback, useEffect, useId, useRef } from 'react';
 
+import { INIT_FORMSET } from 'components/FilterForm/components/FilterFormStore';
 import RunFilterInterstitialModalComponent, {
   ControlledModalRef,
 } from 'components/RunFilterInterstitialModalComponent';
@@ -21,8 +22,9 @@ import { formStore } from 'pages/FlatRuns/FlatRuns';
 import { moveRuns } from 'services/api';
 import projectStore from 'stores/projects';
 import workspaceStore from 'stores/workspaces';
-import { BulkActionResult, FlatRun, Project } from 'types';
+import { BulkActionResult, Project, SelectionType } from 'types';
 import handleError from 'utils/error';
+import { getIdsFilter as getRunIdsFilter } from 'utils/flatRun';
 import { pluralizer } from 'utils/string';
 
 const FORM_ID = 'move-flat-run-form';
@@ -33,14 +35,16 @@ type FormInputs = {
 };
 
 interface Props {
-  flatRuns: Readonly<FlatRun>[];
+  selection: SelectionType;
+  selectionSize: number;
   sourceProjectId: number;
   sourceWorkspaceId?: number;
   onSubmit?: (results: BulkActionResult, destinationProjectId: number) => void | Promise<void>;
 }
 
 const FlatRunMoveModalComponent: React.FC<Props> = ({
-  flatRuns,
+  selection,
+  selectionSize,
   sourceProjectId,
   sourceWorkspaceId,
   onSubmit,
@@ -97,9 +101,12 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
           return;
       }
 
+      const filterFormSet = INIT_FORMSET;
+      const filter = JSON.stringify(getRunIdsFilter(filterFormSet, selection));
+
       const results = await moveRuns({
         destinationProjectId: projId,
-        runIds: flatRuns.map((flatRun) => flatRun.id),
+        filter,
         sourceProjectId,
       });
       await onSubmit?.(results, projId);
@@ -108,13 +115,13 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
       handleError(e, { publicSubject: 'Unable to move runs' });
     }
   }, [
-    flatRuns,
     form,
-    onSubmit,
-    openToast,
-    sourceProjectId,
-    sourceWorkspaceId,
     destinationWorkspaceId,
+    sourceWorkspaceId,
+    sourceProjectId,
+    openToast,
+    selection,
+    onSubmit,
   ]);
 
   return (
@@ -127,9 +134,9 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
           form: idPrefix + FORM_ID,
           handleError,
           handler: handleSubmit,
-          text: `Move ${pluralizer(flatRuns.length, 'Run')}`,
+          text: `Move ${pluralizer(selectionSize, 'Run')}`,
         }}
-        title={`Move ${pluralizer(flatRuns.length, 'Run')}`}>
+        title={`Move ${pluralizer(selectionSize, 'Run')}`}>
         <Form form={form} id={idPrefix + FORM_ID} layout="vertical">
           <Form.Item
             initialValue={sourceWorkspaceId ?? 1}
@@ -196,7 +203,7 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
       <RunFilterInterstitialModalComponent
         filterFormSet={filterFormSetWithoutId}
         ref={controlledModalRef}
-        selection={{ selections: flatRuns.map((flatRun) => flatRun.id), type: 'ONLY_IN' }}
+        selection={selection}
       />
     </>
   );

--- a/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
@@ -219,6 +219,7 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
       <RunMoveWarningModalComponent ref={runMoveWarningFlowRef} />
       <RunFilterInterstitialModalComponent
         filterFormSet={filterFormSetWithoutId}
+        projectId={sourceProjectId}
         ref={controlledModalRef}
         selection={selection ?? { selections: runIds, type: 'ONLY_IN' }}
       />

--- a/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRunMoveModal.tsx
@@ -26,7 +26,6 @@ import projectStore from 'stores/projects';
 import workspaceStore from 'stores/workspaces';
 import { BulkActionResult, Project, SelectionType, XOR } from 'types';
 import handleError from 'utils/error';
-import { combine } from 'utils/filterFormSet';
 import { getIdsFilter as getRunIdsFilter } from 'utils/flatRun';
 import { pluralizer } from 'utils/string';
 
@@ -114,12 +113,11 @@ const FlatRunMoveModalComponent: React.FC<Props> = ({
       };
 
       if (tableFilters !== undefined) {
-        const filters = JSON.parse(tableFilters) as FilterFormSet;
-        const filterFormSet = INIT_FORMSET;
+        const filterFormSet =
+          selection.type === 'ALL_EXCEPT'
+            ? (JSON.parse(tableFilters) as FilterFormSet)
+            : INIT_FORMSET;
         const filter = getRunIdsFilter(filterFormSet, selection);
-        if (selection.type === 'ALL_EXCEPT') {
-          filter.filterGroup = combine(filter.filterGroup, 'and', filters.filterGroup);
-        }
         moveRunsArgs.filter = JSON.stringify(filter);
       } else {
         moveRunsArgs.runIds = runIds;

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1037,6 +1037,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
               projectId={projectId}
               selectedRuns={loadedSelectedRuns}
               selection={settings.selection}
+              selectionSize={selectionSize}
               tableFilterString={filtersString}
               workspaceId={workspaceId}
               onActionComplete={onActionComplete}

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1127,6 +1127,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             <LoadableCount
               labelPlural="runs"
               labelSingular="run"
+              pageSize={settings.pageLimit}
               selectedCount={selectedRunIdSet.size}
               total={total}
             />

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1183,6 +1183,8 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             open={settings.compare}
             projectId={projectId}
             runSelection={settings.selection}
+            searchId={searchId}
+            tableFilters={filtersString}
             onWidthChange={handleCompareWidthChange}>
             <DataGrid<FlatRun, FlatRunAction>
               columns={columns}

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -33,6 +33,7 @@ import { FilterFormStore, ROOT_ID } from 'components/FilterForm/components/Filte
 import {
   AvailableOperators,
   FilterFormSet,
+  FilterFormSetWithoutId,
   FormField,
   FormGroup,
   FormKind,
@@ -516,7 +517,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
     if (isLoadingSettings || Loadable.isNotLoaded(loadableFormset)) return;
     try {
       const filters = JSON.parse(filtersString);
-      const filterFormSet = JSON.parse(filtersString);
+      const filterFormSet = JSON.parse(filtersString) as FilterFormSetWithoutId;
       if (searchId) {
         // only display trials for search
         const searchFilter = {
@@ -527,7 +528,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
           type: V1ColumnType.NUMBER,
           value: searchId,
         };
-        combine(filterFormSet.filterGroup, 'and', searchFilter);
+        filterFormSet.filterGroup = combine(filterFormSet.filterGroup, 'and', searchFilter);
       }
       const offset = page * settings.pageLimit;
       const response = await searchRuns(

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -69,6 +69,7 @@ import userStore from 'stores/users';
 import userSettings from 'stores/userSettings';
 import { DetailedUser, FlatRun, FlatRunAction, ProjectColumn, RunState } from 'types';
 import handleError from 'utils/error';
+import { combine } from 'utils/filterFormSet';
 import { eagerSubscribe } from 'utils/observable';
 import { pluralizer } from 'utils/string';
 
@@ -515,22 +516,18 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
     if (isLoadingSettings || Loadable.isNotLoaded(loadableFormset)) return;
     try {
       const filters = JSON.parse(filtersString);
+      const filterFormSet = JSON.parse(filtersString);
       if (searchId) {
         // only display trials for search
-        const existingFilterGroup = { ...filters.filterGroup };
         const searchFilter = {
           columnName: 'experimentId',
-          kind: 'field',
-          location: 'LOCATION_TYPE_RUN',
-          operator: '=',
-          type: 'COLUMN_TYPE_NUMBER',
+          kind: 'field' as const,
+          location: V1LocationType.RUN,
+          operator: Operator.Eq,
+          type: V1ColumnType.NUMBER,
           value: searchId,
         };
-        filters.filterGroup = {
-          children: [existingFilterGroup, searchFilter],
-          conjunction: 'and',
-          kind: 'group',
-        };
+        combine(filterFormSet.filterGroup, 'and', searchFilter);
       }
       const offset = page * settings.pageLimit;
       const response = await searchRuns(

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1085,6 +1085,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             projectId={projectId}
             runSelection={settings.selection}
             searchId={searchId}
+            tableFilters={filtersString}
             onWidthChange={handleCompareWidthChange}>
             <DataGrid<FlatRun, FlatRunAction>
               columns={columns}

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1085,7 +1085,6 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             projectId={projectId}
             runSelection={settings.selection}
             searchId={searchId}
-            tableFilters={filtersString}
             onWidthChange={handleCompareWidthChange}>
             <DataGrid<FlatRun, FlatRunAction>
               columns={columns}

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -192,8 +192,8 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
     selectionSize,
     dataGridSelection,
     handleSelectionChange,
-    rowRangeToIds,
     loadedSelectedRecords: loadedSelectedRuns,
+    isRangeSelected,
   } = useSelection({
     records: runs,
     selection: settings.selection,
@@ -786,20 +786,6 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
   const handleClearSelect = useCallback(() => {
     handleSelectionChange?.('remove-all');
   }, [handleSelectionChange]);
-
-  const isRangeSelected = useCallback(
-    (range: [number, number]): boolean => {
-      if (settings.selection.type === 'ONLY_IN') {
-        const includedSet = new Set(settings.selection.selections);
-        return rowRangeToIds(range).every((id) => includedSet.has(id));
-      } else if (settings.selection.type === 'ALL_EXCEPT') {
-        const excludedSet = new Set(settings.selection.exclusions);
-        return rowRangeToIds(range).every((id) => !excludedSet.has(id));
-      }
-      return false; // should never be reached
-    },
-    [rowRangeToIds, settings.selection],
-  );
 
   const handleHeaderClick = useCallback(
     (columnId: string): void => {

--- a/webui/react/src/pages/FlatRuns/FlatRuns.tsx
+++ b/webui/react/src/pages/FlatRuns/FlatRuns.tsx
@@ -1021,6 +1021,7 @@ const FlatRuns: React.FC<Props> = ({ projectId, workspaceId, searchId }) => {
             <FlatRunActionButton
               isMobile={isMobile}
               projectId={projectId}
+              searchId={searchId}
               selectedRuns={loadedSelectedRuns}
               selection={settings.selection}
               selectionSize={selectionSize}

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -493,6 +493,50 @@ export const changeExperimentLogRetention = generateDetApi<
   Type.BulkActionResult
 >(Config.changeExperimentLogRetention);
 
+/* Searches */
+
+export const archiveSearches = generateDetApi<
+  Api.V1ArchiveSearchesRequest,
+  Api.V1ArchiveSearchesResponse,
+  Type.BulkActionResult
+>(Config.archiveSearches);
+
+export const deleteSearches = generateDetApi<
+  Api.V1DeleteSearchesRequest,
+  Api.V1DeleteSearchesResponse,
+  Type.BulkActionResult
+>(Config.deleteSearches);
+
+export const killSearches = generateDetApi<
+  Api.V1KillSearchesRequest,
+  Api.V1KillSearchesResponse,
+  Type.BulkActionResult
+>(Config.killSearches);
+
+export const moveSearches = generateDetApi<
+  Api.V1MoveSearchesRequest,
+  Api.V1MoveSearchesResponse,
+  Type.BulkActionResult
+>(Config.moveSearches);
+
+export const unarchiveSearches = generateDetApi<
+  Api.V1UnarchiveSearchesRequest,
+  Api.V1UnarchiveSearchesResponse,
+  void
+>(Config.unarchiveSearches);
+
+export const pauseSearches = generateDetApi<
+  Api.V1ResumeSearchesRequest,
+  Api.V1ResumeSearchesResponse,
+  Type.BulkActionResult
+>(Config.pauseSearches);
+
+export const resumeSearches = generateDetApi<
+  Api.V1ResumeSearchesRequest,
+  Api.V1ResumeSearchesResponse,
+  Type.BulkActionResult
+>(Config.resumeSearches);
+
 /* Tasks */
 
 export const getTask = generateDetApi<

--- a/webui/react/src/services/api.ts
+++ b/webui/react/src/services/api.ts
@@ -7,7 +7,7 @@ import { DeterminedInfo, Telemetry } from 'stores/determinedInfo';
 import { EmptyParams, RawJson, SingleEntityParams } from 'types';
 import * as Type from 'types';
 import { generateDetApi } from 'utils/service';
-import { tensorBoardMatchesSource } from 'utils/task';
+import { tensorBoardMatchesSource, tensorBoardSearchesMatchesSource } from 'utils/task';
 
 /* Authentication */
 
@@ -536,6 +536,31 @@ export const resumeSearches = generateDetApi<
   Api.V1ResumeSearchesResponse,
   Type.BulkActionResult
 >(Config.resumeSearches);
+
+export const cancelSearches = generateDetApi<
+  Api.V1ResumeSearchesRequest,
+  Api.V1ResumeSearchesResponse,
+  Type.BulkActionResult
+>(Config.resumeSearches);
+
+export const launchTensorBoardSearches = generateDetApi<
+  Service.LaunchTensorBoardSearchesParams,
+  Api.V1LaunchTensorboardSearchesResponse,
+  Type.CommandResponse
+>(Config.launchTensorBoardSearches);
+
+export const openOrCreateTensorBoardSearches = async (
+  params: Service.LaunchTensorBoardSearchesParams,
+): Promise<Type.CommandResponse> => {
+  const tensorboards = await getTensorBoards({});
+  const match = tensorboards.find(
+    (tensorboard) =>
+      !terminalCommandStates.has(tensorboard.state) &&
+      tensorBoardSearchesMatchesSource(tensorboard, params),
+  );
+  if (match) return { command: match, warnings: [V1LaunchWarning.CURRENTSLOTSEXCEEDED] };
+  return launchTensorBoardSearches(params);
+};
 
 /* Tasks */
 

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1153,6 +1153,78 @@ export const getTrialWorkloads: DetApi<
     ),
 };
 
+/* Searches */
+
+export const archiveSearches: DetApi<
+  Api.V1ArchiveSearchesRequest,
+  Api.V1ArchiveSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'archiveSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.archiveSearches(params, options),
+};
+
+export const deleteSearches: DetApi<
+  Api.V1DeleteSearchesRequest,
+  Api.V1DeleteSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'deleteSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.deleteSearches(params, options),
+};
+
+export const killSearches: DetApi<
+  Api.V1KillSearchesRequest,
+  Api.V1KillSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'killSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.killSearches(params, options),
+};
+
+export const moveSearches: DetApi<
+  Api.V1MoveSearchesRequest,
+  Api.V1MoveSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'moveSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.moveSearches(params, options),
+};
+
+export const unarchiveSearches: DetApi<
+  Api.V1UnarchiveSearchesRequest,
+  Api.V1UnarchiveSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'unarchiveSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.unarchiveSearches(params, options),
+};
+
+export const pauseSearches: DetApi<
+  Api.V1PauseSearchesRequest,
+  Api.V1PauseSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'pauseSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.pauseSearches(params, options),
+};
+
+export const resumeSearches: DetApi<
+  Api.V1ResumeSearchesRequest,
+  Api.V1ResumeSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'resumeSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.resumeSearches(params, options),
+};
+
 /* Runs */
 
 export const searchRuns: DetApi<

--- a/webui/react/src/services/apiConfig.ts
+++ b/webui/react/src/services/apiConfig.ts
@@ -1225,6 +1225,32 @@ export const resumeSearches: DetApi<
   request: (params, options) => detApi.Internal.resumeSearches(params, options),
 };
 
+export const cancelSearches: DetApi<
+  Api.V1CancelSearchesRequest,
+  Api.V1CancelSearchesResponse,
+  Type.BulkActionResult
+> = {
+  name: 'cancelSearches',
+  postProcess: (response) => decoder.mapV1ActionResults(response.results),
+  request: (params, options) => detApi.Internal.cancelSearches(params, options),
+};
+
+export const launchTensorBoardSearches: DetApi<
+  Service.LaunchTensorBoardSearchesParams,
+  Api.V1LaunchTensorboardSearchesResponse,
+  Type.CommandResponse
+> = {
+  name: 'launchTensorBoard',
+  postProcess: (response) => {
+    return {
+      command: decoder.mapV1TensorBoard(response.tensorboard),
+      warnings: response.warnings || [],
+    };
+  },
+  request: (params: Service.LaunchTensorBoardSearchesParams) =>
+    detApi.Internal.launchTensorboardSearches(params),
+};
+
 /* Runs */
 
 export const searchRuns: DetApi<

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -164,6 +164,18 @@ export interface SearchRunsParams extends PaginationParams {
   sort?: string;
 }
 
+export interface RunBulkActionParams {
+  projectId: number;
+  filter?: string;
+  runIds?: number[];
+}
+
+export interface SearchBulkActionParams {
+  projectId: number;
+  filter?: string;
+  searchIds?: number[];
+}
+
 export interface GetTaskParams {
   taskId: string;
 }

--- a/webui/react/src/services/types.ts
+++ b/webui/react/src/services/types.ts
@@ -300,6 +300,12 @@ export interface LaunchTensorBoardParams {
   filters?: Api.V1BulkExperimentFilters;
 }
 
+export interface LaunchTensorBoardSearchesParams {
+  searchIds?: Array<number>;
+  workspaceId?: number;
+  filter?: string;
+}
+
 export interface LaunchJupyterLabParams {
   config?: {
     description?: string;

--- a/webui/react/src/utils/experiment.ts
+++ b/webui/react/src/utils/experiment.ts
@@ -374,7 +374,7 @@ const idToFilter = (operator: Operator, id: number) =>
 export const getIdsFilter = (
   filterFormSet: FilterFormSetWithoutId,
   selection: SelectionType,
-): FilterFormSetWithoutId | undefined => {
+): FilterFormSetWithoutId => {
   const filterGroup: FilterFormSetWithoutId['filterGroup'] =
     selection.type === 'ALL_EXCEPT'
       ? {

--- a/webui/react/src/utils/task.ts
+++ b/webui/react/src/utils/task.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import { killableCommandStates, killableRunStates, terminalCommandStates } from 'constants/states';
-import { LaunchTensorBoardParams } from 'services/types';
+import { LaunchTensorBoardParams, LaunchTensorBoardSearchesParams } from 'services/types';
 import * as Type from 'types';
 import { CommandState, RunState, State } from 'types';
 
@@ -214,6 +214,23 @@ export const tensorBoardMatchesSource = (
     tensorBoard.misc?.trialIds?.sort();
 
     if (_.isEqual(tensorBoard.misc?.trialIds, source.trialIds)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+// Checks whether tensorboard source matches a given source list.
+export const tensorBoardSearchesMatchesSource = (
+  tensorBoard: Type.CommandTask,
+  source: LaunchTensorBoardSearchesParams,
+): boolean => {
+  if (source.searchIds) {
+    source.searchIds?.sort();
+    tensorBoard.misc?.experimentIds?.sort();
+
+    if (_.isEqual(tensorBoard.misc?.experimentIds, source.searchIds)) {
       return true;
     }
   }


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-238]
Ticket body:

> When All Checkbox is selected,  first select all visible runs, and show actual select all. When filter is applied, select all filtered runs. 
>
> For select checkbox – remove the “Select 5, 10, 25” options and remove the dropdown. Instead, we will simplify the experience to select all visible, select all in table, and none selected.
>
> Also ensure this works on the new Flat Runs and Searches Views. The current flat runs view doesn’t have the count displayed at the moment.
>
> All actions should be available on the frontend when the user has an actual select all selection or the selection contains otherwise unloaded runs or searches.

## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
When selection header is clicked it selects all items on page
![Screenshot 2024-10-18 at 14-01-41 Project Details - Determined](https://github.com/user-attachments/assets/b534f9fd-f274-45f0-89d5-7e5b047deb30)

When "Select all runs in table" is clicked it selects all items in table
![Screenshot 2024-10-18 at 14-01-59 Project Details - Determined](https://github.com/user-attachments/assets/45517226-76b4-49dc-89d7-0b1022f57312)

When selection header is clicked again it unselects all items on page
![Screenshot 2024-10-18 at 14-04-04 Project Details - Determined](https://github.com/user-attachments/assets/6afe4617-aa1e-427c-9b3b-f7ddcd416b53)

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

- Ensure selection works as expected across Runs, Searches, and Experiments tables
- Ensure bulk actions work as expected across Runs, Searches, and Experiments tables
- Ensure comparison view works as expected across Runs and Experiments tables

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-238]: https://hpe-aiatscale.atlassian.net/browse/ET-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ