### PR TITLE
chore: enable merge flag for generated bindings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,11 +3,11 @@
 
 # ignore generated code for cli diffs and merges. treat as binary.
 # ignore generated code for GitHub UIs.
-proto/pkg/**/*    -diff -merge linguist-generated=true
-master/pkg/schemas/expconf/zgen_*    -diff -merge linguist-generated=true
-webui/react/src/services/api-ts-sdk/**/*    -diff -merge linguist-generated=true
-webui/react/src/services/stream/wire.ts    -diff -merge linguist-generated=true
-harness/determined/common/api/bindings.py    -diff -merge linguist-generated=true
-harness/determined/common/streams/wire.py    -diff -merge linguist-generated=true
-docs/swagger-ui/swagger-ui*js*    -diff -merge
+proto/pkg/**/*    -diff linguist-generated=true
+master/pkg/schemas/expconf/zgen_*    -diff linguist-generated=true
+webui/react/src/services/api-ts-sdk/**/*    -diff linguist-generated=true
+webui/react/src/services/stream/wire.ts    -diff linguist-generated=true
+harness/determined/common/api/bindings.py    -diff linguist-generated=true
+harness/determined/common/streams/wire.py    -diff linguist-generated=true
+docs/swagger-ui/swagger-ui*js*    -diff
 docs/swagger-ui/swagger-ui-main* diff merge


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

I think I shouldn't have disabled merge on these. https://github.com/determined-ai/redacted/pull/262#issue-2566638197
>have you seen your PRs getting blocked by: "merge conflict on openapi31.json" files? with the flag we have in git attributes and how it's a single line we've disabled git from automatically attempting to merge these files this changes that

> reduce git merge conflicts by remove the -merge flag and saving the oapi spec as multiline text file.
https://git-scm.com/docs/gitattributes

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ