### PR TITLE
build: INFENG-926: Fix version.sh version string output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
       - checkout
       - run: git fetch --tags
       - run: git tag --list
+      - run: git -c versionsort.suffix='-rc' tag --sort='-v:refname:short' --format='%(refname:short)' --no-contains=$(git merge-base HEAD main) | grep -E -v 'v0.12|-ee' | head -n 1
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - gh/install
       - checkout
       - run: git fetch --tags
-      - run: git tag --list
+      - run: echo $SHELL
       - run: git -c versionsort.suffix='-rc' tag --sort='-v:refname:short' --format='%(refname:short)' --no-contains=$(git merge-base HEAD main)
 
       # this must be first; default to an empty params list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
     executor: continuation/default
     steps:
       - checkout
-      - run: git fetch --tags
       - attach_workspace:
           at: '<<pipeline.parameters.workspace_path>>'
       - continuation/continue:
@@ -59,8 +58,6 @@ jobs:
     steps:
       - gh/install
       - checkout
-      - run: git fetch --tags
-      - run: "./version.sh"
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,7 @@ jobs:
       - gh/install
       - checkout
       - run: git fetch --tags
-      - run: echo $SHELL
-      - run: git -c versionsort.suffix='-rc' tag --sort='-v:refname:short' --format='%(refname:short)' --no-contains=$(git merge-base HEAD main)
+      - run: "./version.sh"
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - gh/install
       - checkout
+      - run: git fetch
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
     executor: continuation/default
     steps:
       - checkout
+      - run: git fetch
       - attach_workspace:
           at: '<<pipeline.parameters.workspace_path>>'
       - continuation/continue:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
     executor: continuation/default
     steps:
       - checkout
-      - run: git fetch
+      - run: git fetch --tags
       - attach_workspace:
           at: '<<pipeline.parameters.workspace_path>>'
       - continuation/continue:
@@ -59,7 +59,7 @@ jobs:
     steps:
       - gh/install
       - checkout
-      - run: git fetch
+      - run: git fetch --tags
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - checkout
       - run: git fetch --tags
       - run: git tag --list
-      - run: git -c versionsort.suffix='-rc' tag --sort='-v:refname:short' --format='%(refname:short)' --no-contains=$(git merge-base HEAD main) | grep -E -v 'v0.12|-ee' | head -n 1
+      - run: git -c versionsort.suffix='-rc' tag --sort='-v:refname:short' --format='%(refname:short)' --no-contains=$(git merge-base HEAD main)
 
       # this must be first; default to an empty params list
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
       - gh/install
       - checkout
       - run: git fetch --tags
+      - run: git tag --list
 
       # this must be first; default to an empty params list
       - run:

--- a/version.sh
+++ b/version.sh
@@ -99,6 +99,14 @@ if [[ -z ${VERSION} ]]; then
 
     echo "test4"
 
+    printf "%s" "$MAYBE_TAG"
+
+    echo "test5"
+
+    grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG")
+
+    echo "test6"
+
     # Filter out additional +metadata from the tag, should it
     # exist. This prevents version strings like
     # 0.751.0+dryrun+27a014b44.

--- a/version.sh
+++ b/version.sh
@@ -92,8 +92,9 @@ if [[ -z ${VERSION} ]]; then
         )
     fi
 
-    # Filter out additional +metadata from tag, should it exist. This prevents
-    # tags like 0.751.0+dryrun+27a014b44.
+    # Filter out additional +metadata from the tag, should it
+    # exist. This prevents version strings like
+    # 0.751.0+dryrun+27a014b44.
     MAYBE_TAG=$(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,

--- a/version.sh
+++ b/version.sh
@@ -103,6 +103,8 @@ if [[ -z ${VERSION} ]]; then
 
     echo "test5"
 
+    which printf
+    which grep
     echo $(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
 
     echo "test6"

--- a/version.sh
+++ b/version.sh
@@ -95,10 +95,11 @@ if [[ -z ${VERSION} ]]; then
     # Filter out additional +metadata from the tag, should it
     # exist. This prevents version strings like
     # 0.751.0+dryrun+27a014b44.
-    # Note: we use [0-9] instead of \d here, because while BSD grep's -E
-    # includes the \d character class, while GNU grep's does not. This means
-    # using \d on macOS will work fine, but it will break on Linux (and thus,
-    # CI). To avoid this, we fall back to standard character sets.
+    # Note: we use [0-9] instead of \d here, because while BSD grep's
+    # -E includes the \d character class, GNU grep's -E does not. This
+    # means using \d on macOS will work fine, but it will break on
+    # Linux (and thus, CI). To avoid this, we fall back to standard
+    # character sets.
     MAYBE_TAG=$(grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' <(printf "%s" "$MAYBE_TAG"))
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,

--- a/version.sh
+++ b/version.sh
@@ -103,7 +103,7 @@ if [[ -z ${VERSION} ]]; then
 
     echo "test5"
 
-    grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG")
+    echo $(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
 
     echo "test6"
 

--- a/version.sh
+++ b/version.sh
@@ -68,11 +68,13 @@ fi
 if [[ -z ${VERSION} ]]; then
     # Check if this branch has any tags (typically, only release branches will
     # have tags).
+    echo "test1"
     MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
     SHA=$(git rev-parse --short HEAD)
 
     # No tag on current branch.
     if [[ -z ${MAYBE_TAG} ]]; then
+        echo "test2"
         # Use git to find the merge base between the current branch and main,
         # and then find the closest tag behind that, using --no-contains. Then,
         # use grep to remove some special cases, namely: old Determined version
@@ -90,12 +92,19 @@ if [[ -z ${VERSION} ]]; then
                 | grep -E -v 'v0.12|-ee' \
                 | head -n 1
         )
+
+        echo "test3"
+        echo "[${MAYBE_TAG}]"
     fi
+
+    echo "test4"
 
     # Filter out additional +metadata from the tag, should it
     # exist. This prevents version strings like
     # 0.751.0+dryrun+27a014b44.
     MAYBE_TAG=$(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
+
+    echo "[${MAYBE_TAG}]"
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,
     # even if we're on the commit with the tag. This is partially because I feel

--- a/version.sh
+++ b/version.sh
@@ -95,6 +95,10 @@ if [[ -z ${VERSION} ]]; then
     # Filter out additional +metadata from the tag, should it
     # exist. This prevents version strings like
     # 0.751.0+dryrun+27a014b44.
+    # Note: we use [0-9] instead of \d here, because while BSD grep's -E
+    # includes the \d character class, while GNU grep's does not. This means
+    # using \d on macOS will work fine, but it will break on Linux (and thus,
+    # CI). To avoid this, we fall back to standard character sets.
     MAYBE_TAG=$(grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' <(printf "%s" "$MAYBE_TAG"))
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,

--- a/version.sh
+++ b/version.sh
@@ -68,7 +68,7 @@ fi
 if [[ -z ${VERSION} ]]; then
     # Check if this branch has any tags (typically, only release branches will
     # have tags).
-    MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null | grep -Eo 'v?\d+\.\d+\.\d+')
+    MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
     SHA=$(git rev-parse --short HEAD)
 
     # No tag on current branch.
@@ -91,6 +91,10 @@ if [[ -z ${VERSION} ]]; then
                 | head -n 1
         )
     fi
+
+    # Filter out additional +metadata from tag, should it exist. This prevents
+    # tags like 0.751.0+dryrun+27a014b44.
+    MAYBE_TAG=$(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,
     # even if we're on the commit with the tag. This is partially because I feel

--- a/version.sh
+++ b/version.sh
@@ -68,13 +68,11 @@ fi
 if [[ -z ${VERSION} ]]; then
     # Check if this branch has any tags (typically, only release branches will
     # have tags).
-    echo "test1"
     MAYBE_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
     SHA=$(git rev-parse --short HEAD)
 
     # No tag on current branch.
     if [[ -z ${MAYBE_TAG} ]]; then
-        echo "test2"
         # Use git to find the merge base between the current branch and main,
         # and then find the closest tag behind that, using --no-contains. Then,
         # use grep to remove some special cases, namely: old Determined version
@@ -92,29 +90,12 @@ if [[ -z ${VERSION} ]]; then
                 | grep -E -v 'v0.12|-ee' \
                 | head -n 1
         )
-
-        echo "test3"
-        echo "[${MAYBE_TAG}]"
     fi
-
-    echo "test4"
-
-    printf "%s" "$MAYBE_TAG"
-
-    echo "test5"
-
-    which printf
-    which grep
-    echo $(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
-
-    echo "test6"
 
     # Filter out additional +metadata from the tag, should it
     # exist. This prevents version strings like
     # 0.751.0+dryrun+27a014b44.
-    MAYBE_TAG=$(grep -Eo 'v?\d+\.\d+\.\d+' <(printf "%s" "$MAYBE_TAG"))
-
-    echo "[${MAYBE_TAG}]"
+    MAYBE_TAG=$(grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+' <(printf "%s" "$MAYBE_TAG"))
 
     # Munge the tag into the form we want. Note: we always append a SHA hash,
     # even if we're on the commit with the tag. This is partially because I feel


### PR DESCRIPTION
## Ticket

INFENG-926

## Description

This fixes a bug in version.sh that would cause an invalid local version string to be output under certain circumstances; specifically, if a tag were made on a commit that was not on the current branch (i.e. reachable with git-describe). This took a code path in version.sh that did not properly remove any existing tag +metadata with grep, leading to version strings like 0.751.0+dryrun+27a014b44. Note the extra plus sign (+). This causes downstream tools, like helm, to fail.

Now, we remove any existing version metadata from the final for all code paths.

This also changes all instances of `\d` character classes to `[0-9]`. This fixes a cross-platform issue where BSD grep's `-E` includes `\d` classes, while GNU grep's `-E` does not. This means the script worked fine on macOS, but broke subtly in CI (and I suppose on anyone's work machine that uses Linux). We avoid this entirely by falling back to standard character sets.

## Test Plan
1. Create a tag with a plus sign `+` in it on a commit on a branch other than this one, `INFENG-926-fix-version-sh`. E.g. `v0.800.0+dryrun`.
1. Switch back to `INFENG-926-fix-version-sh` and run `./version.sh`. The version string returned should have only one `+metadata` part, instead of two.
1. Delete the tag you created.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code