### PR TITLE
Introducing Determined Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Get familiar with Determined by exploring the 30+ examples in the [examples fold
   - [PyTorch API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-pytorch-ug.html)
   - [Keras API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/api-keras-ug.html)
   - [DeepSpeed API](https://docs.determined.ai/latest/model-dev-guide/apis-howto/deepspeed/overview.html)
+- [Ask Determined Guru](https://gurubase.io/g/determined) - it is an Determined-focused AI to answer your questions.
 
 # Community
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Determined Guru](https://gurubase.io/g/determined) to Gurubase. Determined Guru uses the data from this repo and data from the [docs](https://docs.determined.ai/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Determined Guru", which highlights that Determined now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Determined Guru in Gurubase, just let me know that's totally fine.