### PR TITLE
chore: clarify version overrides during helm installs

### DIFF
--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -19,6 +19,10 @@
    <https://github.com/determined-ai/determined>`_ (e.g.,
    ``b13461ed06f2fad339e179af8028d4575db71a81``). Users are encouraged to use a released version.
 
+   -  The version specified in the ``detVersion`` field of your ``values.yaml`` overrides the
+      version specified in ``appVersion``. For more information, see ``detVersion`` in the
+      :ref:`values.yaml config reference <values-yaml-settings>`.
+
 .. note::
 
    If using a non-release branch of the Determined repository, ``appVersion`` is going to be set to
@@ -26,9 +30,21 @@
    ``ImagePullBackOff`` error. Users should remove ``.dev0`` to get the latest released version, or
    they can specify a specific commit hash instead.
 
+.. _values-yaml-settings:
+
 **************************
  ``values.yaml`` Settings
 **************************
+
+-  ``detVersion``: The Determined version to install. This can be a release version (e.g.,
+   ``0.13.0``) or a commit hash from the `upstream Determined repo
+   <https://github.com/determined-ai/determined>`_. Release versions are encouraged.
+
+   -  **NOTE:** This version overrides the version specified in ``appVersion`` of your
+      ``Chart.yaml`` *and* any version specified in your ``helm install`` or ``helm upgrade``
+      command. So, for example, if you install Determined with ``helm install <release_name>
+      <helm_repo> --version <X.Y.Z>`` but set ``detVersion: A.B.C``, the Determined version
+      ``A.B.C`` is installed.
 
 -  ``masterPort``: The port at which the Determined master listens for connections on. (*Required*)
 

--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -42,11 +42,10 @@
 
    -  **NOTE:** This version overrides the version specified in ``appVersion`` of your
       ``Chart.yaml`` *and* any version specified in your ``helm install`` or ``helm upgrade``
-      command. 
+      command.
 
-      -  For example, if you install Determined with 
-         ``helm install <release_name> ... --version <X.Y.Z>`` but set ``detVersion: A.B.C``, the 
-         Determined version ``A.B.C`` is installed.
+      -  For example, if you install Determined with ``helm install <release_name> ... --version
+         <X.Y.Z>`` but set ``detVersion: A.B.C``, the Determined version ``A.B.C`` is installed.
 
 -  ``masterPort``: The port at which the Determined master listens for connections on. (*Required*)
 

--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -42,9 +42,11 @@
 
    -  **NOTE:** This version overrides the version specified in ``appVersion`` of your
       ``Chart.yaml`` *and* any version specified in your ``helm install`` or ``helm upgrade``
-      command. So, for example, if you install Determined with ``helm install <release_name>
-      <helm_repo> --version <X.Y.Z>`` but set ``detVersion: A.B.C``, the Determined version
-      ``A.B.C`` is installed.
+      command. 
+
+      -  For example, if you install Determined with 
+         ``helm install <release_name> ... --version <X.Y.Z>`` but set ``detVersion: A.B.C``, the 
+         Determined version ``A.B.C`` is installed.
 
 -  ``masterPort``: The port at which the Determined master listens for connections on. (*Required*)
 


### PR DESCRIPTION
## Ticket

[CM-582]


## Description
Clarify version overrides (`detVersion` in `values.yaml` overrides appVersion in `Chart.yaml` and `--version` in `helm install` and `helm upgrade` commands) during helm installs in our [helm configuration reference docs](https://docs.determined.ai/latest/reference/deploy/helm-config-reference.html)



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-582]: https://hpe-aiatscale.atlassian.net/browse/CM-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ