### PR TITLE
feat: Deepspeed Trainer

### DIFF
--- a/examples/deepspeed/dcgan/README.md
+++ b/examples/deepspeed/dcgan/README.md
@@ -1,0 +1,49 @@
+# DeepSpeed CIFAR Example
+This example is adapted from the
+[DCGAN example in the DeepSpeedExamples](https://github.com/microsoft/DeepSpeedExamples/tree/master/training/gan)
+repository. It is intended to demonstrate a simple usecase of DeepSpeed with Determined.
+
+## Files
+* **model.py**: The DCGANTrial definition.
+* **gan_model.py**: Network definitions for generator and discriminator.
+* **data.py**: Dataset loading/downloading code.
+
+### Configuration Files
+* **ds_config.json**: The DeepSpeed config file.
+* **mnist.yaml**: Determined config to train the model on mnist on a cluster.
+
+## Data
+This repo supports the same datasets as the original example: `["imagenet", "lfw", "lsun", "cifar10", "mnist", "fake", "celeba"]`.  The `cifar10` and `mnist` datasets will be downloaded as needed, whereas the rest must be mounted on the agent.  For `lsun`, the `data_config.classes` setting must be set.  The `folder` dataset can be used to load an arbitrary torchvision `ImageFolder` that is mounted on the agent.
+
+## To Run Locally
+
+It is recommended to run this from within one of our agent docker images, found at
+https://hub.docker.com/r/determinedai/pytorch-ngc/tags
+
+After installing docker and pulling an image, users can launch a container via
+`docker run --gpus=all -v ~path/to/repo:/src/proj -it <container name>`
+
+Install necessary dependencies via `pip install determined mpi4py`
+
+Then, run the following command:
+```
+python trainer.py
+```
+
+Any additional configs can be specified in `mnist.yaml` and `ds_config.json` accordingly.
+
+## To Run on Cluster
+If you have not yet installed Determined, installation instructions can be found
+under `docs/install-admin.html` or at https://docs.determined.ai/latest/index.html
+
+Run the following command:
+```
+det experiment create mnist.yaml .
+```
+The other configurations can be run by specifying the appropriate configuration file in place
+of `mnist.yaml`.
+
+## Results
+Training `mnist` should yield reasonable looking fake digit images on the images tab in TensorBoard after ~5k steps.
+
+Training `cifar10` does not converge as convincingly, but should look image-like after ~10k steps.

--- a/examples/deepspeed/dcgan/data.py
+++ b/examples/deepspeed/dcgan/data.py
@@ -1,0 +1,104 @@
+import contextlib
+import os
+from typing import cast
+
+import filelock
+import torch
+import torchvision.datasets as dset
+import torchvision.transforms as transforms
+
+CHANNELS_BY_DATASET = {
+    "imagenet": 3,
+    "folder": 3,
+    "lfw": 3,
+    "lsun": 3,
+    "cifar10": 3,
+    "mnist": 1,
+    "fake": 3,
+    "celeba": 3,
+}
+
+
+def get_dataset(data_config: dict) -> torch.utils.data.Dataset:
+    if data_config.get("dataroot", None) is None:
+        if str(data_config.get("dataset"),"").lower() != "fake":
+            raise ValueError('`dataroot` parameter is required for dataset "%s"'
+                            % data_config.get("dataset", ""))
+        else:
+            context = contextlib.nullcontext()
+    else:
+        # Ensure that only one local process attempts to download/validate datasets at once.
+        context = filelock.FileLock(os.path.join(data_config["dataroot"], ".lock"))
+    with context:
+        if data_config["dataset"] in ["imagenet", "folder", "lfw"]:
+            # folder dataset
+            dataset = dset.ImageFolder(
+                root=data_config["dataroot"],
+                transform=transforms.Compose(
+                    [
+                        transforms.Resize(data_config["image_size"]),
+                        transforms.CenterCrop(data_config["image_size"]),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+                    ]
+                ),
+            )
+        elif data_config["dataset"] == "lsun":
+            classes = [c + "_train" for c in data_config["classes"].split(",")]
+            dataset = dset.LSUN(
+                root=data_config["dataroot"],
+                classes=classes,
+                transform=transforms.Compose(
+                    [
+                        transforms.Resize(data_config["image_size"]),
+                        transforms.CenterCrop(data_config["image_size"]),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+                    ]
+                ),
+            )
+        elif data_config["dataset"] == "cifar10":
+            dataset = dset.CIFAR10(
+                root=data_config["dataroot"],
+                download=True,
+                transform=transforms.Compose(
+                    [
+                        transforms.Resize(data_config["image_size"]),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+                    ]
+                ),
+            )
+        elif data_config["dataset"] == "mnist":
+            dataset = dset.MNIST(
+                root=data_config["dataroot"],
+                download=True,
+                transform=transforms.Compose(
+                    [
+                        transforms.Resize(data_config["image_size"]),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5,), (0.5,)),
+                    ]
+                ),
+            )
+        elif data_config["dataset"] == "fake":
+            dataset = dset.FakeData(
+                image_size=(3, data_config["image_size"], data_config["image_size"]),
+                transform=transforms.ToTensor(),
+            )
+        elif data_config["dataset"] == "celeba":
+            dataset = dset.ImageFolder(
+                root=data_config["dataroot"],
+                transform=transforms.Compose(
+                    [
+                        transforms.Resize(data_config["image_size"]),
+                        transforms.CenterCrop(data_config["image_size"]),
+                        transforms.ToTensor(),
+                        transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+                    ]
+                ),
+            )
+        else:
+            unknown_dataset_name = data_config["dataset"]
+            raise Exception(f"Unknown dataset {unknown_dataset_name}")
+    return cast(torch.utils.data.Dataset, dataset)

--- a/examples/deepspeed/dcgan/ds_config.json
+++ b/examples/deepspeed/dcgan/ds_config.json
@@ -1,0 +1,15 @@
+{
+    "train_batch_size": 64,
+    "optimizer": {
+        "type": "Adam",
+        "params": {
+            "lr": 0.0002,
+            "betas": [
+                0.5,
+                0.999
+            ],
+            "eps": 1e-8
+        }
+    },
+    "steps_per_print": 10
+}

--- a/examples/deepspeed/dcgan/gan_model.py
+++ b/examples/deepspeed/dcgan/gan_model.py
@@ -1,0 +1,73 @@
+from typing import cast
+
+import torch
+import torch.nn as nn
+
+
+def weights_init(m: nn.Module) -> None:
+    classname = m.__class__.__name__
+    if classname.find("Conv") != -1:
+        nn.init.normal_(cast(torch.Tensor, m.weight.data), 0.0, 0.02)
+    elif classname.find("BatchNorm") != -1:
+        nn.init.normal_(cast(torch.Tensor, m.weight.data), 1.0, 0.02)
+        nn.init.constant_(cast(torch.Tensor, m.bias.data), 0)
+
+
+class Generator(nn.Module):
+    def __init__(self, ngf: int, nc: int, nz: int) -> None:
+        super(Generator, self).__init__()  # type: ignore
+        self.main = nn.Sequential(
+            # input is Z, going into a convolution
+            nn.ConvTranspose2d(nz, ngf * 8, 4, 1, 0, bias=False),
+            nn.BatchNorm2d(ngf * 8),  # type: ignore
+            nn.ReLU(True),
+            # state size. (ngf*8) x 4 x 4
+            nn.ConvTranspose2d(ngf * 8, ngf * 4, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf * 4),  # type: ignore
+            nn.ReLU(True),
+            # state size. (ngf*4) x 8 x 8
+            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf * 2),  # type: ignore
+            nn.ReLU(True),
+            # state size. (ngf*2) x 16 x 16
+            nn.ConvTranspose2d(ngf * 2, ngf, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf),  # type: ignore
+            nn.ReLU(True),
+            # state size. (ngf) x 32 x 32
+            nn.ConvTranspose2d(ngf, nc, 4, 2, 1, bias=False),
+            nn.Tanh()  # type: ignore
+            # state size. (nc) x 64 x 64
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = self.main(input)
+        return cast(torch.Tensor, output)
+
+
+class Discriminator(nn.Module):
+    def __init__(self, ndf: int, nc: int) -> None:
+        super(Discriminator, self).__init__()  # type: ignore
+        self.main = nn.Sequential(
+            # input is (nc) x 64 x 64
+            nn.Conv2d(nc, ndf, 4, 2, 1, bias=False),
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf) x 32 x 32
+            nn.Conv2d(ndf, ndf * 2, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 2),  # type: ignore
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*2) x 16 x 16
+            nn.Conv2d(ndf * 2, ndf * 4, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 4),  # type: ignore
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*4) x 8 x 8
+            nn.Conv2d(ndf * 4, ndf * 8, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 8),  # type: ignore
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*8) x 4 x 4
+            nn.Conv2d(ndf * 8, 1, 4, 1, 0, bias=False),
+            nn.Sigmoid(),  # type: ignore
+        )
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = self.main(input)
+        return cast(torch.Tensor, output.view(-1, 1).squeeze(1))

--- a/examples/deepspeed/dcgan/mnist.yaml
+++ b/examples/deepspeed/dcgan/mnist.yaml
@@ -22,8 +22,6 @@ resources:
 searcher:
   name: single
   metric: no_validation_metric
-  max_length:
-    batches: 200
 min_validation_period:
   batches: 0
 entrypoint:

--- a/examples/deepspeed/dcgan/mnist.yaml
+++ b/examples/deepspeed/dcgan/mnist.yaml
@@ -1,0 +1,35 @@
+name: dcgan_deepspeed_mnist
+data:
+  dataroot: /data
+  dataset: mnist
+  image_size: 64
+hyperparameters:
+  deepspeed_config: ds_config.json
+  noise_length: 100
+  generator_width_base: 64
+  discriminator_width_base: 64
+  data_workers: 16
+environment:
+  environment_variables:
+    - NCCL_DEBUG=INFO
+    - NCCL_SOCKET_IFNAME=ens,eth,ib
+  image: determinedai/pytorch-ngc-dev:0736b6d
+bind_mounts:
+  - host_path: /tmp
+    container_path: /data
+resources:
+  slots_per_trial: 2
+searcher:
+  name: single
+  metric: no_validation_metric
+  max_length:
+    batches: 200
+min_validation_period:
+  batches: 0
+entrypoint:
+  - python3
+  - -m
+  - determined.launch.deepspeed
+  - python3
+  - trainer.py
+max_restarts: 0

--- a/examples/deepspeed/dcgan/model.py
+++ b/examples/deepspeed/dcgan/model.py
@@ -1,0 +1,208 @@
+import logging
+from typing import Any, Dict, Iterator, Optional, Tuple, Union, cast
+
+import data
+import deepspeed
+import torch
+import torch.nn as nn
+import torch.utils.data
+import torchvision
+from gan_model import Discriminator, Generator, weights_init
+
+from determined.pytorch import DataLoader, TorchData
+from determined.pytorch import deepspeed as det_ds
+
+REAL_LABEL = 1
+FAKE_LABEL = 0
+
+
+class DCGANTrial(det_ds.DeepSpeedTrial):
+    def __init__(self, context: det_ds.DeepSpeedTrialContext,
+                 hparams: dict, data_config: dict) -> None:
+        self.context = context
+        self.hparams = hparams
+        self.data_config = data_config
+        self.logger = self.context.get_tensorboard_writer()
+        num_channels = data.CHANNELS_BY_DATASET[self.data_config["dataset"]]
+        gen_net = Generator(
+            self.hparams["generator_width_base"], num_channels, self.hparams["noise_length"]
+        )
+        gen_net.apply(weights_init)
+        disc_net = Discriminator(self.hparams["discriminator_width_base"], num_channels)
+        disc_net.apply(weights_init)
+        gen_parameters = filter(lambda p: p.requires_grad, gen_net.parameters())
+        disc_parameters = filter(lambda p: p.requires_grad, disc_net.parameters())
+        ds_config = det_ds.overwrite_deepspeed_config(
+            self.hparams["deepspeed_config"], self.hparams.get("overwrite_deepspeed_args", {})
+        )
+        generator, _, _, _ = deepspeed.initialize(
+            model=gen_net, model_parameters=gen_parameters, config=ds_config
+        )
+        discriminator, _, _, _ = deepspeed.initialize(
+            model=disc_net, model_parameters=disc_parameters, config=ds_config
+        )
+
+        self.generator = self.context.wrap_model_engine(generator)
+        self.discriminator = self.context.wrap_model_engine(discriminator)
+        self.fixed_noise = self.context.to_device(
+            torch.randn(
+                self.context.train_micro_batch_size_per_gpu, self.hparams["noise_length"], 1, 1
+            )
+        )
+        self.criterion = nn.BCELoss()
+        self.fp16 = generator.fp16_enabled()
+        self.gradient_accumulation_steps = generator.gradient_accumulation_steps()
+        # Manually perform gradient accumulation.
+        if self.gradient_accumulation_steps > 1:
+            logging.info("Disabling automatic gradient accumulation.")
+            self.context.disable_auto_grad_accumulation()
+
+    def _get_noise(self, dtype: torch.dtype) -> torch.Tensor:
+        return cast(
+            torch.Tensor,
+            self.context.to_device(
+                torch.randn(
+                    self.context.train_micro_batch_size_per_gpu,
+                    self.hparams["noise_length"],
+                    1,
+                    1,
+                    dtype=dtype,
+                )
+            ),
+        )
+
+    def _get_label_constants(
+        self, batch_size: int, dtype: torch.dtype
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        real_label = cast(
+            torch.Tensor,
+            self.context.to_device(torch.full((batch_size,), REAL_LABEL, dtype=dtype)),
+        )
+        fake_label = cast(
+            torch.Tensor,
+            self.context.to_device(torch.full((batch_size,), FAKE_LABEL, dtype=dtype)),
+        )
+        return real_label, fake_label
+
+    def train_batch(
+        self, iter_dataloader: Optional[Iterator[TorchData]], epoch_idx: int, batch_idx: int
+    ) -> Union[torch.Tensor, Dict[str, Any]]:
+        assert iter_dataloader is not None
+        if self.fp16:
+            dtype = torch.float16
+        else:
+            dtype = torch.float32
+        real_label, fake_label = self._get_label_constants(
+            self.context.train_micro_batch_size_per_gpu, dtype
+        )
+        ############################
+        # (1) Update D network: maximize log(D(x)) + log(1 - D(G(z)))
+        ###########################
+        self.discriminator.zero_grad()
+
+        real_sample_count = 0
+        errD_real_sum = 0.0
+        errD_fake_sum = 0.0
+        D_x = 0.0
+        D_G_z1 = 0.0
+        fake_sample_count = (
+            self.context.train_micro_batch_size_per_gpu * self.gradient_accumulation_steps
+        )
+
+        for i in range(self.gradient_accumulation_steps):
+            # Note: at end of epoch, may receive a batch of size smaller than train_micro_batch_size_per_gpu.
+            # In that case, we end up training on more fake examples than real examples.
+            # train with real
+            real, _ = self.context.to_device(next(iter_dataloader))
+            real = cast(torch.Tensor, real)
+            actual_batch_size = real.shape[0]
+            real_sample_count += actual_batch_size
+            if self.fp16:
+                real = real.half()
+            output = self.discriminator(real)
+            # For edge-case small batches, must cut real_label size to match.
+            errD_real = self.criterion(output, real_label[:actual_batch_size])
+            self.discriminator.backward(errD_real)
+            # Undo averaging so we can re-average at end when reporting metrics.
+            errD_real_sum += errD_real * actual_batch_size
+            D_x += output.sum().item()
+            # train with fake
+            noise = self._get_noise(dtype)
+            fake = self.generator(noise)
+            output = self.discriminator(fake.detach())
+            errD_fake = self.criterion(output, fake_label)
+            self.discriminator.backward(errD_fake)
+            errD_fake_sum += errD_fake * self.context.train_micro_batch_size_per_gpu
+            D_G_z1 += output.sum().item()
+            # update
+            self.discriminator.step()
+        D_x /= real_sample_count
+        D_G_z1 /= fake_sample_count
+        errD = (errD_real_sum / real_sample_count) + (errD_fake_sum / fake_sample_count)
+        ############################
+        # (2) Update G network: maximize log(D(G(z)))
+        ###########################
+        self.generator.zero_grad()
+        D_G_z2_sum = 0.0
+        errG_sum = 0.0
+        for i in range(self.gradient_accumulation_steps):
+            if i > 0:
+                # Must repeat forward pass of generator for accumulation steps beyond the first.
+                noise = self._get_noise(dtype)
+                fake = self.generator(noise)
+            output = self.discriminator(fake)
+            errG = self.criterion(output, real_label)  # fake labels are real for generator cost
+            self.generator.backward(errG)
+            errG_sum += errG * self.context._train_micro_batch_size_per_gpu
+            D_G_z2_sum += output.sum().item()
+            self.generator.step()
+
+        if batch_idx % 100 == 0:
+            fake = self.generator(self.fixed_noise)
+            denormalized_real = (real + 1) / 2
+            denormalized_fake = (fake + 1) / 2
+            self.logger.add_image(
+                "real_images", torchvision.utils.make_grid(denormalized_real), batch_idx
+            )
+            self.logger.add_image(
+                "fake_images", torchvision.utils.make_grid(denormalized_fake), batch_idx
+            )
+
+        return {
+            "errD": errD,
+            "errG": errG_sum / fake_sample_count,
+            "D_x": D_x,
+            "D_G_z1": D_G_z1,
+            "D_G_z2": D_G_z2_sum / fake_sample_count,
+        }
+
+    def evaluate_batch(
+        self, dataloader_iter: Optional[Iterator[TorchData]], batch_idx: int
+    ) -> Dict[str, Any]:
+        # TODO: We could add an evaluation metric like FID here.
+        assert dataloader_iter is not None
+        next(dataloader_iter)
+        return {"no_validation_metric": 0.0}
+
+    def build_training_data_loader(self) -> Any:
+        dataset = data.get_dataset(self.data_config)
+        return DataLoader(
+            dataset,
+            batch_size=self.context.train_micro_batch_size_per_gpu,
+            shuffle=True,
+            num_workers=int(self.hparams["data_workers"]),
+        )
+
+    def build_validation_data_loader(self) -> Any:
+        dataset = data.get_dataset(self.data_config)
+        # Since we're not doing validation, limit to single batch.
+        dataset = torch.utils.data.Subset(
+            dataset,
+            list(
+                range(
+                    self.context.train_micro_batch_size_per_gpu
+                    * self.context.distributed.get_size()
+                )
+            ),
+        )
+        return DataLoader(dataset, batch_size=self.context.train_micro_batch_size_per_gpu)

--- a/examples/deepspeed/dcgan/trainer.py
+++ b/examples/deepspeed/dcgan/trainer.py
@@ -1,0 +1,39 @@
+import logging
+import yaml
+
+import determined as det
+from determined import pytorch
+from determined.pytorch import deepspeed as det_ds
+
+import model
+
+
+def main(config_file: str, local: bool=True):
+    info = det.get_cluster_info()
+
+    if local:
+        # For convenience, use hparams from const.yaml for local mode.
+        with open(config_file, "r") as f:
+            experiment_config = yaml.load(f, Loader=yaml.SafeLoader)
+        hparams = experiment_config["hyperparameters"]
+        data_config = experiment_config["data"]
+        max_length = pytorch.Batch(100)  # Train for 100 batches.
+        latest_checkpoint = None
+    else:
+        hparams = info.trial.hparams
+        data_config = info.trial._config["data"]
+        max_length = None  # On-cluster training trains for the searcher's configured length.
+        latest_checkpoint = (
+            info.latest_checkpoint
+        )  # (Optional) Configure checkpoint for pause/resume functionality.
+
+    with det_ds.init() as train_context:
+        trial = model.DCGANTrial(train_context, hparams, data_config)
+        trainer = det_ds.Trainer(trial, train_context)
+        trainer.fit(max_length=max_length, latest_checkpoint=latest_checkpoint)
+
+if __name__ == "__main__":
+    local = det.get_cluster_info() is None
+    # Configure logging
+    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
+    main(config_file="mnist.yaml", local=local)

--- a/examples/deepspeed/gpt_neox/det_utils.py
+++ b/examples/deepspeed/gpt_neox/det_utils.py
@@ -30,7 +30,7 @@ def get_neox_args(context):
             "checkpoint_factor": exp_config["min_validation_period"]["batches"],
             "eval_interval": exp_config["min_validation_period"]["batches"],
             "hostfile": os.environ.get("DET_DEEPSPEED_HOSTFILE_PATH"),
-            "seed": context.env.trial_seed,
+            "seed": context.get_trial_seed(),
         }
     )
     for k, v in overwrite_values.items():

--- a/harness/determined/pytorch/__init__.py
+++ b/harness/determined/pytorch/__init__.py
@@ -24,17 +24,20 @@ from determined.pytorch._metric_utils import (
     _convert_metrics_to_numpy,
     _log_tb_metrics,
 )
+from determined.pytorch._trainer_utils import (
+    Batch,
+    Epoch,
+    _ShouldExit,
+    _TrainBoundary,
+    _TrainBoundaryType,
+    TrainUnit,
+    _TrialState,
+)
 from determined.pytorch._experimental import PyTorchExperimentalContext
 from determined.pytorch._pytorch_context import PyTorchTrialContext
 from determined.pytorch._pytorch_trial import (
     PyTorchTrial,
     _PyTorchTrialController,
-    TrainUnit,
-    _TrainBoundary,
-    _TrainBoundaryType,
-    _TrialState,
-    Batch,
-    Epoch,
 )
 from determined.pytorch._load import CheckpointLoadContext, load_trial_from_checkpoint_path
 from determined.pytorch._trainer import init, Trainer

--- a/harness/determined/pytorch/_trainer_utils.py
+++ b/harness/determined/pytorch/_trainer_utils.py
@@ -1,0 +1,145 @@
+import enum
+import sys
+from collections import abc
+from typing import Optional, Union
+
+from determined import core
+
+
+class TrainUnit:
+    """
+    TrainUnit is the base class for the supported training units (Batch, Epoch) containing
+    the value of unit, where the value can be an int or an implementable collections.abc.Container.
+
+    TrainUnits are used to define periodic training behavior such as checkpointing and validating.
+
+    int values are treated as periods, e.g. Batch(100) will checkpoint/validate every 100 batches.
+    collections.abc.Container values are treated as schedules, e.g. Batch(1,5,10) will
+    checkpoint/validate on batches 1, 5, and 10.
+    """
+
+    def __init__(self, value: Union[int, abc.Container]):
+        self.value = value
+
+    @staticmethod
+    def _from_searcher_unit(
+        length: int, unit: Optional[core.Unit], global_batch_size: Optional[int] = None
+    ) -> "TrainUnit":
+        if unit == core.Unit.EPOCHS:
+            return Epoch(length)
+        elif unit == core.Unit.RECORDS:
+            if global_batch_size is None:
+                raise ValueError("global_batch_size required for searcher unit Records.")
+            return Batch._from_records(length, global_batch_size)
+        elif unit == core.Unit.BATCHES:
+            return Batch(length)
+        else:
+            raise ValueError(f"unrecognized searcher unit {unit}")
+
+    def _to_searcher_unit(self) -> core.Unit:
+        if isinstance(self, Batch):
+            return core.Unit.BATCHES
+        return core.Unit.EPOCHS
+
+    @staticmethod
+    def _from_values(
+        batches: Optional[int] = None,
+        records: Optional[int] = None,
+        epochs: Optional[int] = None,
+        global_batch_size: Optional[int] = None,
+    ) -> "TrainUnit":
+        if sum((batches is not None, records is not None, epochs is not None)) != 1:
+            raise ValueError(f"invalid config: batches={batches} records={records} epochs={epochs}")
+        if batches is not None:
+            if batches < 1:
+                batches = sys.maxsize
+            return Batch(batches)
+        if records is not None:
+            assert global_batch_size, "global_batch_size is required for RECORD units."
+            if records < 1:
+                records = sys.maxsize
+            return Batch._from_records(records, global_batch_size)
+        if epochs is not None:
+            if epochs < 1:
+                epochs = sys.maxsize
+            return Epoch(epochs)
+
+        # Make mypy happy
+        raise ValueError("invalid values")
+
+    def should_stop(self, step_num: int) -> bool:
+        if isinstance(self.value, int):
+            return self._divides(step_num)
+        assert isinstance(self.value, abc.Container)
+        return step_num in self.value
+
+    def _divides(self, steps: int) -> bool:
+        assert isinstance(steps, int) and isinstance(
+            self.value, int
+        ), "_divides can only be called on int types."
+        # Treat <= 0 values as always step
+        if self.value < 1:
+            return True
+        if steps == 0:
+            return False
+        return steps % self.value == 0
+
+
+class Epoch(TrainUnit):
+    """
+    Epoch step type (e.g. Epoch(1) defines 1 epoch)
+    """
+
+    pass
+
+
+class Batch(TrainUnit):
+    """
+    Batch step type (e.g. Batch(1) defines 1 batch)
+    """
+
+    @staticmethod
+    def _from_records(records: int, global_batch_size: int) -> "Batch":
+        return Batch(max(records // global_batch_size, 1))
+
+
+class _ShouldExit(Exception):
+    """
+    ShouldExit breaks out of the top-level train loop from inside function calls.
+    """
+
+    def __init__(self, skip_exit_checkpoint: bool = False):
+        self.skip_exit_checkpoint = skip_exit_checkpoint
+
+
+class _TrialState:
+    def __init__(
+        self,
+        trial_id: int = 0,
+        last_ckpt: int = 0,
+        step_id: int = 0,
+        last_val: int = 0,
+        batches_trained: int = 0,
+        epochs_trained: int = 0,
+    ) -> None:
+        # Store TrialID to distinguish between e.g. pause/restart and continue training.
+        self.trial_id = trial_id
+        self.last_ckpt = last_ckpt
+        self.step_id = step_id
+        self.last_val = last_val
+        self.batches_trained = batches_trained
+        self.epochs_trained = epochs_trained
+
+
+class _TrainBoundaryType(enum.Enum):
+    CHECKPOINT = "CHECKPOINT"
+    REPORT = "REPORT"
+    VALIDATE = "VALIDATE"
+    TRAIN = "TRAIN"
+
+
+class _TrainBoundary:
+    def __init__(self, step_type: _TrainBoundaryType, unit: TrainUnit):
+        self.step_type = step_type
+        self.unit = unit
+        self.limit_reached = False

--- a/harness/determined/pytorch/deepspeed/__init__.py
+++ b/harness/determined/pytorch/deepspeed/__init__.py
@@ -8,3 +8,4 @@ from determined.pytorch.deepspeed._deepspeed_context import (
     overwrite_deepspeed_config,
 )
 from determined.pytorch.deepspeed._deepspeed_trial import DeepSpeedTrial, DeepSpeedTrialController
+from determined.pytorch.deepspeed._trainer import init, Trainer

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -232,16 +232,14 @@ class DeepSpeedTrialContext(pytorch._PyTorchReducerContext):
     def use_pipeline_parallel(self) -> bool:
         return self._use_pipeline_parallel
 
-    @property
-    def train_micro_batch_size_per_gpu(self) -> int:
+    def get_train_micro_batch_size_per_gpu(self) -> int:
         if self._train_micro_batch_size_per_gpu is None:
             raise det.errors.InvalidExperimentException(
                 "Please call wrap_model_engine before accessing train_micro_batch_size."
             )
         return self._train_micro_batch_size_per_gpu
 
-    @property
-    def num_micro_batches_per_slot(self) -> int:
+    def get_num_micro_batches_per_slot(self) -> int:
         if self._num_micro_batches_per_slot is None:
             raise det.errors.InvalidExperimentException(
                 "Please call wrap_model_engine before accessing num_micro_batches_per_slot."

--- a/harness/determined/pytorch/deepspeed/_deepspeed_context.py
+++ b/harness/determined/pytorch/deepspeed/_deepspeed_context.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import pathlib
 import time
 from importlib import util as importutil
 from typing import Any, Dict, List, Optional, Set, Type, Union, cast
@@ -42,7 +43,7 @@ def overwrite_deepspeed_config(
     return util.merge_dicts(cast(Dict[str, Any], base_ds_config), source_ds_dict)
 
 
-class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
+class DeepSpeedTrialContext(pytorch._PyTorchReducerContext):
     """Contains runtime information for any Determined workflow that uses the ``DeepSpeedTrial``
     API.
 
@@ -65,9 +66,37 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
     5. Disable automatic gradient aggregation for non-pipeline-parallel training.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        det.TrialContext.__init__(self, *args, **kwargs)
+    def __init__(
+        self,
+        core_context: det.core.Context,
+        trial_seed: Optional[int],
+        hparams: Optional[Dict],
+        slots_per_trial: int,
+        num_gpus: int,
+        exp_conf: Optional[Dict[str, Any]],
+        steps_completed: int,
+        enable_tensorboard_logging: bool = True,
+    ) -> None:
+        self._core = core_context
+        self.distributed = self._core.distributed
+
         pytorch._PyTorchReducerContext.__init__(self, self.distributed.allgather)
+
+        self._per_slot_batch_size, self._global_batch_size = (
+            util.calculate_batch_sizes(
+                hparams=hparams,
+                slots_per_trial=slots_per_trial,
+                trialname="DeepSpeedTrial",
+            )
+            if hparams and hparams.get("global_batch_size", None)
+            else (None, None)
+        )
+        self._hparams = hparams
+        self._num_gpus = num_gpus
+        self._exp_conf = exp_conf
+
+        self._trial_seed = trial_seed
+        self._steps_completed = steps_completed
 
         self._init_device()
 
@@ -85,13 +114,12 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         # The following attributes are initialized during the lifetime of
         # a DeepSpeedTrialContext.
         self.models = []  # type: List[deepspeed.DeepSpeedEngine]
+        self.profiler = None  # type: Any
         self._epoch_len = None  # type: Optional[int]
 
         self._loss_ids = {}  # type: Dict[torch.Tensor, int]
         self._last_backward_batch_idx = None  # type: Optional[int]
         self._current_batch_idx = None  # type: Optional[int]
-
-        self.profiler = None  # type: Any
 
         self._mpu = det_ds.make_data_parallel_mpu(
             self.distributed
@@ -103,47 +131,12 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         self._data_repro_checks_disabled = False
         self._manual_grad_accumulation = False
 
-        self._check_experiment_config_optimizations()
+        self._stop_requested = False
 
         self._tbd_writer = None  # type: Optional[Any]
-        self._enable_tensorboard_logging = True
+        self._enable_tensorboard_logging = enable_tensorboard_logging
         # Timestamp for batching TensorBoard uploads
         self._last_tb_reset_ts: Optional[float] = None
-
-    def _check_experiment_config_optimizations(self) -> None:
-        """
-        Check if the user specified options in optimizations are incompatible with
-        DeepSpeedTrial.
-        """
-        optimizations_config = self.env.experiment_config.get_optimizations_config()
-        self._average_training_metrics = optimizations_config.get("average_training_metrics", False)
-
-        mixed_precision_val = optimizations_config.get("mixed_precision", "O0")
-        if mixed_precision_val != "O0":
-            raise det.errors.InvalidExperimentException(
-                "Mixed precision is specified through the deepspeed config instead of the "
-                "Determined experiment config.",
-            )
-        aggregation_frequency = optimizations_config.get("aggregation_frequency", 1)
-        if aggregation_frequency > 1:
-            raise det.errors.InvalidExperimentException(
-                "Gradient aggregation is specified through the deepspeed config instead of the "
-                "Determined experiment config.",
-            )
-        other_optimizations_default_values = {
-            "average_aggregated_gradients": True,
-            "gradient_compression": False,
-            "tensor_fusion_threshold": 64,
-            "tensor_fusion_cycle_time": 5,
-            "autotune_tensor_fusion": False,
-        }
-        for opt_field, default_value in other_optimizations_default_values.items():
-            opt_value = optimizations_config.get(opt_field, default_value)
-            if opt_value != default_value:
-                logger.warning(
-                    f"{opt_field}={opt_value} ignored since the setting does not apply "
-                    "to DeepSpeedTrial."
-                )
 
     def set_mpu(self, mpu: det_ds.ModelParallelUnit) -> None:
         """Use a custom model parallel configuration.
@@ -166,12 +159,6 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
                 "Only one MPU can be passed to DeepSpeedTrialContext. "
                 "Please make sure wrap_mpu is only called once in the trial definition."
             )
-        if self.distributed.rank == 0:
-            if not self._mpu.should_report_metrics and not self._average_training_metrics:
-                raise det.errors.InvalidExperimentException(
-                    "Please set optimizations.average_training_metrics in the experiment config "
-                    "to true so that metrics will exist on the chief for report to the master."
-                )
         self._called_set_mpu = True
         self._mpu = mpu
 
@@ -262,8 +249,7 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         return self._num_micro_batches_per_slot
 
     def _init_device(self) -> None:
-        self.n_gpus = len(self.env.container_gpus)
-        if not self.n_gpus:
+        if not self._num_gpus:
             raise det.errors.InvalidExperimentException("GPUs required for DeepSpeedTrial.")
         if self.distributed.size > 1:
             self.device = torch.device("cuda", self.distributed.get_local_rank())
@@ -359,6 +345,38 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
             **kwargs,
         )
 
+    def get_initial_batch(self) -> int:
+        return self._steps_completed
+
+    def get_data_config(self) -> Dict[str, Any]:
+        """
+        Return the data configuration.
+        """
+        return self.get_experiment_config().get("data", {})
+
+    def get_experiment_id(self) -> int:
+        """
+        Return the experiment ID of the current trial.
+        """
+        return int(self._core.train._exp_id)
+
+    def get_trial_id(self) -> int:
+        """
+        Return the trial ID of the current trial.
+        """
+        return int(self._core.train._trial_id)
+
+    def get_trial_seed(self) -> int:
+        if self._trial_seed is None:
+            raise det.errors.InternalException("Trial seed not set.")
+        return self._trial_seed
+
+    def get_tensorboard_path(self) -> pathlib.Path:
+        """
+        Get the path where files for consumption by TensorBoard should be written
+        """
+        return self._core.train.get_tensorboard_path()
+
     def get_tensorboard_writer(self) -> Any:
         """
         This function returns an instance of ``torch.utils.tensorboard.SummaryWriter``
@@ -442,3 +460,86 @@ class DeepSpeedTrialContext(det.TrialContext, pytorch._PyTorchReducerContext):
         Return whether automatic tensorboard logging is enabled
         """
         return self._enable_tensorboard_logging
+
+    def get_global_batch_size(self) -> int:
+        """
+        Return the global batch size.
+        """
+        if self._global_batch_size is None:
+            raise ValueError(
+                "global_batch_size is undefined in this Trial because hparams was not "
+                "configured. Please check the init() call to Trainer API."
+            )
+        return self._global_batch_size
+
+    def get_per_slot_batch_size(self) -> int:
+        """
+        Return the per-slot batch size. When a model is trained with a single GPU, this is equal to
+        the global batch size. When multi-GPU training is used, this is equal to the global batch
+        size divided by the number of GPUs used to train the model.
+        """
+        if self._per_slot_batch_size is None:
+            raise ValueError(
+                "per_slot_batch_size is undefined in this Trial because hparams was not "
+                "configured. Please check the init() call to Trainer API."
+            )
+
+        return self._per_slot_batch_size
+
+    def get_experiment_config(self) -> Dict[str, Any]:
+        if self._exp_conf is None:
+            raise ValueError(
+                "exp_conf is undefined in this Trial. Please check the init() call to Trainer API."
+            )
+        return self._exp_conf
+
+    def get_hparam(self, name: str) -> Any:
+        """
+        Return the current value of the hyperparameter with the given name.
+        """
+        if self._hparams is None:
+            raise ValueError(
+                "hparams is undefined in this Trial because hparams was not "
+                "configured. Please check the init() call to Trainer API."
+            )
+        if name not in self.get_hparams():
+            raise ValueError(
+                "Could not find name '{}' in experiment "
+                "hyperparameters. Please check your experiment "
+                "configuration 'hyperparameters' section.".format(name)
+            )
+        if name == "global_batch_size":
+            logger.warning(
+                "Please use `context.get_per_slot_batch_size()` and "
+                "`context.get_global_batch_size()` instead of accessing "
+                "`global_batch_size` directly."
+            )
+        return self.get_hparams()[name]
+
+    def get_hparams(self) -> Dict[str, Any]:
+        if self._hparams is None:
+            raise ValueError(
+                "hparams is undefined in this Trial because hparams was not "
+                "configured. Please check the init() call to Trainer API."
+            )
+        return self._hparams
+
+    def get_stop_requested(self) -> bool:
+        """
+        Return whether a trial stoppage has been requested.
+        """
+        return self._stop_requested
+
+    def set_stop_requested(self, stop_requested: bool) -> None:
+        """
+        Set a flag to request a trial stoppage. When this flag is set to True,
+        we finish the step, checkpoint, then exit.
+        """
+        if not isinstance(stop_requested, bool):
+            raise AssertionError("stop_requested must be a boolean")
+
+        logger.info(
+            "A trial stoppage has requested. The trial will be stopped "
+            "at the end of the current step."
+        )
+        self._stop_requested = stop_requested

--- a/harness/determined/pytorch/deepspeed/_trainer.py
+++ b/harness/determined/pytorch/deepspeed/_trainer.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 import sys
+import warnings
 from typing import Any, Dict, Iterator, Optional
 
 import deepspeed
@@ -61,11 +62,14 @@ class Trainer:
                 of ``collections.abc.Container`` (list, tuple, etc.). For example, ``Batch(100)``
                 would validate every 100 batches, while ``Batch([5, 30, 45])`` would validate
                 after every 5th, 30th, and 45th batch.
-            max_length: The maximum number of steps to train for. This value is required and
-                only applicable in local training mode. For on-cluster training, this value will
-                be ignored; the searcher’s ``max_length`` must be configured from the experiment
-                configuration. This is a ``TrainUnit`` type (``Batch`` or ``Epoch``) which takes an
-                ``int``. For example, ``Epoch(1)`` would train for a maximum length of one epoch.
+            max_length: The maximum number of steps to train for. This is a ``TrainUnit`` type
+                (``Batch`` or ``Epoch``) which takes an ``int``. For example, ``Epoch(1)`` would
+                train for a maximum length of one epoch.
+                .. note::
+                   If using an ASHA searcher, this value should match the searcher config values in
+                   the experiment config (i.e. ``Epoch(1)`` = `max_time: 1` and `time_metric:
+                   "epochs"`).
+
             reporting_period: The number of steps to train for before reporting metrics and
                 searcher progress. For local training mode, metrics are printed to stdout. This
                 is a ``TrainUnit`` type (``Batch`` or ``Epoch``) which can take an ``int`` or
@@ -113,8 +117,13 @@ class Trainer:
             if max_length is None:
                 raise ValueError("max_length must be defined in local training mode.")
 
-            if not isinstance(max_length.value, int):
-                raise TypeError("max_length must be configured in TrainUnit(int) types.")
+            if not isinstance(max_length, (pytorch.Batch, pytorch.Epoch)) or not isinstance(
+                max_length.value, int
+            ):
+                raise TypeError(
+                    "max_length must either be a det.pytorch.Batch(int) or det.pytorch.Epoch(int) "
+                    "type"
+                )
 
             if profiling_enabled:
                 logger.warning("Profiling is not supported in local training mode.")
@@ -126,12 +135,6 @@ class Trainer:
         else:
             if test_mode:
                 raise ValueError("test_mode is only supported in local training mode.")
-
-            if max_length is not None:
-                logger.warning(
-                    "max_length is ignored when training on-cluster. Please configure the "
-                    "searcher instead."
-                )
 
             assert self._info, "Unable to detect cluster info."
             if latest_checkpoint is None and self._info.latest_checkpoint is not None:
@@ -147,6 +150,39 @@ class Trainer:
             global_batch_size = self._info.trial.hparams.get("global_batch_size", None)
             if global_batch_size:
                 global_batch_size = int(global_batch_size)
+
+            # Backwards compatibility: try to parse legacy `searcher.max_length` if `max_length`
+            # isn't passed in.
+            if max_length is None:
+                max_length_val = core._parse_searcher_max_length(self._info.trial._config)
+                if max_length_val:
+                    warnings.warn(
+                        "Configuring `max_length` from the `searcher.max_length` experiment "
+                        "config, which was deprecated in XXYYZZ and will be removed in a future "
+                        "release. Please set `fit(max_length=X)` with your desired training length "
+                        "directly.",
+                        FutureWarning,
+                        stacklevel=2,
+                    )
+                    max_length_unit = core._parse_searcher_units(self._info.trial._config)
+                    max_length = pytorch.TrainUnit._from_searcher_unit(
+                        max_length_val, max_length_unit, global_batch_size
+                    )
+
+            # If we couldn't parse the legacy `searcher.max_length`, raise an error.
+            if not max_length:
+                raise ValueError(
+                    "`fit(max_length=X)` must be set with your desired training length."
+                )
+            if not isinstance(max_length, (pytorch.Batch, pytorch.Epoch)) or not isinstance(
+                max_length.value, int
+            ):
+                raise TypeError(
+                    "max_length must either be a det.pytorch.Batch(int) or det.pytorch.Epoch(int) "
+                    "type."
+                )
+
+            _check_searcher_length(exp_conf=self._info.trial._config, max_length=max_length)
 
         trial_controller = det_ds.DeepSpeedTrialController(
             trial_inst=self._trial,
@@ -168,6 +204,43 @@ class Trainer:
         )
 
         trial_controller.run()
+
+
+def _check_searcher_length(
+    exp_conf: Dict[str, Any],
+    max_length: pytorch.TrainUnit,
+) -> None:
+    """
+    Certain searchers (ASHA and Adaptive ASHA) require configuring the maximum training length in
+    the experiment config. We check that the `max_length` passed to `fit()` matches the experiment
+    config and log warnings if it doesn't.
+    """
+    time_metric = exp_conf["searcher"].get("time_metric")
+    if time_metric is not None:
+        max_time = exp_conf["searcher"].get("max_time")
+        assert max_time, "`searcher.max_time` not configured"
+        if time_metric == "batches":
+            if not isinstance(max_length, pytorch.Batch) or max_length.value != max_time:
+                logger.warning(
+                    f"`max_length` passed into `fit()` method ({max_length}) does not match "
+                    f"`searcher.max_time` and `searcher.time_metric` from the experiment config "
+                    f"(Batch(value={max_time})). This may result in unexpected hyperparameter "
+                    f"search behavior."
+                )
+        elif time_metric == "epochs":
+            if not isinstance(max_length, pytorch.Epoch) or max_length.value != max_time:
+                logger.warning(
+                    f"`max_length` passed into `fit()` method ({max_length}) does not match "
+                    f"`searcher.max_time` and `searcher.time_metric` from the experiment config "
+                    f"(Epoch(value={max_time})). This may result in unexpected hyperparameter "
+                    f"search behavior."
+                )
+        else:
+            logger.warning(
+                "`searcher.time_metric` must be either 'batches' or 'epochs' "
+                f"for training with PyTorchTrials, but got {time_metric}. "
+                f"Training will proceed with {max_length} but may result in unexpected behavior."
+            )
 
 
 def _initialize_distributed_backend() -> Optional[core.DistributedContext]:

--- a/harness/determined/pytorch/deepspeed/_trainer.py
+++ b/harness/determined/pytorch/deepspeed/_trainer.py
@@ -1,0 +1,262 @@
+import contextlib
+import logging
+import os
+import random
+import sys
+from typing import Any, Dict, Iterator, Optional
+
+import deepspeed
+import numpy as np
+import torch
+
+import determined as det
+from determined import core, gpu, pytorch
+from determined.pytorch import deepspeed as det_ds
+
+logger = logging.getLogger("determined.pytorch.deepspeed")
+
+
+class Trainer:
+    """
+    ``pytorch.deepspeed.Trainer`` is an abstraction on top of a  DeepSpeed training loop
+    that handles many training details under-the-hood, and exposes APIs for configuring
+    training-related features such as automatic checkpointing, validation, profiling,
+    metrics reporting, etc.
+
+    ``Trainer`` must be initialized and called from within a
+    ``pytorch.deepspeed.DeepSpeedTrialContext``.
+    """
+
+    def __init__(self, trial: det_ds.DeepSpeedTrial, context: det_ds.DeepSpeedTrialContext):
+        self._trial = trial
+        self._context = context
+        self._core = self._context._core
+        self._info = det.get_cluster_info()
+        self._local_training = self._info is None or self._info.task_type != "TRIAL"
+
+    def fit(
+        self,
+        checkpoint_period: Optional[pytorch.TrainUnit] = None,
+        validation_period: Optional[pytorch.TrainUnit] = None,
+        max_length: Optional[pytorch.TrainUnit] = None,
+        reporting_period: pytorch.TrainUnit = pytorch.Batch(100),  # noqa: B008
+        checkpoint_policy: str = "best",
+        latest_checkpoint: Optional[str] = None,
+        step_zero_validation: bool = False,
+        test_mode: bool = False,
+        profiling_enabled: bool = False,
+    ) -> None:
+        """
+        ``fit()`` trains a ``DeepSpeedTrial`` configured from the ``Trainer`` and handles
+        checkpointing and validation steps, and metrics reporting.
+
+        Arguments:
+            checkpoint_period: The number of steps to train for before checkpointing. This is
+                a ``TrainUnit`` type (``Batch`` or ``Epoch``) which can take an ``int`` or
+                instance of ``collections.abc.Container`` (list, tuple, etc.). For example,
+                ``Batch(100)`` would checkpoint every 100 batches, while ``Batch([5, 30, 45])``
+                would checkpoint after every 5th, 30th, and 45th batch.
+            validation_period: The number of steps to train for before validating. This is a
+                ``TrainUnit`` type (``Batch`` or ``Epoch``) which can take an ``int`` or instance
+                of ``collections.abc.Container`` (list, tuple, etc.). For example, ``Batch(100)``
+                would validate every 100 batches, while ``Batch([5, 30, 45])`` would validate
+                after every 5th, 30th, and 45th batch.
+            max_length: The maximum number of steps to train for. This value is required and
+                only applicable in local training mode. For on-cluster training, this value will
+                be ignored; the searcher’s ``max_length`` must be configured from the experiment
+                configuration. This is a ``TrainUnit`` type (``Batch`` or ``Epoch``) which takes an
+                ``int``. For example, ``Epoch(1)`` would train for a maximum length of one epoch.
+            reporting_period: The number of steps to train for before reporting metrics and
+                searcher progress. For local training mode, metrics are printed to stdout. This
+                is a ``TrainUnit`` type (``Batch`` or ``Epoch``) which can take an ``int`` or
+                instance of ``collections.abc.Container`` (list, tuple, etc.). For example,
+                ``Batch(100)`` would report every 100 batches, while ``Batch([5, 30, 45])`` would
+                report after every 5th, 30th, and 45th batch.
+            checkpoint_policy: Controls how Determined performs checkpoints after validation
+                operations, if at all. Should be set to one of the following values:
+
+                    best (default): A checkpoint will be taken after every validation operation
+                        that performs better than all previous validations for this experiment.
+                        Validation metrics are compared according to the ``metric`` and
+                        ``smaller_is_better`` fields in the searcher configuration. This option
+                        is only supported for on-cluster training.
+                    all: A checkpoint will be taken after every validation, no matter the
+                        validation performance.
+                    none: A checkpoint will never be taken due to a validation. However,
+                        even with this policy selected, checkpoints are still expected to be taken
+                        after the trial is finished training, due to cluster scheduling decisions,
+                        before search method decisions, or due to ``min_checkpoint_period``.
+            latest_checkpoint: Configures the checkpoint used to start or continue training.
+                This value should be set to ``det.get_cluster_info().latest_checkpoint`` for
+                standard continue training functionality.
+            step_zero_validation: Configures whether to perform an initial validation before
+                training. Defaults to false.
+            test_mode: Runs a minimal loop of training for testing and debugging purposes. Will
+                train and validate one batch. Defaults to false.
+            profiling_enabled: Enables system metric profiling functionality for on-cluster
+                training. Defaults to false.
+        """
+        # Set defaults.
+        if checkpoint_period is None:
+            checkpoint_period = pytorch.Batch(sys.maxsize)
+
+        if validation_period is None:
+            validation_period = pytorch.Batch(sys.maxsize)
+
+        if self._local_training:
+            if checkpoint_policy == "best":
+                logger.warning(
+                    "checkpoint_policy='best' is not supported in local training mode. "
+                    "Falling back to 'all'."
+                )
+                checkpoint_policy = "all"
+            if max_length is None:
+                raise ValueError("max_length must be defined in local training mode.")
+
+            if not isinstance(max_length.value, int):
+                raise TypeError("max_length must be configured in TrainUnit(int) types.")
+
+            if profiling_enabled:
+                logger.warning("Profiling is not supported in local training mode.")
+
+            smaller_is_better = True
+            searcher_metric_name = None
+            steps_completed = 0
+            global_batch_size = None
+        else:
+            if test_mode:
+                raise ValueError("test_mode is only supported in local training mode.")
+
+            if max_length is not None:
+                logger.warning(
+                    "max_length is ignored when training on-cluster. Please configure the "
+                    "searcher instead."
+                )
+
+            assert self._info, "Unable to detect cluster info."
+            if latest_checkpoint is None and self._info.latest_checkpoint is not None:
+                logger.warning(
+                    "latest_checkpoint has not been configured. Pause/resume training will not "
+                    "be able to continue from latest checkpoint. Did you mean to set "
+                    "`fit(latest_checkpoint=info.latest_checkpoint)'?"
+                )
+
+            smaller_is_better = bool(self._info.trial._config["searcher"]["smaller_is_better"])
+            searcher_metric_name = self._info.trial._config["searcher"]["metric"]
+            steps_completed = int(self._info.trial._steps_completed)
+            global_batch_size = self._info.trial.hparams.get("global_batch_size", None)
+            if global_batch_size:
+                global_batch_size = int(global_batch_size)
+
+        trial_controller = det_ds.DeepSpeedTrialController(
+            trial_inst=self._trial,
+            context=self._context,
+            checkpoint_period=checkpoint_period,
+            validation_period=validation_period,
+            smaller_is_better=smaller_is_better,
+            steps_completed=steps_completed,
+            latest_checkpoint=latest_checkpoint,
+            local_training=self._local_training,
+            test_mode=test_mode,
+            reporting_period=reporting_period,
+            searcher_metric_name=searcher_metric_name,
+            checkpoint_policy=checkpoint_policy,
+            step_zero_validation=step_zero_validation,
+            max_length=max_length,
+            global_batch_size=global_batch_size,
+            profiling_enabled=profiling_enabled,
+        )
+
+        trial_controller.run()
+
+
+def _initialize_distributed_backend() -> Optional[core.DistributedContext]:
+    info = det.get_cluster_info()
+    distributed_backend = det._DistributedBackend()
+
+    if distributed_backend.use_deepspeed():
+        # We use an environment variable to allow users to enable custom initialization routine for
+        # distributed training since the pre_execute_hook runs before trial initialization.
+        manual_dist_init = os.environ.get("DET_MANUAL_INIT_DISTRIBUTED")
+        if not manual_dist_init:
+            deepspeed.init_distributed(auto_mpi_discovery=False)
+        return core.DistributedContext.from_deepspeed()
+    elif info and (len(info.container_addrs) > 1 or len(info.slot_ids) > 1):
+        raise ValueError(
+            "In multi-slot managed cluster training, you must wrap your training script with a "
+            "distributed launch layer such as determined.launch.deepspeed."
+        )
+    return None
+
+
+def _set_random_seeds(seed: int) -> None:
+    # Set identical random seeds on all training processes.
+    # When doing distributed training, each worker will start at a unique
+    # offset in the dataset, ensuring that it is processing a unique
+    # training batch.
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.random.manual_seed(seed)
+
+
+@contextlib.contextmanager
+def init(
+    *,
+    hparams: Optional[Dict] = None,
+    exp_conf: Optional[Dict[str, Any]] = None,
+    distributed: Optional[core.DistributedContext] = None,
+    enable_tensorboard_logging: bool = True,
+) -> Iterator[det_ds.DeepSpeedTrialContext]:
+    """
+    Creates a DeepSpeedTrialContext for use with a DeepSpeedTrial. All trainer.* calls
+    must be within the scope of this context because there are resources started in
+    __enter__ that must be cleaned up in __exit__.
+
+    Arguments:
+        hparams: (Optional) instance of hyperparameters for the trial
+        exp_conf: (Optional) for local-training mode. If unset, calling
+            context.get_experiment_config() will fail.
+        distributed: (Optional) custom distributed training configuration
+        enable_tensorboard_logging: Configures if upload to tensorboard is enabled
+    """
+    cluster_info = det.get_cluster_info()
+    local_training = cluster_info is None or cluster_info.task_type != "TRIAL"
+
+    # Pre-execute steps: initialize distributed backend and random seeds.
+    distributed_context = distributed
+
+    if not local_training:
+        distributed_context = _initialize_distributed_backend()
+
+    # Initialize default values.
+    if local_training:
+        trial_seed = None
+        steps_completed = 0
+        num_gpus = len(gpu.get_gpu_uuids())
+    else:
+        assert cluster_info, "Unable to detect cluster info"
+
+        trial_seed = cluster_info.trial.trial_seed
+        exp_conf = cluster_info.trial._config
+        steps_completed = cluster_info.trial._steps_completed
+        num_gpus = len(cluster_info.gpu_uuids)
+
+        _set_random_seeds(trial_seed)
+
+    with core.init(
+        distributed=distributed_context,
+        preempt_mode=core.PreemptMode.WorkersAskChief,
+        tensorboard_mode=core.TensorboardMode.MANUAL,
+    ) as core_context:
+        context = det_ds.DeepSpeedTrialContext(
+            core_context=core_context,
+            trial_seed=trial_seed,
+            hparams=hparams,
+            slots_per_trial=core_context.distributed.get_size(),
+            num_gpus=num_gpus,
+            exp_conf=exp_conf,
+            steps_completed=steps_completed,
+            enable_tensorboard_logging=enable_tensorboard_logging,
+        )
+
+        yield context

--- a/harness/tests/experiment/integrations/test_deepspeed_trial.py
+++ b/harness/tests/experiment/integrations/test_deepspeed_trial.py
@@ -4,17 +4,18 @@ import json
 import os
 import pathlib
 import shutil
-from typing import Any, Dict, Iterator, Optional
+from typing import Iterator
 
+import appdirs
 import pytest
 import torch
 from deepspeed.runtime import config_utils
 
 import determined
-import determined.pytorch.deepspeed as det_deepspeed
-from determined import workload
-from tests.experiment import utils  # noqa: I100
-from tests.experiment.fixtures import deepspeed_linear_model
+import determined.pytorch.deepspeed as det_ds
+from determined import pytorch  # noqa: I2041
+from determined.pytorch.deepspeed import _trainer  # noqa: I2041
+from tests.experiment.fixtures import deepspeed_linear_model  # noqa: I2041
 
 ds_config_path = str(
     pathlib.Path(__file__).resolve().parent.parent.joinpath("fixtures/ds_config.json")
@@ -82,521 +83,229 @@ class TestDeepSpeedTrial:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_fail_manual_init_distributed"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
         with pytest.raises(AssertionError, match=r"Distributed backend is not initialized. .*"):
-            _ = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-                hparams=updated_hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(max_length=pytorch.Batch(16))
 
     def test_manual_init_distributed(self, manual_init_distributed: None):
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_manual_init_distributed"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(max_length=pytorch.Batch(16))
 
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        _ = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=updated_hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
         assert torch.distributed.is_initialized()
 
     def test_linear_model(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=self.hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_manual_grad_acc_metrics(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_manual_grad_acc"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(steps=10, validation_freq=10, train_batch_calls=1)
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=updated_hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(max_length=pytorch.Batch(16))
 
     def test_fail_manual_grad_acc_metrics(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_fail_manual_grad_acc"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(steps=10, validation_freq=10, train_batch_calls=1)
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
         with pytest.raises(AssertionError, match="did not train for gradient accumulation steps"):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-                hparams=updated_hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(max_length=pytorch.Batch(16))
 
     def test_custom_dataloader(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_manual_dataloader"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=updated_hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_fail_dataset_repro_check(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_fail_dataset_repro_check"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
         with pytest.raises(RuntimeError, match=r".* reproducibility .* disable this check .*"):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-                hparams=updated_hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(max_length=pytorch.Batch(16))
 
     def test_invalid_valid_dataset(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
         with pytest.raises(
             determined.errors.InvalidExperimentException,
             match=r".* train micro batches .* should not be less than .*",
         ):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.InvalidValidDatasetTrial,
-                hparams=self.hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.InvalidValidDatasetTrial(train_context, self.hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_invalid_train_metric(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
         with pytest.raises(
             determined.errors.InvalidExperimentException,
             match=r"train_batch() must return a dictionary .*",
         ):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.InvalidTrainMetricTrial,
-                hparams=self.hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.InvalidTrainMetricTrial(train_context, self.hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_invalid_valid_metric(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
         with pytest.raises(
             determined.errors.InvalidExperimentException,
             match=r"evaluate_batch must return a dictionary .*",
         ):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.InvalidValidMetricTrial,
-                hparams=self.hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.InvalidValidMetricTrial(train_context, self.hparams)
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_differing_valid_metric_keys(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
         with pytest.raises(
-            determined.errors.InvalidExperimentException,
-            match=r".* metric names must match across all batches .*",
+            ValueError,
+            match=r"Validation metric names must match across all batches of data: .*",
         ):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.DifferingValidMetricKeyTrial,
-                hparams=self.hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.run()
+            with det_ds.init() as train_context:
+                trial = deepspeed_linear_model.DifferingValidMetricKeyTrial(
+                    train_context, self.hparams
+                )
+                trainer = det_ds.Trainer(trial, train_context)
+                trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_fail_multiple_set_mpu(self):
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=1,
-                validation_freq=1,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
         with pytest.raises(
-            determined.errors.InvalidExperimentException, match=r"Only one MPU can be passed .*"
+            determined.errors.InvalidExperimentException,
+            match=r"Only one MPU can be passed to DeepSpeedTrialContext.",
         ):
-            controller = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-                hparams=self.hparams,
-                workloads=make_workloads(),
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
-            controller.context.set_mpu(
-                det_deepspeed.make_data_parallel_mpu(controller.context.distributed)
-            )
-            controller.context.set_mpu(
-                det_deepspeed.make_data_parallel_mpu(controller.context.distributed)
-            )
+            with det_ds.init() as train_context:
+                _ = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, self.hparams)
+                train_context.set_mpu(det_ds.make_data_parallel_mpu(train_context.distributed))
+                train_context.set_mpu(det_ds.make_data_parallel_mpu(train_context.distributed))
 
     def test_custom_reducer(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["test_custom_reducer"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=updated_hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_linear_non_scalar_metrics(self) -> None:
         updated_hparams = copy.deepcopy(self.hparams)
         updated_hparams["return_non_scalar_metrics"] = True
 
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(
-                steps=10,
-                validation_freq=10,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=updated_hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, updated_hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_linear_pipeline_model(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-
-            yield from trainer.send(steps=1, validation_freq=1, train_batch_calls=1)
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearPipelineEngineTrial,
-            hparams=self.hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearPipelineEngineTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
     def test_two_model_engines(self) -> None:
-        def make_workloads() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearTwoEngineTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
-            yield from trainer.send(
-                steps=1,
-                validation_freq=1,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            training_metrics, validation_metrics = trainer.result()
-
-            for metrics in validation_metrics:
-                assert "loss1" in metrics
-                assert "loss2" in metrics
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearTwoEngineTrial,
-            hparams=self.hparams,
-            workloads=make_workloads(),
-            trial_seed=self.trial_seed,
-            expose_gpus=True,
-        )
-        controller.run()
-
-    @pytest.mark.skipif(not check_shm_size(), reason="insufficient shm size")
-    def test_checkpointing_and_restoring(self, tmp_path: pathlib.Path) -> None:
-        def make_trial_controller_fn(
-            workloads: workload.Stream,
-            checkpoint_dir: Optional[str] = None,
-            latest_checkpoint: Optional[Dict[str, Any]] = None,
-            steps_completed: int = 0,
-        ) -> determined.TrialController:
-            return utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearPipelineEngineTrial,
-                hparams=self.hparams,
-                workloads=workloads,
-                trial_seed=self.trial_seed,
-                checkpoint_dir=checkpoint_dir,
-                latest_checkpoint=latest_checkpoint,
-                steps_completed=steps_completed,
-                expose_gpus=True,
+    def test_checkpointing_and_restoring(self) -> None:
+        with det_ds.init() as train_context:
+            trial1 = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial1, train_context)
+            assert trial1.checkpoint_uuid is None
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
+        with det_ds.init() as train_context:
+            trial2 = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial2, train_context)
+            assert trial1.checkpoint_uuid is not None
+            trainer.fit(
+                validation_period=pytorch.Batch(16),
+                max_length=pytorch.Batch(16),
+                latest_checkpoint=os.path.join(
+                    appdirs.user_data_dir("determined"), trial1.checkpoint_uuid
+                ),
             )
 
-        utils.checkpointing_and_restoring_test(make_trial_controller_fn, tmp_path)
+    def test_restore_invalid_checkpoint(self) -> None:
+        with det_ds.init() as train_context:
+            trial1 = deepspeed_linear_model.LinearDeepSpeedTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial1, train_context)
+            assert trial1.checkpoint_uuid is None
+            trainer.fit(validation_period=pytorch.Batch(16), max_length=pytorch.Batch(16))
 
-    def test_restore_invalid_checkpoint(self, tmp_path: pathlib.Path) -> None:
-        # Build, train, and save a checkpoint with the normal hyperparameters.
-        checkpoint_dir = str(tmp_path.joinpath("checkpoint"))
-        latest_checkpoint = None
-        steps_completed = 0
+        with det_ds.init() as train_context:
+            trial2 = deepspeed_linear_model.LinearTwoEngineTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial2, train_context)
+            assert trial1.checkpoint_uuid is not None
+            with pytest.raises(AssertionError, match="Failed to load deepspeed checkpoint."):
+                trainer.fit(
+                    validation_period=pytorch.Batch(16),
+                    max_length=pytorch.Batch(16),
+                    latest_checkpoint=os.path.join(
+                        appdirs.user_data_dir("determined"), trial1.checkpoint_uuid
+                    ),
+                )
 
-        def make_workloads_1() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-            yield from trainer.send(
-                steps=1,
-                validation_freq=1,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-            interceptor = workload.WorkloadResponseInterceptor()
-            yield from interceptor.send(workload.checkpoint_workload())
-            nonlocal latest_checkpoint, steps_completed
-            latest_checkpoint = interceptor.metrics_result()["uuid"]
-            steps_completed = trainer.get_steps_completed()
-
-        controller1 = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearDeepSpeedTrial,
-            hparams=self.hparams,
-            workloads=make_workloads_1(),
-            trial_seed=self.trial_seed,
-            checkpoint_dir=checkpoint_dir,
-            expose_gpus=True,
-        )
-        controller1.run()
-
-        # Verify that an invalid architecture fails to load from the checkpoint.
-        def make_workloads_2() -> workload.Stream:
-            trainer = utils.TrainAndValidate()
-            yield from trainer.send(
-                steps=1,
-                validation_freq=1,
-                train_batch_calls=self.data_parallel_only_auto_train_batch_calls,
-            )
-
-        with pytest.raises(AssertionError, match="Failed to load deepspeed checkpoint."):
-            controller2 = utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearTwoEngineTrial,
-                hparams=self.hparams,
-                workloads=make_workloads_2(),
-                trial_seed=self.trial_seed,
-                checkpoint_dir=checkpoint_dir,
-                latest_checkpoint=latest_checkpoint,
-                steps_completed=steps_completed,
-                expose_gpus=True,
-            )
-            controller2.run()
-
-    @pytest.mark.skipif(not check_shm_size(), reason="insufficient shm size")
+    # TODO: Remove this particular skip after CI is updated (INFENG-659)
+    @pytest.mark.skipif(shutil.disk_usage("/dev/shm")[0] < 10**8, reason="insufficient shm size")
     def test_reproducibility(self) -> None:
-        def controller_fn(workloads: workload.Stream) -> determined.TrialController:
-            return utils.make_trial_controller_from_trial_implementation(
-                trial_class=deepspeed_linear_model.LinearPipelineEngineTrial,
-                hparams=self.hparams,
-                workloads=workloads,
-                trial_seed=self.trial_seed,
-                expose_gpus=True,
-            )
+        with det_ds.init() as train_context:
+            _trainer._set_random_seeds(self.trial_seed)
+            train_context._trial_seed = self.trial_seed
+            trial1 = deepspeed_linear_model.LinearPipelineEngineTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial1, train_context)
+            trainer.fit(validation_period=pytorch.Batch(100), max_length=pytorch.Batch(1000))
 
-        utils.reproducibility_test(controller_fn, steps=1000, validation_freq=100)
+        with det_ds.init() as train_context:
+            _trainer._set_random_seeds(self.trial_seed)
+            train_context._trial_seed = self.trial_seed
+            trial2 = deepspeed_linear_model.LinearPipelineEngineTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial2, train_context)
+            trainer.fit(validation_period=pytorch.Batch(100), max_length=pytorch.Batch(1000))
 
-    @pytest.mark.skipif(not check_shm_size(), reason="insufficient shm size")
-    def test_callbacks(self, tmp_path: pathlib.Path) -> None:
-        checkpoint_dir = tmp_path.joinpath("checkpoint")
-        latest_checkpoint = None
-        steps_completed = 0
+        assert len(trial1.avg_metrics) == len(trial2.avg_metrics)
+        for A, B in zip(trial1.avg_metrics, trial2.avg_metrics):
+            assert A.keys() == B.keys()
+            for key in A.keys():
+                assert abs(A[key] - B[key]) < 10e-7
 
-        controller = None
+        assert len(trial1.batch_metrics) == len(trial2.batch_metrics)
+        for batch_idx in range(len(trial1.batch_metrics)):
+            for A, B in zip(trial1.batch_metrics[batch_idx], trial2.batch_metrics[batch_idx]):
+                assert A.keys() == B.keys()
+                for key in A.keys():
+                    assert abs(A[key] - B[key]) < 10e-7
 
-        def make_workloads1() -> workload.Stream:
-            nonlocal controller
-            assert controller.trial.counter.trial_startups == 1
+        assert len(trial1.val_metrics) == len(trial2.val_metrics)
+        for A, B in zip(trial1.val_metrics, trial2.val_metrics):
+            assert A.keys() == B.keys()
+            for key in A.keys():
+                assert abs(A[key] - B[key]) < 10e-7
 
-            yield workload.train_workload(1, 1, 0, 4), workload.ignore_workload_response
-            assert controller is not None, "controller was never set!"
-            assert controller.trial.counter.__dict__ == {
-                "trial_startups": 1,
-                "validation_steps_started": 0,
-                "validation_steps_ended": 0,
-                "checkpoints_written": 0,
-                "checkpoints_uploaded": 0,
-                "training_started_times": 1,
-                "training_epochs_started": 2,
-                "training_epochs_ended": 2,
-                "training_workloads_ended": 1,
-                "trial_shutdowns": 0,
-            }
-
-            yield workload.validation_workload(), workload.ignore_workload_response
-            assert controller.trial.counter.__dict__ == {
-                "trial_startups": 1,
-                "validation_steps_started": 1,
-                "validation_steps_ended": 1,
-                "checkpoints_written": 0,
-                "checkpoints_uploaded": 0,
-                "training_started_times": 1,
-                "training_epochs_started": 2,
-                "training_epochs_ended": 2,
-                "training_workloads_ended": 1,
-                "trial_shutdowns": 0,
-            }
-
-            interceptor = workload.WorkloadResponseInterceptor()
-            yield from interceptor.send(workload.checkpoint_workload())
-            nonlocal latest_checkpoint, steps_completed
-            latest_checkpoint = interceptor.metrics_result()["uuid"]
-            steps_completed = 1
-            assert controller.trial.counter.__dict__ == {
+    def test_callbacks(self) -> None:
+        with det_ds.init() as train_context:
+            trial = deepspeed_linear_model.LinearCallbackTrial(train_context, self.hparams)
+            trainer = det_ds.Trainer(trial, train_context)
+            trainer.fit(max_length=pytorch.Epoch(2))
+            assert trial.counter.__dict__ == {
                 "trial_startups": 1,
                 "validation_steps_started": 1,
                 "validation_steps_ended": 1,
@@ -605,50 +314,9 @@ class TestDeepSpeedTrial:
                 "training_started_times": 1,
                 "training_epochs_started": 2,
                 "training_epochs_ended": 2,
-                "training_workloads_ended": 1,
-                "trial_shutdowns": 0,
+                "training_workloads_ended": 2,
+                "trial_shutdowns": 1,
             }
-
-        hparams1 = dict(self.hparams)
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearCallbackTrial,
-            hparams=hparams1,
-            workloads=make_workloads1(),
-            checkpoint_dir=str(checkpoint_dir),
-            expose_gpus=True,
-        )
-        controller.run()
-        assert controller.trial.counter.trial_shutdowns == 1
-
-        # Verify the checkpoint loading callback works.
-        def make_workloads2() -> workload.Stream:
-            yield workload.train_workload(1, 1, 0, 2), workload.ignore_workload_response
-
-        controller = utils.make_trial_controller_from_trial_implementation(
-            trial_class=deepspeed_linear_model.LinearCallbackTrial,
-            hparams=self.hparams,
-            workloads=make_workloads2(),
-            checkpoint_dir=str(checkpoint_dir),
-            latest_checkpoint=latest_checkpoint,
-            steps_completed=steps_completed,
-            expose_gpus=True,
-        )
-        controller.run()
-        assert controller.trial.counter.__dict__ == {
-            # Note: trial_startups will get reset by the loading logic.
-            "trial_startups": 1,
-            "validation_steps_started": 1,
-            "validation_steps_ended": 1,
-            # Note: checkpoints_written, checkpoints_uploaded, and trial_shutdowns, cannot be
-            # persisted, as they are all updated after checkpointing.
-            "checkpoints_written": 0,
-            "checkpoints_uploaded": 0,
-            "training_started_times": 2,
-            "training_epochs_started": 3,
-            "training_epochs_ended": 3,
-            "training_workloads_ended": 2,
-            "trial_shutdowns": 1,
-        }
 
 
 @pytest.mark.deepspeed
@@ -661,16 +329,16 @@ def test_overwrite_deepspeed_config() -> None:
     expected_config = copy.deepcopy(deepspeed_config)
     expected_config["train_micro_batch_size_per_gpu"] = 2
     expected_config["optimizer"]["params"]["lr"] = 0.001
-    result = det_deepspeed.overwrite_deepspeed_config(base_ds_config, source_ds_config)
+    result = det_ds.overwrite_deepspeed_config(base_ds_config, source_ds_config)
     assert result == expected_config
 
     # Test load base deepspeed config from json file.
     base_ds_config = str(
         pathlib.Path(__file__).resolve().parent.parent.joinpath("fixtures/ds_config.json")
     )
-    result = det_deepspeed.overwrite_deepspeed_config(base_ds_config, source_ds_config)
+    result = det_ds.overwrite_deepspeed_config(base_ds_config, source_ds_config)
     assert result == expected_config
 
     # Test fail invalid base_ds_config argument.
     with pytest.raises(TypeError, match="Expected string or dict for base_ds_config argument."):
-        _ = det_deepspeed.overwrite_deepspeed_config([1, 2], source_ds_config)
+        _ = det_ds.overwrite_deepspeed_config([1, 2], source_ds_config)


### PR DESCRIPTION
## Ticket
https://hpe-aiatscale.atlassian.net/browse/MD-501



## Description
Add Deepspeed Trainer API
Refactor some pytorch training classes
Reinstate DCGANTrial as an example of DeepSpeed Trainer



## Test Plan
1. Try DCGAN trainer example. Instructions are in the `README` included with `tests/deepspeed/dcgan`. After it's done, continue the run for 100 more batches.
2. Run GPT NEOX example. After it's done, continue the run for 100 more batches.
3. Deepspeed unit tests pass.



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ