### PR TITLE
chore: change det deploy aws's default deployment type to simple-rds

### DIFF
--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -387,16 +387,22 @@ def deploy_stack(
                 print()
 
                 prompt_needed = True
-            elif tags[constants.deployment_types.TYPE_TAG_KEY] != deployment_type:
-                print("Value of --deployment-type has changed!")
-                prompt_needed = True
+            else:
+                if tags[constants.deployment_types.TYPE_TAG_KEY] != deployment_type:
+                    print("Value of --deployment-type has changed!")
+                    prompt_needed = True
+
+                if tags[constants.deployment_types.TYPE_TAG_KEY] == "simple":
+                    print()
+                    print("Previous value of --deployment-type was 'simple'. This deployment type was")
+                    print("removed in 0.38.0 because AWS Aurora V1 is EoL. Please follow this guide")
+                    print("to migrate to RDS:")
+                    print("\thttps://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e\n")
+                    print()
 
             if prompt_needed:
                 val = input(
                     "If --deployment-type has changed, updating the stack may erase the database.\n"
-                    "If you previously used --deployment-type simple or no value and upgraded\n"
-                    "to 0.38.0, you need to follow this guide to manually migrate Aurora V1:\n"
-                    "\thttps://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e\n"
                     "Are you sure you want to proceed? [y/N]\n"
                 )
                 if val.lower() != "y":

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -394,7 +394,10 @@ def deploy_stack(
             if prompt_needed:
                 val = input(
                     "If --deployment-type has changed, updating the stack may erase the database.\n"
-                    "Are you sure you want to proceed? [y/N]"
+                    "If you previously used --deployment-type simple or no value and upgraded\n"
+                    "to 0.38.0, you need to follow this guide to manually migrate Aurora V1:\n"
+                    "\thttps://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e\n"
+                    "Are you sure you want to proceed? [y/N]\n"
                 )
                 if val.lower() != "y":
                     print("Update canceled.")

--- a/harness/determined/deploy/aws/aws.py
+++ b/harness/determined/deploy/aws/aws.py
@@ -394,10 +394,13 @@ def deploy_stack(
 
                 if tags[constants.deployment_types.TYPE_TAG_KEY] == "simple":
                     print()
-                    print("Previous value of --deployment-type was 'simple'. This deployment type was")
-                    print("removed in 0.38.0 because AWS Aurora V1 is EoL. Please follow this guide")
-                    print("to migrate to RDS:")
-                    print("\thttps://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e\n")
+                    print(
+                        "Previous value of --deployment-type was 'simple'. This deployment type\n"
+                        "was removed in 0.38.0 because AWS Aurora V1 is EoL. Please follow this\n"
+                        "guide to migrate to RDS:\n"
+                        "\thttps://gist.github.com/rb-determined-ai/"
+                        "bfa10182e53968e00a3c88df624e777e"
+                    )
                     print()
 
             if prompt_needed:

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -66,7 +66,6 @@ def error_no_credentials() -> None:
 
 def get_deployment_class(deployment_type: str) -> Type[base.DeterminedDeployment]:
     deployment_type_map = {
-        constants.deployment_types.SIMPLE: simple.Simple,
         constants.deployment_types.SIMPLE_RDS: simple.SimpleRDS,
         constants.deployment_types.SECURE: secure.Secure,
         constants.deployment_types.EFS: vpc.EFS,

--- a/harness/determined/deploy/aws/cli.py
+++ b/harness/determined/deploy/aws/cli.py
@@ -141,10 +141,7 @@ def deploy_aws(command: str, args: argparse.Namespace) -> None:
     ):
         raise cli.CliError("If a CPU or GPU environment image is specified, both should be.")
 
-    if (
-        args.deployment_type != constants.deployment_types.SIMPLE
-        or args.deployment_type != constants.deployment_types.SIMPLE_RDS
-    ):
+    if args.deployment_type != constants.deployment_types.SIMPLE_RDS:
         if args.agent_subnet_id is not None:
             raise ValueError(
                 f"The agent-subnet-id can only be set if the deployment-type=simple. "

--- a/harness/determined/deploy/aws/constants.py
+++ b/harness/determined/deploy/aws/constants.py
@@ -1,12 +1,11 @@
 class deployment_types:
-    SIMPLE = "simple"
     SIMPLE_RDS = "simple-rds"
     SECURE = "secure"
     EFS = "efs"
     GENAI = "genai"
     FSX = "fsx"
     GOVCLOUD = "govcloud"
-    DEPLOYMENT_TYPES = [SIMPLE, SECURE, EFS, FSX, GOVCLOUD, SIMPLE_RDS, GENAI]
+    DEPLOYMENT_TYPES = [SIMPLE_RDS, SECURE, EFS, FSX, GOVCLOUD, GENAI]
     TYPE_TAG_KEY = "deployment-type"
 
 

--- a/harness/determined/deploy/aws/constants.py
+++ b/harness/determined/deploy/aws/constants.py
@@ -11,7 +11,7 @@ class deployment_types:
 
 
 class defaults:
-    DEPLOYMENT_TYPE = deployment_types.SIMPLE
+    DEPLOYMENT_TYPE = deployment_types.SIMPLE_RDS
     DB_PASSWORD = "postgres"
     REGION = "us-west-2"
     STACK_TAG_KEY = "managed-by"

--- a/harness/determined/deploy/aws/deployment_types/simple.py
+++ b/harness/determined/deploy/aws/deployment_types/simple.py
@@ -2,15 +2,18 @@ from determined.deploy.aws import aws, constants
 from determined.deploy.aws.deployment_types import base
 
 
-class Simple(base.DeterminedDeployment):
-    template = "simple.yaml"
-    deployment_type = constants.deployment_types.SIMPLE
+class SimpleRDS(base.DeterminedDeployment):
+    template = "simple-rds.yaml"
+    deployment_type = constants.deployment_types.SIMPLE_RDS
 
     template_parameter_keys = base.COMMON_TEMPLATE_PARAMETER_KEYS + [
         constants.cloudformation.PREEMPTION_ENABLED,
         constants.cloudformation.RETAIN_LOG_GROUP,
         constants.cloudformation.SCHEDULER_TYPE,
         constants.cloudformation.SUBNET_ID_KEY,
+        constants.cloudformation.DB_INSTANCE_TYPE,
+        constants.cloudformation.DB_SNAPSHOT,
+        constants.cloudformation.DB_SIZE,
     ]
 
     def deploy(self, no_prompt: bool, update_terminate_agents: bool) -> None:
@@ -31,18 +34,3 @@ class Simple(base.DeterminedDeployment):
             update_terminate_agents=update_terminate_agents,
         )
         self.print_results()
-
-
-class SimpleRDS(Simple):
-    template = "simple-rds.yaml"
-    deployment_type = constants.deployment_types.SIMPLE_RDS
-
-    template_parameter_keys = base.COMMON_TEMPLATE_PARAMETER_KEYS + [
-        constants.cloudformation.PREEMPTION_ENABLED,
-        constants.cloudformation.RETAIN_LOG_GROUP,
-        constants.cloudformation.SCHEDULER_TYPE,
-        constants.cloudformation.SUBNET_ID_KEY,
-        constants.cloudformation.DB_INSTANCE_TYPE,
-        constants.cloudformation.DB_SNAPSHOT,
-        constants.cloudformation.DB_SIZE,
-    ]


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
[CM-415]
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
**BREAKING CHANGE**

DRAFT PR, this still needs to have the logic wired through to detect the case where:

- det deploy aws up is called w/o specifying the deployment type
- & that deployment type does not match the label on the stack being upgraded
- -> then, we need to give them a link to the one pager & tell them to explicitly specify the deployment type (ideally as `simple-rds`)




## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->

1. Create a Simple cluster using `det deploy aws` **ON AN OLDER VERSION OF DETERMINED**
2. Add some data to the cluster, like some users and experiments (you'll look for this stuff later, so make it memorable)
3. Check out the release candidate then use det deploy to upgrade to the new version. This should fail and print a link to [the migration doc](https://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e).
4. Follow [the migration doc](https://gist.github.com/rb-determined-ai/bfa10182e53968e00a3c88df624e777e) and get a database dump
5. det deploy using RDS and follow the migration guide to restore
6. Make sure your Postgres database is now on RDS and not Aurora
7. Make sure your data is there!



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CM-415]: https://hpe-aiatscale.atlassian.net/browse/CM-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ