### PR TITLE
chore: populate final merged config with defaults when merging invariant configs

### DIFF
--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -228,6 +228,8 @@ func MergeWithInvariantExperimentConfigs(ctx context.Context, workspaceID int,
 	if !reflect.DeepEqual(originalConfig, config) {
 		log.Warnf("some fields were overridden by admin %s config policies", scope)
 	}
+
+	config = schemas.WithDefaults(config)
 	return &config, nil
 }
 

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -1044,10 +1044,12 @@ func TestSchemaCompleteAfterMerge(t *testing.T) {
 		RawCheckpointStorage: &expconf.CheckpointStorageConfigV0{
 			RawSharedFSConfig: &expconf.SharedFSConfigV0{RawHostPath: ptrs.Ptr("host_path")},
 		},
-		RawSearcher: &expconf.SearcherConfigV0{RawSingleConfig: &expconf.SingleConfigV0{
-			RawMaxLength: &expconf.LengthV0{Unit: expconf.Batches, Units: 5},
+		RawSearcher: &expconf.SearcherConfigV0{
+			RawSingleConfig: &expconf.SingleConfigV0{
+				RawMaxLength: &expconf.LengthV0{Unit: expconf.Batches, Units: 5},
+			},
+			RawMetric: ptrs.Ptr("training"),
 		},
-			RawMetric: ptrs.Ptr("training")},
 	}
 	policies, err := UnmarshalConfigPolicy[ExperimentConfigPolicies](incompleteConfig,
 		InvalidExperimentConfigPolicyErr)

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -358,11 +358,6 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	// Lastly, apply any json-schema-defined defaults.
 	config = schemas.WithDefaults(config)
 
-	// Make sure the experiment config has all eventuallyRequired fields.
-	if err = schemas.IsComplete(config); err != nil {
-		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
-	}
-
 	// Merge the config with the optionally specified invariant config specified by task config
 	// policies.
 	configWithInvariantOverrides, err := configpolicy.MergeWithInvariantExperimentConfigs(ctx,
@@ -373,6 +368,11 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	}
 
 	config = *configWithInvariantOverrides
+	// Make sure the experiment config has all eventuallyRequired fields.
+	if err = schemas.IsComplete(config); err != nil {
+		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")
+	}
+
 	// Disallow EOL searchers.
 	if err = config.Searcher().AssertCurrent(); err != nil {
 		return nil, nil, config, nil, nil, errors.Wrap(err, "invalid experiment configuration")


### PR DESCRIPTION
## Ticket

[CM-584]


## Description
Admins can set global and workspace invariant experiment config policies containing config fields that are "incomplete" (they fail our [completeness validator](https://github.com/determined-ai/determined/blob/main/master/pkg/schemas/schema.go#L42) ).
However, users can also submit such incomplete configs when launching experiments, and these configs get populated with pre-defined [defaults](https://github.com/determined-ai/determined/blob/main/master/pkg/schemas/zgen_schemas.go).

Populate the final config with defaults after merging with the workspace and global invariant config (so that invariant config fields are also populated with defaults after overriding/merging is complete).


## Test Plan
CI passes (automated testing)


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-584]: https://hpe-aiatscale.atlassian.net/browse/CM-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ