### PR TITLE
chore: populate exp config priority with enforced priority before opting to rm default

### DIFF
--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/determined-ai/determined/master/internal/rm"
 	"github.com/determined-ai/determined/master/pkg/model"
-	"github.com/determined-ai/determined/master/pkg/ptrs"
 	"github.com/determined-ai/determined/master/pkg/schemas"
 	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 )
@@ -253,7 +252,7 @@ func FindAllowedPriority(scope *int, workloadType string) (limit *int, constrain
 			}
 			if configs.Resources.Priority != nil {
 				adminPriority := *configs.Resources.Priority
-				return ptrs.Ptr(adminPriority), false,
+				return &adminPriority, false,
 					fmt.Errorf("priority set by invariant config: %w", errPriorityImmutable)
 			}
 		case model.ExperimentType:

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -317,7 +317,7 @@ func PriorityUpdateAllowed(wkspID int, workloadType string, priority int, smalle
 
 	// No invariant configs. Check for constraints.
 	if globalExists {
-		return priorityWithinLimit(priority, *wkspEnforcedPriority, smallerHigher), nil
+		return priorityWithinLimit(priority, *globalEnforcedPriority, smallerHigher), nil
 	}
 	if wkspExists {
 		return priorityWithinLimit(priority, *wkspEnforcedPriority, smallerHigher), nil

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -264,7 +264,7 @@ func FindAllowedPriority(scope *int, workloadType string) (limit *int, constrain
 			}
 			if configs.RawResources != nil && configs.RawResources.RawPriority != nil {
 				adminPriority := *configs.RawResources.RawPriority
-				return ptrs.Ptr(adminPriority), false,
+				return &adminPriority, false,
 					fmt.Errorf("priority set by invariant config: %w", errPriorityImmutable)
 			}
 		default:

--- a/master/internal/configpolicy/task_config_policy.go
+++ b/master/internal/configpolicy/task_config_policy.go
@@ -232,10 +232,11 @@ func MergeWithInvariantExperimentConfigs(ctx context.Context, workspaceID int,
 }
 
 // FindAllowedPriority finds the optionally set priority limit in scope's invariant config
-// policies. Returns the invariant config priority if that's set, and otherwise returns the
+// policies. Returns the invariant config priority if that's set, and otherwise returns
 // the priority_limit constraint. If neither of the two is set, returns nil limit.
 func FindAllowedPriority(scope *int, workloadType string) (limit *int, constraintExists bool,
-	err error) {
+	err error,
+) {
 	configPolicies, err := GetTaskConfigPolicies(context.TODO(), scope, workloadType)
 	if err != nil {
 		return nil, false, fmt.Errorf("unable to fetch task config policies: %w", err)

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -25,7 +25,7 @@ func TestFindAllowedPriority(t *testing.T) {
 	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
 
 	// No priority limit to find.
-	_, exists, err := findAllowedPriority(nil, model.ExperimentType)
+	_, exists, err := FindAllowedPriority(nil, model.ExperimentType)
 	require.NoError(t, err)
 	require.False(t, exists)
 
@@ -33,7 +33,7 @@ func TestFindAllowedPriority(t *testing.T) {
 	globalLimit := 10
 	user := db.RequireMockUser(t, pgDB)
 	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit), model.ExperimentType)
-	limit, exists, err := findAllowedPriority(nil, model.ExperimentType)
+	limit, exists, err := FindAllowedPriority(nil, model.ExperimentType)
 	require.Equal(t, globalLimit, limit)
 	require.True(t, exists)
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestFindAllowedPriority(t *testing.T) {
 	configPriority := 15
 	invariantConfig := fmt.Sprintf(`{"resources": {"priority": %d}}`, configPriority)
 	addConfig(t, user, nil, invariantConfig, model.NTSCType)
-	limit, _, err = findAllowedPriority(nil, model.NTSCType)
+	limit, _, err = FindAllowedPriority(nil, model.NTSCType)
 	require.ErrorIs(t, err, errPriorityImmutable)
 	require.Equal(t, configPriority, limit)
 
@@ -50,7 +50,7 @@ func TestFindAllowedPriority(t *testing.T) {
 	configPriority = 7
 	invariantConfig = fmt.Sprintf(`{"resources": {"priority": %d}}`, configPriority)
 	addConfig(t, user, nil, invariantConfig, model.ExperimentType)
-	limit, _, err = findAllowedPriority(nil, model.ExperimentType)
+	limit, _, err = FindAllowedPriority(nil, model.ExperimentType)
 	require.ErrorIs(t, err, errPriorityImmutable)
 	require.Equal(t, configPriority, limit)
 }

--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -34,7 +34,8 @@ func TestFindAllowedPriority(t *testing.T) {
 	user := db.RequireMockUser(t, pgDB)
 	addConstraints(t, user, nil, fmt.Sprintf(`{"priority_limit": %d}`, globalLimit), model.ExperimentType)
 	limit, exists, err := FindAllowedPriority(nil, model.ExperimentType)
-	require.Equal(t, globalLimit, limit)
+	require.NotNil(t, limit)
+	require.Equal(t, globalLimit, *limit)
 	require.True(t, exists)
 	require.NoError(t, err)
 
@@ -44,7 +45,8 @@ func TestFindAllowedPriority(t *testing.T) {
 	addConfig(t, user, nil, invariantConfig, model.NTSCType)
 	limit, _, err = FindAllowedPriority(nil, model.NTSCType)
 	require.ErrorIs(t, err, errPriorityImmutable)
-	require.Equal(t, configPriority, limit)
+	require.NotNil(t, limit)
+	require.Equal(t, configPriority, *limit)
 
 	// Experiment priority set.
 	configPriority = 7
@@ -52,7 +54,8 @@ func TestFindAllowedPriority(t *testing.T) {
 	addConfig(t, user, nil, invariantConfig, model.ExperimentType)
 	limit, _, err = FindAllowedPriority(nil, model.ExperimentType)
 	require.ErrorIs(t, err, errPriorityImmutable)
-	require.Equal(t, configPriority, limit)
+	require.NotNil(t, limit)
+	require.Equal(t, configPriority, *limit)
 }
 
 func TestPriorityUpdateAllowed(t *testing.T) {

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -352,7 +352,6 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	// Apply the scheduler's default priority if priority is not set in an invariant config or		// constraint.
 	// constraint.
 	if config.Resources().Priority() == nil {
-		// Returns an error if RM does not implement priority.
 		enforcedPriority, _, err := configpolicy.FindAllowedPriority(
 			&workspaceID,
 			model.ExperimentType,

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -349,7 +349,7 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 		config.RawCheckpointStorage, &m.config.CheckpointStorage,
 	)
 
-	// Apply the scheduler's default priority if priority is not set in an invariant config or		// constraint.
+	// Apply the scheduler's default priority if priority is not set in an invariant config or
 	// constraint.
 	if config.Resources().Priority() == nil {
 		enforcedPriority, _, err := configpolicy.FindAllowedPriority(
@@ -365,7 +365,6 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 		} else {
 			config.RawResources.RawPriority = enforcedPriority
 		}
-
 	}
 
 	// Lastly, apply any json-schema-defined defaults.

--- a/master/internal/core_experiment.go
+++ b/master/internal/core_experiment.go
@@ -352,14 +352,14 @@ func (m *Master) parseCreateExperiment(ctx context.Context, req *apiv1.CreateExp
 	// Apply the scheduler's default priority if priority is not set in an invariant config or
 	// constraint.
 	if config.Resources().Priority() == nil {
-		enforcedPriority, _, err := configpolicy.FindAllowedPriority(
+		enforcedPriority, constraint, err := configpolicy.FindAllowedPriority(
 			&workspaceID,
 			model.ExperimentType,
 		)
 		if err != nil {
 			return nil, nil, config, nil, nil, err
 		}
-		if enforcedPriority == nil {
+		if enforcedPriority == nil || constraint {
 			prio := masterConfig.DefaultPriorityForPool(poolName.String())
 			config.RawResources.RawPriority = &prio
 		} else {


### PR DESCRIPTION
## Ticket

[CM-586]



## Description

Populate experiment config priority with the enforced priority specified in workspace or global invariant config or constraints policies. 
If priority is not enforced by config policies within the experiment's scope, populate with the experiment config default priority specified by the rm.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-586]: https://hpe-aiatscale.atlassian.net/browse/CM-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ