### PR TITLE
chore: add config policies to CLI reference docs

### DIFF
--- a/docs/manage/config-policies.rst
+++ b/docs/manage/config-policies.rst
@@ -56,6 +56,12 @@ or CLI.
    both the invariant config and constraints for a given scope are updated together. It is not
    possible to update only one of these components independently.
 
+.. note::
+
+   Admins are encouraged to draft and save their config policies for each scope in separate YAML or 
+   JSON files. This allows for consistency between config policies set in the WebUI and CLI and
+   lessens the chance for unintended changes to be made to a given scope's policies.
+
 WebUI
 =====
 

--- a/docs/manage/config-policies.rst
+++ b/docs/manage/config-policies.rst
@@ -90,7 +90,7 @@ Administrators can set Config Policies at both the cluster and workspace levels.
 CLI
 ===
 
-Use the following command to manage workspace-level Config Policies via CLI:
+Use the following command to manage Config Policies via CLI:
 
 .. code:: bash
 

--- a/docs/manage/config-policies.rst
+++ b/docs/manage/config-policies.rst
@@ -58,9 +58,8 @@ or CLI.
 
 .. note::
 
-   Admins are encouraged to draft and save their config policies for each scope in separate YAML or 
-   JSON files. This allows for consistency between config policies set in the WebUI and CLI and
-   lessens the chance for unintended changes to be made to a given scope's policies.
+   It is recommended that administrators save their configuration policies for each scope in
+   separate YAML or JSON files. This provides an easy way to back up and restore policies if needed.
 
 WebUI
 =====

--- a/docs/reference/cli-reference.rst
+++ b/docs/reference/cli-reference.rst
@@ -27,29 +27,30 @@ help documentation. For example, to learn more about individual experiment comma
 
    positional arguments:
      command
-       help                show help for this command
-       auth                manage auth
-       agent (a)           manage agents
-       command (cmd)       manage commands
-       checkpoint (c)      manage checkpoints
-       deploy (d)          manage deployments
-       experiment (e)      manage experiments
-       job (j)             manage job
-       master (m)          manage master
-       model (m)           manage models
-       notebook            manage notebooks
-       oauth               manage OAuth
-       preview-search      preview search
-       resources (res)     query historical resource allocation
-       shell               manage shells
-       slot (s)            manage slots
-       task                manage tasks (commands, experiments, notebooks,
-                           shells, tensorboards)
-       template (tpl)      manage config templates
-       tensorboard         manage TensorBoard instances
-       trial (t)           manage trials
-       user (u)            manage users
-       version             show version information
+       help                   show help for this command
+       auth                   manage auth
+       agent (a)              manage agents
+       command (cmd)          manage commands
+       checkpoint (c)         manage checkpoints
+       deploy (d)             manage deployments
+       experiment (e)         manage experiments
+       job (j)                manage job
+       master (m)             manage master
+       model (m)              manage models
+       notebook               manage notebooks
+       oauth                  manage OAuth
+       preview-search         preview search
+       resources (res)        query historical resource allocation
+       shell                  manage shells
+       slot (s)               manage slots
+       task                   manage tasks (commands, experiments, notebooks,
+                              shells, tensorboards)
+       template (tpl)         manage config templates
+       config-policies (cp)   manage config policies
+       tensorboard            manage TensorBoard instances
+       trial (t)              manage trials
+       user (u)               manage users
+       version                show version information
 
    optional arguments:
      -h, --help            show this help message and exit

--- a/harness/determined/cli/config_policies.py
+++ b/harness/determined/cli/config_policies.py
@@ -90,7 +90,7 @@ def delete_config_policies(args: argparse.Namespace) -> None:
 
 args_description: cli.ArgsDescription = [
     cli.Cmd(
-        "config-policies",
+        "config-policies cp",
         None,
         "manage config policies",
         [
@@ -110,7 +110,8 @@ args_description: cli.ArgsDescription = [
                         "--workspace-name",
                         type=str,
                         required=False,
-                        help="apply config policies to workspace",
+                        help="get config policies from this workspace. When not specified, get "
+                        "global config policies",
                     ),
                     cli.Group(cli.output_format_args["json"], cli.output_format_args["yaml"]),
                 ],
@@ -138,7 +139,8 @@ args_description: cli.ArgsDescription = [
                         "--workspace-name",
                         type=str,
                         required=False,
-                        help="apply config policies to this workspace",
+                        help="apply config policies to this workspace. When not specified, apply "
+                        "global config policies",
                     ),
                 ],
             ),
@@ -158,7 +160,8 @@ args_description: cli.ArgsDescription = [
                         "--workspace-name",
                         type=str,
                         required=False,
-                        help="apply config policies to workspace",
+                        help="delete config policies from this workspace. When not specified, "
+                        "delete global config policies",
                     ),
                 ],
             ),


### PR DESCRIPTION
## Ticket

CM-480


## Description

- Add config policies to CLI reference docs
- give `det config-policies` shorthand name `det cp`
- clarify in the config-policies help messages that policies are applied globally when `--workspace-name` flag is unspecified 


## Test Plan


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ