### PR TITLE
chore: standardize status api errors for task config policies

### DIFF
--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -150,7 +150,7 @@ func (a *apiServer) PutWorkspaceConfigPolicies(
 		Constraints:     constraints,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, settingPoliciesErr+err.Error())
+		return nil, status.Errorf(codes.Internal, settingPoliciesErr+": "+err.Error())
 	}
 
 	return &apiv1.PutWorkspaceConfigPoliciesResponse{
@@ -193,7 +193,7 @@ func (a *apiServer) PutGlobalConfigPolicies(
 		Constraints:     constraints,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, settingPoliciesErr+err.Error())
+		return nil, status.Errorf(codes.Internal, settingPoliciesErr+": "+err.Error())
 	}
 
 	return &apiv1.PutGlobalConfigPoliciesResponse{

--- a/master/internal/api_config_policies.go
+++ b/master/internal/api_config_policies.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	noWorkloadErr          = "no workload type specified."
-	noPoliciesErr          = "no specified config policies."
+	noWorkloadErr          = "no workload type specified"
+	noPoliciesErr          = "no specified config policies"
 	globalPriorityErr      = "global priority limit already exists"
 	invalidWorkloadTypeErr = "invalid workload type"
+	settingPoliciesErr     = "error setting task config policies"
 )
 
 func (a *apiServer) validatePoliciesAndWorkloadType(
@@ -34,16 +35,16 @@ func (a *apiServer) validatePoliciesAndWorkloadType(
 ) error {
 	// Validate workload type
 	if !configpolicy.ValidWorkloadType(workloadType) {
-		errMessage := fmt.Sprintf(invalidWorkloadTypeErr+": %s.", workloadType)
+		errMessage := fmt.Errorf(invalidWorkloadTypeErr+": %s", workloadType)
 		if len(workloadType) == 0 {
-			errMessage = noWorkloadErr
+			errMessage = fmt.Errorf(noWorkloadErr)
 		}
-		return status.Errorf(codes.InvalidArgument, errMessage)
+		return errMessage
 	}
 
 	// Validate policies.
 	if len(configPolicies) == 0 {
-		return status.Errorf(codes.InvalidArgument, noPoliciesErr)
+		return fmt.Errorf(noPoliciesErr)
 	}
 
 	// Validate the input config based on workload type.
@@ -56,7 +57,7 @@ func (a *apiServer) validatePoliciesAndWorkloadType(
 		return configpolicy.ValidateNTSCConfig(globalConfigPolicies, configPolicies,
 			priorityEnabledErr)
 	default:
-		return status.Errorf(codes.InvalidArgument, fmt.Sprintf(invalidWorkloadTypeErr+": %s.", workloadType))
+		return fmt.Errorf(invalidWorkloadTypeErr+": %s", workloadType)
 	}
 }
 
@@ -64,7 +65,7 @@ func parseConfigPolicies(configAndConstraints string) (
 	tcps map[string]interface{}, invariantConfig *string, constraints *string, err error,
 ) {
 	if len(configAndConstraints) == 0 {
-		return nil, nil, nil, status.Error(codes.InvalidArgument, "nothing to parse, empty "+
+		return nil, nil, nil, fmt.Errorf("nothing to parse, empty " +
 			"config and constraints input")
 	}
 	// Standardize to JSON policies file format.
@@ -111,33 +112,33 @@ func (a *apiServer) PutWorkspaceConfigPolicies(
 	// Request Validation
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	w, err := a.GetWorkspaceByID(ctx, req.WorkspaceId, *curUser, false)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanModifyWorkspaceConfigPolicies(ctx, *curUser, w)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	globalConfigPolicies, err := configpolicy.GetTaskConfigPolicies(ctx, nil, req.WorkloadType)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = a.validatePoliciesAndWorkloadType(globalConfigPolicies, req.WorkloadType,
 		req.ConfigPolicies)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	configPolicies, invariantConfig, constraints, err := parseConfigPolicies(req.ConfigPolicies)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	err = configpolicy.SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
@@ -149,13 +150,13 @@ func (a *apiServer) PutWorkspaceConfigPolicies(
 		Constraints:     constraints,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error setting task config policies: %w", err)
+		return nil, status.Errorf(codes.Internal, settingPoliciesErr+err.Error())
 	}
 
 	return &apiv1.PutWorkspaceConfigPoliciesResponse{
 			ConfigPolicies: configpolicy.MarshalConfigPolicy(configPolicies),
 		},
-		err
+		nil
 }
 
 // Add or update global task config policies.
@@ -166,22 +167,22 @@ func (a *apiServer) PutGlobalConfigPolicies(
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanModifyGlobalConfigPolicies(ctx, curUser)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	err = a.validatePoliciesAndWorkloadType(nil, req.WorkloadType, req.ConfigPolicies)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	configPolicies, invariantConfig, constraints, err := parseConfigPolicies(req.ConfigPolicies)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
 	}
 
 	err = configpolicy.SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
@@ -192,13 +193,13 @@ func (a *apiServer) PutGlobalConfigPolicies(
 		Constraints:     constraints,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error setting task config policies: %w", err)
+		return nil, status.Errorf(codes.Internal, settingPoliciesErr+err.Error())
 	}
 
 	return &apiv1.PutGlobalConfigPoliciesResponse{
 			ConfigPolicies: configpolicy.MarshalConfigPolicy(configPolicies),
 		},
-		err
+		nil
 }
 
 // Get workspace task config policies.
@@ -209,22 +210,22 @@ func (a *apiServer) GetWorkspaceConfigPolicies(
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	w, err := a.GetWorkspaceByID(ctx, req.WorkspaceId, *curUser, false)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanViewWorkspaceConfigPolicies(ctx, *curUser, w)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	resp, err := a.getConfigPolicies(ctx, ptrs.Ptr(int(req.WorkspaceId)), req.WorkloadType)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	return &apiv1.GetWorkspaceConfigPoliciesResponse{ConfigPolicies: resp}, nil
@@ -238,17 +239,17 @@ func (a *apiServer) GetGlobalConfigPolicies(
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanViewGlobalConfigPolicies(ctx, curUser)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	resp, err := a.getConfigPolicies(ctx, nil, req.WorkloadType)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 
 	return &apiv1.GetGlobalConfigPoliciesResponse{ConfigPolicies: resp}, nil
@@ -296,17 +297,17 @@ func (a *apiServer) DeleteWorkspaceConfigPolicies(
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	w, err := a.GetWorkspaceByID(ctx, req.WorkspaceId, *curUser, false)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanModifyWorkspaceConfigPolicies(ctx, *curUser, w)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.PermissionDenied, err.Error())
 	}
 
 	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
@@ -320,7 +321,7 @@ func (a *apiServer) DeleteWorkspaceConfigPolicies(
 	err = configpolicy.DeleteConfigPolicies(ctx, ptrs.Ptr(int(req.WorkspaceId)),
 		req.WorkloadType)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &apiv1.DeleteWorkspaceConfigPoliciesResponse{}, nil
 }
@@ -333,12 +334,12 @@ func (a *apiServer) DeleteGlobalConfigPolicies(
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.NotFound, err.Error())
 	}
 
 	err = configpolicy.AuthZProvider.Get().CanModifyGlobalConfigPolicies(ctx, curUser)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.PermissionDenied, err.Error())
 	}
 
 	if !configpolicy.ValidWorkloadType(req.WorkloadType) {
@@ -351,7 +352,7 @@ func (a *apiServer) DeleteGlobalConfigPolicies(
 
 	err = configpolicy.DeleteConfigPolicies(ctx, nil, req.WorkloadType)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, err.Error())
 	}
 	return &apiv1.DeleteGlobalConfigPoliciesResponse{}, nil
 }

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -506,7 +506,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkspaceId:  workspaceID,
 			WorkloadType: model.NTSCType,
 		})
-	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
+	require.Equal(t, status.Error(codes.PermissionDenied, expectedErr.Error()), err)
 
 	_, err = api.PutWorkspaceConfigPolicies(ctx,
 		&apiv1.PutWorkspaceConfigPoliciesRequest{
@@ -514,7 +514,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkloadType:   model.NTSCType,
 			ConfigPolicies: validConstraintsPolicyYAML,
 		})
-	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
+	require.Equal(t, status.Error(codes.PermissionDenied, expectedErr.Error()), err)
 
 	// (Workspace-level) Nil error returns whatever the request returned.
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
@@ -544,14 +544,14 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 
 	_, err = api.DeleteGlobalConfigPolicies(ctx,
 		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType})
-	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
+	require.Equal(t, status.Error(codes.PermissionDenied, expectedErr.Error()), err)
 
 	_, err = api.PutGlobalConfigPolicies(ctx,
 		&apiv1.PutGlobalConfigPoliciesRequest{
 			WorkloadType:   model.NTSCType,
 			ConfigPolicies: validNTSCConfigPolicyYAML,
 		})
-	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
+	require.Equal(t, status.Error(codes.PermissionDenied, expectedErr.Error()), err)
 
 	// (Global) Nil error returns whatever the request returned.
 	configPolicyAuthZ.On("CanModifyGlobalConfigPolicies", mock.Anything, mock.Anything).

--- a/master/internal/api_config_policies_intg_test.go
+++ b/master/internal/api_config_policies_intg_test.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/determined-ai/determined/master/internal/configpolicy"
 	"github.com/determined-ai/determined/master/internal/db"
@@ -504,7 +506,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkspaceId:  workspaceID,
 			WorkloadType: model.NTSCType,
 		})
-	require.Equal(t, expectedErr, err)
+	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
 
 	_, err = api.PutWorkspaceConfigPolicies(ctx,
 		&apiv1.PutWorkspaceConfigPoliciesRequest{
@@ -512,7 +514,7 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 			WorkloadType:   model.NTSCType,
 			ConfigPolicies: validConstraintsPolicyYAML,
 		})
-	require.Equal(t, expectedErr, err)
+	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
 
 	// (Workspace-level) Nil error returns whatever the request returned.
 	workspaceAuthZ.On("CanGetWorkspace", mock.Anything, mock.Anything, mock.Anything).
@@ -542,14 +544,14 @@ func TestAuthZCanModifyConfigPolicies(t *testing.T) {
 
 	_, err = api.DeleteGlobalConfigPolicies(ctx,
 		&apiv1.DeleteGlobalConfigPoliciesRequest{WorkloadType: model.NTSCType})
-	require.Equal(t, expectedErr, err)
+	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
 
 	_, err = api.PutGlobalConfigPolicies(ctx,
 		&apiv1.PutGlobalConfigPoliciesRequest{
 			WorkloadType:   model.NTSCType,
 			ConfigPolicies: validNTSCConfigPolicyYAML,
 		})
-	require.Equal(t, expectedErr, err)
+	require.Equal(t, status.Error(codes.PermissionDenied, err.Error()), err)
 
 	// (Global) Nil error returns whatever the request returned.
 	configPolicyAuthZ.On("CanModifyGlobalConfigPolicies", mock.Anything, mock.Anything).


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
CM-556


## Description
Some of the APIs return a status, e.g. status.Errorf(codes.InvalidArgument, errMessage) and some return a simple error, e.g. fmt.Errorf("error parsing config policies: %w", err). Review the task config policy APIs and ensure we are returning a status code in exported/able functions.


## Test Plan
N/A -- make sure e2e tests pass



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ