### PR TITLE
chore: fix merge exp flake

### DIFF
--- a/master/internal/configpolicy/task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/task_config_policy_intg_test.go
@@ -608,6 +608,7 @@ func TestMergeWithInvariantExperimentConfigs(t *testing.T) {
 		require.NoError(t, err)
 
 		conf.SetName(wkspInvariantConfig.Name())
+		conf.RawReproducibility = wkspInvariantConfig.RawReproducibility
 		require.Equal(t, wkspInvariantConfig, *conf)
 	})
 


### PR DESCRIPTION
## Ticket




## Description

The `reproducibility.experiment_seed` field of the `expconf.ReproducibilityConfig` is automatically populated with `time.Now().Unix()` in the [WithDefaults](https://github.com/determined-ai/determined/blob/main/master/pkg/schemas/expconf/experiment_config.go#L365) pseudointerface implementation. Sometimes, this time is identical for the expected and actual final structs, but other times it's not.
Explicity set this field so that it isn't auto-defaulted to the new current timestamp.


## Test Plan
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ