### PR TITLE
fix: improve sorting for multi-type columns

### DIFF
--- a/webui/react/src/components/MultiSortMenu.tsx
+++ b/webui/react/src/components/MultiSortMenu.tsx
@@ -1,12 +1,17 @@
+import Badge from 'hew/Badge';
 import Button from 'hew/Button';
 import { DirectionType, Sort, validSort } from 'hew/DataGrid/DataGrid';
 import Dropdown, { MenuItem } from 'hew/Dropdown';
 import Icon from 'hew/Icon';
 import Select from 'hew/Select';
 import { Loadable } from 'hew/utils/loadable';
+import { groupBy, mapValues } from 'lodash';
+import { Fragment, useMemo } from 'react';
 
+import { runColumns } from 'pages/FlatRuns/columns';
 import { V1ColumnType } from 'services/api-ts-sdk';
 import { ProjectColumn } from 'types';
+import { removeColumnTypePrefix } from 'utils/flatRun';
 
 import css from './MultiSortMenu.module.scss';
 
@@ -25,6 +30,7 @@ interface MultiSortRowProps {
   onChange?: (sort: Sort) => void;
   onRemove?: () => void;
   bannedSortColumns: Set<string>;
+  typeMap: Record<string, V1ColumnType[]>;
 }
 interface DirectionOptionsProps {
   onChange?: (direction: DirectionType) => void;
@@ -36,6 +42,7 @@ interface ColumnOptionsProps {
   onChange?: (column: string) => void;
   value?: string;
   bannedSortColumns: Set<string>;
+  typeMap: Record<string, V1ColumnType[]>;
 }
 
 export const optionsByColumnType = {
@@ -146,6 +153,7 @@ const ColumnOptions: React.FC<ColumnOptionsProps> = ({
   columns,
   value,
   bannedSortColumns,
+  typeMap,
 }) => (
   <Select
     autoFocus
@@ -154,10 +162,29 @@ const ColumnOptions: React.FC<ColumnOptionsProps> = ({
     loading={Loadable.isNotLoaded(columns)}
     options={Loadable.getOrElse([], columns)
       .filter((c) => !bannedSortColumns.has(c.column))
-      .map((c) => ({
-        label: c.displayName || c.column,
-        value: c.column,
-      }))}
+      .map((c) => {
+        const badges = typeMap[c.column].map((type) => {
+          const copy =
+            (runColumns as readonly string[]).includes(c.column) &&
+            type === V1ColumnType.UNSPECIFIED
+              ? 'BOOLEAN'
+              : removeColumnTypePrefix(type);
+          return (
+            <Fragment key={type}>
+              <Badge text={copy} />{' '}
+            </Fragment>
+          );
+        });
+        const label = (
+          <>
+            {c.displayName || c.column} {badges}
+          </>
+        );
+        return {
+          label,
+          value: c.column,
+        };
+      })}
     placeholder="Select column"
     value={value}
     width="100%"
@@ -171,6 +198,7 @@ const MultiSortRow: React.FC<MultiSortRowProps> = ({
   onChange,
   onRemove,
   bannedSortColumns,
+  typeMap,
 }) => {
   const valueType =
     Loadable.getOrElse([], columns).find((c) => c.column === sort.column)?.type ||
@@ -181,6 +209,7 @@ const MultiSortRow: React.FC<MultiSortRowProps> = ({
         <ColumnOptions
           bannedSortColumns={bannedSortColumns}
           columns={columns}
+          typeMap={typeMap}
           value={sort.column}
           onChange={(column) => onChange?.({ ...sort, column })}
         />
@@ -224,6 +253,27 @@ const MultiSort: React.FC<MultiSortProps> = ({ sorts, columns, onChange, bannedS
     window.document.body.dispatchEvent(new Event('mousedown', { bubbles: true }));
     onChange?.([EMPTY_SORT]);
   };
+  // replace duplicate columns with a single unspecified column for copy
+  // reasons. maintain types so we can display in the select
+  const [mergedColumns, typeMap] = useMemo(() => {
+    const loadableTuple = columns.map((c) => {
+      const columnGroups = groupBy(c, 'column');
+      const fixedColumns = Object.values(columnGroups).flatMap((group) => {
+        if (group.length > 1) {
+          return [
+            {
+              ...group[0],
+              type: V1ColumnType.UNSPECIFIED,
+            },
+          ];
+        }
+        return group;
+      });
+      const typeMap = mapValues(columnGroups, (group) => group.map((column) => column.type));
+      return [fixedColumns, typeMap] as const;
+    });
+    return [loadableTuple.map((l) => l[0]), loadableTuple.map((l) => l[1]).getOrElse({})];
+  }, [columns]);
 
   return (
     <div className={css.base} data-test-component="multiSort">
@@ -231,7 +281,7 @@ const MultiSort: React.FC<MultiSortProps> = ({ sorts, columns, onChange, bannedS
       <div className={css.rows} data-test="rows">
         {sorts.map((sort, idx) => {
           const seenColumns = sorts.slice(0, idx).map((s) => s.column);
-          const columnOptions = Loadable.map(columns, (cols) =>
+          const columnOptions = mergedColumns.map((cols) =>
             cols.filter((c) => !seenColumns.includes(c.column)),
           );
           return (
@@ -240,6 +290,7 @@ const MultiSort: React.FC<MultiSortProps> = ({ sorts, columns, onChange, bannedS
               columns={columnOptions}
               key={sort.column || idx}
               sort={sort}
+              typeMap={typeMap}
               onChange={makeOnRowChange(idx)}
               onRemove={makeOnRowRemove(idx)}
             />


### PR DESCRIPTION

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
ET-836



## Description
this improves the experience for interacting with multi-type columns:

* as sorting is type-agnostic, the multi-sort menu will show all affected types as badges next to the column name

* all columns with the same key will appear as sorted in the header

* multisort menu copy is updated to use the unspecified copy for these columns, instead of specific copy (but header copy for sort menu items remains the same).


## Test Plan
with a project with multi-type metadata columns, visit the project runs page.

* metadata options in the multi-sort menu should report all types in the project
* all multi-type options of the same key should appear sorted when the column sort is applied
* you should be able to change the direction of the sort by interacting with the header menu.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->
