### PR TITLE
chore: SSO improvement feature requires Enterprise Edition.

### DIFF
--- a/master/internal/api_token.go
+++ b/master/internal/api_token.go
@@ -19,8 +19,8 @@ import (
 )
 
 var errAccessTokenRequiresEE = status.Error(
-	codes.InvalidArgument,
-	"users cannot log in with an access token. This feature requires the Enterprise Edition.",
+	codes.FailedPrecondition,
+	"users cannot log in with an access token without a valid Enterprise Edition license set up.",
 )
 
 // PostAccessToken takes user id and optional lifespan, description and creates an

--- a/master/internal/api_token.go
+++ b/master/internal/api_token.go
@@ -12,9 +12,15 @@ import (
 	"github.com/determined-ai/determined/master/internal/api"
 	"github.com/determined-ai/determined/master/internal/db"
 	"github.com/determined-ai/determined/master/internal/grpcutil"
+	"github.com/determined-ai/determined/master/internal/license"
 	"github.com/determined-ai/determined/master/internal/token"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+var errAccessTokenRequiresEE = status.Error(
+	codes.InvalidArgument,
+	"users cannot log in with an access token. This feature requires the Enterprise Edition.",
 )
 
 // PostAccessToken takes user id and optional lifespan, description and creates an
@@ -22,6 +28,10 @@ import (
 func (a *apiServer) PostAccessToken(
 	ctx context.Context, req *apiv1.PostAccessTokenRequest,
 ) (*apiv1.PostAccessTokenResponse, error) {
+	if !license.IsEE() {
+		return nil, errAccessTokenRequiresEE
+	}
+
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -58,6 +68,10 @@ func (a *apiServer) PostAccessToken(
 func (a *apiServer) GetAccessTokens(
 	ctx context.Context, req *apiv1.GetAccessTokensRequest,
 ) (*apiv1.GetAccessTokensResponse, error) {
+	if !license.IsEE() {
+		return nil, errAccessTokenRequiresEE
+	}
+
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
 		return nil, err
@@ -161,6 +175,10 @@ func (a *apiServer) GetAccessTokens(
 func (a *apiServer) PatchAccessToken(
 	ctx context.Context, req *apiv1.PatchAccessTokenRequest,
 ) (*apiv1.PatchAccessTokenResponse, error) {
+	if !license.IsEE() {
+		return nil, errAccessTokenRequiresEE
+	}
+
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[DET-10469](https://hpe-aiatscale.atlassian.net/browse/DET-10469)


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Reducing the scope of SSO improvement project to EE Only.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
`det token create` should work on ee but not oss.


## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-10469]: https://hpe-aiatscale.atlassian.net/browse/DET-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ