### PR TITLE
chore: add checkpoint and max slots config policy enforcements in PATCH experiment

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1218,6 +1218,8 @@ func (a *apiServer) PatchExperiment(
 			}
 			activeConfig.SetResources(resources)
 		}
+
+		// Only allow setting checkpoint storage if it is not specified as an invariant config.
 		newCheckpointStorage := req.Experiment.CheckpointStorage
 
 		if newCheckpointStorage != nil {
@@ -1231,6 +1233,23 @@ func (a *apiServer) PatchExperiment(
 			storage.SetSaveTrialBest(int(newCheckpointStorage.SaveTrialBest))
 			storage.SetSaveTrialLatest(int(newCheckpointStorage.SaveTrialLatest))
 			activeConfig.SetCheckpointStorage(storage)
+
+			// Only allow checkpoint storage changes if it is not specified as an invariant config.
+			w, err := getWorkspaceByConfig(activeConfig)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, fmt.Sprintf("failed to get workspace %s",
+					activeConfig.Workspace()))
+			}
+
+			enforcedChkptConf, err := configpolicy.GetEnforcedConfig[expconf.CheckpointStorageConfig](
+				ctx, &w.ID, "invariant_config", "checkpoint_storage",
+				model.ExperimentType)
+			if err != nil {
+				return nil, fmt.Errorf("unable to fetch task config policies: %w", err)
+			}
+			if enforcedChkptConf != nil {
+				activeConfig.SetCheckpointStorage(*enforcedChkptConf)
+			}
 		}
 
 		// `patch` represents the allowed mutations that can be performed on an experiment, in JSON
@@ -1243,7 +1262,6 @@ func (a *apiServer) PatchExperiment(
 			if !ok {
 				return nil, api.NotFoundErrs("experiment", strconv.Itoa(int(exp.Id)), true)
 			}
-
 			if newResources.MaxSlots != nil {
 				msg := sproto.SetGroupMaxSlots{MaxSlots: ptrs.Ptr(int(*newResources.MaxSlots))}
 				e.SetGroupMaxSlots(msg)
@@ -1471,19 +1489,16 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 	}
 
 	// Determine which workspace the experiment is in.
-	wkspName := activeConfig.Workspace()
-	if wkspName == "" {
-		wkspName = model.DefaultWorkspaceName
-	}
-	ctx := context.TODO()
-	w, err := workspace.WorkspaceByName(ctx, wkspName)
+	w, err := getWorkspaceByConfig(activeConfig)
 	if err != nil {
 		return nil, false, status.Errorf(codes.Internal,
 			fmt.Sprintf("failed to get workspace %s", activeConfig.Workspace()))
 	}
+
 	// Merge the config with the optionally specified invariant config specified by task config
 	// policies.
-	configWithInvariantDefaults, err := configpolicy.MergeWithInvariantExperimentConfigs(ctx,
+	configWithInvariantDefaults, err := configpolicy.MergeWithInvariantExperimentConfigs(
+		context.TODO(),
 		w.ID, mergedConfig)
 	if err != nil {
 		return nil, false,
@@ -1497,6 +1512,15 @@ func (a *apiServer) parseAndMergeContinueConfig(expID int, overrideConfig string
 	}
 
 	return bytes.([]byte), isSingle, nil
+}
+
+func getWorkspaceByConfig(config expconf.ExperimentConfig) (*model.Workspace, error) {
+	wkspName := config.Workspace()
+	if wkspName == "" {
+		wkspName = model.DefaultWorkspaceName
+	}
+	ctx := context.TODO()
+	return workspace.WorkspaceByName(ctx, wkspName)
 }
 
 var errContinueHPSearchCompleted = status.Error(codes.FailedPrecondition,

--- a/master/internal/api_experiment_intg_test.go
+++ b/master/internal/api_experiment_intg_test.go
@@ -2347,3 +2347,27 @@ func TestDeleteExperimentsFiltered(t *testing.T) {
 	}
 	t.Error("expected experiments to delete after 15 seconds and they did not")
 }
+
+func TestGetWorkspaceByConfig(t *testing.T) {
+	api, _, ctx := setupAPITest(t, nil)
+	resp, err := api.PostWorkspace(ctx, &apiv1.PostWorkspaceRequest{
+		Name: uuid.New().String(),
+	})
+	require.NoError(t, err)
+	wkspName := &resp.Workspace.Name
+
+	t.Run("no workspace name", func(t *testing.T) {
+		w, err := getWorkspaceByConfig(expconf.ExperimentConfig{RawWorkspace: ptrs.Ptr("")})
+		require.NoError(t, err)
+
+		// Verify we get the Uncategorized workspace.
+		require.Equal(t, 1, w.ID)
+	})
+	t.Run("has workspace name", func(t *testing.T) {
+		w, err := getWorkspaceByConfig(expconf.ExperimentConfig{
+			RawWorkspace: wkspName,
+		})
+		require.NoError(t, err)
+		require.Equal(t, *wkspName, w.Name)
+	})
+}

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	wkspIDQuery       = "workspace_id = ?"
-	wkspIDGlobalQuery = "workspace_id IS ?"
+	wkspIDQuery          = "workspace_id = ?"
+	wkspIDGlobalQuery    = "workspace_id IS ?"
+	invalidPolicyTypeErr = "invalid policy type"
 	// DefaultInvariantConfigStr is the default invariant config val used for tests.
 	DefaultInvariantConfigStr = `{
 	"description": "random description", 
@@ -115,44 +116,48 @@ func DeleteConfigPolicies(ctx context.Context,
 	return nil
 }
 
-// GetEnforcedConfig gets the fields of the global invariant config or constraint if specified, and
-// the workspace invariant config or constraint otherwise. If neither is specified, returns nil.
-func GetEnforcedConfig[T any](ctx context.Context, wkspID *int, policyType, field, workloadType string) (*T,
+// GetConfigPolicyField fetches the field from an invariant_config or constraints policyType, in order
+// of precedence. Global scope has highest precedence, then workspace. Returns nil if none is found.
+// **NOTE** The field arguments are wrapped in bun.Safe, so you  must specify the "raw" string
+// exactly as you wish for it to be accessed in the database. For example, if you want to access
+// resources.max_slots, the field argument should be "'resources' -> 'max_slots'" NOT
+// "resources -> max_slots".
+// **NOTE**When using this function to retrieve an object of Kind Pointer, set T as the Type of
+// object that the Pointer wraps. For example, if we want an object of type *int, set T to int, so
+// that when its pointer is returned, you get an object of type *int.
+func GetConfigPolicyField[T any](ctx context.Context, wkspID *int, policyType, field, workloadType string) (*T,
 	error,
 ) {
 	if policyType != "invariant_config" && policyType != "constraints" {
-		return nil, fmt.Errorf("invalid policy type :%s", policyType)
+		return nil, fmt.Errorf("%s :%s", invalidPolicyTypeErr, policyType)
 	}
 
 	var confBytes []byte
 	var conf T
 	err := db.Bun().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		globalField := tx.NewSelect().
-			ColumnExpr("? -> ? AS globconf", bun.Safe(policyType), bun.Safe(field)).
-			Table("task_config_policies").
+		var globalBytes []byte
+		err := tx.NewSelect().Table("task_config_policies").
+			ColumnExpr("? -> ?", bun.Safe(policyType), bun.Safe(field)).
 			Where("workspace_id IS NULL").
-			Where("workload_type = ?", workloadType)
-
-		wkspField := tx.NewSelect().
-			ColumnExpr("? -> ? AS wkspconf", bun.Safe(policyType), bun.Safe(field)).
-			Table("task_config_policies").
-			Where("workspace_id = '?'", wkspID).
-			Where("workload_type = ?", workloadType)
-
-		both := tx.NewSelect().TableExpr("global_field").
-			Join("NATURAL JOIN wksp_field")
-
-		err := tx.NewSelect().ColumnExpr("coalesce(globconf, wkspconf)").
-			With("global_field", globalField).
-			With("wksp_field", wkspField).
-			Table("both").With("both", both).
-			Scan(ctx, &confBytes)
-		if err != nil {
+			Where("workload_type = ?", workloadType).Scan(ctx, &globalBytes)
+		if err == nil && len(globalBytes) > 0 {
+			confBytes = globalBytes
+		}
+		if err != nil && err != sql.ErrNoRows {
 			return err
 		}
-		return nil
+
+		var wkspBytes []byte
+		err = tx.NewSelect().Table("task_config_policies").
+			ColumnExpr("? -> ?", bun.Safe(policyType), bun.Safe(field)).
+			Where("workspace_id = ?", wkspID).
+			Where("workload_type = ?", workloadType).Scan(ctx, &wkspBytes)
+		if err == nil && len(globalBytes) == 0 {
+			confBytes = wkspBytes
+		}
+		return err
 	})
-	if err == sql.ErrNoRows {
+	if err == sql.ErrNoRows || len(confBytes) == 0 {
 		return nil, nil
 	}
 	if err != nil {

--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/determined-ai/determined/master/pkg/etc"
 	"github.com/determined-ai/determined/master/pkg/model"
 	"github.com/determined-ai/determined/master/pkg/ptrs"
+	"github.com/determined-ai/determined/master/pkg/schemas/expconf"
 
 	"github.com/stretchr/testify/require"
 )
@@ -658,4 +659,174 @@ func requireEqualTaskPolicy(t *testing.T, exp *model.TaskConfigPolicies, act *mo
 		require.NoError(t, err)
 		require.Equal(t, expJSONMap, actJSONMap)
 	}
+}
+
+func TestGetEnforcedConfig(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, etc.SetRootPath(db.RootFromDB))
+	pgDB, cleanup := db.MustResolveNewPostgresDatabase(t)
+	defer cleanup()
+	db.MustMigrateTestPostgres(t, pgDB, db.MigrationsFromDB)
+
+	user := db.RequireMockUser(t, pgDB)
+
+	w := model.Workspace{Name: uuid.NewString(), UserID: user.ID}
+	_, err := db.Bun().NewInsert().Model(&w).Exec(ctx)
+	require.NoError(t, err)
+
+	globalConf := `
+{
+	"checkpoint_storage": {
+		"type": "shared_fs",
+		"host_path": "global_host_path",
+		"container_path": "global_container_path"
+	}
+}
+`
+	wkspConf := `
+{
+	"checkpoint_storage": {
+		"type": "shared_fs",
+		"host_path": "wksp_host_path",
+		"container_path": "wksp_container_path",
+		"checkpoint_path": "wksp_checkpoint_path"
+	}
+}
+`
+
+	t.Run("checkpoint storage config", func(t *testing.T) {
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   user.ID,
+			InvariantConfig: &globalConf,
+		})
+		require.NoError(t, err)
+
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkspaceID:     &w.ID,
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   user.ID,
+			InvariantConfig: &wkspConf,
+		})
+		require.NoError(t, err)
+
+		checkpointStorage, err := GetEnforcedConfig[expconf.CheckpointStorageConfig](ctx, &w.ID,
+			"invariant_config", "'checkpoint_storage'", model.ExperimentType)
+		require.NoError(t, err)
+		require.NotNil(t, checkpointStorage)
+		require.Equal(t, expconf.CheckpointStorageConfigV0{
+			RawSharedFSConfig: &expconf.SharedFSConfigV0{
+				RawHostPath:      ptrs.Ptr("global_host_path"),
+				RawContainerPath: ptrs.Ptr("global_container_path"),
+			},
+		}, *checkpointStorage)
+	})
+
+	globalConf = `{
+	"debug": true
+}`
+	wkspConf = `
+	{
+		"resources": {
+			"max_slots": 15
+		}
+	}
+`
+
+	t.Run("max slots config", func(t *testing.T) {
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   user.ID,
+			InvariantConfig: &globalConf,
+		})
+		require.NoError(t, err)
+
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkspaceID:     &w.ID,
+			WorkloadType:    model.ExperimentType,
+			LastUpdatedBy:   user.ID,
+			InvariantConfig: &wkspConf,
+		})
+		require.NoError(t, err)
+
+		maxSlots, err := GetEnforcedConfig[int](ctx, &w.ID, "invariant_config",
+			"'resources' -> 'max_slots'", model.ExperimentType)
+		require.NoError(t, err)
+		require.NotNil(t, maxSlots)
+		require.Equal(t, 15, *maxSlots)
+	})
+
+	globalConstraints := `
+	{
+		"resources": {
+			"max_slots": 25
+		}
+	}
+`
+
+	wkspConstraints := `
+	{
+		"resources": {
+			"max_slots": 20
+		}
+	}
+`
+
+	t.Run("max slots constraints", func(t *testing.T) {
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkloadType:  model.ExperimentType,
+			LastUpdatedBy: user.ID,
+			Constraints:   &globalConstraints,
+		})
+		require.NoError(t, err)
+
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkspaceID:   &w.ID,
+			WorkloadType:  model.ExperimentType,
+			LastUpdatedBy: user.ID,
+			Constraints:   &wkspConstraints,
+		})
+		require.NoError(t, err)
+
+		maxSlots, err := GetEnforcedConfig[int](ctx, &w.ID, "constraints",
+			"'resources' -> 'max_slots'", model.ExperimentType)
+		require.NoError(t, err)
+		require.NotNil(t, maxSlots)
+		require.Equal(t, 25, *maxSlots)
+	})
+
+	globalConstraints = `
+	{
+		"priority_limit": 40
+	}
+`
+
+	wkspConstraints = `
+	{
+		"priority_limit": 50
+	}
+`
+
+	t.Run("priority constraints", func(t *testing.T) {
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkloadType:  model.ExperimentType,
+			LastUpdatedBy: user.ID,
+			Constraints:   &globalConstraints,
+		})
+		require.NoError(t, err)
+
+		err = SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
+			WorkspaceID:   &w.ID,
+			WorkloadType:  model.ExperimentType,
+			LastUpdatedBy: user.ID,
+			Constraints:   &wkspConstraints,
+		})
+		require.NoError(t, err)
+
+		maxSlots, err := GetEnforcedConfig[int](ctx, &w.ID, "constraints",
+			"'priority_limit'", model.ExperimentType)
+		require.NoError(t, err)
+		require.NotNil(t, maxSlots)
+		require.Equal(t, 40, *maxSlots)
+	})
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -307,26 +307,26 @@ func configPolicyOverlap(config1, config2 interface{}) {
 // enforced max slots for the workspace if that's set as an invariant config, and returns the
 // requested max slots otherwise. Returns an error when max slots is not set as an invariant config
 // and the requested max slots violates the constriant.
-func CanSetMaxSlots(slotsReq *int, wkspID int) (bool, *int, error) {
+func CanSetMaxSlots(slotsReq *int, wkspID int) (*int, error) {
 	if slotsReq == nil {
-		return true, slotsReq, nil
+		return slotsReq, nil
 	}
 	enforcedMaxSlots, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
 		"invariant_config",
 		"'resources' -> 'max_slots'", model.ExperimentType)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
 
 	if enforcedMaxSlots != nil {
-		return true, enforcedMaxSlots, nil
+		return enforcedMaxSlots, nil
 	}
 
 	maxSlotsLimit, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
 		"constraints",
 		"'resources' -> 'max_slots'", model.ExperimentType)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
 
 	var canSetReqSlots bool
@@ -334,8 +334,8 @@ func CanSetMaxSlots(slotsReq *int, wkspID int) (bool, *int, error) {
 		canSetReqSlots = true
 	}
 	if !canSetReqSlots {
-		return false, nil, fmt.Errorf(SlotsReqTooHighErr+": %d > %d", *slotsReq, *maxSlotsLimit)
+		return nil, fmt.Errorf(SlotsReqTooHighErr+": %d > %d", *slotsReq, *maxSlotsLimit)
 	}
 
-	return true, slotsReq, nil
+	return slotsReq, nil
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -2,6 +2,7 @@ package configpolicy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -27,6 +28,9 @@ const (
 	InvalidNTSCConfigPolicyErr = "invalid ntsc config policy"
 	// NotSupportedConfigPolicyErr is the error reported when admins attempt to set NTSC invariant config.
 	NotSupportedConfigPolicyErr = "not supported"
+	// SlotsReqTooHighErr is the error reported when the requested slots violates the max slots
+	// constraint.
+	SlotsReqTooHighErr = "requested slots is violates max slots constraint"
 )
 
 // ConfigPolicyWarning logs a warning for the configuration policy component.
@@ -297,4 +301,41 @@ func configPolicyOverlap(config1, config2 interface{}) {
 			}
 		}
 	}
+}
+
+// CanSetMaxSlots returns true if the slots requested don't violate a constraint. It returns the
+// enforced max slots for the workspace if that's set as an invariant config, and returns the
+// requested max slots otherwise. Returns an error when max slots is not set as an invariant config
+// and the requested max slots violates the constriant.
+func CanSetMaxSlots(slotsReq *int, wkspID int) (bool, *int, error) {
+	if slotsReq == nil {
+		return true, slotsReq, nil
+	}
+	enforcedMaxSlots, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
+		"invariant_config",
+		"'resources' -> 'max_slots'", model.ExperimentType)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if enforcedMaxSlots != nil {
+		return true, enforcedMaxSlots, nil
+	}
+
+	maxSlotsLimit, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
+		"constraints",
+		"'resources' -> 'max_slots'", model.ExperimentType)
+	if err != nil {
+		return false, nil, err
+	}
+
+	var canSetReqSlots bool
+	if maxSlotsLimit == nil || *slotsReq <= *maxSlotsLimit {
+		canSetReqSlots = true
+	}
+	if !canSetReqSlots {
+		return false, nil, fmt.Errorf(SlotsReqTooHighErr+": %d > %d", *slotsReq, *maxSlotsLimit)
+	}
+
+	return true, slotsReq, nil
 }

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -624,10 +624,9 @@ func TestCanSetMaxSlots(t *testing.T) {
 	ctx := context.Background()
 	w := createWorkspaceWithUser(ctx, t, user.ID)
 	t.Run("nil slots request", func(t *testing.T) {
-		canSetReqSlots, slots, err := CanSetMaxSlots(nil, w.ID)
+		slots, err := CanSetMaxSlots(nil, w.ID)
 		require.NoError(t, err)
 		require.Nil(t, slots)
-		require.True(t, canSetReqSlots)
 	})
 
 	err := SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
@@ -652,22 +651,20 @@ func TestCanSetMaxSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("slots different than config higher", func(t *testing.T) {
-		canSetReqSlots, slots, err := CanSetMaxSlots(ptrs.Ptr(15), w.ID)
+		slots, err := CanSetMaxSlots(ptrs.Ptr(15), w.ID)
 		require.NoError(t, err)
-		require.True(t, canSetReqSlots)
 		require.NotNil(t, slots)
 		require.Equal(t, 13, *slots)
 	})
 
 	t.Run("slots different than config lower", func(t *testing.T) {
-		canSetReqSlots, slots, err := CanSetMaxSlots(ptrs.Ptr(10), w.ID)
+		slots, err := CanSetMaxSlots(ptrs.Ptr(10), w.ID)
 		require.NoError(t, err)
-		require.True(t, canSetReqSlots)
 		require.NotNil(t, slots)
 		require.Equal(t, 13, *slots)
 	})
 
-	t.Run("just constarints slots higher", func(t *testing.T) {
+	t.Run("just constraints slots higher", func(t *testing.T) {
 		err := SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
 			WorkspaceID:   &w.ID,
 			WorkloadType:  model.ExperimentType,
@@ -680,14 +677,14 @@ func TestCanSetMaxSlots(t *testing.T) {
 	}
 	`),
 		})
+		require.NoError(t, err)
 
-		canSetReqSlots, slots, err := CanSetMaxSlots(ptrs.Ptr(25), w.ID)
+		slots, err := CanSetMaxSlots(ptrs.Ptr(25), w.ID)
 		require.ErrorContains(t, err, SlotsReqTooHighErr)
-		require.False(t, canSetReqSlots)
 		require.Nil(t, slots)
 	})
 
-	t.Run("just constarints slots lower", func(t *testing.T) {
+	t.Run("just constraints slots lower", func(t *testing.T) {
 		err := SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
 			WorkspaceID:   &w.ID,
 			WorkloadType:  model.ExperimentType,
@@ -700,10 +697,10 @@ func TestCanSetMaxSlots(t *testing.T) {
 	}
 	`),
 		})
-
-		canSetReqSlots, slots, err := CanSetMaxSlots(ptrs.Ptr(20), w.ID)
 		require.NoError(t, err)
-		require.True(t, canSetReqSlots)
+
+		slots, err := CanSetMaxSlots(ptrs.Ptr(20), w.ID)
+		require.NoError(t, err)
 		require.NotNil(t, slots)
 		require.Equal(t, 20, *slots)
 	})

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -1116,14 +1116,13 @@ func (e *internalExperiment) setWeight(weight float64) error {
 	// Only set requested weight if it is not set in an invariant config.
 	w, err := getWorkspaceByConfig(e.activeConfig)
 	if err != nil {
-		log.Warnf("unable to set max slots")
-		return fmt.Errorf("unable to set weight, ")
+		return fmt.Errorf("error getting workspace: %w", err)
 	}
 	enforcedWeight, err := configpolicy.GetConfigPolicyField[float64](context.TODO(), &w.ID,
 		"invariant_config",
 		"'resources' -> 'weight'", model.ExperimentType)
 	if err != nil {
-		return err
+		return fmt.Errorf("error checking against config policies: %w", err)
 	}
 	if enforcedWeight != nil {
 		weight = *enforcedWeight

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -418,8 +418,8 @@ func (e *internalExperiment) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 		return
 	}
 
-	canContinue, slots, err := configpolicy.CanSetMaxSlots(msg.MaxSlots, w.ID)
-	if !canContinue {
+	slots, err := configpolicy.CanSetMaxSlots(msg.MaxSlots, w.ID)
+	if err != nil {
 		log.Warnf("unable to set max slots: %s", err.Error())
 		return
 	}
@@ -1123,8 +1123,7 @@ func (e *internalExperiment) setWeight(weight float64) error {
 		"invariant_config",
 		"'resources' -> 'weight'", model.ExperimentType)
 	if err != nil {
-		log.Warnf("unable to set weight %v", weight)
-		return nil
+		return err
 	}
 	if enforcedWeight != nil {
 		weight = *enforcedWeight


### PR DESCRIPTION
## Ticket

[CM-583]



## Description
add checkpoint and max slots config policy enforcements in PATCH experiment


## Test Plan
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[CM-583]: https://hpe-aiatscale.atlassian.net/browse/CM-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ