### PR TITLE
feat: determined_master_host and friends helm support, better defaults

### DIFF
--- a/.circleci/devcluster/multi-k8s.devcluster.yaml
+++ b/.circleci/devcluster/multi-k8s.devcluster.yaml
@@ -39,7 +39,7 @@ stages:
           slot_resource_requests:
             cpu: 1
           kubeconfig_path: /tmp/defaultrm-kubeconf
-          determined_master_ip: $DOCKER_LOCALHOST
+          determined_master_host: $DOCKER_LOCALHOST
           determined_master_port: 8080
           internal_task_gateway:
             gateway_name: contour
@@ -60,7 +60,7 @@ stages:
             slot_resource_requests:
               cpu: 1
             kubeconfig_path: /tmp/additionalrm-kubeconf
-            determined_master_ip: $DOCKER_LOCALHOST
+            determined_master_host: $DOCKER_LOCALHOST
             determined_master_port: 8080
           resource_pools:
             - pool_name: additional_pool

--- a/.circleci/devcluster/single-k8s.devcluster.yaml
+++ b/.circleci/devcluster/single-k8s.devcluster.yaml
@@ -33,5 +33,5 @@ stages:
           slot_resource_requests:
             cpu: 1
           kubeconfig_path: ~/.kube/config
-          determined_master_ip: $DOCKER_LOCALHOST
+          determined_master_host: $DOCKER_LOCALHOST
           determined_master_port: 8080

--- a/docs/release-notes/add-host-port-scheme-to-helm.rst
+++ b/docs/release-notes/add-host-port-scheme-to-helm.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+**New Features**
+
+-  Helm: Support configuring ``determined_master_host``, ``determined_master_port``, and
+   ``determined_master_scheme``. These control how tasks address the Determined API server and are
+   useful when installations span multiple Kubernetes clusters or there are proxies in between tasks
+   and the master. Also, ``determined_master_host`` now defaults to the service host,
+   ``<det_namespace>.<det_service_name>.svc.cluster.local``, instead of the service IP.

--- a/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
+++ b/docs/setup-cluster/k8s/setup-multiple-resource-managers.rst
@@ -156,7 +156,7 @@ the same as the “cluster name” for a given cluster.
 
    If an additional resource manager needs to connect to the Determined master through a gateway
    requiring TLS, ``resource_manager.determined_master_scheme`` should be set to ``https``. If
-   ``resource_manager.determined_master_scheme`` is not set ``determined_master_ip`` will assume
+   ``resource_manager.determined_master_scheme`` is not set ``determined_master_host`` will assume
    ``https`` if the master is terminating TLS and ``http`` otherwise.
 
 *******

--- a/helm/charts/determined/templates/master-config.yaml
+++ b/helm/charts/determined/templates/master-config.yaml
@@ -224,6 +224,21 @@ stringData:
       fluent:
         {{- toYaml .Values.fluent | nindent 8}}
       {{- end }}
+      {{- if .Values.determinedMasterHost }}
+      {{- if .Values.determinedMasterScheme }}
+      determined_master_scheme: {{ .Values.determinedMasterScheme | quote }}
+      {{- else if .Values.tlsSecret }}
+      determined_master_scheme: "https"
+      {{- else }}
+      determined_master_scheme: "http"
+      {{- end }}
+      determined_master_host: {{ .Values.determinedMasterHost | quote }}
+      {{- if .Values.determinedMasterPort }}
+      determined_master_port: {{ .Values.determinedMasterPort }}
+      {{- else }}
+      determined_master_port: {{ .Values.masterPort }}
+      {{- end }}
+      {{- end }}
 
       default_aux_resource_pool: {{.Values.defaultAuxResourcePool}}
       default_compute_resource_pool: {{.Values.defaultComputeResourcePool}}

--- a/helm/charts/determined/values.yaml
+++ b/helm/charts/determined/values.yaml
@@ -409,6 +409,16 @@ resourcePools:
 ## Configure the initial user password for the cluster
 # initialUserPassword:
 
+# determinedMasterHost configures the hostname that tasks launched by the primary resource manager use when
+# communicating with our API server. This is useful when installations span multiple Kubernetes clusters and when there
+# are proxies in between tasks and the master. It defaults to `<det_namespace>.<det_service_name>.svc.cluster.local`.
+# determinedMasterHost:
+# determinedMasterPort configures the port for the host above. It defaults to `masterPort` specified elsewhere. Must
+# be used with determinedMasterHost or it is ineffective.
+# determinedMasterPort:
+# determinedMasterScheme configures the scheme for the host and port above. It defaults to `https` if our API server
+# is deployed with TLS, else `http`. Must be used with determinedMasterHost or it is ineffective.
+# determinedMasterScheme:
 # additional_resource_managers:
 #   - resource_manager:
 #       type: kubernetes
@@ -417,7 +427,7 @@ resourcePools:
 #       default_namespace: default
 #       kubeconfig_secret_name: additionalrm
 #       kubeconfig_secret_value: config
-#       determined_master_ip: 10.11.12.13
+#       determined_master_host: 10.11.12.13
 #       determined_master_port: 8080
 #     resource_pools:
 #       - pool_name: additional_pool

--- a/master/cmd/determined-master/root_test.go
+++ b/master/cmd/determined-master/root_test.go
@@ -228,6 +228,89 @@ func TestApplyBackwardsCompatibility(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "determined master ip to host rename, ip set",
+			before: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                 "kubernetes",
+					"determined_master_ip": "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                 "kubernetes",
+						"determined_master_ip": "10.0.0.2",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                   "kubernetes",
+					"determined_master_host": "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                   "kubernetes",
+						"determined_master_host": "10.0.0.2",
+					},
+				},
+			},
+		},
+		{
+			name: "determined master ip to host rename, both set",
+			before: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                   "kubernetes",
+					"determined_master_host": "10.0.0.1",
+					"determined_master_ip":   "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                   "kubernetes",
+						"determined_master_host": "10.0.0.2",
+						"determined_master_ip":   "10.0.0.2",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                   "kubernetes",
+					"determined_master_host": "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                   "kubernetes",
+						"determined_master_host": "10.0.0.2",
+					},
+				},
+			},
+		},
+		{
+			name: "determined master ip to host rename, host set get left alone",
+			before: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                   "kubernetes",
+					"determined_master_host": "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                   "kubernetes",
+						"determined_master_host": "10.0.0.2",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"resource_manager": map[string]interface{}{
+					"type":                   "kubernetes",
+					"determined_master_host": "10.0.0.1",
+				},
+				"additional_resource_managers": []map[string]any{
+					{
+						"type":                   "kubernetes",
+						"determined_master_host": "10.0.0.2",
+					},
+				},
+			},
+		},
 	}
 	for ix := range tcs {
 		tc := tcs[ix]

--- a/master/internal/config/resource_manager_config.go
+++ b/master/internal/config/resource_manager_config.go
@@ -188,7 +188,7 @@ type KubernetesResourceManagerConfig struct {
 	KubeconfigPath string       `json:"kubeconfig_path"`
 
 	DetMasterScheme string `json:"determined_master_scheme,omitempty"`
-	DetMasterIP     string `json:"determined_master_ip,omitempty"`
+	DetMasterHost   string `json:"determined_master_host,omitempty"`
 	DetMasterPort   int32  `json:"determined_master_port,omitempty"`
 
 	DefaultAuxResourcePool     string `json:"default_aux_resource_pool"`
@@ -294,33 +294,27 @@ func (k *KubernetesResourceManagerConfig) UnmarshalJSON(data []byte) error {
 
 // Validate implements the check.Validatable interface.
 func (k KubernetesResourceManagerConfig) Validate() []error {
-	var checkSlotType error
+	var errs []error
 	switch k.SlotType {
 	case device.CPU, device.CUDA, device.ROCM:
 	default:
-		checkSlotType = errors.Errorf("slot_type must be cuda, cpu, or rocm")
+		errs = append(errs, errors.New("slot_type must be cuda, cpu, or rocm"))
 	}
 
-	var checkCPUResource error
 	if k.SlotType == device.CPU {
-		checkCPUResource = check.GreaterThan(
-			k.SlotResourceRequests.CPU, float32(0), "slot_resource_requests.cpu must be > 0")
+		errs = append(errs, check.GreaterThan(
+			k.SlotResourceRequests.CPU, float32(0), "slot_resource_requests.cpu must be > 0"))
 	}
 
-	var checkRMScheduler error
 	if k.DefaultScheduler == PriorityScheduling {
-		checkRMScheduler = fmt.Errorf("the ``priority`` scheduler was deprecated, please " +
-			"use the default Kubernetes scheduler or coscheduler")
+		errs = append(errs, errors.New("the ``priority`` scheduler was deprecated, please "+
+			"use the default Kubernetes scheduler or coscheduler"))
 	} else if k.DefaultScheduler != "" && k.DefaultScheduler != "coscheduler" {
-		checkRMScheduler = fmt.Errorf("only blank or ``coscheduler`` values allowed for Kubernetes scheduler")
+		errs = append(errs, errors.New("only blank or ``coscheduler`` values allowed for Kubernetes scheduler"))
 	}
 
-	return []error{
-		checkSlotType,
-		checkCPUResource,
-		check.NotEmpty(k.ClusterName, "cluster_name is required"),
-		checkRMScheduler,
-	}
+	errs = append(errs, check.NotEmpty(k.ClusterName, "cluster_name is required"))
+	return errs
 }
 
 // PodSlotResourceRequests contains the per-slot container requests.

--- a/master/internal/rm/kubernetesrm/job.go
+++ b/master/internal/rm/kubernetesrm/job.go
@@ -80,7 +80,7 @@ type podNodeInfo struct {
 type job struct {
 	// Configuration details. Set in initialization (the `newJob` constructor) and never modified after.
 	clusterID       string
-	masterIP        string
+	masterHost      string
 	masterPort      int32
 	masterScheme    string
 	masterTLSConfig model.TLSClientConfig
@@ -133,7 +133,7 @@ func newJob(
 	clusterID string,
 	clientSet k8sClient.Interface,
 	namespace string,
-	masterIP string,
+	masterHost string,
 	masterPort int32,
 	masterScheme string,
 	masterTLSConfig model.TLSClientConfig,
@@ -156,7 +156,7 @@ func newJob(
 		allocationID:          msg.allocationID,
 		clientSet:             clientSet,
 		namespace:             namespace,
-		masterIP:              masterIP,
+		masterHost:            masterHost,
 		masterPort:            masterPort,
 		masterScheme:          masterScheme,
 		masterTLSConfig:       masterTLSConfig,

--- a/master/internal/rm/kubernetesrm/jobs.go
+++ b/master/internal/rm/kubernetesrm/jobs.go
@@ -432,7 +432,7 @@ func (j *jobsService) getMasterHostAndPort() error {
 	if err != nil {
 		return fmt.Errorf("failed to get master service: %w", err)
 	}
-	j.detMasterHost = fmt.Sprintf("%s.%s.svc.cluster.local", masterService.Namespace, masterService.Name)
+	j.detMasterHost = fmt.Sprintf("%s.%s.svc.cluster.local", masterService.Name, masterService.Namespace)
 	j.detMasterPort = masterService.Spec.Ports[0].Port
 	j.syslog.Infof("master URL set to %s:%d", j.detMasterHost, j.detMasterPort)
 	return nil

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager.go
@@ -96,7 +96,7 @@ func New(
 		config.PodSlotResourceRequests{CPU: k.config.SlotResourceRequests.CPU},
 		k.poolsConfig,
 		k.taskContainerDefaults,
-		k.config.DetMasterIP,
+		k.config.DetMasterHost,
 		k.config.DetMasterPort,
 		k.config.DetMasterScheme,
 		k.config.KubeconfigPath,

--- a/master/internal/rm/kubernetesrm/spec.go
+++ b/master/internal/rm/kubernetesrm/spec.go
@@ -135,9 +135,9 @@ func (j *job) configureEnvVars(
 	}
 
 	envVarsMap["DET_CLUSTER_ID"] = j.clusterID
-	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s://%s:%d", masterScheme, j.masterIP, j.masterPort)
-	envVarsMap["DET_MASTER_HOST"] = j.masterIP
-	envVarsMap["DET_MASTER_ADDR"] = j.masterIP
+	envVarsMap["DET_MASTER"] = fmt.Sprintf("%s://%s:%d", masterScheme, j.masterHost, j.masterPort)
+	envVarsMap["DET_MASTER_HOST"] = j.masterHost
+	envVarsMap["DET_MASTER_ADDR"] = j.masterHost
 	envVarsMap["DET_MASTER_PORT"] = strconv.Itoa(int(j.masterPort))
 	envVarsMap["DET_SLOT_IDS"] = fmt.Sprintf("[%s]", strings.Join(slotIDs, ","))
 	if j.masterTLSConfig.CertificateName != "" {

--- a/master/internal/rm/kubernetesrm/spec_test.go
+++ b/master/internal/rm/kubernetesrm/spec_test.go
@@ -422,7 +422,7 @@ func TestDetMasterEnvVar(t *testing.T) {
 			}
 
 			j := &job{
-				masterIP:        "example.com",
+				masterHost:      "example.com",
 				masterPort:      1234,
 				masterScheme:    c.masterScheme,
 				masterTLSConfig: c.masterTLSConfig,

--- a/tools/k8s/devcluster.yaml
+++ b/tools/k8s/devcluster.yaml
@@ -51,7 +51,7 @@ stages:
           slot_resource_requests:
             cpu: 1
           kubeconfig_path: ~/.kube/config
-          determined_master_ip: $DOCKER_LOCALHOST
+          determined_master_host: $DOCKER_LOCALHOST
           determined_master_port: 8080
 
 # Example custom stage running the coscheduler in a docker container.  In real

--- a/tools/k8s/multicluster.yaml
+++ b/tools/k8s/multicluster.yaml
@@ -60,7 +60,7 @@ stages:
           slot_resource_requests:
             cpu: 1
           kubeconfig_path: ~/.kube/config
-          determined_master_ip: $DOCKER_LOCALHOST
+          determined_master_host: $DOCKER_LOCALHOST
           determined_master_port: 8080
         
         additional_resource_managers:
@@ -72,7 +72,7 @@ stages:
               slot_resource_requests:
                 cpu: 1
               kubeconfig_path: ~/.kube/extraconfig
-              determined_master_ip: $DOCKER_LOCALHOST
+              determined_master_host: $DOCKER_LOCALHOST
               determined_master_port: 8080
             resource_pools:
               - pool_name: extra

--- a/tools/k8s/remote_connect.py
+++ b/tools/k8s/remote_connect.py
@@ -325,7 +325,7 @@ def update_devcluster(cfg: Config, gateway: Gateway, remote_port: int) -> pathli
             + "These will be ignored."
         )
     assert resource_manager["type"] == "kubernetes"
-    resource_manager["determined_master_ip"] = cfg.reverse_proxy_host
+    resource_manager["determined_master_host"] = cfg.reverse_proxy_host
     resource_manager["determined_master_port"] = remote_port
     assert gateway.ip is not None, "Gateway IP is not set"
     resource_manager.update(gateway.to_config())


### PR DESCRIPTION
…rt, better defaults" (#10134)"

This reverts commit 782f7a09fcd4699a00d87c74c838a1a01af3fdd7.

<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
DFR-529/530

## Description
When `determined_master_ip` is unsettable via Helm and defaults to the service IP, life with proxies is hard. This change renames `determined_master_ip` to `determined_master_host` everywhere with some backwards compatibility, defaults `determined_master_host` to `<det_namespace>.<det_service_name>.svc.cluster.local`, and makes all of this overridable in Helm.

Reverted this, re-landing, had an embarrassing typo that broke everything.

## Test Plan
Has automated tests, that's why I knew to revert.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ