### PR TITLE
build: INFENG-938: Tweak version string format

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -68,8 +68,8 @@ release-and-rc-filters: &release-and-rc-filters
       - /.*/
   tags:
     only:
-      # Tags like: v2.5.0, v3.0.1+rc2
-      - /v\d+\.\d+\.\d+(rc\d+)?/
+      # Tags like: v2.5.0, v3.0.1-rc2
+      - /v\d+\.\d+\.\d+(-rc\d+)?/
 
 rc-filters: &rc-filters
   branches:
@@ -77,8 +77,8 @@ rc-filters: &rc-filters
       - /.*/
   tags:
     only:
-      # Tags like: v2.5.0rc3
-      - /v\d+\.\d+\.\d+rc\d+/
+      # Tags like: v2.5.0-rc3
+      - /v\d+\.\d+\.\d+-rc\d+/
 
 release-filters: &release-filters
   branches:


### PR DESCRIPTION
## Ticket

INFENG-938

## Description

Restore previous version tag format, which places a hyphen '-' between the patch revision part and the remainder of the version string. So, for example, instead of a string like v0.38.0rc3, we will look for v0.38.0-rc3. The former is not SemVer-compliant, whereas the latteris.

This fixes an issue where Helm breaks when using release candidate versions, because it expects the string to be SemVer-compliant. Setuptools, by contrast, can munge the hyphenated version into a more canonical PEP 440-compliant format, so we prefer the new SemVer-compliant format instead.

## Test Plan

Using your favorite regex tool of choice, verify that the new regular expressions match new rc version strings, like `v0.38.0-rc3`.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code