### PR TITLE
fix: set max slots and checkpoint gc policy should comply with config policies

### DIFF
--- a/master/internal/api_experiment.go
+++ b/master/internal/api_experiment.go
@@ -1241,7 +1241,7 @@ func (a *apiServer) PatchExperiment(
 			}
 
 			enforcedChkptConf, err := configpolicy.GetConfigPolicyField[expconf.CheckpointStorageConfig](
-				ctx, &w.ID, "invariant_config", "'checkpoint_storage'",
+				ctx, &w.ID, []string{"checkpoint_storage"}, "invariant_config",
 				model.ExperimentType)
 			if err != nil {
 				return nil, fmt.Errorf("unable to fetch task config policies: %w", err)
@@ -1306,7 +1306,6 @@ func (a *apiServer) PatchExperiment(
 			}
 		}
 
-		// `patch` represents the allowed mutations that can be performed on an experiment, in JSON
 		if err := a.m.db.SaveExperimentConfig(modelExp.ID, activeConfig); err != nil {
 			return nil, errors.Wrapf(err, "patching experiment %d", modelExp.ID)
 		}

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -111,24 +111,28 @@ func DeleteConfigPolicies(ctx context.Context,
 	return nil
 }
 
-// GetConfigPolicyField fetches the field from an invariant_config or constraints policyType, in order
-// of precedence. Global scope has highest precedence, then workspace. Returns nil if none is found.
-// **NOTE** The field arguments are wrapped in bun.Safe, so you  must specify the "raw" string
-// exactly as you wish for it to be accessed in the database. For example, if you want to access
-// resources.max_slots, the field argument should be "'resources' -> 'max_slots'" NOT
-// "resources -> max_slots".
+// GetConfigPolicyField fetches the accessField from an invariant_config or constraints policy
+// (determined by policyType) in order of precedence. Global policies takes precedence over workspace
+// policies. Returns nil if the accessField is not set at either scope.
+// **NOTE** The accessField elements are to be specified in the "order of access", meaning that the
+// most nested config field should be the last element of accessField while the outermost
+// config field should be the first element of accessField.
+// For example, if you want to access resources.max_slots, accessField should be
+// []string{"resources", "max_slots"}. If you just want to access the entire resources config, then
+// accessField should be []string{"resources"}.
 // **NOTE**When using this function to retrieve an object of Kind Pointer, set T as the Type of
 // object that the Pointer wraps. For example, if we want an object of type *int, set T to int, so
-// that when its pointer is returned, you get an object of type *int.
-func GetConfigPolicyField[T any](ctx context.Context, wkspID *int, policyType, field, workloadType string) (*T,
+// that when its pointer is returned, we get an object of type *int.
+func GetConfigPolicyField[T any](ctx context.Context, wkspID *int, accessField []string, policyType,
+	workloadType string) (*T,
 	error,
 ) {
 	if policyType != "invariant_config" && policyType != "constraints" {
 		return nil, fmt.Errorf("%s :%s", invalidPolicyTypeErr, policyType)
 	}
 
+	field := "'" + strings.Join(accessField, "' -> '") + "'"
 	var confBytes []byte
-	var conf T
 	err := db.Bun().RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		var globalBytes []byte
 		err := tx.NewSelect().Table("task_config_policies").
@@ -159,6 +163,7 @@ func GetConfigPolicyField[T any](ctx context.Context, wkspID *int, policyType, f
 		return nil, nil
 	}
 
+	var conf T
 	err = json.Unmarshal(confBytes, &conf)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling config field: %w", err)

--- a/master/internal/configpolicy/postgres_task_config_policy.go
+++ b/master/internal/configpolicy/postgres_task_config_policy.go
@@ -150,6 +150,9 @@ func GetConfigPolicyField[T any](ctx context.Context, wkspID *int, policyType, f
 		if err == nil && len(globalBytes) == 0 {
 			confBytes = wkspBytes
 		}
+		if len(globalBytes) > 0 || len(wkspBytes) > 0 {
+			err = nil
+		}
 		return err
 	})
 	if err == sql.ErrNoRows || len(confBytes) == 0 {

--- a/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
+++ b/master/internal/configpolicy/postgres_task_config_policy_intg_test.go
@@ -693,7 +693,7 @@ func TestGetEnforcedConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		checkpointStorage, err := GetConfigPolicyField[expconf.CheckpointStorageConfig](ctx, &w.ID,
-			"invariant_config", "'checkpoint_storage'", model.ExperimentType)
+			[]string{"checkpoint_storage"}, "invariant_config", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, checkpointStorage)
 
@@ -726,7 +726,7 @@ func TestGetEnforcedConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		checkpointStorage, err := GetConfigPolicyField[expconf.CheckpointStorageConfig](ctx, &w.ID,
-			"invariant_config", "'checkpoint_storage'", model.ExperimentType)
+			[]string{"checkpoint_storage"}, "invariant_config", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, checkpointStorage)
 
@@ -766,8 +766,8 @@ func TestGetEnforcedConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		maxSlots, err := GetConfigPolicyField[int](ctx, &w.ID, "invariant_config",
-			"'resources' -> 'max_slots'", model.ExperimentType)
+		maxSlots, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"resources", "max_slots"}, "invariant_config", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, maxSlots)
 
@@ -805,8 +805,8 @@ func TestGetEnforcedConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		maxSlots, err := GetConfigPolicyField[int](ctx, &w.ID, "constraints",
-			"'resources' -> 'max_slots'", model.ExperimentType)
+		maxSlots, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"resources", "max_slots"}, "constraints", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, maxSlots)
 
@@ -841,8 +841,8 @@ func TestGetEnforcedConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		priority, err := GetConfigPolicyField[int](ctx, &w.ID, "constraints",
-			"'priority_limit'", model.ExperimentType)
+		priority, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"priority_limit"}, "constraints", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, priority)
 
@@ -863,8 +863,8 @@ func TestGetEnforcedConfig(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		priority, err := GetConfigPolicyField[int](ctx, &w.ID, "constraints",
-			"'priority_limit'", model.ExperimentType)
+		priority, err := GetConfigPolicyField[int](ctx, &w.ID, []string{"priority_limit"},
+			"constraints", model.ExperimentType)
 		require.NoError(t, err)
 		require.NotNil(t, priority)
 
@@ -873,22 +873,22 @@ func TestGetEnforcedConfig(t *testing.T) {
 	})
 
 	t.Run("field not set in config", func(t *testing.T) {
-		maxRestarts, err := GetConfigPolicyField[int](ctx, &w.ID, "invariant_config",
-			"'max_restarts'", model.ExperimentType)
+		maxRestarts, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"max_restarts"}, "invariant_config", model.ExperimentType)
 		require.NoError(t, err)
 		require.Nil(t, maxRestarts)
 	})
 
 	t.Run("nonexistent constraints field", func(t *testing.T) {
-		maxRestarts, err := GetConfigPolicyField[int](ctx, &w.ID, "constraints",
-			"'max_restarts'", model.ExperimentType)
+		maxRestarts, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"max_restarts"}, "constraints", model.ExperimentType)
 		require.NoError(t, err)
 		require.Nil(t, maxRestarts)
 	})
 
 	t.Run("invalid policy type", func(t *testing.T) {
-		_, err := GetConfigPolicyField[int](ctx, &w.ID, "bad policy",
-			"'debug'", model.ExperimentType)
+		_, err := GetConfigPolicyField[int](ctx, &w.ID,
+			[]string{"debug"}, "bad policy", model.ExperimentType)
 		require.ErrorContains(t, err, invalidPolicyTypeErr)
 	})
 }

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -321,7 +321,7 @@ func CanSetMaxSlots(slotsReq *int, wkspID int) error {
 	}
 
 	if enforcedMaxSlots != nil && *slotsReq != *enforcedMaxSlots {
-		return fmt.Errorf(SlotsAlreadySetErr)
+		return fmt.Errorf(SlotsAlreadySetErr+":max_slots of %d is enforced", *enforcedMaxSlots)
 	}
 
 	maxSlotsLimit, err := GetConfigPolicyField[int](context.TODO(), &wkspID,

--- a/master/internal/configpolicy/utils.go
+++ b/master/internal/configpolicy/utils.go
@@ -31,6 +31,8 @@ const (
 	// SlotsReqTooHighErr is the error reported when the requested slots violates the max slots
 	// constraint.
 	SlotsReqTooHighErr = "requested slots is violates max slots constraint"
+	// SlotsAlreadySetErr is the error reported when slots are already set in an invariant config.
+	SlotsAlreadySetErr = "max slots is already set in an invariant config policy"
 )
 
 // ConfigPolicyWarning logs a warning for the configuration policy component.
@@ -307,26 +309,26 @@ func configPolicyOverlap(config1, config2 interface{}) {
 // enforced max slots for the workspace if that's set as an invariant config, and returns the
 // requested max slots otherwise. Returns an error when max slots is not set as an invariant config
 // and the requested max slots violates the constriant.
-func CanSetMaxSlots(slotsReq *int, wkspID int) (*int, error) {
+func CanSetMaxSlots(slotsReq *int, wkspID int) error {
 	if slotsReq == nil {
-		return slotsReq, nil
+		return nil
 	}
 	enforcedMaxSlots, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
 		"invariant_config",
 		"'resources' -> 'max_slots'", model.ExperimentType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	if enforcedMaxSlots != nil {
-		return enforcedMaxSlots, nil
+	if enforcedMaxSlots != nil && *slotsReq != *enforcedMaxSlots {
+		return fmt.Errorf(SlotsAlreadySetErr)
 	}
 
 	maxSlotsLimit, err := GetConfigPolicyField[int](context.TODO(), &wkspID,
 		"constraints",
 		"'resources' -> 'max_slots'", model.ExperimentType)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	var canSetReqSlots bool
@@ -334,8 +336,8 @@ func CanSetMaxSlots(slotsReq *int, wkspID int) (*int, error) {
 		canSetReqSlots = true
 	}
 	if !canSetReqSlots {
-		return nil, fmt.Errorf(SlotsReqTooHighErr+": %d > %d", *slotsReq, *maxSlotsLimit)
+		return fmt.Errorf(SlotsReqTooHighErr+": %d > %d", *slotsReq, *maxSlotsLimit)
 	}
 
-	return slotsReq, nil
+	return nil
 }

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -624,9 +624,8 @@ func TestCanSetMaxSlots(t *testing.T) {
 	ctx := context.Background()
 	w := createWorkspaceWithUser(ctx, t, user.ID)
 	t.Run("nil slots request", func(t *testing.T) {
-		slots, err := CanSetMaxSlots(nil, w.ID)
+		err := CanSetMaxSlots(nil, w.ID)
 		require.NoError(t, err)
-		require.Nil(t, slots)
 	})
 
 	err := SetTaskConfigPolicies(ctx, &model.TaskConfigPolicies{
@@ -640,28 +639,17 @@ func TestCanSetMaxSlots(t *testing.T) {
 	}
 }
 `),
-		Constraints: ptrs.Ptr(`
-{
-	"resources": {
-		"max_slots": 13
-	}
-}
-`),
 	})
 	require.NoError(t, err)
 
 	t.Run("slots different than config higher", func(t *testing.T) {
-		slots, err := CanSetMaxSlots(ptrs.Ptr(15), w.ID)
-		require.NoError(t, err)
-		require.NotNil(t, slots)
-		require.Equal(t, 13, *slots)
+		err = CanSetMaxSlots(ptrs.Ptr(15), w.ID)
+		require.ErrorContains(t, err, SlotsAlreadySetErr)
 	})
 
 	t.Run("slots different than config lower", func(t *testing.T) {
-		slots, err := CanSetMaxSlots(ptrs.Ptr(10), w.ID)
-		require.NoError(t, err)
-		require.NotNil(t, slots)
-		require.Equal(t, 13, *slots)
+		err = CanSetMaxSlots(ptrs.Ptr(10), w.ID)
+		require.ErrorContains(t, err, SlotsAlreadySetErr)
 	})
 
 	t.Run("just constraints slots higher", func(t *testing.T) {
@@ -679,9 +667,8 @@ func TestCanSetMaxSlots(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		slots, err := CanSetMaxSlots(ptrs.Ptr(25), w.ID)
+		err = CanSetMaxSlots(ptrs.Ptr(25), w.ID)
 		require.ErrorContains(t, err, SlotsReqTooHighErr)
-		require.Nil(t, slots)
 	})
 
 	t.Run("just constraints slots lower", func(t *testing.T) {
@@ -699,9 +686,7 @@ func TestCanSetMaxSlots(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		slots, err := CanSetMaxSlots(ptrs.Ptr(20), w.ID)
+		err = CanSetMaxSlots(ptrs.Ptr(20), w.ID)
 		require.NoError(t, err)
-		require.NotNil(t, slots)
-		require.Equal(t, 20, *slots)
 	})
 }

--- a/master/internal/configpolicy/utils_test.go
+++ b/master/internal/configpolicy/utils_test.go
@@ -643,12 +643,12 @@ func TestCanSetMaxSlots(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("slots different than config higher", func(t *testing.T) {
-		err = CanSetMaxSlots(ptrs.Ptr(15), w.ID)
+		err := CanSetMaxSlots(ptrs.Ptr(15), w.ID)
 		require.ErrorContains(t, err, SlotsAlreadySetErr)
 	})
 
 	t.Run("slots different than config lower", func(t *testing.T) {
-		err = CanSetMaxSlots(ptrs.Ptr(10), w.ID)
+		err := CanSetMaxSlots(ptrs.Ptr(10), w.ID)
 		require.ErrorContains(t, err, SlotsAlreadySetErr)
 	})
 

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -418,13 +418,12 @@ func (e *internalExperiment) SetGroupMaxSlots(msg sproto.SetGroupMaxSlots) {
 		return
 	}
 
-	slots, err := configpolicy.CanSetMaxSlots(msg.MaxSlots, w.ID)
+	err = configpolicy.CanSetMaxSlots(msg.MaxSlots, w.ID)
 	if err != nil {
 		log.Warnf("unable to set max slots: %s", err.Error())
 		return
 	}
 
-	msg.MaxSlots = slots
 	resources := e.activeConfig.Resources()
 	resources.SetMaxSlots(msg.MaxSlots)
 	e.activeConfig.SetResources(resources)

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -1123,8 +1123,8 @@ func (e *internalExperiment) setWeight(weight float64) error {
 	if err != nil {
 		return fmt.Errorf("error checking against config policies: %w", err)
 	}
-	if enforcedWeight != nil {
-		weight = *enforcedWeight
+	if enforcedWeight != nil && weight != *enforcedWeight {
+		return fmt.Errorf("weight is enforced as an invariant config policy of %v", *enforcedWeight)
 	}
 
 	resources := e.activeConfig.Resources()

--- a/master/internal/experiment.go
+++ b/master/internal/experiment.go
@@ -1118,8 +1118,7 @@ func (e *internalExperiment) setWeight(weight float64) error {
 		return fmt.Errorf("error getting workspace: %w", err)
 	}
 	enforcedWeight, err := configpolicy.GetConfigPolicyField[float64](context.TODO(), &w.ID,
-		"invariant_config",
-		"'resources' -> 'weight'", model.ExperimentType)
+		[]string{"resources", "weight"}, "invariant_config", model.ExperimentType)
 	if err != nil {
 		return fmt.Errorf("error checking against config policies: %w", err)
 	}


### PR DESCRIPTION
## Ticket
CM-590


## Description
This PR fixes a couple of issues:
- `det e set max-slots` to comply with invariant config and constraints
- `det e set gc-policy` to comply with invariant configs



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ