### PR TITLE
build: INFENG-937: Publish Helm chart release candidates

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1910,6 +1910,20 @@ jobs:
           command: make -C agent release-ee
       - run: mkdir /tmp/pkgs && cp -v */dist/*.{rpm,deb,tar.gz} /tmp/pkgs
 
+  publish-helm-gh-rc:
+    docker:
+      - image: <<pipeline.parameters.docker-image>>
+        environment:
+          GO111MODULE: "on"
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - reinstall-go
+      - make-component:
+          component: helm
+          target: release-gh-rc
+
   publish-helm-gh:
     parameters:
       ee:
@@ -5574,6 +5588,12 @@ workflows:
             - build-helm
           context: determined-production
           filters: *release-filters
+
+      - publish-helm-gh-rc:
+          requires:
+            - build-helm
+          context: determined-production
+          filters: *rc-filters
 
       - upload-try-now-template:
           context: determined-production

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -26,6 +26,18 @@ release-gh:
 	git clean -df
 	goreleaser --rm-dist
 
+.PHONY: release-gh-rc
+release-gh-rc: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
+# The following line lists all tags by creation date, finds the current tag and
+# the next line after, then prints that second line, which should be the most
+# recent previous tag. This works if the previous tag is both a minor release,
+# or an rc release.
+release-gh-rc: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release-gh-rc:
+	go install github.com/goreleaser/goreleaser@v1.14.1
+	git clean -df
+	goreleaser --rm-dist
+
 .PHONY: release-gh-dryrun
 release-gh-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')


### PR DESCRIPTION
## Ticket

INFENG-937

## Description

This changeset adds a Helm makefile target and CircleCI job to publish release candidate Determined Helm charts. This is necessary to deploy release candidates onto the new GKE cluster.

Previously, bumpversion would increment the rc version of the Helm chart, then commit this to the release branch (along with other similar version bumps). `rph` would then use this in-tree version of the Helm chart to upgrade the Helm release on the (old/existing) release party GKE cluster. Because we aren't managing versions on disk anymore, though, we need to install the Helm chart from somewhere else, which means we have to publish it somewhere in the first place for ArgoCD to find. This is more consistent anyway; we already publish Python package release candidates, for example.

We already publish production releases to helm.determined.ai, so this attempts to use that existing automation to publish release candidates.

## Test Plan

We'll have to do this one live, unfortunately. I don't quite have the time to figure out how to modify the dryrun job to produce the results we want, especially given the additional automation that publishing Helm charts uses (GitHub Actions, specifically).

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code