### PR TITLE
build: INFENG-938: Update version format in Makefiles

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -128,21 +128,21 @@ package-ee: packaging/LICENSE buildx
 
 .PHONY: release
 release: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release: packaging/LICENSE buildx
 	goreleaser --rm-dist
 	make publish-nvcr
 
 .PHONY: release-dryrun
 release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 # We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
 release-dryrun: packaging/LICENSE buildx
 	goreleaser --rm-dist -f ./.goreleaser_dryrun.yml
 
 .PHONY: release-ee
 release-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
-release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
+release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-ee: packaging/LICENSE buildx
 	goreleaser --rm-dist -f ./.goreleaser_ee.yml
 

--- a/helm/Makefile
+++ b/helm/Makefile
@@ -20,7 +20,7 @@ clean:
 
 .PHONY: release-gh
 release-gh: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release-gh: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release-gh:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
@@ -31,7 +31,8 @@ release-gh-rc: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
 # The following line lists all tags by creation date, finds the current tag and
 # the next line after, then prints that second line, which should be the most
 # recent previous tag. This works if the previous tag is both a minor release,
-# or an rc release.
+# or an rc release. Also, this is a separate make target because it makes it
+# easier to compute tag diffs for release notes.
 release-gh-rc: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release-gh-rc:
 	go install github.com/goreleaser/goreleaser@v1.14.1
@@ -40,7 +41,7 @@ release-gh-rc:
 
 .PHONY: release-gh-dryrun
 release-gh-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release-gh-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release-gh-dryrun:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df
@@ -48,7 +49,7 @@ release-gh-dryrun:
 
 .PHONY: release-gh-ee
 release-gh-ee: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)-ee
-release-gh-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
+release-gh-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-gh-ee:
 	go install github.com/goreleaser/goreleaser@v1.14.1
 	git clean -df

--- a/master/Makefile
+++ b/master/Makefile
@@ -270,7 +270,7 @@ package-small: gen buildx-small
 release: export DET_SEGMENT_MASTER_KEY ?=
 release: export DET_SEGMENT_WEBUI_KEY ?=
 release: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 release: gen buildx
 	$(GORELEASER) --rm-dist
 	make publish-nvcr
@@ -279,7 +279,7 @@ release: gen buildx
 release-dryrun: export DET_SEGMENT_MASTER_KEY ?=
 release-dryrun: export DET_SEGMENT_WEBUI_KEY ?=
 release-dryrun: export GORELEASER_CURRENT_TAG := $(VERSION_TAG)
-release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
+release-dryrun: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "$(VERSION_TAG)" -A1 | sed -n '2 p')
 # We intentionally do not invoke `make publish-nvcr(-dryrun)` here.
 release-dryrun: gen buildx
 	$(GORELEASER) --rm-dist -f ./.goreleaser_dryrun.yml
@@ -290,7 +290,7 @@ release-ee: export DET_SEGMENT_WEBUI_KEY ?=
 release-ee: export DET_EE_LICENSE_KEY = $(shell cat ../license.txt)
 release-ee: export DET_EE_PUBLIC_KEY = $(shell cat ../public.txt)
 release-ee: export GORELEASER_CURRENT_TAG := $(VERSION)-ee
-release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
+release-ee: export GORELEASER_PREVIOUS_TAG := $(shell git tag --sort=-creatordate | grep -E '^v?[0-9.]+-ee$$' | grep "$(VERSION_TAG)-ee" -A1 | sed -n '2 p')
 release-ee: gen buildx
 	$(GORELEASER) --rm-dist -f ./.goreleaser_ee.yml
 


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket

INFENG-938

## Description

Add an optional `v` in the grep regular expression that computes previous version tags in GoReleaser Makefile targets for master, agent, and helm. This ensures continuity between the previous tag format, which used bare version strings, and the new tag format, all of which begin with a literal `v`. Otherwise, when trying to derive a previous tag that begins with a `v`, the grep would fail.

Note that things would still otherwise work fine for the next release, because previous tags would still satisfy the format. Subsequent releases, however, would be incorrect, because the tag would begin with a `v` and thus not match. `GORELEASER_PREVIOUS_TAG` is used for determining which release notes to include, and having it set incorrectly would cause problems for the GitHub release.

## Test Plan

There are a few different cases to test. First, we'll test the upcoming case, which is: an rc release with the new tag style, against an existing minor release with the old tag style.

1. Check out this branch.
1. Tag `HEAD`: `git tag v0.38.0-rc0`.
1. Run `export VERSION='v0.38.0-rc0`. Note: it must match the tag. This is necessary to mimic the make target command that sets `GORELEASER_PREVIOUS_TAG`, although it does require that the tag actually exists.
1. Run `git tag --sort=-creatordate | grep "${VERSION}" -A1 | sed -n '2 p'`, to test the behavior of `GORELEASER_PREVIOUS_TAG` for the `release-gh-rc` make target.
1. The output should be `0.37.0`, which is the correct previous tag for a release candidate build.
1. Delete the new tag: `git tag -d v0.38.0-rc0`.

Next, test the case where we have a new rc tag, after a previous rc tag.

1. Tag `HEAD~1`: `git tag v0.38.0-rc0 HEAD~1`.
1. Tag `HEAD`: `git tag v0.38.0-rc1`.
1. Run `export VERSION='v0.38.0-rc1'`.
1. Run `git tag --sort=-creatordate | grep "${VERSION}" -A1 | sed -n '2 p'`, to test the behavior of `GORELEASER_PREVIOUS_TAG` for the `release-gh-rc` make target.
1. The output should be `v0.38.0-rc0`, as that is, indeed, the previous tag.
1. Delete the new tags: `git tag -d v0.38.0-rc0 v0.38.0-rc1`.

Next, test the case where we have a new minor tag, while the previous tag is using the old tag format. The output should be the previous non-rc tag (in our case, a minor release tag).

1. Tag `HEAD~2`: `git tag v0.38.0-rc0 HEAD~2`.
1. Tag `HEAD~1`: `git tag v0.38.0-rc1 HEAD~1`.
1. Tag `HEAD`: `git tag v0.38.0`.
1. Run `export VERSION='v0.38.0'`.
1. Run `git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "${VERSION}" -A1 | sed -n '2 p'`, to simulate the `release-gh` make target.
1. The output should be `0.37.0`, which is the correct previous non-rc tag.
1. Delete the new tags: `git tag -d v0.38.0-rc0 v0.38.0-rc1 v0.38.0`.

Finally, test the case where we have a new minor release tag, with the previous tag also using the new tag format. The output should be the previous non-rc tag using the new format.

1. Tag `HEAD~2`: `git tag v0.38.0 HEAD~2`.
1. Tag `HEAD~1`: `git tag v0.39.0-rc0 HEAD~1`.
1. Tag `HEAD`: `git tag v0.39.0`.
1. Run `export VERSION='v0.39.0'`.
1. Run `git tag --sort=-creatordate | grep -E '^v?[0-9.]+$$' | grep "${VERSION}" -A1 | sed -n '2 p'`, to simulate the `release-gh` make target.
1. The output should be `v0.38.0`, which is the correct previous non-rc tag with the new format.
1. Delete the new tags: `git tag -d v0.38.0 v0.39.0-rc0 v0.39.0`.

Note: please ensure that all of your local testing tags are cleaned up!

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ