### PR TITLE
build: INFENG-940: Fix logic error in CircleCI config make-component job

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -1507,9 +1507,9 @@ commands:
           no_output_timeout: <<parameters.no_output_timeout>>
           command: |
             if <<parameters.dryrun>>; then
-              make -C <<parameters.component>> <<parameters.target>>
-            else
               make -C <<parameters.component>> <<parameters.target>>-dryrun
+            else
+              make -C <<parameters.component>> <<parameters.target>>
             fi
 
 jobs:


### PR DESCRIPTION
## Ticket

INFENG-940

## Description
Reverse the polarity of the CircleCI `make-component` job so it obeys the `dryrun` boolean variable properly, otherwise it will work the opposite way.

## Test Plan
Obverse the if statement and make sure it's correct.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code