### PR TITLE
build: INFENG-943: GoReleaser configure prerelease

### DIFF
--- a/helm/.goreleaser.yml
+++ b/helm/.goreleaser.yml
@@ -11,6 +11,7 @@ release:
   extra_files:
     - glob: build/determined-latest.tgz
       name_template: "determined-helm-chart_{{ .Env.VERSION }}.tgz"
+  prerelease: auto
 
   # be sure to keep this in sync between agent/master/helm
   # the "include" functionality is only in the pro version

--- a/helm/.goreleaser_ee.yml
+++ b/helm/.goreleaser_ee.yml
@@ -11,6 +11,7 @@ release:
   extra_files:
     - glob: build/determined-latest.tgz
       name_template: "determined-helm-chart_{{ .Env.VERSION }}.tgz"
+  prerelease: auto
 
   # be sure to keep this in sync between agent/master/helm
   # the "include" functionality is only in the pro version


### PR DESCRIPTION
## Ticket

INFENG-943

## Description
Set `prerelease: auto` in both Helm GoReleaser configs. GoReleaser will make intelligent decisions based on the tag and avoid setting release candidate Helm chart releases as "latest".

I'm not sure how this plays with the [make_latest](https://goreleaser.com/customization/release/?h=make_latest#github) option, which also exists and is set to `true` by default, but marking a release as a pre-release (in GitHub) also turns off the "latest" flag, so I guess we'll see.

## Test Plan

We'll have to do it live.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code