### PR TITLE
fix: error message fix for duplicate model name

### DIFF
--- a/master/internal/api_model.go
+++ b/master/internal/api_model.go
@@ -290,7 +290,7 @@ func (a *apiServer) PostModel(
 
 	if err != nil && strings.Contains(err.Error(), db.CodeUniqueViolation) {
 		return nil,
-			status.Errorf(codes.AlreadyExists, "avoid names equal to other models (case-insensitive)")
+			status.Errorf(codes.AlreadyExists, "avoid names equal to other models (case-sensitive)")
 	}
 	return &apiv1.PostModelResponse{Model: m},
 		errors.Wrapf(err, "error creating model %q in database", req.Name)
@@ -426,7 +426,7 @@ func (a *apiServer) PatchModel(
 
 	if err != nil && strings.Contains(err.Error(), db.CodeUniqueViolation) {
 		return nil,
-			status.Errorf(codes.AlreadyExists, "avoid names equal to other models (case-insensitive)")
+			status.Errorf(codes.AlreadyExists, "avoid names equal to other models (case-sensitive)")
 	}
 	return &apiv1.PatchModelResponse{Model: finalModel},
 		errors.Wrapf(err, "error updating model %q in database", currModel.Name)


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-842]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
More accurate error message for model names


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- Make sure when user create a model with an identical name, the error message should be `avoid names equal to other models (case-sensitive)` instead of  `case-insensitive`


## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-842]: https://hpe-aiatscale.atlassian.net/browse/ET-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ