### PR TITLE
test: archive/unarchive experiment e2e test

### DIFF
--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -399,6 +399,19 @@ test.describe('Experiment List', () => {
     });
   });
 
+  test('Archive/Unarchive an experiment', async () => {
+    projectDetailsPage._page.setDefaultTimeout(60_000);
+
+    const row = projectDetailsPage.f_experimentList.dataGrid.getRowByIndex(0);
+
+    const experimentActionDropdown = await row.experimentActionDropdown.open();
+    await expect((await row.getCellByColumnName('State')).pwLocator).toHaveText('canceled');
+    await experimentActionDropdown.menuItem('Archive').pwLocator.click();
+    await expect(experimentActionDropdown.menuItem('Unarchive').pwLocator).toBeVisible();
+    await experimentActionDropdown.menuItem('Unarchive').pwLocator.click();
+    await expect(experimentActionDropdown.menuItem('Archive').pwLocator).toBeVisible();
+  });
+
   test.describe('Experiment List Pagination', () => {
     test.beforeAll(({ newProject }) => {
       Array(51)
@@ -676,36 +689,6 @@ test.describe('Experiment List', () => {
         Promise.resolve(true),
       );
       await expect(newProjectRows.length).toBe(1);
-    });
-
-    test('Archive an experiment', async () => {
-      if (experimentId === undefined) throw new Error('No experiment ID was found');
-
-      const newExperimentRow =
-        await projectDetailsPage.f_experimentList.dataGrid.getRowByColumnValue(
-          'ID',
-          experimentId.toString(),
-        );
-
-      const experimentActionDropdown = await newExperimentRow.experimentActionDropdown.open();
-
-      await experimentActionDropdown.menuItem('Archive').pwLocator.click();
-      await expect(experimentActionDropdown.menuItem('Unarchive').pwLocator).toBeVisible();
-    });
-
-    test('Unarchive an experiment', async () => {
-      if (experimentId === undefined) throw new Error('No experiment ID was found');
-
-      const newExperimentRow =
-        await projectDetailsPage.f_experimentList.dataGrid.getRowByColumnValue(
-          'ID',
-          experimentId.toString(),
-        );
-
-      const experimentActionDropdown = await newExperimentRow.experimentActionDropdown.open();
-
-      await experimentActionDropdown.menuItem('Unarchive').pwLocator.click();
-      await expect(experimentActionDropdown.menuItem('Archive').pwLocator).toBeVisible();
     });
   });
 });

--- a/webui/react/src/e2e/tests/experimentList.spec.ts
+++ b/webui/react/src/e2e/tests/experimentList.spec.ts
@@ -677,5 +677,35 @@ test.describe('Experiment List', () => {
       );
       await expect(newProjectRows.length).toBe(1);
     });
+
+    test('Archive an experiment', async () => {
+      if (experimentId === undefined) throw new Error('No experiment ID was found');
+
+      const newExperimentRow =
+        await projectDetailsPage.f_experimentList.dataGrid.getRowByColumnValue(
+          'ID',
+          experimentId.toString(),
+        );
+
+      const experimentActionDropdown = await newExperimentRow.experimentActionDropdown.open();
+
+      await experimentActionDropdown.menuItem('Archive').pwLocator.click();
+      await expect(experimentActionDropdown.menuItem('Unarchive').pwLocator).toBeVisible();
+    });
+
+    test('Unarchive an experiment', async () => {
+      if (experimentId === undefined) throw new Error('No experiment ID was found');
+
+      const newExperimentRow =
+        await projectDetailsPage.f_experimentList.dataGrid.getRowByColumnValue(
+          'ID',
+          experimentId.toString(),
+        );
+
+      const experimentActionDropdown = await newExperimentRow.experimentActionDropdown.open();
+
+      await experimentActionDropdown.menuItem('Unarchive').pwLocator.click();
+      await expect(experimentActionDropdown.menuItem('Archive').pwLocator).toBeVisible();
+    });
   });
 });


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->
[ET-664]


## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
- Archive/unarchive an experiment e2e test


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
- CI should pass


## Checklist

- [x] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[ET-664]: https://hpe-aiatscale.atlassian.net/browse/ET-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ