### PR TITLE
fix: maxPoolSlotCapacity bug

### DIFF
--- a/webui/react/src/components/HyperparameterSearchModal.tsx
+++ b/webui/react/src/components/HyperparameterSearchModal.tsx
@@ -291,7 +291,18 @@ const HyperparameterSearchModal = ({ closeModal, experiment, trial }: Props): JS
   );
 
   const maxSlots = useMemo(
-    () => (resourcePool ? maxPoolSlotCapacity(resourcePool) : 0),
+    /**
+     * On-premise deployments don't have dynamic agents and we don't know how many
+     * agents might connect.
+     *
+     * This is a work around for dynamic agents such as Kubernetes where `slotsAvailable`,
+     * `slotsPerAgents` and `maxAgents` are all zero. This value is used for form
+     * validation and it is too strict to allow anything to run experiments. Intentially
+     * generalized and not matching against Kubernetes, in case other schedulers return
+     * zeroes, and this would at least unblock experiments, and the backend would be able
+     * to return capacity issues.
+     */
+    () => (resourcePool ? maxPoolSlotCapacity(resourcePool) || Infinity : 0),
     [resourcePool],
   );
 

--- a/webui/react/src/stores/cluster.tsx
+++ b/webui/react/src/stores/cluster.tsx
@@ -49,18 +49,7 @@ export const maxPoolSlotCapacity = (pool: ResourcePool): number => {
   if (pool.maxAgents > 0 && pool.slotsPerAgent && pool.slotsPerAgent > 0) {
     return pool.maxAgents * pool.slotsPerAgent;
   }
-  /**
-   * On-premise deployments don't have dynamic agents and we don't know how many
-   * agents might connect.
-   *
-   * This is a work around for dynamic agents such as Kubernetes where `slotsAvailable`,
-   * `slotsPerAgents` and `maxAgents` are all zero. This value is used for form
-   * validation and it is too strict to allow anything to run experiments. Intentially
-   * generalized and not matching against Kubernetes, in case other schedulers return
-   * zeroes, and this would at least unblock experiments, and the backend would be able
-   * to return capacity issues.
-   */
-  return pool.slotsAvailable || Infinity;
+  return pool.slotsAvailable;
 };
 
 /**


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Addressing the bug described here: https://hpe-aiatscale.slack.com/archives/CLCE8D998/p1730317938890049

Avoids erroneously dividing by Infinity and returning "0%" as the value for `clusterStatus`. 
(Should be 26+0/40+0 = 26/40 instead of 26+0/40+Infinity = 0).

Also will make `SlotAllocationBar` show "0/0" instead of "0/Infinity".

Could cause divide-by-zero errors anywhere a number is divided by the result of `maxPoolSlotCapacity`, but it looks like we're guarding against those anyway and it seems like a preferable error compared to this one.

## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ