### PR TITLE
fix: swap latest main and preview clusters to RDS

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3443,7 +3443,7 @@ jobs:
         default: "m6i.large"
       cluster-id:
         type: string
-        default: determined-${CIRCLE_BRANCH////--}
+        default: determined-rds-${CIRCLE_BRANCH////--}
       max-dynamic-agents:
         type: integer
         default: 1
@@ -3481,7 +3481,7 @@ jobs:
           max-dynamic-agents: <<parameters.max-dynamic-agents>>
           enable-cors: <<parameters.enable-cors>>
           reattach-enabled: <<parameters.reattach-enabled>>
-          deployment-type: simple
+          deployment-type: simple-rds
           extra-tags: <<parameters.extra-tags>>
           ee: <<parameters.ee>>
 
@@ -4202,7 +4202,7 @@ workflows:
           requires:
             - package-and-push-system-dev
           max-dynamic-agents: 1
-          cluster-id: determined-preview
+          cluster-id: determined-preview-rds
           compute-agent-instance-type: t2.medium
 
   test-e2e:


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
We removed `--deployment-type=simple` because Aurora V1 is going away, so these deployments need to move to RDS. My idea is to rename these deployments so CFN will be happy then manually run the migration guide to restore DB state on the new clusters. Alternatively, we can just lose the state but that kinda sucks.

## Test Plan
N / A

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ