### PR TITLE
fix: ban archive columns in filter for experiment/search search

### DIFF
--- a/webui/react/src/components/Searches/Searches.tsx
+++ b/webui/react/src/components/Searches/Searches.tsx
@@ -88,7 +88,7 @@ interface Props {
   project: Project;
 }
 
-const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal']);
+const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal', 'archived']);
 const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetricsVal']);
 
 const makeSortString = (sorts: ValidSort[]): string =>

--- a/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
+++ b/webui/react/src/pages/F_ExpList/F_ExperimentList.tsx
@@ -101,7 +101,7 @@ interface Props {
 
 const NO_PINS_WIDTH = 200;
 
-export const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal']);
+export const BANNED_FILTER_COLUMNS = new Set(['searcherMetricsVal', 'archived']);
 const BANNED_SORT_COLUMNS = new Set(['tags', 'searcherMetricsVal']);
 
 const makeSortString = (sorts: ValidSort[]): string =>


### PR DESCRIPTION

## Ticket
ET-843



## Description
This fixes an issue where the archived columns were available to filter on even though boolean columns aren't valid for searches. when used in a search, the search would fail with a 500 error.



## Test Plan
when viewing the searches or experiments for a project, the user should not be able to see or select the "archived" column in the filter menu.



## Checklist

- [x] Changes have been manually QA'd
- [x] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [x] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ