### PR TITLE
docs: update docs for non-Trial-centric world

### DIFF
--- a/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
+++ b/docs/model-dev-guide/api-guides/apis-howto/api-core-ug.rst
@@ -305,45 +305,25 @@ configuration file.
  Step 4: Hyperparameter Search
 *******************************
 
-With the Core API you can run advanced hyperparameter searches with arbitrary training code. The
-hyperparameter search logic is in the master, which coordinates many different Trials. Each trial
-runs a train-validate-report loop:
-
-.. table::
-
-   +----------+--------------------------------------------------------------------------+
-   | Train    | Train until a point chosen by the hyperparameter search algorithm and    |
-   |          | obtained via the Core API.  The length of training is absolute, so you   |
-   |          | have to keep track of how much you have already trained to know how much |
-   |          | more to train.                                                           |
-   +----------+--------------------------------------------------------------------------+
-   | Validate | Validate your model to obtain the metric you configured in the           |
-   |          | ``searcher.metric`` field of your experiment config.                     |
-   +----------+--------------------------------------------------------------------------+
-   | Report   | Use the Core API to report results to the master.                        |
-   +----------+--------------------------------------------------------------------------+
+With the Core API you can run advanced hyperparameter searches with any training loop. The
+hyperparameter search logic is in the master, which can create trials and can decide to preempt them
+if they are underpeforming.
 
 To perform a hyperparameter search, we'll update our script to define the hyperparameter search
 settings we want to use for our experiment. More specifically, we'll need to define the following
 settings in our experiment configuration file:
 
--  ``name:`` ``adaptive_asha`` (name of our searcher. For all options, visit :ref:`search-methods`.
--  ``metric``: ``test_loss``
--  ``smaller_is_better``: ``True`` (This is equivalent to minimization vs. maximization of
-   objective.)
--  ``max_trials``: 500 (This is the maximum number of trials the searcher should run.)
--  ``time_metric``: ``epochs`` (This is the name of the "time" metric which we report in validation
+-  ``name: adaptive_asha`` (name of our searcher. For all options, visit :ref:`search-methods`).
+-  ``metric: test_loss``
+-  ``smaller_is_better: true`` (This is equivalent to minimization vs. maximization of objective.)
+-  ``max_trials: 50`` (This is the maximum number of trials the searcher should run.)
+-  ``time_metric: epochs`` (This is the name of the "time" metric which we report in validation
    metrics).
--  ``max_time``: 20 (The max number of epochs a trial will report. For more information, visit
+-  ``max_time: 20`` (The max number of epochs a trial will report. For more information, visit
    Adaptive ASHA in the :ref:`Experiment Configuration Reference <experiment-configuration>`.
 
 In addition, we also need to define the hyperparameters themselves. Adaptive ASHA will pick values
 between the ``minval`` and ``maxval`` for each hyperparameter for each trial.
-
-.. note::
-
-   To see early stopping in action, try setting ``max_trials`` to over 500 and playing around with
-   the hyperparameter search values.
 
 In this step, we’ll run our experiment using the ``model_def_adaptive.py`` script and its
 accompanying ``adaptive.yaml`` experiment configuration file.
@@ -373,6 +353,15 @@ hardcoded values:
    :language: python
    :start-after: # Docs snippet start: per trial basis
    :end-before: # Docs snippet end: per trial basis
+   :dedent:
+
+Lastly, to comply with the requirements of the ASHA search, we must report an ``epochs`` metric with
+our validation metrics, since we set ``time_metric: epochs`` in our searcher:
+
+.. literalinclude:: ../../../../examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
+   :language: python
+   :start-after: # Docs snippet start: report epochs
+   :end-before: # Docs snippet end: report epochs
    :dedent:
 
 Step 4.1: Run the Experiment

--- a/docs/model-dev-guide/create-experiment.rst
+++ b/docs/model-dev-guide/create-experiment.rst
@@ -110,6 +110,8 @@ Example Python script command:
 
    script.py [args...]
 
+.. _predefined-launchers:
+
 **********************
  Predefined Launchers
 **********************

--- a/examples/computer_vision/iris_tf_keras/train.py
+++ b/examples/computer_vision/iris_tf_keras/train.py
@@ -112,11 +112,12 @@ def main(core_context, strategy, checkpoint, continue_id, hparams, epochs):
         callbacks=[det_cb, tb_cb],
     )
 
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--epochs", type=int, default=100, help="how long to train for")
+    parser.add_argument("--epochs", type=int, default=500, help="how long to train for")
     args = parser.parse_args()
 
     info = det.get_cluster_info()

--- a/examples/deepspeed/dcgan/data.py
+++ b/examples/deepspeed/dcgan/data.py
@@ -21,9 +21,10 @@ CHANNELS_BY_DATASET = {
 
 def get_dataset(data_config: dict) -> torch.utils.data.Dataset:
     if data_config.get("dataroot", None) is None:
-        if str(data_config.get("dataset"),"").lower() != "fake":
-            raise ValueError('`dataroot` parameter is required for dataset "%s"'
-                            % data_config.get("dataset", ""))
+        if str(data_config.get("dataset"), "").lower() != "fake":
+            raise ValueError(
+                '`dataroot` parameter is required for dataset "%s"' % data_config.get("dataset", "")
+            )
         else:
             context = contextlib.nullcontext()
     else:

--- a/examples/deepspeed/dcgan/model.py
+++ b/examples/deepspeed/dcgan/model.py
@@ -17,8 +17,9 @@ FAKE_LABEL = 0
 
 
 class DCGANTrial(det_ds.DeepSpeedTrial):
-    def __init__(self, context: det_ds.DeepSpeedTrialContext,
-                 hparams: dict, data_config: dict) -> None:
+    def __init__(
+        self, context: det_ds.DeepSpeedTrialContext, hparams: dict, data_config: dict
+    ) -> None:
         self.context = context
         self.hparams = hparams
         self.data_config = data_config

--- a/examples/diffusion/textual_inversion_stable_diffusion/detsd/trainer.py
+++ b/examples/diffusion/textual_inversion_stable_diffusion/detsd/trainer.py
@@ -246,9 +246,7 @@ class DetSDTextualInversionTrainer:
                         trainer.logger.info(f"Step {trainer.steps_completed} completed.")
 
                         is_end_of_training = trainer.steps_completed == trainer.num_sgd_steps
-                        time_to_report = (
-                            trainer.steps_completed % trainer.metric_report_freq == 0
-                        )
+                        time_to_report = trainer.steps_completed % trainer.metric_report_freq == 0
                         time_to_ckpt = trainer.steps_completed % trainer.checkpoint_freq == 0
 
                         # Report metrics, checkpoint, and preempt as appropriate.

--- a/examples/tutorials/core_api_pytorch_mnist/adaptive.yaml
+++ b/examples/tutorials/core_api_pytorch_mnist/adaptive.yaml
@@ -28,7 +28,7 @@ searcher:
   name: adaptive_asha
   metric: test_loss
   smaller_is_better: true
-  max_trials: 500
+  max_trials: 50
   time_metric: epochs
   max_time: 20
-entrypoint: python3 model_def_adaptive.py
+entrypoint: python3 model_def_adaptive.py --epochs 20

--- a/examples/tutorials/core_api_pytorch_mnist/distributed.yaml
+++ b/examples/tutorials/core_api_pytorch_mnist/distributed.yaml
@@ -28,9 +28,8 @@ hyperparameters:
 max_restarts: 0
 records_per_epoch: 60000
 searcher:
-  name: adaptive_asha
+  name: single
   metric: test_loss
   smaller_is_better: true
-  max_trials: 500
 resources:
   slots_per_trial: 4

--- a/examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
+++ b/examples/tutorials/core_api_pytorch_mnist/model_def_adaptive.py
@@ -99,10 +99,12 @@ def test(args, model, device, test_loader, core_context, steps_completed, epochs
         )
     )
 
+    # Docs snippet start: report epochs
     core_context.train.report_validation_metrics(
         steps_completed=steps_completed,
         metrics={"test_loss": test_loss, "epochs": epochs_completed},
     )
+    # Docs snippet end: report epochs
 
 
 def load_state(checkpoint_directory, trial_id):


### PR DESCRIPTION
The model debugging guide was completely out-of-date, and needed a near-total rewrite.

Additionally, the Core API user guide had additional details that needed updating, which I missed in my first pass.

Also, there were issues with two examples:

 - the iris example was not configured to train long enough to actually converge, which looks bad for an example

 - The core_api_mnist_pytorch example had a couple show-stopper bugs, so not all of its stages ran at all.

Finally, several examples touched in the searcher-context-removal project needed `make fmt` applied to them.