### PR TITLE
ci: take removed API out of performance tests

### DIFF
--- a/performance/daist/daist/rest_api/tasks.py
+++ b/performance/daist/daist/rest_api/tasks.py
@@ -205,9 +205,6 @@ def read_only_tasks(resources: Resources) -> LocustTasksWithMeta:
             f"/best_searcher_validation_metric",
             test_name="get experiment best searcher validation metric"))
         tasks.append(LocustGetTaskWithMeta(
-            f"/api/v1/experiments/{resources.experiment_id}/searcher_events",
-            test_name="get experiment searcher events"))
-        tasks.append(LocustGetTaskWithMeta(
             f"/api/v1/experiments/{resources.experiment_id}/validation-history",
             test_name="get experiment validation history"))
         if resources.experiment_file is not None:


### PR DESCRIPTION
## Description

Deprecating searcher context eliminated this API, so we can just take it out of performance tests.

## Test Plan

We should see the failure rate go back to 0 in performance tests.

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code