### PR TITLE
fix: revert: fix: resolve indefinitely queued (STOPPING_COMPLETED) trials

### DIFF
--- a/e2e_tests/tests/cluster/test_master_restart.py
+++ b/e2e_tests/tests/cluster/test_master_restart.py
@@ -117,33 +117,6 @@ def test_master_restart_reattach_recover_experiment_k8s(
 
 
 @pytest.mark.managed_devcluster
-def test_master_agent_restart_reattach_recover_experiment(
-    restartable_managed_cluster: managed_cluster.ManagedCluster,
-) -> None:
-    sess = api_utils.user_session()
-
-    try:
-        # Start an experiment
-        exp_ref = noop.create_experiment(sess, [noop.Sleep(10)])
-
-        # Kill the agent & master
-        restartable_managed_cluster.kill_agent()
-        restartable_managed_cluster.kill_master()
-
-        # Restart the agent & master
-        restartable_managed_cluster.restart_master()
-        restartable_managed_cluster.restart_agent(True)
-
-        assert exp_ref.wait(interval=0.01) == client.ExperimentState.COMPLETED
-        trials = exp.experiment_trials(sess, exp_ref.id)
-        assert (trials[0].trial.state) == bindings.trialv1State.COMPLETED
-    except Exception:
-        restartable_managed_cluster.restart_master()
-        restartable_managed_cluster.restart_agent()
-        raise
-
-
-@pytest.mark.managed_devcluster
 def test_master_restart_generic_task(
     managed_cluster_restarts: managed_cluster.ManagedCluster,
 ) -> None:

--- a/master/internal/trial_intg_test.go
+++ b/master/internal/trial_intg_test.go
@@ -41,6 +41,8 @@ func TestTrial(t *testing.T) {
 		EarlyStoppedBySearcher: false,
 		EarlyExitedByUserCode:  false,
 	}))
+	require.True(t, alloc.AssertExpectations(t))
+	require.NotNil(t, tr.allocationID)
 
 	// Running stage.
 	require.NoError(t, tr.PatchSearcherState(experiment.TrialSearcherState{
@@ -48,8 +50,6 @@ func TestTrial(t *testing.T) {
 		EarlyStoppedBySearcher: true,
 		EarlyExitedByUserCode:  false,
 	}))
-	require.True(t, alloc.AssertExpectations(t))
-	require.NotNil(t, tr.allocationID)
 
 	dbTrial, err := internaldb.TrialByID(context.TODO(), tr.id)
 	require.NoError(t, err)
@@ -123,7 +123,6 @@ func setup(t *testing.T) (
 		"StartAllocation", mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return(nil)
-	as.On("Signal", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	a, _, _ := setupAPITest(t, nil)
 	j := &model.Job{JobID: model.NewJobID(), JobType: model.JobTypeExperiment}


### PR DESCRIPTION
This PR causes issues where experiments that run a searcher then expect to save a checkpoint are thwarted by the master simply stopping the experiment before that happens.
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ