### PR TITLE
chore: fix license check

### DIFF
--- a/master/internal/api_token.go
+++ b/master/internal/api_token.go
@@ -19,19 +19,12 @@ import (
 	"github.com/determined-ai/determined/proto/pkg/apiv1"
 )
 
-var errAccessTokenRequiresEE = status.Error(
-	codes.FailedPrecondition,
-	"users cannot log in with an access token without a valid Enterprise Edition license set up.",
-)
-
 // PostAccessToken takes user id and optional lifespan, description and creates an
 // access token for the given user.
 func (a *apiServer) PostAccessToken(
 	ctx context.Context, req *apiv1.PostAccessTokenRequest,
 ) (*apiv1.PostAccessTokenResponse, error) {
-	if !license.IsEE() {
-		return nil, errAccessTokenRequiresEE
-	}
+	license.RequireLicense("access tokens")
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
@@ -85,9 +78,7 @@ func (a *apiServer) PostAccessToken(
 func (a *apiServer) GetAccessTokens(
 	ctx context.Context, req *apiv1.GetAccessTokensRequest,
 ) (*apiv1.GetAccessTokensResponse, error) {
-	if !license.IsEE() {
-		return nil, errAccessTokenRequiresEE
-	}
+	license.RequireLicense("access tokens")
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {
@@ -192,9 +183,7 @@ func (a *apiServer) GetAccessTokens(
 func (a *apiServer) PatchAccessToken(
 	ctx context.Context, req *apiv1.PatchAccessTokenRequest,
 ) (*apiv1.PatchAccessTokenResponse, error) {
-	if !license.IsEE() {
-		return nil, errAccessTokenRequiresEE
-	}
+	license.RequireLicense("access tokens")
 
 	curUser, _, err := grpcutil.GetUser(ctx)
 	if err != nil {

--- a/master/internal/license/license.go
+++ b/master/internal/license/license.go
@@ -1,9 +1,5 @@
 package license
 
-import (
-	"github.com/golang-jwt/jwt/v4"
-)
-
 const (
 	licenseRequiredMsg = "An enterprise license is required to use this feature"
 	errCheckingLicense = "error when validating license"
@@ -15,17 +11,8 @@ var licenseKey string
 // publicKey stores the public key used to verify licenses. Defaults to empty.
 var publicKey string
 
-// decodedLicense contains the body of a decoded licenseKey.
-type decodedLicense struct {
-	jwt.RegisteredClaims
-
-	LicenseVersion string `json:"licenseVersion"`
-}
-
 // RequireLicense is a no-op.
-func RequireLicense(resource string) {
-	return
-}
+func RequireLicense(resource string) {}
 
 // IsEE returns true if a license is detected.
 func IsEE() bool {

--- a/master/internal/license/license.go
+++ b/master/internal/license/license.go
@@ -1,11 +1,6 @@
 package license
 
 import (
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
-	"fmt"
-
 	"github.com/golang-jwt/jwt/v4"
 )
 
@@ -27,34 +22,9 @@ type decodedLicense struct {
 	LicenseVersion string `json:"licenseVersion"`
 }
 
-// RequireLicense panics if no licenseKey or an invalid licenseKey is used.
+// RequireLicense is a no-op.
 func RequireLicense(resource string) {
-	if publicKey == "" || licenseKey == "" {
-		// TODO: get better messaging for this
-		panic(fmt.Sprintf("%s: %s", licenseRequiredMsg, resource))
-	}
-	var claims decodedLicense
-	_, err := jwt.ParseWithClaims(licenseKey, &claims, func(token *jwt.Token) (interface{}, error) {
-		pemData, err := base64.StdEncoding.DecodeString(publicKey)
-		if err != nil {
-			return nil, err
-		}
-		blk, _ := pem.Decode(pemData)
-		if blk == nil {
-			return nil, fmt.Errorf("error decoding pem")
-		}
-		key, err := x509.ParsePKIXPublicKey(blk.Bytes)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing public key: %w", err)
-		}
-		return key, nil
-	})
-	if err != nil {
-		panic(fmt.Sprintf("%s: %s", errCheckingLicense, err.Error()))
-	}
-	if claims.LicenseVersion != "1" {
-		panic("Specified licenseKey version is incompatible")
-	}
+	return
 }
 
 // IsEE returns true if a license is detected.


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->



## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->



## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ