### PR TITLE
fix: make some k8s tests pass

### DIFF
--- a/master/internal/rm/kubernetesrm/jobs_test.go
+++ b/master/internal/rm/kubernetesrm/jobs_test.go
@@ -123,7 +123,8 @@ func TestListPodsInAllNamespaces(t *testing.T) {
 		},
 	}
 
-	var expectedPods []k8sV1.Pod = append(detPods, outsidePod)
+	//nolint:gocritic
+	expectedPods := append(detPods, outsidePod)
 	expectedPodList := k8sV1.PodList{Items: expectedPods}
 	emptyNS.On("List", mock.Anything, mock.Anything).Once().
 		Return(&k8sV1.PodList{Items: expectedPods}, nil)
@@ -203,7 +204,8 @@ func TestHealthStatus(t *testing.T) {
 		},
 	}
 
-	var expectedPods []k8sV1.Pod = append(detPods, outsidePod)
+	//nolint:gocritic
+	expectedPods := append(detPods, outsidePod)
 	emptyNS.On("List", mock.Anything, mock.Anything).Once().
 		Return(&k8sV1.PodList{Items: expectedPods}, nil)
 

--- a/master/internal/rm/kubernetesrm/jobs_test.go
+++ b/master/internal/rm/kubernetesrm/jobs_test.go
@@ -123,8 +123,7 @@ func TestListPodsInAllNamespaces(t *testing.T) {
 		},
 	}
 
-	var expectedPods []k8sV1.Pod
-	copy(expectedPods, append(detPods, outsidePod))
+	var expectedPods []k8sV1.Pod = append(detPods, outsidePod)
 	expectedPodList := k8sV1.PodList{Items: expectedPods}
 	emptyNS.On("List", mock.Anything, mock.Anything).Once().
 		Return(&k8sV1.PodList{Items: expectedPods}, nil)
@@ -133,7 +132,7 @@ func TestListPodsInAllNamespaces(t *testing.T) {
 	opts := metaV1.ListOptions{}
 	actualPodList, err := js.listPodsInAllNamespaces(ctx, opts)
 	require.NoError(t, err)
-	require.NotNil(t, actualPodList)
+	require.NotEmpty(t, actualPodList)
 	require.ElementsMatch(t, expectedPodList.Items, actualPodList)
 
 	forbiddenErr := k8error.NewForbidden(schema.GroupResource{}, "forbidden",
@@ -204,8 +203,7 @@ func TestHealthStatus(t *testing.T) {
 		},
 	}
 
-	var expectedPods []k8sV1.Pod
-	copy(expectedPods, append(detPods, outsidePod))
+	var expectedPods []k8sV1.Pod = append(detPods, outsidePod)
 	emptyNS.On("List", mock.Anything, mock.Anything).Once().
 		Return(&k8sV1.PodList{Items: expectedPods}, nil)
 

--- a/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
+++ b/master/internal/rm/kubernetesrm/kubernetes_resource_manager_intg_test.go
@@ -778,6 +778,7 @@ func TestHealthCheck(t *testing.T) {
 		jobsService: &jobsService{
 			podInterfaces: map[string]typedV1.PodInterface{
 				"namespace": mockPodInterface,
+				"":          mockPodInterface,
 			},
 			syslog: logrus.WithField("namespace", "test"),
 		},


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Some tests weren't passing but I didn't wanna block cutting the RC or manual testing. This should fix the k8s tests that weren't passing.


## Test Plan
None; automated test changes only


<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ