### PR TITLE
chore: eliminate use of fury repo

### DIFF
--- a/harness/Makefile
+++ b/harness/Makefile
@@ -14,8 +14,7 @@ publish:
 	twine upload --verbose --non-interactive dist/*
 
 .PHONY: publish-ee
-publish-ee:
-	twine upload --verbose --non-interactive dist/* --repository-url https://push.fury.io/determined-ai
+publish-ee: ;
 
 .PHONY: publish-dryrun
 publish-dryrun:


### PR DESCRIPTION
# chore: eliminate use of fury repo

## Description
No longer needed

## Test Plan
Will just re-run the build

## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code
