### PR TITLE
ci: remove deploying latest main and preview clusters

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3836,38 +3836,6 @@ workflows:
               only:
                 - main
 
-      - deploy:
-          name: deploy-latest-main-cluster
-          enable-cors: true
-          reattach-enabled: true
-          extra-tags: "long_running=determined_preview_cluster"
-          context:
-            - aws
-            - aws-ci-cluster-default-user-credentials
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - package-and-push-system-dev
-          max-dynamic-agents: 2
-
-      - deploy:
-          name: deploy-preview-cluster
-          enable-cors: true
-          context:
-            - aws
-            - aws-ci-cluster-default-user-credentials
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - package-and-push-system-dev
-          max-dynamic-agents: 1
-          cluster-id: determined-preview-rds
-          compute-agent-instance-type: t2.medium
-
   test-e2e:
     <<: *do-not-run-on-manual-trigger
     jobs:


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->

Remove the CI jobs that deploy/update clusters:
* latest-main cluster
* Netlify preview cluster


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ