### PR TITLE
ci: remove deploying latest gke cluster

### DIFF
--- a/.circleci/real_config.yml
+++ b/.circleci/real_config.yml
@@ -3148,61 +3148,6 @@ jobs:
           extra-tags: <<parameters.extra-tags>>
           ee: <<parameters.ee>>
 
-  deploy-latest-gke:
-    parameters:
-      det-version:
-        type: string
-      cluster-id:
-        type: string
-        default: latest-ee-gke
-      region:
-        type: string
-        default: us-west1
-      gcloud-service-key:
-        default: GCLOUD_SERVICE_KEY
-        description: The gcloud service key
-        type: env_var_name
-      google-compute-zone:
-        default: GOOGLE_COMPUTE_ZONE
-        description: The Google compute zone to connect with via the gcloud CLI
-        type: env_var_name
-      google-project-id:
-        default: GOOGLE_PROJECT_ID
-        description: The Google project ID to connect with via the gcloud CLI
-        type: env_var_name
-    docker:
-      - image: <<pipeline.parameters.docker-image>>
-    steps:
-      - checkout
-      - add-and-fetch-upstream
-      - skip-if-only-docs
-      - set-slack-user-id
-      - gcloud/install:
-          version: "319.0.0"
-      - kubernetes/install-kubectl
-      - gcloud/initialize:
-          gcloud-service-key: <<parameters.gcloud-service-key>>
-          google-compute-zone: <<parameters.google-compute-zone>>
-          google-project-id: <<parameters.google-project-id>>
-      - run:
-          command: gcloud container clusters get-credentials <<parameters.cluster-id>> --project determined-ai --region <<parameters.region>>
-          name: Get Kubeconfig
-      - helm/upgrade-helm-chart:
-          chart: helm/charts/determined
-          helm-version: v3.2.4
-          namespace: "default"
-          wait: true
-          release-name: <<parameters.cluster-id>>
-          values-to-override: |
-            detVersion=<<parameters.det-version>>,\
-            maxSlotsPerPod=4,\
-            checkpointStorage.type=gcs,\
-            checkpointStorage.bucket=det-ci,\
-            imagePullSecretName=release-cred,\
-            masterPort=80,\
-            security.authz.type=rbac,\
-            enterpriseEdition=true
-
   test-e2e-aws:
     parameters:
       cluster-id-prefix:
@@ -4383,17 +4328,6 @@ workflows:
               parallelism: [2]
               mark: ["det_deploy_local"]
               det-version: [$CIRCLE_SHA1]
-
-      - deploy-latest-gke:
-          name: deploy-latest-gke-master
-          context: gcp
-          det-version: $CIRCLE_SHA1
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - package-and-push-system-dev-ee
 
   test-e2e-longrunning:
     <<: *do-not-run-on-manual-trigger


### PR DESCRIPTION
## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Remove deploying/updating latest GKE cluster in CI.




## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ