### PR TITLE
fix: A less-than/greater-than error in the daist stdout logging filter.

### DIFF
--- a/performance/daist/daist/framework/log.py
+++ b/performance/daist/daist/framework/log.py
@@ -15,7 +15,7 @@ class StdoutFilter(logging.Filter):
         self._level = level
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return record.levelno <= self._level
+        return record.levelno >= self._level
 
 
 def start(path: Path, file_level: int, stdout_level: int):


### PR DESCRIPTION
## PR TITLE (Commit Body)
Fix: A less-than/greater-than error in the daist stdout logging filter.

## Ticket
N/A

## Description
There is a standard output filter implemented for the daist testing framework that had a logical error in it. The filter is inherited from the `logging.Filter` class, overriding the `filter` method. This method should return `False` if a logging record should be filtered (i.e.  not output to standard out). The incorrect logic was returning `True`.

## Test Plan
![image](https://github.com/user-attachments/assets/b2fbba6d-0228-41f9-ae5b-b4c42265adaf)

## Checklist

- [x ] Changes have been manually QA'd
- [?] New features have been approved by the corresponding PM
- [x] User-facing API changes have the "User-facing API Change" label
- [ let me know if needed] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [x ] Licenses have been included for new code which was copied and/or modified from any external code