### PR TITLE
docs: add warning to the obsolete docs and update links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,6 +168,7 @@ linkcheck_ignore = [
     r"^http://127.0.0.1",
     r"^\.\./",
     "https://www.hpe.com/us/en/hpe-machine-learning-development-environment.html",
+    r"https://mldes\.ext\.hpe\.com.*",
 ]
 
 linkcheck_timeout = 20

--- a/docs/reference/deploy/helm-config-reference.rst
+++ b/docs/reference/deploy/helm-config-reference.rst
@@ -122,11 +122,11 @@
    -  ``type: gcs``: Checkpoints are stored on Google Cloud Storage (GCS). Authentication is done
       using GCP's "`Application Default Credentials
       <https://googleapis.dev/python/google-api-core/latest/auth.html>`__" approach. When using
-      Determined inside Google Kubernetes Engine (GCE), the simplest approach is to ensure that the
+      Determined inside Google Kubernetes Engine (GKE), the simplest approach is to ensure that the
       nodes used by Determined are running in a service account that has the "Storage Object Admin"
       role on the GCS bucket being used for checkpoints. As an alternative (or when running outside
       of GKE), you can add the appropriate `service account credentials
-      <https://cloud.google.com/docs/authentication/provide-credentials-adc#attached-sa>`__ to your
+      <https://cloud.google.com/docs/authentication/set-up-adc-attached-service-account>`__ to your
       container (e.g., via a bind-mount), and then set the ``GOOGLE_APPLICATION_CREDENTIALS``
       environment variable to the container path where the credentials are located. See
       :ref:`environment-variables` for more information on how to set environment variables in trial

--- a/docs/reference/deploy/master-config-reference.rst
+++ b/docs/reference/deploy/master-config-reference.rst
@@ -1311,7 +1311,7 @@ inside Google Compute Engine (GCE), the simplest approach is to ensure that the 
 Determined are running in a service account that has the "Storage Object Admin" role on the GCS
 bucket being used for checkpoints. As an alternative (or when running outside of GCE), you can add
 the appropriate `service account credentials
-<https://cloud.google.com/docs/authentication/provide-credentials-adc#attached-sa>`__ to your
+<https://cloud.google.com/docs/authentication/set-up-adc-attached-service-account>`__ to your
 container (e.g., via a bind-mount), and then set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment
 variable to the container path where the credentials are located. See :ref:`environment-variables`
 for more information on how to set environment variables in trial environments.

--- a/docs/reference/experiment-config-reference.rst
+++ b/docs/reference/experiment-config-reference.rst
@@ -522,7 +522,7 @@ inside Google Compute Engine (GCE), the simplest approach is to ensure that the 
 Determined are running in a service account that has the "Storage Object Admin" role on the GCS
 bucket being used for checkpoints. As an alternative (or when running outside of GCE), you can add
 the appropriate `service account credentials
-<https://cloud.google.com/docs/authentication/provide-credentials-adc#attached-sa>`__ to your
+<https://cloud.google.com/docs/authentication/set-up-adc-attached-service-account>`__ to your
 container (e.g., via a bind-mount), and then set the ``GOOGLE_APPLICATION_CREDENTIALS`` environment
 variable to the container path where the credentials are located. See :ref:`environment-variables`
 for more details on how to set environment variables in containers.

--- a/docs/setup-cluster/mldes/_index.rst
+++ b/docs/setup-cluster/mldes/_index.rst
@@ -6,7 +6,8 @@
 
 .. attention::
 
-   MLDES only supports Determined Enterprise Edition.
+   MLDE Managed Service has been discontinued. This page is now obsolete but is left here for
+   historical reasons.
 
 **********
  Overview


### PR DESCRIPTION
<!---
## PR TITLE (Commit Body)
When squash-merging, GitHub will use this as the commit message.
Check the "Example Commit Body" for conventional commit semantics.
-->
## Ticket
<!---
A reference to the Jira ticket or Github issue. e.g. "[DET-1234]" or #123.
-->



## Description
<!---
A description of the PR. For breaking changes, lead with "BREAKING CHANGE:".
--->
Add an obsolete notice to the `deploying via MLDE managed service` page.
Add the links in `deploying via MLDE managed service` to the linkcheck ignore list.
Update Google Cloud links.


## Test Plan
<!---
Describe the scenarios in which you've tested your change, with screenshots as
appropriate. Reviewers may ask questions about this test plan to ensure adequate
coverage of changes.
-->
CI passes.


## Checklist

- [ ] Changes have been manually QA'd
- [ ] New features have been approved by the corresponding PM
- [ ] User-facing API changes have the "User-facing API Change" label
- [ ] Release notes have been added as a separate file under `docs/release-notes/`
  See [Release Note](https://github.com/determined-ai/determined/blob/master/docs/release-notes/README.md) for details.
- [ ] Licenses have been included for new code which was copied and/or modified from any external code

<!---
Example Commit Body:
docs: tweak recommended "pip install" usage [DET-123]

Specifically, this title should contain a type and a description
of the change being made:

User-facing change types:

- docs: docs-only change
- feat: new user-facing feature
- fix: bug fix
- perf: performance improvement

Internal change types:

- build: build system change (anything in a `Makefile`, mostly)
- chore: any internal change not covered by another type
- ci: anything that touches `.circleci`
- refactor: internal refactor
- style: style change
- test: new tests

See https://www.conventionalcommits.org/en/v1.0.0/ for background.

The first line should also:

- be at most 89 characters long
- contain a description that is at most 72 characters long
- not end with sentence-ending punctuation
- start (after the type) with a lowercase imperative ("add", "fix")
-->


[DET-123]: https://hpe-aiatscale.atlassian.net/browse/DET-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ