### PR TITLE
fix: enforce authorization on generic task kill/pause/unpause

### DIFF
--- a/master/internal/api_generic_tasks.go
+++ b/master/internal/api_generic_tasks.go
@@ -493,6 +493,9 @@ func (a *apiServer) KillGenericTask(
 	ctx context.Context, req *apiv1.KillGenericTaskRequest,
 ) (*apiv1.KillGenericTaskResponse, error) {
 	killTaskID := model.TaskID(req.TaskId)
+	if _, _, err := a.canDoActionsOnTask(ctx, killTaskID); err != nil {
+		return nil, err
+	}
 	var taskModel model.Task
 	err := db.Bun().NewSelect().Model(&taskModel).
 		Where("task_id = ?", killTaskID).
@@ -544,6 +547,9 @@ func (a *apiServer) KillGenericTask(
 func (a *apiServer) PauseGenericTask(
 	ctx context.Context, req *apiv1.PauseGenericTaskRequest,
 ) (*apiv1.PauseGenericTaskResponse, error) {
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId)); err != nil {
+		return nil, err
+	}
 	var taskModel model.Task
 	err := db.Bun().NewSelect().Model(&taskModel).
 		Where("task_id = ?", req.TaskId).
@@ -599,6 +605,9 @@ func (a *apiServer) PauseGenericTask(
 func (a *apiServer) UnpauseGenericTask(
 	ctx context.Context, req *apiv1.UnpauseGenericTaskRequest,
 ) (*apiv1.UnpauseGenericTaskResponse, error) {
+	if _, _, err := a.canDoActionsOnTask(ctx, model.TaskID(req.TaskId)); err != nil {
+		return nil, err
+	}
 	var taskModel model.Task
 	err := db.Bun().NewSelect().Model(&taskModel).
 		Where("task_id = ?", req.TaskId).

--- a/master/internal/api_generic_tasks_intg_test.go
+++ b/master/internal/api_generic_tasks_intg_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+// +build integration
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	authz2 "github.com/determined-ai/determined/master/internal/authz"
+	"github.com/determined-ai/determined/master/internal/db"
+	"github.com/determined-ai/determined/master/pkg/model"
+	"github.com/determined-ai/determined/proto/pkg/apiv1"
+)
+
+// requireMockGenericTask creates a generic task (with a backing command_state row so that
+// command.IdentifyTask can resolve its workspace) and returns its task ID.
+func requireMockGenericTask(
+	ctx context.Context, t *testing.T, userID model.UserID,
+) model.TaskID {
+	pgDB := db.SingleDB()
+
+	jID := db.RequireMockJob(t, pgDB, &userID)
+	taskID := model.NewTaskID()
+	state := model.TaskStateActive
+	require.NoError(t, db.AddTask(ctx, &model.Task{
+		TaskID:    taskID,
+		JobID:     &jID,
+		TaskType:  model.TaskTypeGeneric,
+		StartTime: time.Now().UTC().Truncate(time.Millisecond),
+		State:     &state,
+	}))
+
+	alloc := db.RequireMockAllocation(t, pgDB, taskID)
+
+	commandState := struct {
+		bun.BaseModel `bun:"table:command_state"`
+
+		TaskID             model.TaskID
+		AllocationID       model.AllocationID
+		GenericCommandSpec map[string]any
+	}{
+		TaskID:       taskID,
+		AllocationID: alloc.AllocationID,
+		GenericCommandSpec: map[string]any{
+			"TaskType": model.TaskTypeGeneric,
+			"Metadata": map[string]any{
+				"workspace_id": 1,
+			},
+			"Base": map[string]any{
+				"Owner": map[string]any{
+					"id": userID,
+				},
+			},
+		},
+	}
+	_, err := db.Bun().NewInsert().Model(&commandState).Exec(ctx)
+	require.NoError(t, err)
+
+	return taskID
+}
+
+// TestGenericTaskLifecycleAuthZ verifies that KillGenericTask, PauseGenericTask, and
+// UnpauseGenericTask enforce authorization before acting on a task. A user that is not
+// permitted to view the task's workspace must not be able to kill, pause, or unpause it.
+// Regression test for the missing-authorization vulnerability where any authenticated
+// user could disrupt another user's generic tasks by supplying the task ID.
+func TestGenericTaskLifecycleAuthZ(t *testing.T) {
+	api, authZNSC, curUser, ctx := setupNTSCAuthzTest(t)
+	taskID := requireMockGenericTask(ctx, t, curUser.ID)
+
+	// Deny the caller access to the task's workspace.
+	authZNSC.On("CanGetNSC", mock.Anything, curUser, mock.Anything).
+		Return(authz2.PermissionDeniedError{})
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "kill",
+			call: func() error {
+				_, err := api.KillGenericTask(ctx, &apiv1.KillGenericTaskRequest{
+					TaskId: string(taskID),
+				})
+				return err
+			},
+		},
+		{
+			name: "pause",
+			call: func() error {
+				_, err := api.PauseGenericTask(ctx, &apiv1.PauseGenericTaskRequest{
+					TaskId: string(taskID),
+				})
+				return err
+			},
+		},
+		{
+			name: "unpause",
+			call: func() error {
+				_, err := api.UnpauseGenericTask(ctx, &apiv1.UnpauseGenericTaskRequest{
+					TaskId: string(taskID),
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			require.Error(t, err, "expected an authorization error")
+			// Permission-denied is surfaced as NotFound so the endpoint does not leak
+			// the existence of tasks the caller cannot access.
+			require.Equal(t, codes.NotFound, status.Code(err))
+		})
+	}
+
+	authZNSC.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

`KillGenericTask`, `PauseGenericTask`, and `UnpauseGenericTask` in `master/internal/api_generic_tasks.go` looked up a task solely by ID and acted on it **without any authorization check**. As a result, any authenticated user could cancel, pause, or unpause another user's generic tasks just by supplying the task ID — a cross-user denial-of-service on shared multi-user clusters.

This fixes #10270.

## Root cause

The sibling read endpoints in the same subsystem already gate access:

- `GetTask` and `GetGenericTaskConfig` (`master/internal/api_task.go`) both call `a.canDoActionsOnTask(...)`, which for generic/NTSC tasks routes through `canAccessNTSCTask` → `CanGetNSC`.
- Sibling NSC lifecycle endpoints (`KillCommand`, `KillNotebook`, `KillShell`, `KillTensorboard`) all check the authz provider before acting.

The three generic-task lifecycle endpoints skipped this step entirely.

## Change

Add an `a.canDoActionsOnTask(ctx, taskID)` check at the top of each of the three handlers, before the task is fetched and mutated — matching the pattern already used by `GetGenericTaskConfig`. Permission-denied is surfaced as `NotFound`, consistent with the existing endpoints, so task existence is not leaked to unauthorized callers.

## Testing

- Added `TestGenericTaskLifecycleAuthZ` (`master/internal/api_generic_tasks_intg_test.go`), which mocks the NSC authz provider to deny access and asserts that all three endpoints reject the request. The test fails on `main` (endpoints proceed without an authz call) and passes with this change.
- Verified existing related tests still pass: `TestGetTask`, `TestGetGenericTaskConfig`, `TestAuthZCanTerminateNSC`.

```
--- PASS: TestGenericTaskLifecycleAuthZ (0.82s)
    --- PASS: TestGenericTaskLifecycleAuthZ/kill
    --- PASS: TestGenericTaskLifecycleAuthZ/pause
    --- PASS: TestGenericTaskLifecycleAuthZ/unpause
```

## Notes

No API/proto changes; the fix is limited to server-side authorization enforcement. Behavior for authorized callers is unchanged.